### PR TITLE
perf(ai-gateway): omit disabled Codex tool metadata

### DIFF
--- a/packages/core-ai-gateway/src/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/codex/responses/adapter.ts
@@ -639,10 +639,9 @@ function forChatGptBackend(request: CanonicalResponseRequest): CanonicalResponse
   for (const field of CHATGPT_UNSUPPORTED_FIELDS) {
     delete copy[field];
   }
-  if (isClaudeCodeSuggestionMode(request)) {
-    // Claude Code asks for one short text suggestion after the visible turn has already ended. Its
-    // own prompt forbids tool use, so replaying the full tool catalog on this stateless backend adds
-    // tens of kilobytes without creating a legal model action.
+  if (request.tool_choice === "none" || isClaudeCodeSuggestionMode(request)) {
+    // 명시적 no-tools 요청과 Claude Code Suggestion turn은 이 stateless backend에 tool
+    // metadata를 재전송하지 않는다. 전자는 caller의 정확한 선택이고 후자는 합법적인 tool action이 없다.
     delete copy.tools;
     delete copy.tool_choice;
     delete copy.native_tools;

--- a/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
@@ -114,6 +114,44 @@ describe("codex responses adapter", () => {
     expect(body.store).toBe(false);
   });
 
+  it("omits all tool controls for explicit tool_choice none", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request({
+      tools: [{
+        type: "function",
+        name: "Bash",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+      }],
+      tool_choice: "none",
+      parallel_tool_calls: true,
+      native_tools: [{ type: "web_search" }],
+    }), { apiKey: "k" });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("tools");
+    expect(body).not.toHaveProperty("tool_choice");
+    expect(body).not.toHaveProperty("native_tools");
+    expect(body).not.toHaveProperty("parallel_tool_calls");
+  });
+
+  it("keeps ordinary auto tool controls on the Codex backend", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request({
+      tools: [{
+        type: "function",
+        name: "Bash",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+      }],
+      tool_choice: "auto",
+      parallel_tool_calls: true,
+    }), { apiKey: "k" });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(body.tools).toHaveLength(1);
+    expect(body.tool_choice).toBe("auto");
+    expect(body.parallel_tool_calls).toBe(true);
+  });
+
   it("omits tools from Claude Code suggestion-mode requests", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
     await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request({


### PR DESCRIPTION
## Summary

- Omit function and hosted-tool metadata from Codex ChatGPT Responses requests when the caller explicitly sets `tool_choice` to `none`.
- Preserve ordinary `auto` tool requests and the existing Claude Code Suggestion Mode classifier.
- Reduce the measured five-trial Luna-medium workload by 6,020 request-body bytes and 1,025 input tokens while keeping 20/20 tool calls/results and zero caller errors.

## Type of Change

- Internal provider-wire performance optimization

## Scope

- `packages/core-ai-gateway` Codex Responses adapter and tests

## Test Plan

- [x] `pnpm --dir packages/core-ai-gateway test` — 646 tests passed
- [x] `pnpm --dir packages/core-ai-gateway typecheck`
- [x] `pnpm --dir packages/core-ai-gateway build`
- [x] `pnpm check:core-boundary`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty`
- [x] Real Codex `gpt-5.6-luna-fast` / medium before-and-after workload — 5/5 successful trials on each revision

## Changelog

- Codex no-tool turns no longer resend an unusable tool catalog; caller-visible tool execution and final output remain unchanged.