### PR TITLE
perf(ai-gateway): defer unselected Grok tools

### DIFF
--- a/.changelog.d/xai-agent-loop-optimization.md
+++ b/.changelog.d/xai-agent-loop-optimization.md
@@ -1,0 +1,13 @@
+---
+branch: xai-agent-loop-optimization
+---
+
+### fleet-cli
+#### Changed
+- Reduced repeated Grok 4.6 tool-schema uploads during tool-search loops while preserving selected and continuation-referenced tools.
+  ko: 선택된 도구와 연속 호출에서 참조된 도구를 유지하면서 도구 검색 루프에서 반복되는 Grok 4.6 도구 스키마 전송을 줄였습니다.
+
+### fleet-console
+#### Changed
+- Reduced repeated Grok 4.6 tool-schema uploads during gateway Operations that use tool search while preserving selected and continuation-referenced tools.
+  ko: 선택된 도구와 연속 호출에서 참조된 도구를 유지하면서 도구 검색을 사용하는 게이트웨이 Operation에서 반복되는 Grok 4.6 도구 스키마 전송을 줄였습니다.

--- a/packages/core-ai-gateway/src/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/xai/responses/adapter.ts
@@ -40,8 +40,8 @@ export const DEFAULT_XAI_RESPONSES_FUNCTION_CALL_TIMEOUT_MS = 30_000;
  */
 type XaiResponsesWireRequest = Omit<
   CanonicalResponseRequest,
-  "metadata" | "native_tools"
->;
+  "metadata" | "native_tools" | "tools"
+> & { tools?: XaiWireTool[] };
 
 export interface XaiResponsesAdapterOptions {
   fetch?: FetchLike;
@@ -91,7 +91,7 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
 
     const controller = new AbortController();
     const unlinkAbort = linkAbortSignal(options.signal, controller);
-    const payload = forXaiResponsesBackend(request);
+    const payload = forXaiResponsesBackend(request, xaiWireTools(request));
     // Exact JSON body sent upstream, including each tool's `parameters` and any `strict` flag.
     wireLog("xai-responses.wire.request", { url: this.url, payload });
     let response: Response;
@@ -150,10 +150,15 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
       }, this.functionCallTimeoutMs)
     };
   }
+
+  wireTools(request: CanonicalResponseRequest): readonly NonNullable<CanonicalResponseRequest["tools"]>[number][] {
+    return xaiWireTools(request) ?? [];
+  }
 }
 
 function forXaiResponsesBackend(
   request: CanonicalResponseRequest,
+  tools: readonly XaiWireTool[] | undefined = xaiWireTools(request),
 ): XaiResponsesWireRequest {
   const { metadata: _metadata, native_tools: _nativeTools, ...rest } = request;
   return {
@@ -166,10 +171,41 @@ function forXaiResponsesBackend(
       const { reasoning_content: _reasoningContent, ...wireItem } = item;
       return wireItem;
     }),
-    ...(request.tools === undefined
-      ? {}
-      : { tools: request.tools.map(({ defer_loading: _deferLoading, ...tool }) => tool) }),
+    ...(tools === undefined ? {} : { tools: [...tools] }),
   };
+}
+
+type XaiWireTool = Omit<NonNullable<CanonicalResponseRequest["tools"]>[number], "defer_loading">;
+
+function xaiWireTools(request: CanonicalResponseRequest): XaiWireTool[] | undefined {
+  if (request.tools === undefined) return undefined;
+  const tools = request.tools;
+  const toolSearchActive = tools.some((tool) => isToolSearchName(tool.name));
+  const selectedName = request.tool_choice && typeof request.tool_choice === "object"
+    ? request.tool_choice.name
+    : undefined;
+  const referencedNames = new Set(
+    request.input.flatMap((item) => item.type === "function_call_output" ? item.tool_references ?? [] : []),
+  );
+  return tools
+    .filter((tool) => !toolSearchActive || tool.defer_loading !== true
+      || isToolSearchName(tool.name)
+      || (selectedName !== undefined && toolNameMatches(tool.name, selectedName))
+      || referencedNames.has(tool.name))
+    .map(({ defer_loading: _deferLoading, ...tool }) => tool);
+}
+
+function toolLeafName(name: string): string {
+  const separator = name.lastIndexOf("__");
+  return separator === -1 ? name : name.slice(separator + 2);
+}
+
+function isToolSearchName(name: string): boolean {
+  return toolLeafName(name).replace(/[_-]/g, "").toLowerCase() === "toolsearch";
+}
+
+function toolNameMatches(declaredName: string, selectedName: string): boolean {
+  return declaredName === selectedName || toolLeafName(declaredName) === toolLeafName(selectedName);
 }
 
 type ReadOptions = UpstreamReadOptions;

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -546,6 +546,92 @@ describe("Grok Responses function-call assembly", () => {
   });
 });
 
