### PR TITLE
feat(ai-gateway): withhold Web Search from non-Claude, non-Kimi providers

### DIFF
--- a/.changelog.d/gateway-web-search-filter.md
+++ b/.changelog.d/gateway-web-search-filter.md
@@ -1,0 +1,13 @@
+---
+branch: gateway-web-search-filter
+---
+
+### fleet-cli
+#### Changed
+- Gateway models other than Claude and Kimi no longer receive Claude Code's Web Search tool, so those models stop attempting a search they cannot run.
+  ko: Claude와 Kimi를 제외한 게이트웨이 모델에는 Claude Code의 Web Search 도구를 넘기지 않아, 실행할 수 없는 검색을 시도하지 않습니다.
+
+### fleet-console
+#### Changed
+- Gateway models other than Claude and Kimi no longer receive Claude Code's Web Search tool, so those models stop attempting a search they cannot run.
+  ko: Claude와 Kimi를 제외한 게이트웨이 모델에는 Claude Code의 Web Search 도구를 넘기지 않아, 실행할 수 없는 검색을 시도하지 않습니다.

--- a/packages/core-ai-gateway/src/anthropic/claude-context.ts
+++ b/packages/core-ai-gateway/src/anthropic/claude-context.ts
@@ -619,3 +619,86 @@ function withheldClaudeSkillStub(name: string, tokens: number, budget: number): 
     + `over the ${budget}-token ceiling one skill may take from this model's context window. `
     + `Read the skill's own files if you need it, or run this work on a model with a larger window.]`;
 }
+
+/** Claude Code's client-side Web Search tool. */
+export const CLAUDE_WEB_SEARCH_TOOL_NAME = "WebSearch";
+/** Anthropic's server-side web search tool name. */
+export const ANTHROPIC_WEB_SEARCH_TOOL_NAME = "web_search";
+/** Anthropic's server-side web search tool type. */
+export const ANTHROPIC_WEB_SEARCH_TOOL_TYPE = "web_search_20250305";
+
+interface ClaudeToolLike {
+  readonly name?: unknown;
+  readonly type?: unknown;
+}
+
+interface ClaudeToolChoiceLike {
+  readonly type?: unknown;
+  readonly name?: unknown;
+  readonly disable_parallel_tool_use?: unknown;
+}
+
+/** Structural shape of an Anthropic tools request, kept local so this module stays a leaf. */
+interface ClaudeToolsRequestLike<TTool, TChoice> {
+  readonly tools?: readonly TTool[];
+  readonly tool_choice?: TChoice;
+}
+
+export interface ClaudeWebSearchOmitResult<R> {
+  readonly request: R;
+  readonly changed: boolean;
+}
+
+function isClaudeWebSearchTool(tool: ClaudeToolLike): boolean {
+  return tool.type === ANTHROPIC_WEB_SEARCH_TOOL_TYPE
+    || tool.name === CLAUDE_WEB_SEARCH_TOOL_NAME
+    || tool.name === ANTHROPIC_WEB_SEARCH_TOOL_NAME;
+}
+
+function isClaudeWebSearchToolChoice(choice: ClaudeToolChoiceLike | undefined): boolean {
+  return choice?.type === "tool"
+    && (choice.name === CLAUDE_WEB_SEARCH_TOOL_NAME
+      || choice.name === ANTHROPIC_WEB_SEARCH_TOOL_NAME);
+}
+
+/**
+ * Drop Claude Code's Web Search tool definitions from a request.
+ *
+ * Past `tool_use` / `tool_result` history stays in `messages` — only the
+ * catalog is withheld. The caller decides which requests this applies to.
+ */
+export function omitClaudeWebSearchTools<
+  TTool extends ClaudeToolLike,
+  TChoice extends ClaudeToolChoiceLike,
+  R extends ClaudeToolsRequestLike<TTool, TChoice>,
+>(request: R): ClaudeWebSearchOmitResult<R> {
+  const tools = request.tools;
+  const kept = tools?.filter((tool) => !isClaudeWebSearchTool(tool));
+  const toolsChanged = tools !== undefined && kept !== undefined && kept.length !== tools.length;
+  const choice = request.tool_choice;
+  const choiceChanged = isClaudeWebSearchToolChoice(choice);
+  if (!toolsChanged && !choiceChanged) {
+    return { request, changed: false };
+  }
+
+  const { tools: _tools, tool_choice: _toolChoice, ...rest } = request;
+  return {
+    request: {
+      ...rest,
+      ...(toolsChanged
+        ? (kept.length === 0 ? {} : { tools: kept })
+        : (tools === undefined ? {} : { tools })),
+      ...(choiceChanged
+        ? {
+            tool_choice: {
+              type: "auto",
+              ...(choice?.disable_parallel_tool_use === undefined
+                ? {}
+                : { disable_parallel_tool_use: choice.disable_parallel_tool_use }),
+            } as TChoice,
+          }
+        : (choice === undefined ? {} : { tool_choice: choice })),
+    } as R,
+    changed: true,
+  };
+}

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -6,7 +6,10 @@ import {
   anthropicNativeHeaders,
   ANTHROPIC_MESSAGES_URL,
 } from "../anthropic/native.js";
