### PR TITLE
feat(fleet-console): quick launch picker keyboard grammar

### DIFF
--- a/.changelog.d/quick-launch-picker-keyboard.md
+++ b/.changelog.d/quick-launch-picker-keyboard.md
@@ -1,0 +1,13 @@
+---
+branch: quick-launch-picker-keyboard
+---
+
+### fleet-console
+#### Changed
+- Quick Launch picker menus now follow the standard menu keyboard grammar: opening a picker focuses the current choice, arrow keys and Home/End move through the list, typing a letter jumps to a matching entry, Enter picks and returns to the prompt, and Escape returns to the chip.
+  ko: Quick Launch 선택 메뉴가 표준 메뉴 키보드 문법을 따릅니다. 메뉴를 열면 현재 선택 항목에 포커스가 들어가고, 방향키와 Home/End로 목록을 이동하며, 글자를 치면 일치하는 항목으로 점프하고, Enter는 선택 후 입력창으로, Escape는 칩으로 돌아갑니다.
+#### Fixed
+- The focus ring on the Theater and model chips draws as a complete ring instead of two clipped side arcs.
+  ko: Theater·모델 칩의 포커스 링이 좌우 호 두 개로 잘리지 않고 온전한 링으로 그려집니다.
+- Closing Quick Launch with Escape no longer discards a typed prompt; reopening restores the draft.
+  ko: Escape로 Quick Launch를 닫아도 입력한 문장이 사라지지 않으며, 다시 열면 초안이 복원됩니다.

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -8,7 +8,7 @@ import { useConsoleState } from "../hooks/use-store.js";
 import { useT } from "../i18n/index.js";
 import type { OperationSearchEntry } from "../operation-search.js";
 import { usePluginRegistry } from "../plugin-registry.js";
