### PR TITLE
perf(core-ai-gateway): omit disabled OpenCode tool catalogs

### DIFF
--- a/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
@@ -3,6 +3,7 @@ import type {
   AdapterResponse,
   AiGatewayAdapter,
   CanonicalError,
+  CanonicalFunctionTool,
   CanonicalInputMessage,
   CanonicalResponseEvent,
   CanonicalResponseRequest,
@@ -122,8 +123,7 @@ export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
     const controller = new AbortController();
     const unlinkAbort = linkAbortSignal(options.signal, controller);
     const supportsImageInput = imageInputPolicy.get(this)?.(request.model) ?? true;
-    const omitTools = suggestionModeToolOmissionPolicy.has(this)
-      && isClaudeCodeSuggestionMode(request);
+    const omitTools = toolOmissionPolicy.has(this) && shouldOmitTools(request);
     const payload = forChatCompletionsBackend(request, supportsImageInput, omitTools);
     wireLog("openai-chat.wire.request", { url: this.url, payload });
     let response: Response;
@@ -187,8 +187,11 @@ const imageInputPolicy = new WeakMap<
  */
 const argumentPruningPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
 
-/** OpenCode 전용 Claude Code Suggestion Mode 요청은 도구 호출을 허용하지 않는다. */
-const suggestionModeToolOmissionPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
+/**
+ * OpenCode 인스턴스는 `shouldOmitTools`가 참일 때 wire에서 도구 catalog를 통째로 뺀다.
+ * 이 omission은 provider 실측에 근거하므로 generic class에는 결합하지 않는다.
+ */
+const toolOmissionPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
 const CLAUDE_CODE_SUGGESTION_MODE_PREFIX =
   "[SUGGESTION MODE: Suggest what the user might naturally type next into Claude Code.]";
 const CLAUDE_CODE_SUGGESTION_MODE_SUFFIXES = [
@@ -227,8 +230,29 @@ export class OpencodeGoChatCompletionsAdapter extends OpenAIChatCompletionsAdapt
     // 미선언 인자 키 정화도 같은 이유로 provider instance 한정이다 — 이 wire가 strict를
     // 무시한다는 실측은 OpenCode의 것이고, 다른 백엔드에 대해서는 측정된 바가 없다.
     argumentPruningPolicy.set(this, true);
-    suggestionModeToolOmissionPolicy.set(this, true);
+    // no-tools 조건은 Suggestion Mode에 더해 `tool_choice: "none"`까지 wire에서 catalog를
+    // 뺀다 — generic class의 호환 동작은 바꾸지 않고 provider instance에만 결합한다.
+    toolOmissionPolicy.set(this, true);
   }
+
+  /**
+   * preflight sizing은 wire에 실릴 catalog로 세야 한다. no-tools 조건에서는 실제 wire에
+   * 도구가 없는데 전체 catalog를 청구하면 발생하지 않는 비용이 잡힌다.
+   */
+  wireTools(request: CanonicalResponseRequest): readonly CanonicalFunctionTool[] {
+    return shouldOmitTools(request) ? [] : request.tools ?? [];
+  }
+}
+
+/**
+ * OpenCode Go 인스턴스가 wire에서 도구 catalog를 생략할 조건.
+ *
+ * `tool_choice: "none"`은 모델이 도구를 호출하지 말라는 명시이고, Suggestion Mode는
+ * wire 자체가 도구 스키마를 거부한다. 두 경우 모두 도구 정의는 호출 결과에 관여하지 않고
+ * wire payload만 키운다.
+ */
+function shouldOmitTools(request: CanonicalResponseRequest): boolean {
+  return request.tool_choice === "none" || isClaudeCodeSuggestionMode(request);
 }
 
 function isClaudeCodeSuggestionMode(request: CanonicalResponseRequest): boolean {

--- a/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
@@ -202,6 +202,65 @@ describe("chat completions request translation", () => {
     expect(generic).toHaveProperty("tools");
   });
 
+  it("omits the tool catalog for tool_choice none on the OpenCode wrapper only", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    const tools: CanonicalResponseRequest["tools"] = [{
+      type: "function",
+      name: "Read",
+      parameters: { type: "object", properties: {} },
+    }];
+    const wireTools = [{
+      type: "function" as const,
+      function: { name: "Read", parameters: { type: "object", properties: {} } },
+    }];
+    const opencode = new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock });
+
+    // positive: 일반 프롬프트 + none이면 tools/tool_choice/parallel_tool_calls를 모두
+    // 생략하고, preflight용 wireTools도 빈 catalog를 보고한다.
+    await opencode.stream(request({
+      tools,
+      tool_choice: "none",
+      parallel_tool_calls: true,
+    }), { apiKey: "k" });
+    const noneBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(noneBody).not.toHaveProperty("tools");
+    expect(noneBody).not.toHaveProperty("tool_choice");
+    expect(noneBody).not.toHaveProperty("parallel_tool_calls");
+    expect(opencode.wireTools(request({ tools, tool_choice: "none", parallel_tool_calls: true }))).toEqual([]);
+
+    // negative: auto / required / forced function은 tools와 wireTools를 유지한다.
+    for (const toolChoice of ["auto" as const, "required" as const]) {
+      fetchMock.mockClear();
+      await opencode.stream(request({
+        tools,
+        tool_choice: toolChoice,
+        parallel_tool_calls: true,
+      }), { apiKey: "k" });
+      const kept = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+      expect(kept.tools).toEqual(wireTools);
+      expect(kept.tool_choice).toBe(toolChoice);
+      expect(opencode.wireTools(request({ tools, tool_choice: toolChoice }))).toEqual(tools);
+    }
+    fetchMock.mockClear();
+    const forced = { type: "function", name: "Read" } as const;
+    await opencode.stream(request({ tools, tool_choice: forced }), { apiKey: "k" });
+    const forcedBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(forcedBody.tools).toEqual(wireTools);
+    expect(forcedBody.tool_choice).toEqual({ type: "function", function: { name: "Read" } });
+    expect(opencode.wireTools(request({ tools, tool_choice: forced }))).toEqual(tools);
+
+    // generic adapter + none은 호환성 때문에 기존대로 tools와 tool_choice가 wire에 남는다.
+    fetchMock.mockClear();
+    await adapter(fetchMock).stream(request({
+      tools,
+      tool_choice: "none",
+      parallel_tool_calls: true,
+    }), { apiKey: "k" });
+    const genericBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(genericBody.tools).toEqual(wireTools);
+    expect(genericBody.tool_choice).toBe("none");
+  });
+
   it("replays reasoning only for DeepSeek V4 assistant tool turns", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
     await adapter(fetchMock).stream(request({


### PR DESCRIPTION
## Summary

- OpenCode Go Chat Completions 요청에서 `tool_choice: \"none\"` 또는 기존 Suggestion Mode로 도구 사용이 비활성화된 경우 `tools`, `tool_choice`, `parallel_tool_calls`를 wire에서 생략합니다.
- 동일한 classifier를 `wireTools()`에도 적용해 preflight context sizing이 실제 provider wire catalog와 일치하도록 했습니다.
- DeepSeek V4 Flash live trial 5회에서 no-tool 요청 body를 6,075B에서 1,300B로 78.6% 줄였고, ordinary 5-operation tool loop의 caller/provider amplification 1.0과 결과를 유지했습니다. Provider-reported input token 및 latency 개선은 관찰되지 않아 주장하지 않습니다.

## Test Plan

- [x] `pnpm --dir packages/core-ai-gateway test` — 645 tests passed
- [x] `pnpm --dir packages/core-ai-gateway typecheck`
- [x] `pnpm --dir packages/core-ai-gateway build`
- [x] `pnpm --dir runtime/fleet-console build`
- [x] `pnpm exec node scripts/compile-changelog-fragments.mjs --check --allow-empty`
- [x] `git diff --check`
- [x] DeepSeek explicit no-tool live trials — before/after 5/5 successful
- [x] DeepSeek ordinary 5-operation tool-loop live trials — before/after 5/5 successful
- [x] DeepSeek multiturn prior-tool-history plus `tool_choice: \"none\"` live trials — 5/5 successful