-import { pruneClaudeSkillPayloads } from "../anthropic/claude-context.js";
+import {
+  omitClaudeWebSearchTools,
+  pruneClaudeSkillPayloads,
+} from "../anthropic/claude-context.js";
 import type { AnthropicMessagesRequest } from "../anthropic/protocol.js";
 import { UnsupportedReasoningEffortError } from "../canonical/index.js";
 import { CodexResponsesAdapter } from "../codex/responses/adapter.js";
@@ -265,6 +268,12 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
       });
       for (const skill of pruned.withheld) withheldSkills.add(skill.name);
       if (pruned.changed) body = { ...body, messages: [...pruned.messages] };
+    }
+    // Claude Code의 Web Search는 Claude·Kimi 소유 능력이다. 다른 공급자에게 정의를
+    // 넘기면 모델이 호출을 시도한다. 네이티브 Anthropic(`!target`)과 Kimi는 그대로 둔다.
+    if (target && target.provider !== "kimi") {
+      const omitted = omitClaudeWebSearchTools(body);
+      if (omitted.changed) body = omitted.request;
     }
 
     let credential = "";

--- a/packages/core-ai-gateway/tests/anthropic/claude-web-search-omit.test.ts
+++ b/packages/core-ai-gateway/tests/anthropic/claude-web-search-omit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { omitClaudeWebSearchTools } from "../../src/anthropic/claude-context.js";
+
+const READ = {
+  name: "Read",
+  input_schema: { type: "object", properties: {} },
+};
+
+const WEB_SEARCH_CLIENT = {
+  name: "WebSearch",
+  input_schema: {
+    type: "object",
+    properties: { query: { type: "string" } },
+    required: ["query"],
+  },
+};
+
+const WEB_SEARCH_NATIVE = {
+  type: "web_search_20250305",
+  name: "web_search",
+};
+
+describe("omitClaudeWebSearchTools", () => {
+  it("drops Claude Code's WebSearch helper and Anthropic's hosted web_search", () => {
+    const request = {
+      tools: [READ, WEB_SEARCH_CLIENT, WEB_SEARCH_NATIVE],
+    };
+
+    const result = omitClaudeWebSearchTools(request);
+
+    expect(result.changed).toBe(true);
+    expect(result.request.tools).toEqual([READ]);
+    expect(request.tools).toHaveLength(3);
+  });
+
+  it("omits the tools key when every definition was a web search tool", () => {
+    const result = omitClaudeWebSearchTools({ tools: [WEB_SEARCH_CLIENT] });
+
+    expect(result.changed).toBe(true);
+    expect(result.request).not.toHaveProperty("tools");
+  });
+
+  it("leaves a request without web search byte-for-byte intact", () => {
+    const request = { tools: [READ], tool_choice: { type: "auto" as const } };
+
+    const result = omitClaudeWebSearchTools(request);
+
+    expect(result.changed).toBe(false);
+    expect(result.request).toBe(request);
+  });
+
+  it("resets a tool_choice that named the omitted web search tool", () => {
+    const result = omitClaudeWebSearchTools({
+      tools: [READ, WEB_SEARCH_CLIENT],
+      tool_choice: { type: "tool", name: "WebSearch", disable_parallel_tool_use: true },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.request.tools).toEqual([READ]);
+    expect(result.request.tool_choice).toEqual({
+      type: "auto",
+      disable_parallel_tool_use: true,
+    });
+  });
+
+  it("resets a Web Search tool_choice even when the catalog has no matching definition", () => {
+    const result = omitClaudeWebSearchTools({
+      tools: [READ],
+      tool_choice: { type: "tool", name: "WebSearch", disable_parallel_tool_use: true },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.request.tools).toEqual([READ]);
+    expect(result.request.tool_choice).toEqual({
+      type: "auto",
+      disable_parallel_tool_use: true,
+    });
+  });
+
+  it("does not touch messages, including prior WebSearch tool_use history", () => {
+    const messages = [{
+      role: "assistant" as const,
+      content: [{ type: "tool_use", id: "call_1", name: "WebSearch", input: { query: "x" } }],
+    }];
+    const request = { tools: [WEB_SEARCH_CLIENT], messages };
+
+    const result = omitClaudeWebSearchTools(request);
+
+    expect(result.request.messages).toBe(messages);
+  });
+});

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -181,6 +181,64 @@ describe("upstream credential", () => {
     }));
   });
 