+describe("Grok Responses tool loading", () => {
+  const tools = [
+    { type: "function" as const, name: "ToolSearch", parameters: {}, defer_loading: true },
+    { type: "function" as const, name: "deferred", parameters: {}, defer_loading: true },
+    { type: "function" as const, name: "eager", parameters: {}, defer_loading: false },
+  ];
+
+  it("filters deferred tools only when ToolSearch is declared", () => {
+    const adapter = new XaiResponsesAdapter();
+    expect(adapter.wireTools(xaiRequest({ tools })).map((tool) => tool.name)).toEqual([
+      "ToolSearch",
+      "eager",
+    ]);
+    expect(adapter.wireTools(xaiRequest({
+      tools: [{ ...tools[1] }, { ...tools[2] }],
+    }))).toEqual([
+      expect.objectContaining({ name: "deferred" }),
+      expect.objectContaining({ name: "eager" }),
+    ]);
+  });
+
+  it("restores only referenced deferred tools on continuation", () => {
+    const adapter = new XaiResponsesAdapter();
+    expect(adapter.wireTools(xaiRequest({
+      tools: [...tools, { type: "function" as const, name: "unreferenced", parameters: {}, defer_loading: true }],
+      input: [{ type: "function_call_output", call_id: "c", output: "ok", tool_references: ["deferred"] }],
+    })).map((tool) => tool.name)).toEqual(["ToolSearch", "deferred", "eager"]);
+  });
+
+  it("does not treat near-match names as ToolSearch", () => {
+    const adapter = new XaiResponsesAdapter();
+    expect(adapter.wireTools(xaiRequest({
+      tools: [{ ...tools[1], name: "ToolSearcher" }],
+    }))).toEqual([expect.objectContaining({ name: "ToolSearcher" })]);
+  });
+
+  it("keeps an explicitly selected deferred tool", () => {
+    const adapter = new XaiResponsesAdapter();
+    expect(adapter.wireTools(xaiRequest({
+      tools,
+      tool_choice: { type: "function", name: "deferred" },
+    })).map((tool) => tool.name)).toEqual(["ToolSearch", "deferred", "eager"]);
+  });
+
+  it("matches an unqualified selected leaf to a qualified declared tool", () => {
+    const adapter = new XaiResponsesAdapter();
+    expect(adapter.wireTools(xaiRequest({
+      tools: [...tools.slice(0, 1), { ...tools[1], name: "mcp__deferred" }],
+      tool_choice: { type: "function", name: "deferred" },
+    })).map((tool) => tool.name)).toEqual(["ToolSearch", "mcp__deferred"]);
+  });
+
+  it("matches qualified selected and declared names by leaf", () => {
+    const adapter = new XaiResponsesAdapter();
+    expect(adapter.wireTools(xaiRequest({
+      tools: [...tools.slice(0, 1), { ...tools[1], name: "mcp__deferred" }],
+      tool_choice: { type: "function", name: "other__deferred" },
+    })).map((tool) => tool.name)).toEqual(["ToolSearch", "mcp__deferred"]);
+  });
+
+  it("does not match a near-match leaf", () => {
+    const adapter = new XaiResponsesAdapter();
+    expect(adapter.wireTools(xaiRequest({
+      tools: [...tools.slice(0, 1), { ...tools[1], name: "mcp__deferredExtra" }],
+      tool_choice: { type: "function", name: "deferred" },
+    })).map((tool) => tool.name)).toEqual(["ToolSearch"]);
+  });
+
+  it("omits tools from the payload when the request has no tools", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("data: [DONE]\\n\\n", { status: 200 }));
+    await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("tools");
+  });
+
+  it("uses the same canonical subset for wireTools and the serialized payload", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("data: [DONE]\\n\\n", { status: 200 }));
+    const adapter = new XaiResponsesAdapter({ fetch: fetchMock });
+    const request = xaiRequest({ tools, tool_choice: { type: "function", name: "deferred" } });
+    await adapter.stream(request, { apiKey: "k" });
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as { tools: Array<{ name: string }> };
+    expect(body.tools.map((tool) => tool.name)).toEqual(adapter.wireTools(request)?.map((tool) => tool.name));
+    expect(body.tools.every((tool) => !("defer_loading" in tool))).toBe(true);
+  });
+});
+
 describe("Grok Responses adapter", () => {
   it("uses the CLI proxy with subscription and model headers", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response("data: [DONE]\n\n", { status: 200 }));


### PR DESCRIPTION
## Summary

- Keep xAI Responses tool serialization provider-local and omit `defer_loading: true` schemas while `ToolSearch` is active, retaining eager tools, `ToolSearch`, explicit `tool_choice` targets, and continuation-referenced tools.
- Use the same filtered subset for context-window preflight and the serialized upstream body while preserving legacy no-tool and non-`ToolSearch` request shapes.
- Add classifier, correlation, near-match, no-tool, and payload-consistency coverage.

## Measurements

Five successful `grok-4.6` low trials before and after the change used the same prompt, 28-tool catalog, permission mode, output-token limit, and success criteria.

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request body bytes | 3,266,395 | 39,447 | -98.79% |
| Tool-schema bytes | 3,240,920 | 14,225 | -99.56% |
| Input tokens | 512,100 | 11,632 | -97.73% |
| Cached-input tokens | 434,560 | 6,400 | -98.53% |
| Output tokens | 2,082 | 1,684 | -19.12% |
| Reasoning tokens | 1,817 | 1,420 | -21.85% |
| Mean wall time | 10,497.4 ms | 8,280.3 ms | -21.12% |
| Median wall time | 10,752.9 ms | 8,165.5 ms | -24.06% |

Caller calls/results/errors remained `20/20/0`, provider requests/completed/failed remained `20/20/0`, and caller-call amplification remained `1.00x`.

## Semantic Invariants

- Requests without `ToolSearch` retain the full declared tool catalog.
- Requests without tools continue to omit the `tools` property.
- Explicitly selected and `tool_references`-correlated deferred tools remain available.
- `ToolSearcher` does not activate filtering, and qualified tool names match only by an exact leaf.
- `defer_loading`, `tool_references`, `is_error`, and `reasoning_content` remain provider-neutral metadata and are not serialized upstream.
- Live adversarial probes passed for no-tool, near-match, and error-result continuations; unreferenced deferred tools were absent from all filtered requests.

## Test Plan

- [x] `pnpm --dir packages/core-ai-gateway test` — 32 files, 653 tests passed
- [x] `pnpm --dir packages/core-ai-gateway typecheck`
- [x] `pnpm --dir packages/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 18 entries validated
- [x] `git diff --check`
- [x] Independent read-only diff verification — no verified findings