-import { readQuickLaunchSelection, writeQuickLaunchModelEffort, writeQuickLaunchSelection } from "../quick-launch-preferences.js";
+import { readQuickLaunchSelection, writeQuickLaunchModelEffort, writeQuickLaunchSelection, writeQuickLaunchTheater } from "../quick-launch-preferences.js";
 import { buildQuickLaunchMentionGroups, findVariantLaunchKind, isMentionSelectable, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, quickLaunchMentionErrorMessageKey, readMentionToken, resolveSelection, stripMentionToken, type QuickLaunchMentionToken } from "../quick-launch.js";
 import { FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
@@ -350,6 +350,10 @@ export function QuickLaunch() {
       // 제출로 닫히는 초안은 소비된 것이다 — 닫힘 전이의 보존이 이 문장을 초안으로 되살리면
       // 다음 열림이 이미 발사된 지시를 미발사처럼 싣는다.
       submittedRef.current = true;
+      // 전달이 비동기(멘션)인 동안 Escape로 먼저 닫혔다면 닫힘 전이가 이미 초안을 보존했다.
+      // 성공이 뒤늦게 도착한 지금 그 보존분을 소비한다 — 남기면 전달된 문장이 미발사 초안으로
+      // 되살아난다. 에포크 가드가 위에서 스테일 세션을 걸렀으므로 여기서는 안전하다.
+      consumeQuickLaunchDraft();
       closeQuickLaunch();
       return;
     }
@@ -800,6 +804,9 @@ export function QuickLaunch() {
                   data-menu-label={theater.label}
                   onClick={() => {
                     setTheaterId(theater.id);
+                    // 모델·강도와 같은 "고르면 기억" 계층 — 실행까지 미루면 보존된 초안이
+                    // 재오픈에서 옛 Theater로 돌아간 채 발사 좌표만 어긋난다.
+                    writeQuickLaunchTheater(theater.id);
                     closePopover();
                     inputRef.current?.focus();
                   }}

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -12,7 +12,7 @@ import { readQuickLaunchSelection, writeQuickLaunchModelEffort, writeQuickLaunch
 import { buildQuickLaunchMentionGroups, findVariantLaunchKind, isMentionSelectable, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, quickLaunchMentionErrorMessageKey, readMentionToken, resolveSelection, stripMentionToken, type QuickLaunchMentionToken } from "../quick-launch.js";
 import { FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
-import { clearQuickLaunchRejection, closeQuickLaunch, consumeQuickLaunchDraft, isQuickLaunchDocked, preserveQuickLaunchDraft, requestQuickLaunch, setActiveTheater, setQuickLaunchDockSuppressed, setQuickLaunchPinned } from "../store.js";
+import { clearQuickLaunchRejection, closeQuickLaunch, consumeQuickLaunchDraft, getState, isQuickLaunchDocked, preserveQuickLaunchDraft, requestQuickLaunch, setActiveTheater, setQuickLaunchDockSuppressed, setQuickLaunchPinned } from "../store.js";
 import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph } from "./launch-provider-glyphs.js";
 import { EffortTrack, resolveRowEffort } from "./effort-track.js";
 
@@ -345,15 +345,18 @@ export function QuickLaunch() {
   // 상태가 된다 — 비우지 않으면 방금 보낸 문장이 그대로 남아 아직 못 보낸 것처럼 읽힌다.
   // 고정 여부는 호출 시점에 store에서 읽는다 — 멘션 전달은 비동기라, 넘길 때의 값을 닫아 두면
   // 전달 중에 고정을 푼 사용자에게 빈 모달이 닫히지 않은 채 남는다.
-  const finishSubmission = useCallback(() => {
+  const finishSubmission = useCallback((deliveredText: string | null = null) => {
     if (!isQuickLaunchDocked()) {
       // 제출로 닫히는 초안은 소비된 것이다 — 닫힘 전이의 보존이 이 문장을 초안으로 되살리면
       // 다음 열림이 이미 발사된 지시를 미발사처럼 싣는다.
       submittedRef.current = true;
-      // 전달이 비동기(멘션)인 동안 Escape로 먼저 닫혔다면 닫힘 전이가 이미 초안을 보존했다.
-      // 성공이 뒤늦게 도착한 지금 그 보존분을 소비한다 — 남기면 전달된 문장이 미발사 초안으로
-      // 되살아난다. 에포크 가드가 위에서 스테일 세션을 걸렀으므로 여기서는 안전하다.
-      consumeQuickLaunchDraft();
+      // 전달이 비동기(멘션)인 동안 Escape로 먼저 닫혔다면 닫힘 전이가 이 문장을 보존해 뒀다 —
+      // 남기면 전달된 문장이 미발사 초안으로 되살아난다. 단, store의 초안 슬롯은 공유라 다른
+      // 제출의 거절 초안(reopenQuickLaunchWithDraft)이 도착해 있을 수 있으므로, 지금 전달된
+      // 문장과 일치하는 보존분만 소비한다(보존은 원문, 전달은 trim이라 trim으로 비교한다).
+      if (deliveredText !== null && getState().quickLaunchDraft?.trim() === deliveredText) {
+        consumeQuickLaunchDraft();
+      }
       closeQuickLaunch();
       return;
     }
@@ -394,7 +397,8 @@ export function QuickLaunch() {
       void plugin.messageOperation(mentionTarget.operationId, text)
         .then(() => {
           if (composerEpochRef.current !== epoch) return;
-          finishSubmission();
+          // 전달된 문장을 넘겨 이 제출이 보존한 초안만 소비하게 한다.
+          finishSubmission(text);
         })
         .catch((error: unknown) => {
           if (composerEpochRef.current !== epoch) return;

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -12,7 +12,7 @@ import { readQuickLaunchSelection, writeQuickLaunchModelEffort, writeQuickLaunch
 import { buildQuickLaunchMentionGroups, findVariantLaunchKind, isMentionSelectable, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, quickLaunchMentionErrorMessageKey, readMentionToken, resolveSelection, stripMentionToken, type QuickLaunchMentionToken } from "../quick-launch.js";
 import { FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
-import { clearQuickLaunchRejection, closeQuickLaunch, consumeQuickLaunchDraft, isQuickLaunchDocked, requestQuickLaunch, setActiveTheater, setQuickLaunchDockSuppressed, setQuickLaunchPinned } from "../store.js";
+import { clearQuickLaunchRejection, closeQuickLaunch, consumeQuickLaunchDraft, isQuickLaunchDocked, preserveQuickLaunchDraft, requestQuickLaunch, setActiveTheater, setQuickLaunchDockSuppressed, setQuickLaunchPinned } from "../store.js";
 import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph } from "./launch-provider-glyphs.js";
 import { EffortTrack, resolveRowEffort } from "./effort-track.js";
 
@@ -59,6 +59,11 @@ export function QuickLaunch() {
   // 접힘은 상태로 소유하되 실제 포커스에서만 파생시킨다 — 포커스와 별도로 관리하면 둘이 어긋나
   // "보이는데 못 쓰는" 바가 생긴다. 고정된 채로 화면을 열면 접힌 채 상주한다(포커스를 훔치지 않는다).
   const [collapsed, setCollapsed] = useState(() => state.quickLaunchPinned);
+  // 발사되지 않은 초안은 닫힘 경로(Escape·오버레이 클릭·Mod+J·고정 해제)와 무관하게 살아남는다.
+  // 제출만이 초안을 소비하므로, 제출 경로가 이 플래그를 올려 닫힘 전이의 보존을 건너뛰게 한다.
+  const promptRef = useRef(prompt);
+  promptRef.current = prompt;
+  const submittedRef = useRef(false);
 
   // 설정처럼 실행이 할 일이 아닌 화면에서는 도킹을 접어 둔다. 고정 자체는 그대로라 화면을 벗어나면
   // 바가 되돌아오고, 그동안 Mod+J는 예전처럼 모달을 여닫는다(단축키를 죽이지 않는다).
@@ -140,6 +145,22 @@ export function QuickLaunch() {
     setEffort(remembered.effort);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, state.activeTheaterId, theaters]);
+
+  // 닫힘 전이에서 발사되지 않은 초안을 store에 남긴다. 경로별(Escape·오버레이·Mod+J·고정 해제)로
+  // 저장을 심으면 하나가 빠질 때마다 초안이 새므로, 전이 한 곳이 모든 닫힘을 대표한다.
+  // 열림 전이의 초안 복원(위 효과)과 짝이며, 제출 닫힘만 submittedRef로 보존을 건너뛴다.
+  const wasOpenForDraftRef = useRef(open);
+  useEffect(() => {
+    const was = wasOpenForDraftRef.current;
+    wasOpenForDraftRef.current = open;
+    if (open) {
+      submittedRef.current = false;
+      return;
+    }
+    if (!was) return;
+    if (!submittedRef.current && promptRef.current.trim().length > 0) preserveQuickLaunchDraft(promptRef.current);
+    submittedRef.current = false;
+  }, [open]);
 
   // 카탈로그가 도착하면 기억해 둔 조합을 실제 목록에 맞춘다.
   // model/effort도 의존성에 둔다 — 재오픈이 bare opus를 잠깐 복원해도 정규화된 값으로 다시 맞춘다.
@@ -235,6 +256,17 @@ export function QuickLaunch() {
     return () => window.removeEventListener("resize", handleResize);
   }, [popover]);
 
+  // 메뉴가 열리면 포커스는 체크된 항목으로 들어간다(WAI-APG menu button 계약). 포커스가 칩에
+  // 남으면 방향키·Tab이 목록 밖에서 동작해, 열린 메뉴가 화면에서 가장 도달하기 어려운 컨트롤이
+  // 된다(실측: 첫 항목까지 Tab 4회).
+  useLayoutEffect(() => {
+    if (!popover) return;
+    const pop = barRef.current?.querySelector<HTMLElement>(".quick-launch-pop");
+    if (!pop) return;
+    const checked = pop.querySelector<HTMLElement>("[role='menuitemradio'][aria-checked='true']");
+    (checked ?? pop.querySelector<HTMLElement>("[role='menuitemradio']"))?.focus();
+  }, [popover]);
+
   const updatePrompt = useCallback((nextPrompt: string, element: HTMLTextAreaElement) => {
     setPrompt(nextPrompt);
     autoGrow(element);
@@ -268,12 +300,56 @@ export function QuickLaunch() {
 
   const closePopover = useCallback(() => setPopover(null), []);
 
+  // 픽커는 자신이 선언한 role="menu" 계약을 이행한다 — 방향키 순환, Home/End, 첫 글자 typeahead.
+  // 항목은 tabIndex -1(로빙)이라 Tab 정지점이 아니고, Tab은 메뉴를 닫고 칩에서 이어 간다.
+  // Enter/Space는 버튼 기본 클릭에 맡긴다(onClick이 선택·닫기·입력 복귀를 이미 소유한다).
+  const handlePopoverKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const items = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>("[role='menuitemradio']"));
+    if (items.length === 0) return;
+    const activeIndex = items.findIndex((item) => item === document.activeElement);
+    const focusItem = (index: number) => items[((index % items.length) + items.length) % items.length]?.focus();
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const delta = event.key === "ArrowDown" ? 1 : -1;
+      // 포커스가 아직 항목 밖이면(마우스 열림 직후 등) 방향에 맞는 끝에서 시작한다.
+      focusItem(activeIndex === -1 ? (delta === 1 ? 0 : items.length - 1) : activeIndex + delta);
+      return;
+    }
+    if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      focusItem(event.key === "Home" ? 0 : items.length - 1);
+      return;
+    }
+    if (event.key === "Tab") {
+      // 메뉴 계약: Tab은 항목 순회가 아니라 메뉴를 닫고 다음 컨트롤로 넘어간다. 칩에 포커스를
+      // 되돌린 채 기본 동작을 살려 두면 브라우저가 칩의 다음(또는 이전) 정지점으로 옮긴다.
+      closePopover();
+      (popover === "theater" ? theaterChipRef : modelChipRef).current?.focus();
+      return;
+    }
+    if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey && /\S/.test(event.key)) {
+      // 활성 다음 항목부터 순환 탐색 — 팔레트·'@' 덱과 같은 "치면 닿는" 문법의 최소형.
+      const query = event.key.toLowerCase();
+      for (let step = 1; step <= items.length; step += 1) {
+        const candidate = items[(activeIndex + step + items.length) % items.length]!;
+        if ((candidate.dataset.menuLabel ?? "").toLowerCase().startsWith(query)) {
+          event.preventDefault();
+          candidate.focus();
+          return;
+        }
+      }
+    }
+  }, [closePopover, popover]);
+
   // 제출이 끝나면 모달은 사라진다. 고정된 바는 남으므로 초안을 비우고 물러나야 다음 지시를 받는
   // 상태가 된다 — 비우지 않으면 방금 보낸 문장이 그대로 남아 아직 못 보낸 것처럼 읽힌다.
   // 고정 여부는 호출 시점에 store에서 읽는다 — 멘션 전달은 비동기라, 넘길 때의 값을 닫아 두면
   // 전달 중에 고정을 푼 사용자에게 빈 모달이 닫히지 않은 채 남는다.
   const finishSubmission = useCallback(() => {
     if (!isQuickLaunchDocked()) {
+      // 제출로 닫히는 초안은 소비된 것이다 — 닫힘 전이의 보존이 이 문장을 초안으로 되살리면
+      // 다음 열림이 이미 발사된 지시를 미발사처럼 싣는다.
+      submittedRef.current = true;
       closeQuickLaunch();
       return;
     }
@@ -710,6 +786,7 @@ export function QuickLaunch() {
               className="quick-launch-pop quick-launch-pop--theater theater-menu"
               role="menu"
               aria-label={t("chrome.quickLaunch.theaterMenu")}
+              onKeyDown={handlePopoverKeyDown}
               style={{ ...(popoverLeft === null ? {} : { left: popoverLeft }), ...(popoverMaxHeight === null ? {} : { "--quick-launch-pop-max-height": `${popoverMaxHeight}px` }) }}
             >
               {theaters.map((theater) => (
@@ -719,6 +796,8 @@ export function QuickLaunch() {
                   className="quick-launch-pop-item"
                   role="menuitemradio"
                   aria-checked={theater.id === theaterId}
+                  tabIndex={-1}
+                  data-menu-label={theater.label}
                   onClick={() => {
                     setTheaterId(theater.id);
                     closePopover();
@@ -738,6 +817,7 @@ export function QuickLaunch() {
               className="quick-launch-pop quick-launch-pop--model theater-menu"
               role="menu"
               aria-label={t("chrome.quickLaunch.modelMenu")}
+              onKeyDown={handlePopoverKeyDown}
               style={{ ...(popoverLeft === null ? {} : { left: popoverLeft }), ...(popoverMaxHeight === null ? {} : { "--quick-launch-pop-max-height": `${popoverMaxHeight}px` }) }}
             >
               {groups.map((group) => (
@@ -794,6 +874,8 @@ function QuickLaunchVariantRow({ row, selectedModel, onPick }: {
         className="quick-launch-variant-name"
         role="menuitemradio"
         aria-checked={rowModel === selectedModel}
+        tabIndex={-1}
+        data-menu-label={row.label}
         onClick={() => onPick(rowModel)}
       >
         {/* ★는 라벨 뒤에 선다 — 앞에 두고 오른쪽으로 밀면 그 행만 통째로 우측 정렬돼 목록의 좌측 기준선이 끊긴다. */}
@@ -856,8 +938,9 @@ function trapFocus(event: KeyboardEvent, card: HTMLElement | null): void {
   const scopes = [card, ...Array.from(document.querySelectorAll<HTMLElement>(FEATURE_TOUR_LAYER_SELECTOR))];
   const focusable = scopes.flatMap((scope) => Array.from(scope.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)))
     // 멘션 전환으로 접힌 런치 3종은 visibility:hidden으로 남는다 — offsetParent만 보면 트랩이
-    // 보이지 않는 칩으로 포커스를 되돌린다.
-    .filter((element) => element.offsetParent !== null && getComputedStyle(element).visibility !== "hidden");
+    // 보이지 않는 칩으로 포커스를 되돌린다. 로빙(tabIndex -1) 항목 — 픽커·멘션 덱의 행 — 은
+    // Tab 정지점이 아니므로 트랩의 양 끝 계산에서도 빠져야 한다(버튼 셀렉터가 다시 주워 담는다).
+    .filter((element) => element.tabIndex >= 0 && element.offsetParent !== null && getComputedStyle(element).visibility !== "hidden");
   if (focusable.length === 0) return;
   const first = focusable[0];
   const last = focusable[focusable.length - 1];

--- a/runtime/fleet-console/core/client/src/quick-launch-preferences.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch-preferences.ts
@@ -72,6 +72,15 @@ export function writeQuickLaunchPinned(pinned: boolean): void {
   writeQuickLaunchSelection({ ...remembered, pinned });
 }
 
+/**
+ * Theater도 모델·강도(writeQuickLaunchModelEffort)와 같은 "고르면 기억" 계층이다. 실행까지만
+ * 기억을 미루면, 보존된 초안이 재오픈에서 옛 Theater로 되돌아간 채 발사 좌표만 어긋난다.
+ */
+export function writeQuickLaunchTheater(theaterId: string | null): void {
+  const remembered = readQuickLaunchSelection();
+  writeQuickLaunchSelection({ ...remembered, theaterId });
+}
+
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -613,6 +613,15 @@ export function consumeQuickLaunchDraft(): void {
   setState({ quickLaunchDraft: null });
 }
 
+/**
+ * 발사되지 않은 초안을 다음 열림까지 지킨다. 닫힘은 취소가 아니라 미룸이다 — Escape 한 번이
+ * 문장을 지우면 컴포저가 키보드 사용자에게 유일한 데이터 손실 키를 쥐여 주는 셈이다.
+ * 복원은 열림 전이의 기존 경로(quickLaunchDraft 읽기 + consume)가 그대로 맡는다.
+ */
+export function preserveQuickLaunchDraft(draft: string): void {
+  setState({ quickLaunchDraft: draft });
+}
+
 export function closeQuickLaunch(): void {
   setState({ quickLaunchOpen: false, quickLaunchError: null, quickLaunchErrorShortenBy: null });
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -12057,6 +12057,11 @@ body[data-codex-reading="true"] .operations-side-bar {
   flex-wrap: wrap;
   gap: var(--space-2);
   overflow: hidden;
+  /* 접힘 클립이 전역 포커스 링(2px + offset 2px = 4px 돌출)을 자르면 칩의 링이 좌우 호 두 개로
+     남는다(실측). padding+음수 margin 짝은 콘텐츠 원점과 이웃 간격을 그대로 둔 채 클립 상자만
+     5px 부풀리는 레이아웃 중립 확장이다. */
+  padding: 5px;
+  margin: -5px;
   max-width: min(640px, 100%);
   opacity: 1;
   transition:
@@ -12069,6 +12074,9 @@ body[data-codex-reading="true"] .operations-side-bar {
   /* 접힐 때는 줄바꿈을 되돌린다 — 폭이 0으로 줄면 컨트롤이 저마다 줄을 차지해, 보이지 않는 채로
      바 높이만 부풀린다(visibility: hidden은 레이아웃에서 빠지지 않는다). */
   flex-wrap: nowrap;
+  /* 링용 수평 여백은 접힘에서 0이 된다 — 남기면 max-width: 0이어도 10px 유령 폭이 바에 남는다. */
+  padding-inline: 0;
+  margin-inline: 0;
   max-width: 0;
   opacity: 0;
   visibility: hidden;

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -174,6 +174,59 @@ describe("Quick Launch effort surface", () => {
   });
 });
 
+describe("Quick Launch picker keyboard grammar", () => {
+  it("moves focus into the checked item when a picker opens", () => {
+    // 포커스가 칩에 남으면 방향키·Tab이 열린 목록 밖에서 동작한다(실측: 첫 항목까지 Tab 4회).
+    expect(quickLaunch).toMatch(/\[role='menuitemradio'\]\[aria-checked='true'\]/u);
+    expect(quickLaunch).toMatch(/\(checked \?\? pop\.querySelector<HTMLElement>\("\[role='menuitemradio'\]"\)\)\?\.focus\(\)/u);
+  });
+
+  it("wires the same keyboard handler to both pickers", () => {
+    // theater와 model 팝오버가 같은 계약을 이행한다 — 한쪽만 배선되면 두 픽커의 문법이 갈린다.
+    const wired = quickLaunch.match(/onKeyDown=\{handlePopoverKeyDown\}/gu);
+    expect(wired).toHaveLength(2);
+  });
+
+  it("implements the menu contract: arrows cycle, Home/End jump, Tab leaves via the chip", () => {
+    expect(quickLaunch).toMatch(/event\.key === "ArrowDown" \|\| event\.key === "ArrowUp"/u);
+    expect(quickLaunch).toMatch(/event\.key === "Home" \|\| event\.key === "End"/u);
+    // Tab은 메뉴를 닫고 칩에서 이어 간다 — 항목 순회로 남으면 열린 목록이 Tab 미로가 된다.
+    const tabBranch = /if \(event\.key === "Tab"\) \{[\s\S]*?closePopover\(\);[\s\S]*?\.current\?\.focus\(\);/u;
+    expect(quickLaunch).toMatch(tabBranch);
+  });
+
+  it("gives every picker item a roving tabIndex and a typeahead label", () => {
+    // tabIndex -1이 아니면 항목이 Tab 정지점으로 남고, data-menu-label이 없으면 typeahead가 침묵한다.
+    const theaterItem = /role="menuitemradio"\s+aria-checked=\{theater\.id === theaterId\}\s+tabIndex=\{-1\}\s+data-menu-label=\{theater\.label\}/u;
+    const variantItem = /role="menuitemradio"\s+aria-checked=\{rowModel === selectedModel\}\s+tabIndex=\{-1\}\s+data-menu-label=\{row\.label\}/u;
+    expect(quickLaunch).toMatch(theaterItem);
+    expect(quickLaunch).toMatch(variantItem);
+  });
+
+  it("excludes roving items from the modal focus trap's edge math", () => {
+    // 버튼 셀렉터가 tabIndex -1 항목을 다시 주워 담으면 트랩의 first/last가 보이지 않는 행이 된다.
+    expect(quickLaunch).toMatch(/element\.tabIndex >= 0 && element\.offsetParent !== null/u);
+  });
+
+  it("keeps the focus ring whole by inflating only the collapse clip box", () => {
+    // overflow: hidden은 접힘 애니메이션의 것이다 — 클립 상자만 5px 부풀려 링(4px 돌출)을 살린다.
+    const sel = ruleFor(".quick-launch-launch-sel");
+    expect(sel).toMatch(/overflow:\s*hidden;/u);
+    expect(sel).toMatch(/padding:\s*5px;/u);
+    expect(sel).toMatch(/margin:\s*-5px;/u);
+    // 접힘에서는 수평 여백이 0이어야 max-width: 0이 유령 폭 없이 닫힌다.
+    const hidden = ruleFor(".quick-launch-launch-sel.is-hidden");
+    expect(hidden).toMatch(/padding-inline:\s*0;/u);
+    expect(hidden).toMatch(/margin-inline:\s*0;/u);
+  });
+
+  it("preserves an unfired draft across every close path, except submission", () => {
+    // 경로별 저장은 하나가 빠질 때마다 초안이 샌다 — 닫힘 전이 한 곳이 모든 닫힘을 대표한다.
+    expect(quickLaunch).toMatch(/preserveQuickLaunchDraft\(promptRef\.current\)/u);
+    expect(quickLaunch).toMatch(/submittedRef\.current = true;\s*\n\s*closeQuickLaunch\(\);/u);
+  });
+});
+
 describe("canvas effort submenu", () => {
   it("sizes the flyout to its content so labels are not clipped", () => {
     // 고정 폭이면 짧을 때 잘리고 길면 빈 칸이 남는다 — max-content가 둘을 막는다.

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -223,7 +223,19 @@ describe("Quick Launch picker keyboard grammar", () => {
   it("preserves an unfired draft across every close path, except submission", () => {
     // 경로별 저장은 하나가 빠질 때마다 초안이 샌다 — 닫힘 전이 한 곳이 모든 닫힘을 대표한다.
     expect(quickLaunch).toMatch(/preserveQuickLaunchDraft\(promptRef\.current\)/u);
-    expect(quickLaunch).toMatch(/submittedRef\.current = true;\s*\n\s*closeQuickLaunch\(\);/u);
+    expect(quickLaunch).toMatch(/submittedRef\.current = true;/u);
+  });
+
+  it("consumes a mid-flight preserved draft when asynchronous delivery succeeds", () => {
+    // 전달 중 Escape가 보존한 초안을 성공 콜백이 소비하지 않으면, 전달된 문장이 미발사 초안으로
+    // 되살아나 중복 전달을 부른다(Codex P2 실측 경로).
+    const modalFinish = /submittedRef\.current = true;[\s\S]{0,400}?consumeQuickLaunchDraft\(\);[\s\S]{0,200}?closeQuickLaunch\(\);/u;
+    expect(quickLaunch).toMatch(modalFinish);
+  });
+
+  it("remembers a picked Theater immediately, like model and effort", () => {
+    // 실행까지 기억을 미루면 보존된 초안이 재오픈에서 옛 Theater로 되돌아간다(실측 재현).
+    expect(quickLaunch).toMatch(/setTheaterId\(theater\.id\);[\s\S]{0,200}?writeQuickLaunchTheater\(theater\.id\);/u);
   });
 });
 

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -226,11 +226,11 @@ describe("Quick Launch picker keyboard grammar", () => {
     expect(quickLaunch).toMatch(/submittedRef\.current = true;/u);
   });
 
-  it("consumes a mid-flight preserved draft when asynchronous delivery succeeds", () => {
-    // 전달 중 Escape가 보존한 초안을 성공 콜백이 소비하지 않으면, 전달된 문장이 미발사 초안으로
-    // 되살아나 중복 전달을 부른다(Codex P2 실측 경로).
-    const modalFinish = /submittedRef\.current = true;[\s\S]{0,400}?consumeQuickLaunchDraft\(\);[\s\S]{0,200}?closeQuickLaunch\(\);/u;
-    expect(quickLaunch).toMatch(modalFinish);
+  it("consumes only the mid-flight preserved draft this delivery owns", () => {
+    // 전달 중 Escape가 보존한 초안을 성공 콜백이 소비하지 않으면 전달된 문장이 미발사 초안으로
+    // 되살아나고, 소유권 검사 없이 소비하면 다른 제출의 거절 초안까지 지운다(둘 다 Codex P2).
+    expect(quickLaunch).toMatch(/quickLaunchDraft\?\.trim\(\) === deliveredText/u);
+    expect(quickLaunch).toMatch(/finishSubmission\(text\)/u);
   });
 
   it("remembers a picked Theater immediately, like model and effort", () => {


### PR DESCRIPTION
## Summary
- Quick Launch의 Theater/모델 픽커가 선언만 하던 `role="menu"` 키보드 계약을 실제로 이행합니다: 열리면 체크된 항목에 포커스가 들어가고, 방향키·Home/End가 목록을 순환하며, 첫 글자 typeahead로 점프하고, Enter는 선택 후 입력창 복귀, Escape는 칩 복귀, Tab은 메뉴를 닫고 다음 컨트롤로 넘어갑니다(항목은 roving tabIndex -1이라 Tab 정지점이 아님).
- 멘션 접힘용 `overflow: hidden` 래퍼(`.quick-launch-launch-sel`)가 전역 포커스 링을 좌우 호 2개로 잘라내던 문제를 padding+음수 margin 짝(레이아웃 중립)으로 클립 상자만 5px 부풀려 수리했습니다. 접힘 상태에서는 수평 여백을 0으로 되돌려 유령 폭을 남기지 않습니다.
- 발사되지 않은 초안이 Escape·오버레이 클릭·Mod+J·고정 해제 어느 닫힘 경로로도 사라지지 않도록 닫힘 전이 한 곳에서 store에 보존하고, 제출 닫힘만 보존을 건너뜁니다. 재오픈 시 기존 초안 복원 경로가 그대로 되살립니다.

측정 근거: 격리 콘솔 실측에서 픽커 열림 후 첫 항목 도달까지 Tab 4회(모델 칩→강도 트랙→apex→핀 경유), 방향키는 무반응, Escape는 초안 소실이었습니다.

## Test Plan
- [x] `pnpm vitest run tests/quick-launch-layout.test.tsx` — 31건 green (신규 키보드 문법 계약 7건 포함)
- [x] `pnpm vitest run tests/instrument-design-contract.test.ts` — 57건 green
- [x] `pnpm exec tsc --noEmit -p core/client` — 0 오류
- [x] `pnpm build` — 성공
- [x] console-e2e 격리 QA: 모달·도킹 양쪽에서 열림 자동 포커스 / ↓↑ 순환 / typeahead(b→beacon-harbor) / Enter 선택 후 입력 복귀 / Escape 칩 복귀 / Tab 메뉴 닫고 이동 / Esc·Mod+J 초안 보존·제출 비보존 / 링 온전 렌더·접힘 폭 0 실측 통과