+  it("withholds Claude Code's Web Search tools from translated providers", async () => {
+    const gateway = stubGateway();
+    const streamSpy = vi.spyOn(gateway, "stream");
+    const router = createAiGatewayRouter({ gateway, readAuth });
+    const res = response();
+    await router.handle(ctx({
+      res,
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-sol-fast",
+      tools: [
+        { name: "Read", input_schema: { type: "object", properties: {} } },
+        { name: "WebSearch", input_schema: { type: "object", properties: { query: { type: "string" } } } },
+        { type: "web_search_20250305", name: "web_search" },
+      ],
+      toolChoice: { type: "tool", name: "web_search" },
+      messages: [{
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "WebSearch", input: { query: "x" } }],
+      }],
+    }));
+
+    expect(res.status).toBe(200);
+    const [request] = streamSpy.mock.calls[0] ?? [];
+    expect(request?.tools?.map((tool) => tool.name)).toEqual(["Read"]);
+    expect(request?.tool_choice).toEqual({ type: "auto" });
+    expect(request?.messages).toEqual([{
+      role: "assistant",
+      content: [{ type: "tool_use", id: "call_1", name: "WebSearch", input: { query: "x" } }],
+    }]);
+  });
+
+  it("withholds Claude Code's Web Search tools from Cursor", async () => {
+    const gateway = stubGateway();
+    const streamSpy = vi.spyOn(gateway, "stream");
+    const router = createAiGatewayRouter({
+      gateway,
+      readAuth,
+      readCursorToken: () => "cursor-subscription-token",
+    });
+    const res = response();
+    await router.handle(ctx({
+      res,
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--cursor--grok-4.5",
+      tools: [
+        { name: "Read", input_schema: { type: "object", properties: {} } },
+        { name: "WebSearch", input_schema: { type: "object", properties: { query: { type: "string" } } } },
+        { type: "web_search_20250305", name: "web_search" },
+      ],
+      toolChoice: { type: "tool", name: "WebSearch" },
+    }));
+
+    expect(res.status).toBe(200);
+    const [request] = streamSpy.mock.calls[0] ?? [];
+    expect(request?.tools?.map((tool) => tool.name)).toEqual(["Read"]);
+    expect(request?.tool_choice).toEqual({ type: "auto" });
+  });
+
   it("projects Codex usage from the registry when Claude strips the 1M marker", async () => {
     const gateway = stubGateway();
     const streamSpy = vi.spyOn(gateway, "stream");
@@ -677,6 +735,36 @@ describe("OpenCode Go passthrough", () => {
     expect(`${JSON.stringify(res.headers)}${res.body}`).not.toContain("opencode-secret");
   });
 
+  it("withholds Claude Code's Web Search tools from OpenCode", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      "event: message_stop\n\n",
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ));
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      readOpencodeApiKey: async () => "opencode-secret",
+    });
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--opencode--minimax-m3[1m]",
+      tools: [
+        { name: "Read", input_schema: { type: "object", properties: {} } },
+        { name: "WebSearch", input_schema: { type: "object", properties: { query: { type: "string" } } } },
+        { type: "web_search_20250305", name: "web_search" },
+      ],
+      toolChoice: { type: "tool", name: "WebSearch" },
+    }));
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      readonly tools?: ReadonlyArray<{ readonly name?: string }>;
+      readonly tool_choice?: { readonly type?: string };
+    };
+    expect(body.tools?.map((tool) => tool.name)).toEqual(["Read"]);
+    expect(body.tool_choice).toEqual({ type: "auto" });
+  });
+
   it("drops output_config entirely when effort was its only field", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response(
       "event: message_stop\n\n",
@@ -780,6 +868,33 @@ describe("Grok CLI Responses", () => {
     expect(headers.get("x-grok-client-version")).toBe("1.0.3");
     expect(headers.get("x-grok-model-override")).toBe("grok-4.6");
     expect(body.model).toBe("grok-4.6");
+  });
+
+  it("withholds Claude Code's Web Search tools from the Grok CLI wire", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      "data: [DONE]\n\n",
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ));
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      readXaiToken: () => "grok-subscription-token",
+    });
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--xai--grok-4.6",
+      tools: [
+        { name: "Read", input_schema: { type: "object", properties: {} } },
+        { name: "WebSearch", input_schema: { type: "object", properties: { query: { type: "string" } } } },
+        { type: "web_search_20250305", name: "web_search" },
+      ],
+    }));
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      readonly tools?: ReadonlyArray<{ readonly name?: string; readonly type?: string }>;
+    };
+    expect(body.tools?.map((tool) => tool.name ?? tool.type)).toEqual(["Read"]);
   });
 
   it("refuses an xAI model without an active Grok CLI sign-in", async () => {
@@ -914,6 +1029,34 @@ describe("Kimi passthrough", () => {
       type: "tool_result",
       content: [{ type: "text", text: "Tool available: mcp__fleet__wiki_read" }],
     });
+  });
+
+  it("forwards Claude Code's Web Search tools to Kimi unchanged", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      "event: message_stop\n\n",
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ));
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      readKimiApiKey: async () => "kimi-secret",
+    });
+
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--kimi--k3-256k",
+      tools: [
+        { name: "Read", input_schema: { type: "object", properties: {} } },
+        { name: "WebSearch", input_schema: { type: "object", properties: { query: { type: "string" } } } },
+        { type: "web_search_20250305", name: "web_search" },
+      ],
+    }));
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      readonly tools?: ReadonlyArray<{ readonly name?: string }>;
+    };
+    expect(body.tools?.map((tool) => tool.name)).toEqual(["Read", "WebSearch", "web_search"]);
   });
 
   it.each([
@@ -1235,6 +1378,29 @@ describe("anthropic passthrough", () => {
     await router.handle(ctx({ res, model: "claude-sonnet-4-6" }));
 
     expect(res.status).toBe(401);
+  });
+
+  it("forwards Claude Code's Web Search tools to native Anthropic unchanged", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      "event: message_stop\n\n",
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ));
+    const router = createAiGatewayRouter({ fetch: fetchMock, readAuth });
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-sonnet-4-6",
+      tools: [
+        { name: "Read", input_schema: { type: "object", properties: {} } },
+        { name: "WebSearch", input_schema: { type: "object", properties: { query: { type: "string" } } } },
+        { type: "web_search_20250305", name: "web_search" },
+      ],
+    }));
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      readonly tools?: ReadonlyArray<{ readonly name?: string; readonly type?: string }>;
+    };
+    expect(body.tools?.map((tool) => tool.name)).toEqual(["Read", "WebSearch", "web_search"]);
   });
 
   it("does not rewrite the echoed model on the real-Anthropic path", async () => {


### PR DESCRIPTION
## Summary
- Claude Code의 Web Search 도구 정의는 Claude·Kimi에만 전달합니다. Codex, Cursor, OpenCode, xAI에는 `WebSearch`/`web_search`를 `tools[]`에서 걷어내고, 그 도구를 가리키는 `tool_choice`는 `auto`로 되돌립니다.
- 네이티브 Anthropic(`!target`)과 Kimi 경로는 그대로 두고, 과거 `tool_use`/`tool_result` 히스토리는 유지합니다.
- 사용자가 게이트웨이 모델에서 실행할 수 없는 검색을 시도하지 않게 하는 제품 동작 변경입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (630, omit + router 케이스 포함)
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 라우터: Claude/Kimi 유지, Codex/Cursor/OpenCode/xAI 제거, tool_choice-only 리셋