### PR TITLE
refactor(core-agent): unify Claude execution loops

### DIFF
--- a/packages/core-agent/AGENTS.md
+++ b/packages/core-agent/AGENTS.md
@@ -2,7 +2,7 @@
 
 Fleet-domain-agnostic in-process MCP, tool-registry, binary-resolution, and update substrate.
 
-This package drives no model and speaks no agent protocol. Callers that need one bring their own transport and hand this package only the MCP session and tool wiring.
+The `./claude` subpath owns vendor-neutral Claude gateway transport and execution mechanics. Fleet identities, prompts, tool policies, and UI events remain forbidden here.
 
 ## Directory index
 
@@ -15,6 +15,6 @@ This package drives no model and speaks no agent protocol. Callers that need one
 
 - Do not hard-code Fleet identities, reserved IDs, package names, lifecycle policy, or browser exposure rules; callers own them.
 - Public isolation uses a generic scope identity; Fleet-specific scope mapping happens in the caller. Host-session tool narrowing is expressed as a caller-supplied tool-id predicate, never as a built-in tool allowlist.
-- Each MCP session owns its own port and bearer token and is disposed with the session; nothing here retains a live child process.
+- Each MCP session owns its own port and bearer token and is disposed with the session; MCP sessions do not retain child processes.
 - Whoever hands a child both internal MCP sessions and external MCP servers must call `assertInternalMcpTokensNotShared` before spawning. An internal bearer token reaching an external server is a credential leak that no other gate catches.
 - `McpServerConfig.toolTimeoutSeconds` is seconds. Providers that take milliseconds must convert at their own boundary.

--- a/packages/core-agent/src/claude/execution-events.ts
+++ b/packages/core-agent/src/claude/execution-events.ts
@@ -1,0 +1,123 @@
+import type { ClaudeGatewayMessage } from "./contracts.js";
+
+export type ClaudeExecutionEvent =
+  | { readonly kind: "text"; readonly text: string }
+  | { readonly kind: "thinking"; readonly text: string }
+  | {
+      readonly kind: "tool-start";
+      readonly id?: string;
+      readonly name: string;
+      readonly input: unknown;
+    }
+  | {
+      readonly kind: "tool-end";
+      readonly id?: string;
+      readonly name?: string;
+      readonly isError: boolean;
+    }
+  | {
+      readonly kind: "result";
+      readonly isError: boolean;
+      readonly detail?: string;
+      readonly source: "message" | "incomplete" | "watchdog";
+    };
+
+export interface ClaudeExecutionEventDecoder {
+  decode(message: ClaudeGatewayMessage): readonly ClaudeExecutionEvent[];
+}
+
+/**
+ * 자식이 흘리는 메시지를 정규화한다.
+ *
+ * 모양은 실측으로 고정했다. 답변 텍스트와 사고가 같은 `content_block_delta` 자리로 오되
+ * `text_delta`와 `thinking_delta`로 갈리며, 도구는 assistant의 `tool_use`로 시작해 user의
+ * `tool_result`로 끝난다. 이름은 앞쪽에만 실려 있어 id로 짝짓는다. 한 디코더의 짝짓기는
+ * 그 인스턴스 수명 동안만 유효하다.
+ */
+export function createClaudeExecutionEventDecoder(): ClaudeExecutionEventDecoder {
+  const toolNames = new Map<string, string>();
+  return {
+    decode(message: ClaudeGatewayMessage): readonly ClaudeExecutionEvent[] {
+      if (!isRecord(message)) return [];
+      if (message.type === "stream_event") return decodeStreamEvent(message);
+      if (message.type === "assistant") return decodeAssistant(message, toolNames);
+      if (message.type === "user") return decodeUser(message, toolNames);
+      if (message.type === "result") return decodeResult(message);
+      return [];
+    },
+  };
+}
+
+function decodeStreamEvent(message: Record<string, unknown>): readonly ClaudeExecutionEvent[] {
+  const inner = record(message.event);
+  if (inner.type !== "content_block_delta") return [];
+  const delta = record(inner.delta);
+  if (delta.type === "text_delta" && typeof delta.text === "string" && delta.text.length > 0) {
+    return [{ kind: "text", text: delta.text }];
+  }
+  if (delta.type === "thinking_delta" && typeof delta.thinking === "string" && delta.thinking.length > 0) {
+    return [{ kind: "thinking", text: delta.thinking }];
+  }
+  return [];
+}
+
+function decodeAssistant(
+  message: Record<string, unknown>,
+  toolNames: Map<string, string>,
+): readonly ClaudeExecutionEvent[] {
+  const events: ClaudeExecutionEvent[] = [];
+  for (const block of blocks(message.message)) {
+    if (block.type !== "tool_use") continue;
+    const name = typeof block.name === "string" ? block.name : "tool";
+    const id = typeof block.id === "string" ? block.id : undefined;
+    if (id !== undefined) toolNames.set(id, name);
+    events.push({
+      kind: "tool-start",
+      ...(id === undefined ? {} : { id }),
+      name,
+      input: block.input,
+    });
+  }
+  return events;
+}
+
+function decodeUser(
+  message: Record<string, unknown>,
+  toolNames: Map<string, string>,
+): readonly ClaudeExecutionEvent[] {
+  const events: ClaudeExecutionEvent[] = [];
+  for (const block of blocks(message.message)) {
+    if (block.type !== "tool_result") continue;
+    const id = typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
+    const name = id === undefined ? undefined : toolNames.get(id);
+    events.push({
+      kind: "tool-end",
+      ...(id === undefined ? {} : { id }),
+      ...(name === undefined ? {} : { name }),
+      isError: block.is_error === true,
+    });
+  }
+  return events;
+}
+
+function decodeResult(message: Record<string, unknown>): readonly ClaudeExecutionEvent[] {
+  return [{
+    kind: "result",
+    isError: message.is_error === true,
+    ...(typeof message.result === "string" ? { detail: message.result } : {}),
+    source: "message",
+  }];
+}
+
+function blocks(message: unknown): readonly Record<string, unknown>[] {
+  const content = record(message).content;
+  return Array.isArray(content) ? content.map(record) : [];
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/core-agent/src/claude/execution-loop.ts
+++ b/packages/core-agent/src/claude/execution-loop.ts
@@ -1,0 +1,380 @@
+import type {
+  ClaudeGatewayMessage,
+  ClaudeGatewayRun,
+  ClaudeGatewaySdk,
+  ClaudeGatewayTurn,
+} from "./contracts.js";
+import {
+  createClaudeExecutionEventDecoder,
+  type ClaudeExecutionEvent,
+} from "./execution-events.js";
+
+export type ClaudeExecutionContinuation =
+  | { readonly kind: "resume-child" }
+  | { readonly kind: "oneshot" };
+
+export type ClaudeExecutionSettlement =
+  | { readonly kind: "result" }
+  | { readonly kind: "result-required"; readonly watchdogMs?: number };
+
+export type ClaudeExecutionTurn = Omit<ClaudeGatewayTurn, "prompt" | "resume">;
+
+export interface ClaudeExecutionLoopOptions {
+  readonly createSdk: () => Promise<ClaudeGatewaySdk>;
+  readonly buildTurn: (prompt: string) => ClaudeExecutionTurn | Promise<ClaudeExecutionTurn>;
+  readonly continuation: ClaudeExecutionContinuation;
+  readonly settlement: ClaudeExecutionSettlement;
+  readonly onEvent?: (event: ClaudeExecutionEvent) => void;
+}
+
+export interface ClaudeExecutionLoop {
+  start(): Promise<void>;
+  run(prompt: string): Promise<void>;
+  cancel(): void;
+  dispose(): Promise<void>;
+}
+
+type ClaudeResultEvent = Extract<ClaudeExecutionEvent, { kind: "result" }>;
+
+/**
+ * 한 턴의 런과 그 턴만의 종료. 늦은 정리 콜백이 지금 active인 다른 턴을 닫지 않게
+ * 런 객체 식별로 close한다.
+ */
+interface TurnHandle {
+  readonly run: ClaudeGatewayRun;
+  /** 합성 결과 없이 이 턴만 닫고 대기 문을 연다. */
+  stop(): void;
+  /** 이 턴의 런만 한 번 close하고 active에서 뺀다. */
+  close(): void;
+}
+
+/**
+ * Claude 게이트웨이 턴의 실행 루프.
+ *
+ * SDK 생성·폐기, 직렬 큐, 세션 resume, 디코더, 종료 정산, 취소를 한 곳에서 소유한다.
+ * 호출자가 넣는 것은 턴 조립과 이벤트 수신뿐이고, `prompt`와 `resume`은 루프가 쓴다 — 조립기가
+ * 그 키를 실으면 호출자가 세션을 가로채거나 프롬프트를 바꿔 끼운 것과 같아서 런타임에 거부한다.
+ */
+export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): ClaudeExecutionLoop {
+  let sdk: ClaudeGatewaySdk | null = null;
+  let started = false;
+  let disposed = false;
+  let active: TurnHandle | null = null;
+  let resumeId: string | null = null;
+  let queueTail: Promise<void> = Promise.resolve();
+  let startFlight: Promise<void> | null = null;
+  let disposeFlight: Promise<void> | null = null;
+
+  async function start(): Promise<void> {
+    if (disposed) throw new Error("Session disposed");
+    if (started) return;
+    if (startFlight === null) startFlight = startSdk();
+    try {
+      await startFlight;
+    } catch (error) {
+      // 생성 실패는 재시도할 수 있다. 폐기가 이긴 레이스는 종점이라 비행을 남긴다.
+      if (!disposed) startFlight = null;
+      throw error;
+    }
+  }
+
+  async function startSdk(): Promise<void> {
+    const created = await options.createSdk();
+    if (disposed) {
+      await created.dispose().catch(() => undefined);
+      throw new Error("Session disposed");
+    }
+    sdk = created;
+    started = true;
+    // 할당과 폐기 사이에 끼면 위에서 놓친 인스턴스를 여기서 거둔다.
+    if (disposed) {
+      sdk = null;
+      started = false;
+      await created.dispose().catch(() => undefined);
+      throw new Error("Session disposed");
+    }
+  }
+
+  function run(prompt: string): Promise<void> {
+    if (disposed) return Promise.reject(new Error("Session disposed"));
+    if (!started || sdk === null) return Promise.reject(new Error("Session not started"));
+    if (typeof prompt !== "string" || prompt.trim().length === 0) {
+      return Promise.reject(new Error("Message required"));
+    }
+    const work = queueTail.then(() => runTurn(prompt));
+    // 거절된 턴이 꼬리를 끊으면 뒤에 줄 선 턴이 영영 시작되지 않는다.
+    queueTail = work.catch(() => undefined);
+    return work;
+  }
+
+  /**
+   * startTurn이 돌려준 런은 SDK 슬롯을 점유한다. next()가 거절되면 `done`이 아니라서
+   * 슬롯이 안 풀리므로, 기대한 런이 지금 active일 때만 한 번 close한다.
+   */
+  function closeRun(expected: ClaudeGatewayRun): void {
+    const current = active;
+    if (current === null || current.run !== expected) return;
+    current.close();
+  }
+
+  function cancel(): void {
+    active?.stop();
+  }
+
+  function dispose(): Promise<void> {
+    if (disposeFlight) return disposeFlight;
+    disposed = true;
+    active?.stop();
+    disposeFlight = disposeResources();
+    return disposeFlight;
+  }
+
+  async function disposeResources(): Promise<void> {
+    // 폐기 직후 큐에 붙은 꼬리까지 기다린다. 한 번 await한 뒤에 꼬리가 바뀌면 그 새 꼬리도 기다린다.
+    let observed = queueTail;
+    for (;;) {
+      await observed.catch(() => undefined);
+      if (observed === queueTail) break;
+      observed = queueTail;
+    }
+    await startFlight?.catch(() => undefined);
+    const owned = sdk;
+    sdk = null;
+    started = false;
+    await owned?.dispose().catch(() => undefined);
+  }
+
+  async function runTurn(prompt: string): Promise<void> {
+    // 폐기 뒤에 줄 서 있던 턴은 새 SDK 턴을 열지 않는다.
+    if (disposed) return;
+    const owned = sdk;
+    if (!owned) throw new Error("Session not started");
+
+    let settled = false;
+    let failed = false;
+    let failure: unknown;
+    let pendingResult: ClaudeResultEvent | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let handle: TurnHandle | null = null;
+    const decoder = createClaudeExecutionEventDecoder();
+    const gate = createGate();
+
+    const clearTimer = (): void => {
+      if (timer === undefined) return;
+      clearTimeout(timer);
+      timer = undefined;
+    };
+
+    /**
+     * 이 턴의 대기 문을 연다. close는 이 턴의 런만, 한 번만. 이터레이터 EOF/return을 기다리지 않는다.
+     * close 예외는 정리 실패일 뿐이라 타이머와 문을 남겨 두지 않는다.
+     */
+    const complete = (): void => {
+      if (settled) return;
+      settled = true;
+      try {
+        clearTimer();
+        if (handle !== null) closeRun(handle.run);
+      } finally {
+        gate.open();
+      }
+    };
+
+    const fail = (error: unknown): void => {
+      if (!failed) {
+        failed = true;
+        failure = error;
+      }
+      complete();
+    };
+
+    const queueResult = (event: ClaudeResultEvent): void => {
+      if (settled) return;
+      pendingResult = event;
+      complete();
+    };
+
+    try {
+      const built = await options.buildTurn(prompt);
+      if (disposed) return;
+      assertLoopOwnedKeysAbsent(built);
+
+      const resume =
+        options.continuation.kind === "resume-child" && resumeId !== null
+          ? { resume: resumeId }
+          : {};
+      let run: ClaudeGatewayRun;
+      try {
+        run = await owned.startTurn({ ...built, prompt, ...resume });
+      } catch (error) {
+        if (disposed) return;
+        throw error;
+      }
+      const startedRun: ClaudeGatewayRun = run;
+      let closed = false;
+      handle = {
+        run: startedRun,
+        stop() {
+          complete();
+        },
+        close() {
+          if (closed) return;
+          closed = true;
+          if (active === handle) active = null;
+          try {
+            startedRun.close();
+          } catch {
+            // close는 정리. 정리 예외가 결과·관찰자·이터레이터·취소·폐기 종점을 바꾸지 않는다.
+          }
+        },
+      };
+      active = handle;
+      if (disposed) {
+        complete();
+        return;
+      }
+
+      timer = armWatchdog(options.settlement, () => {
+        // 타이머는 던지지 않는다. 관찰자 호출은 게이트가 열린 뒤 runTurn에서 한다.
+        try {
+          if (settled || disposed) return;
+          queueResult({ kind: "result", isError: true, source: "watchdog" });
+        } catch {
+          // 워치독 콜백에서 예외가 새면 프로세스가 받는다.
+        }
+      });
+
+      const consume = async (): Promise<void> => {
+        let iterator: AsyncIterator<ClaudeGatewayMessage> | undefined;
+        try {
+          // 팩토리 동기 throw도 실패 턴 경로로 보낸다. try 밖에서 던지면 consume이 게이트를 못 연다.
+          iterator = startedRun[Symbol.asyncIterator]();
+          while (!settled) {
+            const step = await iterator.next();
+            if (step.done) {
+              if (!settled && !disposed && options.settlement.kind === "result-required") {
+                queueResult({ kind: "result", isError: true, source: "incomplete" });
+              }
+              break;
+            }
+            // 종점 뒤에 도착한 next는 세션 id도 이벤트도 쓰지 않는다.
+            if (settled || disposed) break;
+            const message = step.value;
+            if (
+              options.continuation.kind === "resume-child"
+              && resumeId === null
+              && typeof message.session_id === "string"
+            ) {
+              resumeId = message.session_id;
+            }
+            for (const event of decoder.decode(message)) {
+              if (event.kind === "result") {
+                // 디코더가 낸 result는 종점이다. return()/EOF를 기다리지 않고 이 턴만 닫는다.
+                queueResult(event);
+                break;
+              }
+              try {
+                options.onEvent?.(event);
+              } catch (error) {
+                fail(error);
+                break;
+              }
+            }
+          }
+        } catch (error) {
+          // 종점 뒤에 close가 유발한 이터레이터 오류는 삼킨다.
+          if (disposed || settled) return;
+          fail(error);
+        } finally {
+          complete();
+          // return()이 걸려도 run()은 이미 정산됐다. 늦은 정리가 새 턴을 닫지 않게 기다리지 않는다.
+          const closing = iterator?.return?.();
+          if (closing !== undefined) void closing.catch(() => undefined);
+        }
+      };
+
+      const consumption = consume();
+      consumption.catch(() => undefined);
+      await gate.promise;
+
+      if (disposed) return;
+      // 종점 관찰자는 consume/타이머가 아니라 여기서 호출한다. 생성기 스택에 동기 throw가
+      // 안 남고, 같은 오류로 run()을 거절한다.
+      if (pendingResult !== undefined && !failed) {
+        try {
+          options.onEvent?.(pendingResult);
+        } catch (error) {
+          failed = true;
+          failure = error;
+        }
+      }
+    } catch (error) {
+      if (!disposed && !failed) {
+        failed = true;
+        failure = error;
+      }
+    } finally {
+      complete();
+    }
+    if (disposed) return;
+    if (failed) return Promise.reject(failure);
+  }
+
+  return { start, run, cancel, dispose };
+}
+
+function assertLoopOwnedKeysAbsent(built: ClaudeExecutionTurn): void {
+  if (!built || typeof built !== "object") return;
+  const record = built as unknown as Record<string, unknown>;
+  if (Object.hasOwn(record, "prompt") || Object.hasOwn(record, "resume")) {
+    throw new TypeError("buildTurn must not set prompt or resume; those keys are loop-owned.");
+  }
+}
+
+/**
+ * 양수 유한 대기만 타이머로 쓴다. 0·음수·NaN·Infinity는 없는 것과 같다.
+ * `unref`는 이 타이머만으로 프로세스가 살아 남지 않게 한다.
+ */
+function watchdogMsOf(settlement: ClaudeExecutionSettlement): number | undefined {
+  if (settlement.kind !== "result-required") return undefined;
+  const watchdogMs = settlement.watchdogMs;
+  if (typeof watchdogMs !== "number" || !Number.isFinite(watchdogMs) || watchdogMs <= 0) {
+    return undefined;
+  }
+  return watchdogMs;
+}
+
+/**
+ * 턴 하나의 대기 문. Promise는 항상 fulfill한다. 관찰자/이터레이터 실패는 문이 열린 뒤
+ * runTurn이 다시 던진다 — consume이나 타이머에서 reject하면 await가 붙기 전에
+ * unhandled rejection이 된다.
+ */
+function createGate(): {
+  readonly promise: Promise<void>;
+  open(): void;
+} {
+  let opened = false;
+  let resolvePromise: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    open() {
+      if (opened) return;
+      opened = true;
+      resolvePromise();
+    },
+  };
+}
+
+function armWatchdog(
+  settlement: ClaudeExecutionSettlement,
+  onTimeout: () => void,
+): ReturnType<typeof setTimeout> | undefined {
+  const watchdogMs = watchdogMsOf(settlement);
+  if (watchdogMs === undefined) return undefined;
+  const timer = setTimeout(onTimeout, watchdogMs);
+  timer.unref?.();
+  return timer;
+}

--- a/packages/core-agent/src/claude/execution-loop.ts
+++ b/packages/core-agent/src/claude/execution-loop.ts
@@ -48,6 +48,12 @@ interface TurnHandle {
   close(): void;
 }
 
+interface TurnControl {
+  canceled: boolean;
+  onCancel: (() => void) | null;
+  cancel(): void;
+}
+
 /**
  * Claude 게이트웨이 턴의 실행 루프.
  *
@@ -60,6 +66,7 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
   let started = false;
   let disposed = false;
   let active: TurnHandle | null = null;
+  let cancelTurn: (() => void) | null = null;
   let resumeId: string | null = null;
   let queueTail: Promise<void> = Promise.resolve();
   let startFlight: Promise<void> | null = null;
@@ -101,7 +108,18 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
     if (typeof prompt !== "string" || prompt.trim().length === 0) {
       return Promise.reject(new Error("Message required"));
     }
-    const work = queueTail.then(() => runTurn(prompt));
+    const control = createTurnControl();
+    // 첫 턴은 Promise microtask가 runTurn에 들어가기 전에도 취소 대상이다. 뒤에 줄 선 턴은
+    // 현재 턴이 끝날 때까지 이 자리를 빼앗지 않는다.
+    if (cancelTurn === null) cancelTurn = control.cancel;
+    const work = queueTail.then(async () => {
+      if (cancelTurn === null) cancelTurn = control.cancel;
+      try {
+        await runTurn(prompt, control);
+      } finally {
+        if (cancelTurn === control.cancel) cancelTurn = null;
+      }
+    });
     // 거절된 턴이 꼬리를 끊으면 뒤에 줄 선 턴이 영영 시작되지 않는다.
     queueTail = work.catch(() => undefined);
     return work;
@@ -118,7 +136,7 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
   }
 
   function cancel(): void {
-    active?.stop();
+    cancelTurn?.();
   }
 
   function dispose(): Promise<void> {
@@ -144,7 +162,7 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
     await owned?.dispose().catch(() => undefined);
   }
 
-  async function runTurn(prompt: string): Promise<void> {
+  async function runTurn(prompt: string, control: TurnControl): Promise<void> {
     // 폐기 뒤에 줄 서 있던 턴은 새 SDK 턴을 열지 않는다.
     if (disposed) return;
     const owned = sdk;
@@ -194,9 +212,14 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
       complete();
     };
 
+    control.onCancel = () => {
+      if (handle !== null) complete();
+    };
+
     try {
+      if (control.canceled) return;
       const built = await options.buildTurn(prompt);
-      if (disposed) return;
+      if (disposed || control.canceled) return;
       assertLoopOwnedKeysAbsent(built);
 
       const resume =
@@ -207,7 +230,7 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
       try {
         run = await owned.startTurn({ ...built, prompt, ...resume });
       } catch (error) {
-        if (disposed) return;
+        if (disposed || control.canceled) return;
         throw error;
       }
       const startedRun: ClaudeGatewayRun = run;
@@ -229,7 +252,7 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
         },
       };
       active = handle;
-      if (disposed) {
+      if (disposed || control.canceled) {
         complete();
         return;
       }
@@ -309,11 +332,12 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
         }
       }
     } catch (error) {
-      if (!disposed && !failed) {
+      if (!disposed && !control.canceled && !failed) {
         failed = true;
         failure = error;
       }
     } finally {
+      control.onCancel = null;
       complete();
     }
     if (disposed) return;
@@ -321,6 +345,18 @@ export function createClaudeExecutionLoop(options: ClaudeExecutionLoopOptions): 
   }
 
   return { start, run, cancel, dispose };
+}
+
+function createTurnControl(): TurnControl {
+  const control: TurnControl = {
+    canceled: false,
+    onCancel: null,
+    cancel() {
+      control.canceled = true;
+      control.onCancel?.();
+    },
+  };
+  return control;
 }
 
 function assertLoopOwnedKeysAbsent(built: ClaudeExecutionTurn): void {

--- a/packages/core-agent/src/claude/index.ts
+++ b/packages/core-agent/src/claude/index.ts
@@ -6,6 +6,8 @@
  * 끌어오게 된다.
  */
 export { createClaudeGatewaySdk } from "./sdk.js";
+export { createClaudeExecutionEventDecoder } from "./execution-events.js";
+export { createClaudeExecutionLoop } from "./execution-loop.js";
 export { defineTool, createEmbeddedMcpServer } from "../mcp/embedded/server.js";
 export type {
   ClaudeGatewayEffort,
@@ -23,4 +25,15 @@ export type {
   ClaudeGatewayToolResult,
   ClaudeGatewayTurn,
 } from "./contracts.js";
+export type {
+  ClaudeExecutionEvent,
+  ClaudeExecutionEventDecoder,
+} from "./execution-events.js";
+export type {
+  ClaudeExecutionContinuation,
+  ClaudeExecutionLoop,
+  ClaudeExecutionLoopOptions,
+  ClaudeExecutionSettlement,
+  ClaudeExecutionTurn,
+} from "./execution-loop.js";
 export { readClaudeSessionTitle } from "./session-info.js";

--- a/packages/core-agent/src/claude/sdk.ts
+++ b/packages/core-agent/src/claude/sdk.ts
@@ -125,8 +125,11 @@ export async function createClaudeGatewaySdk(
           };
         },
         close(): void {
-          run.close();
-          release();
+          try {
+            run.close();
+          } finally {
+            release();
+          }
         },
       };
       active = tracked;

--- a/packages/core-agent/src/claude/vendor-sdk.ts
+++ b/packages/core-agent/src/claude/vendor-sdk.ts
@@ -51,7 +51,13 @@ export function runVendorQuery(input: VendorQueryInput): ClaudeGatewayRun {
       if (closed) return;
       closed = true;
       // AsyncGenerator.return()은 이미 끝난 generator에도 안전하다. 진행 중이던 턴은 여기서 끊긴다.
-      void run.return?.(undefined);
+      // cleanup 예외는 결과·프로세스 종점을 바꾸지 않는다. 반환 Promise는 기다리지 않는다.
+      try {
+        const closing = run.return?.(undefined);
+        if (closing !== undefined) void closing.catch(() => undefined);
+      } catch {
+        // return() 호출 자체의 동기 throw도 같은 cleanup 실패다.
+      }
     },
   };
 }

--- a/packages/core-agent/tests/claude-execution-events.test.ts
+++ b/packages/core-agent/tests/claude-execution-events.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createClaudeExecutionEventDecoder,
+  type ClaudeExecutionEventDecoder,
+} from "../src/claude/index.js";
+import type { ClaudeGatewayMessage } from "../src/claude/index.js";
+
+describe("createClaudeExecutionEventDecoder", () => {
+  it("emits text and thinking only from non-empty content_block_delta payloads", () => {
+    const decoder = createClaudeExecutionEventDecoder();
+    expect(decoder.decode(textDelta("hi"))).toEqual([{ kind: "text", text: "hi" }]);
+    expect(decoder.decode(thinkingDelta("hmm"))).toEqual([{ kind: "thinking", text: "hmm" }]);
+    expect(decoder.decode(textDelta(""))).toEqual([]);
+    expect(decoder.decode(thinkingDelta(""))).toEqual([]);
+    expect(decoder.decode(delta("input_json_delta", { partial_json: "{" }))).toEqual([]);
+  });
+
+  it("starts tools from assistant tool_use blocks and falls the name back to tool", () => {
+    const decoder = createClaudeExecutionEventDecoder();
+    expect(decoder.decode({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "ignore" },
+          { type: "tool_use", id: "t1", name: "WebSearch", input: { query: "fleet" } },
+          { type: "tool_use", id: "t2", input: { path: "a.ts" } },
+          { type: "tool_use", name: "orphan", input: 3 },
+        ],
+      },
+    })).toEqual([
+      { kind: "tool-start", id: "t1", name: "WebSearch", input: { query: "fleet" } },
+      { kind: "tool-start", id: "t2", name: "tool", input: { path: "a.ts" } },
+      { kind: "tool-start", name: "orphan", input: 3 },
+    ]);
+  });
+
+  it("ends tools from user tool_result blocks and correlates the remembered name", () => {
+    const decoder = createClaudeExecutionEventDecoder();
+    decoder.decode({
+      type: "assistant",
+      message: { content: [{ type: "tool_use", id: "t1", name: "WebFetch", input: { url: "https://x" } }] },
+    });
+    expect(decoder.decode({
+      type: "user",
+      message: {
+        content: [
+          { type: "tool_result", tool_use_id: "t1", is_error: false },
+          { type: "tool_result", tool_use_id: "missing", is_error: true },
+          { type: "tool_result", is_error: 1 },
+        ],
+      },
+    })).toEqual([
+      { kind: "tool-end", id: "t1", name: "WebFetch", isError: false },
+      { kind: "tool-end", id: "missing", isError: true },
+      { kind: "tool-end", isError: false },
+    ]);
+  });
+
+  it("does not leak tool names across decoder instances", () => {
+    const first = createClaudeExecutionEventDecoder();
+    first.decode({
+      type: "assistant",
+      message: { content: [{ type: "tool_use", id: "t1", name: "WebSearch", input: {} }] },
+    });
+    const second = createClaudeExecutionEventDecoder();
+    expect(second.decode({
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "t1", is_error: false }] },
+    })).toEqual([{ kind: "tool-end", id: "t1", isError: false }]);
+  });
+
+  it("maps a result message, taking only a string result as detail", () => {
+    const decoder = createClaudeExecutionEventDecoder();
+    expect(decoder.decode({ type: "result", is_error: false })).toEqual([
+      { kind: "result", isError: false, source: "message" },
+    ]);
+    expect(decoder.decode({ type: "result", is_error: true, result: "denied" })).toEqual([
+      { kind: "result", isError: true, detail: "denied", source: "message" },
+    ]);
+    expect(decoder.decode({ type: "result", is_error: true, result: { nested: true } })).toEqual([
+      { kind: "result", isError: true, source: "message" },
+    ]);
+  });
+
+  it("returns nothing for malformed and unrelated shapes", () => {
+    const decoder = createClaudeExecutionEventDecoder();
+    const malformed: unknown[] = [
+      null,
+      undefined,
+      "stream_event",
+      { type: "system", subtype: "init", session_id: "child" },
+      { type: "rate_limit_event" },
+      { type: "stream_event" },
+      { type: "stream_event", event: null },
+      { type: "stream_event", event: { type: "content_block_start" } },
+      { type: "stream_event", event: { type: "content_block_delta", delta: null } },
+      { type: "assistant" },
+      { type: "assistant", message: { content: "not-an-array" } },
+      { type: "assistant", message: { content: [null, "x"] } },
+      { type: "user", message: { content: [{ type: "text", text: "hi" }] } },
+      { type: "user" },
+    ];
+    for (const value of malformed) {
+      expect(decodeUnknown(decoder, value), JSON.stringify(value)).toEqual([]);
+    }
+  });
+});
+
+function decodeUnknown(decoder: ClaudeExecutionEventDecoder, value: unknown): unknown {
+  return decoder.decode(value as ClaudeGatewayMessage);
+}
+
+function textDelta(text: string): ClaudeGatewayMessage {
+  return delta("text_delta", { text });
+}
+
+function thinkingDelta(thinking: string): ClaudeGatewayMessage {
+  return delta("thinking_delta", { thinking });
+}
+
+function delta(type: string, payload: Record<string, unknown>): ClaudeGatewayMessage {
+  return { type: "stream_event", event: { type: "content_block_delta", delta: { type, ...payload } } };
+}

--- a/packages/core-agent/tests/claude-execution-loop.test.ts
+++ b/packages/core-agent/tests/claude-execution-loop.test.ts
@@ -1,0 +1,1102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createClaudeExecutionLoop,
+  type ClaudeExecutionContinuation,
+  type ClaudeExecutionEvent,
+  type ClaudeExecutionLoopOptions,
+  type ClaudeExecutionSettlement,
+  type ClaudeExecutionTurn,
+} from "../src/claude/index.js";
+import type { ClaudeGatewayMessage, ClaudeGatewayRun, ClaudeGatewaySdk, ClaudeGatewayTurn } from "../src/claude/index.js";
+import * as root from "../src/index.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("public boundary", () => {
+  it("exports the loop and decoder only from the claude subpath", () => {
+    expect("createClaudeExecutionLoop" in root).toBe(false);
+    expect("createClaudeExecutionEventDecoder" in root).toBe(false);
+  });
+});
+
+describe("createClaudeExecutionLoop lifecycle", () => {
+  it("is start-idempotent and concurrent-call safe, creating one SDK", async () => {
+    const created = deferred<ClaudeGatewaySdk>();
+    const createSdk = vi.fn(() => created.promise);
+    const loop = makeLoop({ createSdk });
+    const first = loop.start();
+    const second = loop.start();
+    expect(createSdk).toHaveBeenCalledOnce();
+    created.resolve(fakeSdk());
+    await Promise.all([first, second]);
+    await loop.start();
+    expect(createSdk).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("disposes a late SDK when disposal wins the creation race", async () => {
+    const created = deferred<ClaudeGatewaySdk>();
+    const sdk = fakeSdk();
+    const loop = makeLoop({ createSdk: () => created.promise });
+    const starting = loop.start();
+    const disposing = loop.dispose();
+    created.resolve(sdk);
+    await expect(starting).rejects.toThrow("Session disposed");
+    await disposing;
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("rejects run before start, after dispose, and on a blank prompt", async () => {
+    const loop = makeLoop();
+    await expect(loop.run("hello")).rejects.toThrow("Session not started");
+    await loop.start();
+    await expect(loop.run("")).rejects.toThrow("Message required");
+    await expect(loop.run("   \n\t")).rejects.toThrow("Message required");
+    await loop.dispose();
+    await expect(loop.run("hello")).rejects.toThrow("Session disposed");
+    await expect(loop.start()).rejects.toThrow("Session disposed");
+  });
+});
+
+describe("createClaudeExecutionLoop queue", () => {
+  it("runs queued prompts in call order", async () => {
+    const order: string[] = [];
+    const firstTurn = deferred<void>();
+    const sdk = fakeSdk({
+      startTurn: async (turn) => {
+        order.push(turn.prompt);
+        if (turn.prompt === "first") await firstTurn.promise;
+        return immediateRun([resultMessage()]);
+      },
+    });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const first = loop.run("first");
+    const second = loop.run("second");
+    await vi.waitFor(() => expect(order).toEqual(["first"]));
+    firstTurn.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first", "second"]);
+    await loop.dispose();
+  });
+
+  it("lets a later queued turn run after an earlier turn fails", async () => {
+    const sdk = fakeSdk({
+      startTurn: async (turn) => {
+        if (turn.prompt === "bad") throw new Error("boom");
+        return immediateRun([resultMessage()]);
+      },
+    });
+    const events: ClaudeExecutionEvent[] = [];
+    const loop = makeLoop({ createSdk: async () => sdk, onEvent: (event) => events.push(event) });
+    await loop.start();
+    await expect(loop.run("bad")).rejects.toThrow("boom");
+    await loop.run("good");
+    expect(events).toEqual([{ kind: "result", isError: false, source: "message" }]);
+    await loop.dispose();
+  });
+});
+
+describe("createClaudeExecutionLoop continuation", () => {
+  it("resumes a child session only after observing the first session_id", async () => {
+    const sdk = fakeSdk({
+      startTurn: async () => immediateRun([
+        { type: "system", subtype: "init", session_id: "child-session" },
+        resultMessage(),
+      ]),
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      continuation: { kind: "resume-child" },
+    });
+    await loop.start();
+    await loop.run("first");
+    await loop.run("second");
+    expect(sdk.startTurn.mock.calls[0]?.[0].resume).toBeUndefined();
+    expect(sdk.startTurn.mock.calls[1]?.[0].resume).toBe("child-session");
+    expect(sdk.startTurn.mock.calls[0]?.[0].prompt).toBe("first");
+    await loop.dispose();
+  });
+
+  it("neither captures nor forwards resume in oneshot mode", async () => {
+    const sdk = fakeSdk({
+      startTurn: async () => immediateRun([
+        { type: "system", subtype: "init", session_id: "child-session" },
+        resultMessage(),
+      ]),
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      continuation: { kind: "oneshot" },
+    });
+    await loop.start();
+    await loop.run("first");
+    await loop.run("second");
+    expect(sdk.startTurn.mock.calls[0]?.[0].resume).toBeUndefined();
+    expect(sdk.startTurn.mock.calls[1]?.[0].resume).toBeUndefined();
+    await loop.dispose();
+  });
+
+  it("ignores a late session_id from a canceled turn after a newer turn has started", async () => {
+    const abandoned = hangFirstNext();
+    const live = hangUntilReleasedThenMessages([
+      { type: "system", subtype: "init", session_id: "live" },
+      resultMessage(),
+    ]);
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "old") return abandoned;
+      if (turn.prompt === "new") return live;
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      continuation: { kind: "resume-child" },
+    });
+    await loop.start();
+    const first = loop.run("old");
+    await abandoned.started;
+    loop.cancel();
+    await first;
+    expect(abandoned.close).toHaveBeenCalledOnce();
+
+    const second = loop.run("new");
+    await live.started;
+    expect(sdk.startTurn.mock.calls[1]?.[0].resume).toBeUndefined();
+
+    abandoned.releaseNext({ type: "system", subtype: "init", session_id: "abandoned" });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(live.close).not.toHaveBeenCalled();
+    expect(runs[1]?.close).not.toHaveBeenCalled();
+
+    live.release();
+    await second;
+    await loop.run("later");
+    expect(sdk.startTurn.mock.calls[2]?.[0].resume).toBe("live");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["old", "new", "later"]);
+    expect(abandoned.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("rejects a builder result that carries prompt or resume", async () => {
+    const sdk = fakeSdk();
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      buildTurn: (prompt) => {
+        if (prompt === "prompt-key") return { model: "sonnet", prompt: "stolen" } as ClaudeExecutionTurn;
+        if (prompt === "resume-key") return { model: "sonnet", resume: "hijack" } as ClaudeExecutionTurn;
+        return { model: "sonnet" };
+      },
+    });
+    await loop.start();
+    await expect(loop.run("prompt-key")).rejects.toThrow(/loop-owned/);
+    await expect(loop.run("resume-key")).rejects.toThrow(/loop-owned/);
+    expect(sdk.startTurn).not.toHaveBeenCalled();
+    await loop.run("ok");
+    expect(sdk.startTurn).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+});
+
+describe("createClaudeExecutionLoop settlement", () => {
+  it("forwards decoded events in order from a decoder isolated to the turn", async () => {
+    const sdk = fakeSdk({
+      startTurn: async (turn) => {
+        if (turn.prompt === "one") {
+          return immediateRun([
+            textDelta("hi"),
+            {
+              type: "assistant",
+              message: { content: [{ type: "tool_use", id: "t1", name: "WebSearch", input: { q: 1 } }] },
+            },
+            resultMessage(),
+          ]);
+        }
+        return immediateRun([
+          { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "t1", is_error: false }] } },
+          resultMessage("done"),
+        ]);
+      },
+    });
+    const events: ClaudeExecutionEvent[] = [];
+    const loop = makeLoop({ createSdk: async () => sdk, onEvent: (event) => events.push(event) });
+    await loop.start();
+    await loop.run("one");
+    await loop.run("two");
+    expect(events).toEqual([
+      { kind: "text", text: "hi" },
+      { kind: "tool-start", id: "t1", name: "WebSearch", input: { q: 1 } },
+      { kind: "result", isError: false, source: "message" },
+      { kind: "tool-end", id: "t1", isError: false },
+      { kind: "result", isError: false, detail: "done", source: "message" },
+    ]);
+    await loop.dispose();
+  });
+
+  it("emits no synthetic result on clean EOF when settlement is result", async () => {
+    const events: ClaudeExecutionEvent[] = [];
+    const sdk = fakeSdk({ startTurn: async () => immediateRun([textDelta("hi")]) });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result" },
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("hello");
+    expect(events).toEqual([{ kind: "text", text: "hi" }]);
+    await loop.dispose();
+  });
+
+  it("emits incomplete when result-required EOFs without a result", async () => {
+    const events: ClaudeExecutionEvent[] = [];
+    const sdk = fakeSdk({ startTurn: async () => immediateRun([textDelta("hi")]) });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result-required" },
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("hello");
+    expect(events).toEqual([
+      { kind: "text", text: "hi" },
+      { kind: "result", isError: true, source: "incomplete" },
+    ]);
+    await loop.dispose();
+  });
+
+  it("does not emit incomplete after a message result", async () => {
+    const events: ClaudeExecutionEvent[] = [];
+    const sdk = fakeSdk({
+      startTurn: async () => immediateRun([resultMessage(), textDelta("late")]),
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result-required" },
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("hello");
+    expect(events).toEqual([{ kind: "result", isError: false, source: "message" }]);
+    await loop.dispose();
+  });
+
+  it("closes the active run once on a result and resolves without waiting for iterator EOF", async () => {
+    const events: ClaudeExecutionEvent[] = [];
+    const hanging = resultThenHang();
+    const sdk = fakeSdk({ startTurn: async () => hanging });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("hello");
+    expect(events).toEqual([{ kind: "result", isError: false, source: "message" }]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("emits a message result once when run.close() throws and still resolves", async () => {
+    const events: ClaudeExecutionEvent[] = [];
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "hello") return resultThenThrowOnClose();
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("hello");
+    expect(events).toEqual([{ kind: "result", isError: false, source: "message" }]);
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+    await loop.run("later");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["hello", "later"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+  });
+
+  it("resolves a message result even when iterator.return() never settles", async () => {
+    const events: ClaudeExecutionEvent[] = [];
+    const hanging = resultThenHangReturn();
+    const sdk = fakeSdk({ startTurn: async () => hanging });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("hello");
+    expect(events).toEqual([{ kind: "result", isError: false, source: "message" }]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not close a newer run when an old iterator.return() later settles", async () => {
+    const old = resultThenHangReturn();
+    const next = hangPastClose();
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "old") return old;
+      return next;
+    });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    await loop.run("old");
+    expect(old.close).toHaveBeenCalledOnce();
+    const later = loop.run("new");
+    await next.started;
+    expect(next.close).not.toHaveBeenCalled();
+    old.releaseReturn();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(next.close).not.toHaveBeenCalled();
+    expect(runs[1]?.close).not.toHaveBeenCalled();
+    loop.cancel();
+    await later;
+    expect(next.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("emits only the result when later text and an iterator error are already buffered", async () => {
+    const events: ClaudeExecutionEvent[] = [];
+    const sdk = fakeSdk({
+      startTurn: async () => immediateRun(
+        [resultMessage(), textDelta("late")],
+        new Error("late"),
+      ),
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("hello");
+    expect(events).toEqual([{ kind: "result", isError: false, source: "message" }]);
+    await loop.dispose();
+  });
+
+  it("emits watchdog exactly once and ignores a later iterator error", async () => {
+    vi.useFakeTimers();
+    const events: ClaudeExecutionEvent[] = [];
+    const hanging = hangingRun({ throwOnClose: true });
+    const sdk = fakeSdk({ startTurn: async () => hanging });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result-required", watchdogMs: 1_000 },
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    const running = loop.run("hello");
+    await hanging.started;
+    await vi.advanceTimersByTimeAsync(1_000);
+    await running;
+    expect(events).toEqual([{ kind: "result", isError: true, source: "watchdog" }]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects run with a watchdog onEvent throw and still closes the SDK slot once", async () => {
+    vi.useFakeTimers();
+    const hanging = hangingRun({ throwOnClose: true });
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "hello") return hanging;
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result-required", watchdogMs: 1_000 },
+      onEvent: (event) => {
+        if (event.kind === "result" && event.source === "watchdog") {
+          throw new Error("watchdog listener failed");
+        }
+      },
+    });
+    await loop.start();
+    const running = loop.run("hello");
+    await hanging.started;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await expect(running).rejects.toThrow("watchdog listener failed");
+    await loop.run("later");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["hello", "later"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("resolves a nonthrowing watchdog without waiting for iterator EOF", async () => {
+    vi.useFakeTimers();
+    const events: ClaudeExecutionEvent[] = [];
+    const hanging = hangPastClose();
+    const sdk = fakeSdk({ startTurn: async () => hanging });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result-required", watchdogMs: 1_000 },
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    const running = loop.run("hello");
+    await hanging.started;
+    await vi.advanceTimersByTimeAsync(1_000);
+    await running;
+    expect(events).toEqual([{ kind: "result", isError: true, source: "watchdog" }]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a watchdog observer throw without waiting for iterator EOF", async () => {
+    vi.useFakeTimers();
+    const hanging = hangPastClose();
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "hello") return hanging;
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result-required", watchdogMs: 1_000 },
+      onEvent: (event) => {
+        if (event.kind === "result" && event.source === "watchdog") {
+          throw new Error("watchdog listener failed");
+        }
+      },
+    });
+    await loop.start();
+    const running = loop.run("hello");
+    await hanging.started;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await expect(running).rejects.toThrow("watchdog listener failed");
+    await loop.run("later");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["hello", "later"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a message-result observer throw and still closes the SDK slot once", async () => {
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "bad") return immediateRun([resultMessage("ok")]);
+      return immediateRun([resultMessage()]);
+    });
+    let failed = false;
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => {
+        if (!failed && event.kind === "result" && event.source === "message") {
+          failed = true;
+          throw new Error("result listener failed");
+        }
+      },
+    });
+    await loop.start();
+    await expect(loop.run("bad")).rejects.toThrow("result listener failed");
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+    await loop.run("good");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["bad", "good"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("rejects an incomplete observer throw and still closes the SDK slot once", async () => {
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "bad") return immediateRun([textDelta("hi")]);
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result-required" },
+      onEvent: (event) => {
+        if (event.kind === "result" && event.source === "incomplete") {
+          throw new Error("incomplete listener failed");
+        }
+      },
+    });
+    await loop.start();
+    await expect(loop.run("bad")).rejects.toThrow("incomplete listener failed");
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+    await loop.run("good");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["bad", "good"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("does not arm a watchdog for non-positive delays", async () => {
+    vi.useFakeTimers();
+    const hanging = hangingRun();
+    const sdk = fakeSdk({ startTurn: async () => hanging });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      settlement: { kind: "result-required", watchdogMs: 0 },
+    });
+    await loop.start();
+    const running = loop.run("hello");
+    await hanging.started;
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(hanging.close).not.toHaveBeenCalled();
+    hanging.close();
+    await running;
+    await loop.dispose();
+  });
+
+  it("rejects an iterator failure before a terminal result, once", async () => {
+    const sdk = fakeSdk({
+      startTurn: async () => immediateRun([], new Error("stream died")),
+    });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    await expect(loop.run("hello")).rejects.toThrow("stream died");
+    await loop.dispose();
+  });
+
+  it("does not reject a later iterator error after a terminal result", async () => {
+    const events: ClaudeExecutionEvent[] = [];
+    const sdk = fakeSdk({
+      startTurn: async () => immediateRun([resultMessage("ok")], new Error("late")),
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("hello");
+    expect(events).toEqual([{ kind: "result", isError: false, detail: "ok", source: "message" }]);
+    await loop.dispose();
+  });
+});
+
+describe("createClaudeExecutionLoop cancel and dispose", () => {
+  it("cancels only the active run and is safe to call repeatedly", async () => {
+    const first = hangingRun();
+    const second = hangingRun();
+    const runs = [first, second];
+    const sdk = fakeSdk({ startTurn: async () => runs.shift() ?? immediateRun([resultMessage()]) });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const running = loop.run("one");
+    await first.started;
+    loop.cancel();
+    loop.cancel();
+    await running;
+    expect(first.close).toHaveBeenCalledOnce();
+    expect(second.close).not.toHaveBeenCalled();
+    const later = loop.run("two");
+    await second.started;
+    second.close();
+    await later;
+    expect(second.close).toHaveBeenCalled();
+    await loop.dispose();
+  });
+
+  it("resolves cancel without waiting for iterator cleanup", async () => {
+    const hanging = neverUnblockOnClose();
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "one") return hanging;
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const running = loop.run("one");
+    await hanging.started;
+    loop.cancel();
+    loop.cancel();
+    await running;
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await loop.run("two");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["one", "two"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("cancels quietly when run.close() throws", async () => {
+    const hanging = neverUnblockOnClose({ throwFromClose: true });
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "one") return hanging;
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const running = loop.run("one");
+    await hanging.started;
+    loop.cancel();
+    loop.cancel();
+    await running;
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await loop.run("two");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["one", "two"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("closes an active turn on dispose, skips queued turns, and disposes the SDK once", async () => {
+    const active = hangingRun({ throwOnClose: true });
+    const startTurn = vi.fn(async (turn: ClaudeGatewayTurn) => {
+      if (turn.prompt === "active") return active;
+      return immediateRun([resultMessage()]);
+    });
+    const sdk = fakeSdk({ startTurn });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const first = loop.run("active");
+    const queued = loop.run("queued");
+    await active.started;
+    await loop.dispose();
+    await expect(first).resolves.toBeUndefined();
+    await expect(queued).resolves.toBeUndefined();
+    expect(startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["active"]);
+    expect(active.close).toHaveBeenCalledOnce();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(active.close).toHaveBeenCalledOnce();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("disposes without waiting for iterator cleanup", async () => {
+    const hanging = neverUnblockOnClose();
+    const startTurn = vi.fn(async (turn: ClaudeGatewayTurn) => {
+      if (turn.prompt === "active") return hanging;
+      return immediateRun([resultMessage()]);
+    });
+    const sdk = fakeSdk({ startTurn });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const first = loop.run("active");
+    const queued = loop.run("queued");
+    await hanging.started;
+    await loop.dispose();
+    await expect(first).resolves.toBeUndefined();
+    await expect(queued).resolves.toBeUndefined();
+    expect(startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["active"]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("disposes quietly when run.close() throws", async () => {
+    const hanging = neverUnblockOnClose({ throwFromClose: true });
+    const startTurn = vi.fn(async (turn: ClaudeGatewayTurn) => {
+      if (turn.prompt === "active") return hanging;
+      return immediateRun([resultMessage()]);
+    });
+    const sdk = fakeSdk({ startTurn });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const first = loop.run("active");
+    const queued = loop.run("queued");
+    await hanging.started;
+    await loop.dispose();
+    await expect(first).resolves.toBeUndefined();
+    await expect(queued).resolves.toBeUndefined();
+    expect(startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["active"]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(hanging.close).toHaveBeenCalledOnce();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("closes once after an iterator failure so a queued turn can occupy the SDK slot", async () => {
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "bad") return immediateRun([textDelta("hi")], new Error("stream died"));
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const failed = loop.run("bad");
+    const queued = loop.run("good");
+    await expect(failed).rejects.toThrow("stream died");
+    await queued;
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["bad", "good"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("rejects a synchronous asyncIterator factory throw, closes once, and runs a later queued turn", async () => {
+    const factoryError = new Error("iterator factory failed");
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "bad") return throwingIteratorFactory(factoryError);
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const failed = loop.run("bad");
+    const queued = loop.run("good");
+    await expect(failed).rejects.toBe(factoryError);
+    await queued;
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["bad", "good"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("closes once after a nonterminal onEvent throw so a later turn can occupy the SDK slot", async () => {
+    const { sdk, runs } = exclusiveSdk((turn) => {
+      if (turn.prompt === "bad") return immediateRun([textDelta("hi"), resultMessage()]);
+      return immediateRun([resultMessage()]);
+    });
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => {
+        if (event.kind === "text") throw new Error("listener failed");
+      },
+    });
+    await loop.start();
+    await expect(loop.run("bad")).rejects.toThrow("listener failed");
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+    await loop.run("good");
+    expect(sdk.startTurn).toHaveBeenCalledTimes(2);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("closes once on clean EOF so the next turn can occupy the SDK slot", async () => {
+    const { sdk, runs } = exclusiveSdk(() => immediateRun([textDelta("hi")]));
+    const events: ClaudeExecutionEvent[] = [];
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    await loop.run("first");
+    expect(events).toEqual([{ kind: "text", text: "hi" }]);
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+    await loop.run("second");
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["first", "second"]);
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+    await loop.dispose();
+    expect(runs[0]?.close).toHaveBeenCalledOnce();
+    expect(runs[1]?.close).toHaveBeenCalledOnce();
+  });
+
+  it("suppresses a startTurn failure once dispose has begun", async () => {
+    const startTurnGate = deferred<void>();
+    const sdk = fakeSdk({
+      startTurn: async () => {
+        await startTurnGate.promise;
+        throw new Error("sdk went away");
+      },
+    });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const running = loop.run("hello");
+    await vi.waitFor(() => expect(sdk.startTurn).toHaveBeenCalled());
+    const disposing = loop.dispose();
+    startTurnGate.resolve();
+    await expect(running).resolves.toBeUndefined();
+    await disposing;
+  });
+});
+
+function makeLoop(overrides: Partial<ClaudeExecutionLoopOptions> = {}) {
+  const continuation: ClaudeExecutionContinuation = overrides.continuation ?? { kind: "resume-child" };
+  const settlement: ClaudeExecutionSettlement = overrides.settlement ?? { kind: "result" };
+  return createClaudeExecutionLoop({
+    createSdk: overrides.createSdk ?? (async () => fakeSdk()),
+    buildTurn: overrides.buildTurn ?? (() => ({ model: "sonnet" })),
+    continuation,
+    settlement,
+    ...(overrides.onEvent ? { onEvent: overrides.onEvent } : {}),
+  });
+}
+
+function fakeSdk(overrides: {
+  startTurn?: (turn: ClaudeGatewayTurn) => Promise<ClaudeGatewayRun>;
+} = {}): ClaudeGatewaySdk & {
+  readonly dispose: ReturnType<typeof vi.fn>;
+  readonly startTurn: ReturnType<typeof vi.fn>;
+} {
+  const dispose = vi.fn(async () => undefined);
+  const startTurn = vi.fn(overrides.startTurn ?? (async () => immediateRun([resultMessage()])));
+  return {
+    configDir: "/tmp/fake",
+    models: ["sonnet"],
+    startTurn,
+    dispose,
+  };
+}
+
+type FakeRun = ClaudeGatewayRun & { readonly close: ReturnType<typeof vi.fn> };
+
+/**
+ * 실 SDK와 같이, 앞 턴의 close() 전에는 다음 startTurn을 거부한다.
+ * next() 거절만으로는 슬롯이 풀리지 않는 계약을 테스트가 그대로 재현한다.
+ */
+function exclusiveSdk(createRun: (turn: ClaudeGatewayTurn) => FakeRun): {
+  readonly sdk: ClaudeGatewaySdk & {
+    readonly dispose: ReturnType<typeof vi.fn>;
+    readonly startTurn: ReturnType<typeof vi.fn>;
+  };
+  readonly runs: FakeRun[];
+} {
+  let active: FakeRun | null = null;
+  const runs: FakeRun[] = [];
+  const sdk = fakeSdk({
+    startTurn: async (turn) => {
+      if (active !== null) {
+        throw new Error("A turn is already running on this instance. Await it, or create another instance.");
+      }
+      const run = createRun(turn);
+      const innerClose = run.close;
+      const close = vi.fn(() => {
+        if (active === run) active = null;
+        innerClose();
+      });
+      Object.assign(run, { close });
+      active = run;
+      runs.push(run);
+      return run;
+    },
+  });
+  return { sdk, runs };
+}
+
+function throwingIteratorFactory(error: unknown): FakeRun {
+  const close = vi.fn();
+  return {
+    close,
+    [Symbol.asyncIterator](): AsyncIterator<ClaudeGatewayMessage> {
+      throw error;
+    },
+  };
+}
+
+function resultThenThrowOnClose(error: unknown = new Error("close failed")): FakeRun {
+  const close = vi.fn(() => {
+    throw error;
+  });
+  return {
+    close,
+    async *[Symbol.asyncIterator]() {
+      yield resultMessage();
+    },
+  };
+}
+
+function immediateRun(
+  messages: readonly ClaudeGatewayMessage[],
+  iterateError?: unknown,
+): ClaudeGatewayRun & { readonly close: ReturnType<typeof vi.fn> } {
+  const close = vi.fn();
+  return {
+    close,
+    async *[Symbol.asyncIterator]() {
+      for (const message of messages) yield message;
+      if (iterateError !== undefined) throw iterateError;
+    },
+  };
+}
+
+function hangFirstNext(): ClaudeGatewayRun & {
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly started: Promise<void>;
+  releaseNext(message: ClaudeGatewayMessage): void;
+} {
+  const started = deferred<void>();
+  const nextGate = deferred<ClaudeGatewayMessage>();
+  let yielded = false;
+  const close = vi.fn();
+  return {
+    close,
+    started: started.promise,
+    releaseNext(message) {
+      nextGate.resolve(message);
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          started.resolve();
+          if (!yielded) {
+            yielded = true;
+            const value = await nextGate.promise;
+            return { value, done: false };
+          }
+          return { value: undefined, done: true };
+        },
+        async return() {
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+function hangUntilReleasedThenMessages(
+  messages: readonly ClaudeGatewayMessage[],
+): ClaudeGatewayRun & {
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly started: Promise<void>;
+  release(): void;
+} {
+  const started = deferred<void>();
+  const gate = deferred<void>();
+  const close = vi.fn();
+  return {
+    close,
+    started: started.promise,
+    release() {
+      gate.resolve();
+    },
+    async *[Symbol.asyncIterator]() {
+      started.resolve();
+      await gate.promise;
+      for (const message of messages) yield message;
+    },
+  };
+}
+
+function resultThenHang(): ClaudeGatewayRun & { readonly close: ReturnType<typeof vi.fn> } {
+  const close = vi.fn();
+  return {
+    close,
+    async *[Symbol.asyncIterator]() {
+      yield resultMessage();
+      // close()가 이터레이터를 끝내지 않는다. 메시지 종점 뒤에 EOF를 기다리면 run()이 멈춘다.
+      await new Promise(() => undefined);
+    },
+  };
+}
+
+/**
+ * 생성기가 아니라 수동 이터레이터. 첫 next는 result를 주고 return()은 호출 측이 풀어 주기 전에는
+ * 끝나지 않는다. 생성기 return()은 yield 자리에서 바로 끝나서 약한 가짜다.
+ */
+function resultThenHangReturn(): ClaudeGatewayRun & {
+  readonly close: ReturnType<typeof vi.fn>;
+  releaseReturn(): void;
+} {
+  let yielded = false;
+  const returnGate = deferred<void>();
+  const close = vi.fn();
+  return {
+    close,
+    releaseReturn() {
+      returnGate.resolve();
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          if (!yielded) {
+            yielded = true;
+            return { value: resultMessage(), done: false };
+          }
+          await new Promise(() => undefined);
+          return { value: undefined, done: true };
+        },
+        async return() {
+          await returnGate.promise;
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+/** close()가 next/return 어느 쪽도 풀지 않는다. 취소·폐기가 EOF를 기다리면 멈춘다. */
+function neverUnblockOnClose(options: { throwFromClose?: boolean } = {}): ClaudeGatewayRun & {
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly started: Promise<void>;
+} {
+  const started = deferred<void>();
+  const close = vi.fn(() => {
+    if (options.throwFromClose) throw new Error("close failed");
+  });
+  return {
+    close,
+    started: started.promise,
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          started.resolve();
+          await new Promise(() => undefined);
+          return { value: undefined, done: true };
+        },
+        async return() {
+          await new Promise(() => undefined);
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+function hangPastClose(): ClaudeGatewayRun & {
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly started: Promise<void>;
+} {
+  const started = deferred<void>();
+  const close = vi.fn();
+  return {
+    close,
+    started: started.promise,
+    async *[Symbol.asyncIterator]() {
+      started.resolve();
+      // close()가 이터레이터를 끝내지 않는다. 워치독 종점은 EOF를 기다리면 안 된다.
+      await new Promise(() => undefined);
+    },
+  };
+}
+
+function hangingRun(options: { throwOnClose?: boolean } = {}): ClaudeGatewayRun & {
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly started: Promise<void>;
+} {
+  let closed = false;
+  const gate = deferred<void>();
+  const started = deferred<void>();
+  const close = vi.fn(() => {
+    closed = true;
+    gate.resolve();
+  });
+  return {
+    close,
+    started: started.promise,
+    async *[Symbol.asyncIterator]() {
+      started.resolve();
+      if (!closed) await gate.promise;
+      if (options.throwOnClose) throw new Error("run closed");
+    },
+  };
+}
+
+function resultMessage(result?: string): ClaudeGatewayMessage {
+  return {
+    type: "result",
+    is_error: false,
+    session_id: "child-session",
+    ...(result === undefined ? {} : { result }),
+  };
+}
+
+function textDelta(text: string): ClaudeGatewayMessage {
+  return {
+    type: "stream_event",
+    event: { type: "content_block_delta", delta: { type: "text_delta", text } },
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/packages/core-agent/tests/claude-execution-loop.test.ts
+++ b/packages/core-agent/tests/claude-execution-loop.test.ts
@@ -574,6 +574,57 @@ describe("createClaudeExecutionLoop settlement", () => {
 });
 
 describe("createClaudeExecutionLoop cancel and dispose", () => {
+  it("remembers cancellation while startTurn is pending and leaves the queued turn untouched", async () => {
+    const starting = deferred<ClaudeGatewayRun>();
+    const canceled = immediateRun([textDelta("late"), resultMessage()]);
+    const sdk = fakeSdk({
+      startTurn: async (turn) => turn.prompt === "one"
+        ? starting.promise
+        : immediateRun([resultMessage("next")]),
+    });
+    const events: ClaudeExecutionEvent[] = [];
+    const loop = makeLoop({
+      createSdk: async () => sdk,
+      onEvent: (event) => events.push(event),
+    });
+    await loop.start();
+    const first = loop.run("one");
+    const queued = loop.run("two");
+    await vi.waitFor(() => expect(sdk.startTurn).toHaveBeenCalledOnce());
+    loop.cancel();
+    starting.resolve(canceled);
+    await Promise.all([first, queued]);
+    expect(canceled.close).toHaveBeenCalledOnce();
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual(["one", "two"]);
+    expect(events).toEqual([
+      { kind: "result", isError: false, detail: "next", source: "message" },
+    ]);
+    await loop.dispose();
+  });
+
+  it("does not let an idle cancel preempt the next turn", async () => {
+    const sdk = fakeSdk();
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    loop.cancel();
+    await loop.run("one");
+    expect(sdk.startTurn).toHaveBeenCalledOnce();
+    await loop.dispose();
+  });
+
+  it("keeps cancellation quiet when a pending startTurn rejects", async () => {
+    const starting = deferred<ClaudeGatewayRun>();
+    const sdk = fakeSdk({ startTurn: async () => starting.promise });
+    const loop = makeLoop({ createSdk: async () => sdk });
+    await loop.start();
+    const running = loop.run("one");
+    await vi.waitFor(() => expect(sdk.startTurn).toHaveBeenCalledOnce());
+    loop.cancel();
+    starting.reject(new Error("start failed after cancel"));
+    await expect(running).resolves.toBeUndefined();
+    await loop.dispose();
+  });
+
   it("cancels only the active run and is safe to call repeatedly", async () => {
     const first = hangingRun();
     const second = hangingRun();

--- a/packages/core-agent/tests/claude-sdk.test.ts
+++ b/packages/core-agent/tests/claude-sdk.test.ts
@@ -7,6 +7,7 @@ import { CLAUDE_GATEWAY_MODEL_CACHE_RELPATH } from "../src/claude/launch-env.js"
 
 // 자식 프로세스를 띄우지 않는다. 검증 대상은 spawn 직전까지의 조립과 거부다.
 const runVendorQuery = vi.fn();
+let vendorClose: () => void = () => {};
 vi.mock("../src/claude/vendor-sdk.js", () => ({
   runVendorQuery: (input: unknown) => {
     runVendorQuery(input);
@@ -14,7 +15,7 @@ vi.mock("../src/claude/vendor-sdk.js", () => ({
       [Symbol.asyncIterator]: async function* () {
         yield { type: "result", subtype: "success" };
       },
-      close: () => {},
+      close: () => vendorClose(),
     };
   },
   defineVendorTool: vi.fn(),
@@ -34,6 +35,7 @@ async function drain(run: AsyncIterable<unknown>): Promise<void> {
 
 beforeEach(() => {
   runVendorQuery.mockClear();
+  vendorClose = () => {};
 });
 
 describe("construction", () => {
@@ -169,6 +171,18 @@ describe("fail-closed refusals", () => {
     await expect(sdk.startTurn({ prompt: "hi", model: LUNA })).rejects.toThrow(/already running/);
     await drain(first);
     // 슬롯은 스트림 소진으로 돌아온다.
+    await drain(await sdk.startTurn({ prompt: "hi", model: LUNA }));
+    await sdk.dispose();
+  });
+
+  it("releases the active slot when underlying close throws", async () => {
+    vendorClose = () => {
+      throw new Error("close failed");
+    };
+    const sdk = await createClaudeGatewaySdk({ baseUrl: BASE_URL, models: [LUNA] });
+    const first = await sdk.startTurn({ prompt: "hi", model: LUNA });
+    expect(() => first.close()).toThrow("close failed");
+    vendorClose = () => {};
     await drain(await sdk.startTurn({ prompt: "hi", model: LUNA }));
     await sdk.dispose();
   });

--- a/packages/core-agent/tests/claude-vendor-sdk.test.ts
+++ b/packages/core-agent/tests/claude-vendor-sdk.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const query = vi.fn();
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (input: unknown) => query(input),
+  createSdkMcpServer: vi.fn(),
+  getSessionInfo: vi.fn(),
+  tool: vi.fn(),
+}));
+
+const { runVendorQuery } = await import("../src/claude/vendor-sdk.js");
+
+afterEach(() => {
+  query.mockReset();
+});
+
+describe("runVendorQuery close", () => {
+  it("swallows a synchronous return() throw and is exact-once", () => {
+    const returnFn = vi.fn(() => {
+      throw new Error("sync cleanup");
+    });
+    query.mockReturnValue(makeVendorRun(returnFn));
+    const run = runVendorQuery({ prompt: "hi", options: {} });
+    expect(() => run.close()).not.toThrow();
+    expect(() => run.close()).not.toThrow();
+    expect(returnFn).toHaveBeenCalledOnce();
+  });
+
+  it("swallows a rejected return() Promise and is exact-once", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const returnFn = vi.fn(() => Promise.reject(new Error("async cleanup")));
+      query.mockReturnValue(makeVendorRun(returnFn));
+      const run = runVendorQuery({ prompt: "hi", options: {} });
+      expect(() => run.close()).not.toThrow();
+      expect(() => run.close()).not.toThrow();
+      expect(returnFn).toHaveBeenCalledOnce();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});
+
+function makeVendorRun(returnFn: () => Promise<unknown>): AsyncGenerator<unknown, void> {
+  return {
+    async *[Symbol.asyncIterator]() {},
+    async next() {
+      return { done: true, value: undefined };
+    },
+    return: returnFn,
+    async throw() {
+      return { done: true, value: undefined };
+    },
+  } as unknown as AsyncGenerator<unknown, void>;
+}

--- a/packages/fleet-analyst/src/session.ts
+++ b/packages/fleet-analyst/src/session.ts
@@ -1,11 +1,12 @@
 import {
+  createClaudeExecutionLoop,
   createClaudeGatewaySdk,
   createEmbeddedMcpServer,
   defineTool,
+  type ClaudeExecutionEvent,
+  type ClaudeExecutionLoop,
+  type ClaudeExecutionTurn,
   type ClaudeGatewayEffort,
-  type ClaudeGatewayMessage,
-  type ClaudeGatewayRun,
-  type ClaudeGatewaySdk,
 } from "@dotobokuri/core-agent/claude";
 
 import { resolveAnalystSystemPrompt } from "./prompt.js";
@@ -20,48 +21,55 @@ const GATEWAY_EFFORTS = new Set<ClaudeGatewayEffort>(["low", "medium", "high", "
 export class AnalystSession {
   private readonly options: AnalystSessionOptions;
   private readonly tools: AnalystTools;
-  private sdk: ClaudeGatewaySdk | null = null;
-  private run: ClaudeGatewayRun | null = null;
-  /** 같은 분석 대화를 이어 가기 위한 자식 세션 id. 첫 턴이 알려 준다. */
-  private resumeId: string | null = null;
+  private readonly loop: ClaudeExecutionLoop;
   private started = false;
   private disposed = false;
-  private turn: Promise<void> = Promise.resolve();
-  private disposeFlight: Promise<void> | null = null;
 
   constructor(options: AnalystSessionOptions) {
     this.options = { ...options };
     this.tools = new AnalystTools(this.options);
+    this.loop = createClaudeExecutionLoop({
+      createSdk: async () => this.options.createSdk?.(this.sdkOptions()) ?? createClaudeGatewaySdk(this.sdkOptions()),
+      buildTurn: () => this.buildTurn(),
+      continuation: { kind: "resume-child" },
+      settlement: { kind: "result" },
+      onEvent: (event) => {
+        for (const mapped of toAnalystEvents(event)) this.options.onEvent?.(mapped);
+      },
+    });
   }
 
   async start(): Promise<void> {
     if (this.disposed) throw new Error("Session disposed");
     if (this.started) return;
     await this.tools.refresh();
-    this.throwIfDisposed();
-    const sdk = await (this.options.createSdk?.(this.sdkOptions()) ?? createClaudeGatewaySdk(this.sdkOptions()));
     if (this.disposed) {
-      await sdk.dispose().catch(() => undefined);
+      await this.loop.dispose();
       throw new Error("Session disposed");
     }
-    this.sdk = sdk;
+    await this.loop.start();
+    if (this.disposed) {
+      await this.loop.dispose();
+      throw new Error("Session disposed");
+    }
     this.started = true;
   }
 
   send(text: string): Promise<void> {
-    if (this.disposed) return Promise.reject(new Error("Session disposed"));
-    if (!this.started || !this.sdk) return Promise.reject(new Error("Session not started"));
-    if (!text.trim()) return Promise.reject(new Error("Message required"));
-    const run = this.turn.then(() => this.runTurn(text));
-    this.turn = run.catch(() => undefined);
-    return run;
+    return this.loop.run(text).catch((error: unknown) => {
+      if (this.disposed) throw error;
+      const message = errorMessage(error);
+      if (message === "Session not started" || message === "Message required" || message === "Session disposed") {
+        throw error;
+      }
+      this.options.onEvent?.({ type: "error", error: { code: "analysis_error", message: redactTranscriptString(message) } });
+      throw error;
+    });
   }
 
   dispose(): Promise<void> {
-    if (this.disposeFlight) return this.disposeFlight;
     this.disposed = true;
-    this.disposeFlight = this.disposeResources();
-    return this.disposeFlight;
+    return this.loop.dispose();
   }
 
   private sdkOptions(): { readonly baseUrl: string; readonly models: readonly string[]; readonly env?: Readonly<Record<string, string>> } {
@@ -72,49 +80,20 @@ export class AnalystSession {
     };
   }
 
-  private async runTurn(text: string): Promise<void> {
-    const sdk = this.sdk;
-    if (!sdk) throw new Error("Session not started");
-    const emit = (event: AnalystEvent): void => this.options.onEvent?.(event);
-    // 분석가의 도구는 관측 대상 세션의 원문을 다룬다. 나가는 모든 문자열은 색인기가 쓰는 것과
-    // 같은 규칙으로 가린다.
-    const redact = redactTranscriptString;
-    let run: ClaudeGatewayRun;
-    try {
-      run = await sdk.startTurn({
-        prompt: text,
-        model: this.options.model,
-        systemPrompt: { mode: "replace", text: resolveAnalystSystemPrompt(this.options.language) },
-        cwd: this.options.cwd,
-        // 관측자는 이 기계를 건드리지 않는다. 내장 도구를 전부 없애면 아래 MCP 도구만 남는다 —
-        // 앞선 ACP 권한 분류기가 도구 이름을 추측해 걸러내던 일을 구조가 대신한다.
-        tools: [],
-        mcpServers: { [ANALYST_MCP_SERVER]: this.mcpServer() },
-        allowedTools: this.tools.specs().map((spec) => `mcp__${ANALYST_MCP_SERVER}__${spec.id}`),
-        permissionMode: "dontAsk",
-        // 텍스트와 사고를 흘려 보내려면 부분 메시지가 필요하다.
-        includePartialMessages: true,
-        ...(this.effort() === undefined ? {} : { effort: this.effort()! }),
-        ...(this.resumeId === null ? {} : { resume: this.resumeId }),
-      });
-    } catch (error) {
-      emit({ type: "error", error: { code: "analysis_error", message: redact(errorMessage(error)) } });
-      throw error;
-    }
-    this.run = run;
-    const toolNames = new Map<string, string>();
-    try {
-      for await (const event of run) {
-        if (typeof event.session_id === "string" && this.resumeId === null) this.resumeId = event.session_id;
-        for (const mapped of toAnalystEvents(event, toolNames, redact)) emit(mapped);
-      }
-    } catch (error) {
-      if (this.disposed) return;
-      emit({ type: "error", error: { code: "analysis_error", message: redact(errorMessage(error)) } });
-      throw error;
-    } finally {
-      if (this.run === run) this.run = null;
-    }
+  private buildTurn(): ClaudeExecutionTurn {
+    return {
+      model: this.options.model,
+      systemPrompt: { mode: "replace", text: resolveAnalystSystemPrompt(this.options.language) },
+      cwd: this.options.cwd,
+      // 관측자는 이 기계를 건드리지 않는다. 내장 도구를 전부 없애면 아래 MCP 도구만 남는다.
+      tools: [],
+      mcpServers: { [ANALYST_MCP_SERVER]: this.mcpServer() },
+      allowedTools: this.tools.specs().map((spec) => `mcp__${ANALYST_MCP_SERVER}__${spec.id}`),
+      permissionMode: "dontAsk",
+      // 텍스트와 사고를 흘려 보내려면 부분 메시지가 필요하다.
+      includePartialMessages: true,
+      ...(this.effort() === undefined ? {} : { effort: this.effort()! }),
+    };
   }
 
   /** 분석 도구는 이 프로세스 안에서 돈다. 자식은 이름으로 부를 뿐 실행하지 않는다. */
@@ -138,83 +117,31 @@ export class AnalystSession {
       ? effort as ClaudeGatewayEffort
       : undefined;
   }
-
-  private async disposeResources(): Promise<void> {
-    this.run?.close();
-    this.run = null;
-    await this.turn.catch(() => undefined);
-    const sdk = this.sdk;
-    this.sdk = null;
-    this.started = false;
-    await sdk?.dispose().catch(() => undefined);
-  }
-
-  private throwIfDisposed(): void {
-    if (this.disposed) throw new Error("Session disposed");
-  }
 }
 
 /**
- * 자식이 흘리는 메시지를 분석가의 이벤트로 옮긴다.
+ * 정규화된 실행 이벤트를 분석가의 이벤트로 옮긴다.
  *
- * 모양은 실측으로 고정했다. 답변 텍스트와 사고가 같은 `content_block_delta` 자리로 오되
- * `text_delta`와 `thinking_delta`로 갈리며, 분석가는 앞선 ACP 경로에서 둘 다 별개 이벤트로
- * 내보냈으므로 여기서도 둘 다 옮긴다. `artifact` 이벤트는 이 경로가 아니라 publish_artifact
- * 도구 핸들러가 직접 낸다.
+ * 답변 텍스트와 사고는 별개로 나간다. `artifact` 이벤트는 이 경로가 아니라
+ * publish_artifact 도구 핸들러가 직접 낸다.
  */
-export function toAnalystEvents(
-  event: ClaudeGatewayMessage,
-  toolNames: Map<string, string>,
-  redact: (value: string) => string,
-): readonly AnalystEvent[] {
-  if (event.type === "stream_event") {
-    const inner = record(event.event);
-    if (inner.type !== "content_block_delta") return [];
-    const delta = record(inner.delta);
-    if (delta.type === "text_delta" && typeof delta.text === "string" && delta.text.length > 0) {
-      return [{ type: "chunk", text: redact(delta.text) }];
-    }
-    if (delta.type === "thinking_delta" && typeof delta.thinking === "string" && delta.thinking.length > 0) {
-      return [{ type: "thought", text: redact(delta.thinking) }];
-    }
-    return [];
+export function toAnalystEvents(event: ClaudeExecutionEvent): readonly AnalystEvent[] {
+  const redact = redactTranscriptString;
+  switch (event.kind) {
+    case "text":
+      return [{ type: "chunk", text: redact(event.text) }];
+    case "thinking":
+      return [{ type: "thought", text: redact(event.text) }];
+    case "tool-start":
+      return [{ type: "tool", title: redact(event.name), status: "running" }];
+    case "tool-end":
+      return [{ type: "tool", title: redact(event.name ?? "tool"), status: event.isError ? "error" : "done" }];
+    case "result":
+      if (event.isError) {
+        return [{ type: "error", error: { code: "analysis_error", message: redact(event.detail ?? "Analysis turn failed") } }];
+      }
+      return [{ type: "complete" }];
   }
-  if (event.type === "assistant") {
-    const events: AnalystEvent[] = [];
-    for (const block of blocks(event.message)) {
-      if (block.type !== "tool_use") continue;
-      const name = typeof block.name === "string" ? block.name : "tool";
-      if (typeof block.id === "string") toolNames.set(block.id, name);
-      events.push({ type: "tool", title: redact(name), status: "running" });
-    }
-    return events;
-  }
-  if (event.type === "user") {
-    const events: AnalystEvent[] = [];
-    for (const block of blocks(event.message)) {
-      if (block.type !== "tool_result") continue;
-      const name = typeof block.tool_use_id === "string" ? toolNames.get(block.tool_use_id) ?? "tool" : "tool";
-      events.push({ type: "tool", title: redact(name), status: block.is_error === true ? "error" : "done" });
-    }
-    return events;
-  }
-  if (event.type === "result") {
-    if (event.is_error === true) {
-      const detail = typeof event.result === "string" ? event.result : "Analysis turn failed";
-      return [{ type: "error", error: { code: "analysis_error", message: redact(detail) } }];
-    }
-    return [{ type: "complete" }];
-  }
-  return [];
-}
-
-function blocks(message: unknown): readonly Record<string, unknown>[] {
-  const content = record(message).content;
-  return Array.isArray(content) ? content.map(record) : [];
-}
-
-function record(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/fleet-analyst/tests/session.test.ts
+++ b/packages/fleet-analyst/tests/session.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { ClaudeGatewayMessage, ClaudeGatewaySdk, ClaudeGatewayTurn } from "@dotobokuri/core-agent/claude";
+import type { ClaudeExecutionEvent, ClaudeGatewayMessage, ClaudeGatewaySdk, ClaudeGatewayTurn } from "@dotobokuri/core-agent/claude";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { AnalystSession, toAnalystEvents } from "../src/session.js";
@@ -24,9 +24,9 @@ class FakeSdk {
   readonly models = ["test-model"];
   readonly dispose = vi.fn(async () => undefined);
   readonly close = vi.fn();
-  readonly startTurn: ReturnType<typeof vi.fn>;
+  startTurn: ReturnType<typeof vi.fn>;
 
-  constructor(stream: readonly ClaudeGatewayMessage[] = [{ type: "result", subtype: "success", is_error: false, session_id: "child-session" }]) {
+  constructor(stream: readonly ClaudeGatewayMessage[] = [resultMessage()]) {
     const close = this.close;
     this.startTurn = vi.fn(async (_turn: ClaudeGatewayTurn) => ({
       [Symbol.asyncIterator]: async function* () {
@@ -62,14 +62,13 @@ it("binds the SDK to the host gateway and only the selected model", async () => 
 });
 
 it("removes every built-in tool and admits only the analyst's own MCP tools", async () => {
-  // 앞선 ACP 경로는 도구 이름을 접두사로 알아보고 shell 같은 native 도구를 거부했다. 이제
-  // 내장 도구가 아예 없으므로 거부할 것이 남지 않는다.
   const { analyst, sdk } = await session();
   await analyst.start();
   await analyst.send("hello");
   const turn = sdk.startTurn.mock.calls[0]?.[0] as ClaudeGatewayTurn;
   expect(turn.tools).toEqual([]);
   expect(turn.permissionMode).toBe("dontAsk");
+  expect(turn.includePartialMessages).toBe(true);
   expect(turn.allowedTools).toEqual([
     "mcp__session_analyst__session_outline",
     "mcp__session_analyst__session_events",
@@ -83,14 +82,14 @@ it("removes every built-in tool and admits only the analyst's own MCP tools", as
 });
 
 it("carries the analyst prompt as a replace-mode system prompt, not as user content", async () => {
-  // ACP 기본값 prepend는 이 프롬프트를 첫 사용자 메시지 본문에 실었다. 그러면 프롬프트 안의
-  // 안티-인젝션 조항이 자기가 삼키는 transcript와 같은 층위에 놓인다.
   const { analyst, sdk } = await session();
   await analyst.start();
   await analyst.send("hello");
   const turn = sdk.startTurn.mock.calls[0]?.[0] as ClaudeGatewayTurn;
   expect(turn.systemPrompt?.mode).toBe("replace");
   expect(turn.systemPrompt?.text).toContain("You are Session Analyst");
+  expect(turn.prompt).toBe("hello");
+  expect(Object.hasOwn(turn, "resume")).toBe(false);
   await analyst.dispose();
 });
 
@@ -123,26 +122,125 @@ it("continues the same analysis by resuming the child's session", async () => {
   await analyst.start();
   await analyst.send("first");
   await analyst.send("second");
+  expect((sdk.startTurn.mock.calls[0]?.[0] as ClaudeGatewayTurn).prompt).toBe("first");
   expect((sdk.startTurn.mock.calls[0]?.[0] as ClaudeGatewayTurn).resume).toBeUndefined();
+  expect((sdk.startTurn.mock.calls[1]?.[0] as ClaudeGatewayTurn).prompt).toBe("second");
   expect((sdk.startTurn.mock.calls[1]?.[0] as ClaudeGatewayTurn).resume).toBe("child-session");
   await analyst.dispose();
 });
 
-it("rejects sends before start and disposes idempotently", async () => {
-  const { analyst } = await session();
-  await expect(analyst.send("hello")).rejects.toThrow("Session not started");
-  await expect(analyst.dispose()).resolves.toBeUndefined();
-  await expect(analyst.dispose()).resolves.toBeUndefined();
+it("serializes queued sends and recovers after a failed turn", async () => {
+  const events: AnalystEvent[] = [];
+  const order: string[] = [];
+  const first = hangingRun();
+  const sdk = new FakeSdk();
+  sdk.startTurn = vi.fn(async (turn: ClaudeGatewayTurn) => {
+    order.push(turn.prompt);
+    if (turn.prompt === "first") return first;
+    if (turn.prompt === "bad") throw new Error("boom");
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        yield resultMessage();
+      },
+      close: sdk.close,
+    };
+  });
+  const { analyst } = await session({ onEvent: (event) => events.push(event) }, sdk);
+  await analyst.start();
+  const firstSend = analyst.send("first");
+  const secondSend = analyst.send("second");
+  await first.started;
+  expect(order).toEqual(["first"]);
+  first.close();
+  await Promise.all([firstSend, secondSend]);
+  expect(order).toEqual(["first", "second"]);
+  await expect(analyst.send("bad")).rejects.toThrow("boom");
+  await analyst.send("good");
+  expect(order).toEqual(["first", "second", "bad", "good"]);
+  expect(events).toEqual([
+    { type: "complete" },
+    { type: "error", error: { code: "analysis_error", message: "boom" } },
+    { type: "complete" },
+  ]);
+  await analyst.dispose();
 });
 
-it("cancels an active turn on disposal and rejects later sends", async () => {
-  const { analyst, sdk } = await session();
+it("rejects sends before start, blank prompts, and after dispose", async () => {
+  const events: AnalystEvent[] = [];
+  const { analyst } = await session({ onEvent: (event) => events.push(event) });
+  await expect(analyst.send("hello")).rejects.toThrow("Session not started");
   await analyst.start();
-  void analyst.send("long prompt");
-  await Promise.resolve();
+  await expect(analyst.send("")).rejects.toThrow("Message required");
+  await expect(analyst.send("   \n\t")).rejects.toThrow("Message required");
   await analyst.dispose();
+  await expect(analyst.send("hello")).rejects.toThrow("Session disposed");
+  await expect(analyst.start()).rejects.toThrow("Session disposed");
+  await expect(analyst.dispose()).resolves.toBeUndefined();
+  expect(events).toEqual([]);
+});
+
+it("closes an active turn on disposal and disposes the SDK once", async () => {
+  const hanging = hangingRun();
+  const sdk = new FakeSdk();
+  sdk.startTurn = vi.fn(async () => hanging);
+  const { analyst } = await session({}, sdk);
+  await analyst.start();
+  const sending = analyst.send("long prompt");
+  await hanging.started;
+  await analyst.dispose();
+  await expect(sending).resolves.toBeUndefined();
   await expect(analyst.send("too late")).rejects.toThrow("Session disposed");
+  expect(hanging.close).toHaveBeenCalledOnce();
   expect(sdk.dispose).toHaveBeenCalledOnce();
+  await analyst.dispose();
+  expect(hanging.close).toHaveBeenCalledOnce();
+  expect(sdk.dispose).toHaveBeenCalledOnce();
+});
+
+it("disposes a late SDK when disposal wins start", async () => {
+  const created = deferred<ClaudeGatewaySdk>();
+  const creating = deferred<void>();
+  const sdk = new FakeSdk();
+  const analyst = new AnalystSession({
+    capturePath: await capture(),
+    cwd: process.cwd(),
+    baseUrl: BASE_URL,
+    model: "test-model",
+    createSdk: async (args) => {
+      sdk.create(args);
+      creating.resolve();
+      return created.promise;
+    },
+  });
+  const starting = analyst.start();
+  await creating.promise;
+  const disposing = analyst.dispose();
+  created.resolve(sdk as unknown as ClaudeGatewaySdk);
+  await expect(starting).rejects.toThrow("Session disposed");
+  await disposing;
+  expect(sdk.dispose).toHaveBeenCalledOnce();
+  await analyst.dispose();
+  expect(sdk.dispose).toHaveBeenCalledOnce();
+});
+
+it("emits one analysis_error and rejects when the iterator fails", async () => {
+  const events: AnalystEvent[] = [];
+  const sdk = new FakeSdk();
+  sdk.startTurn = vi.fn(async () => ({
+    close: sdk.close,
+    async *[Symbol.asyncIterator]() {
+      yield { type: "stream_event", event: { type: "content_block_delta", delta: { type: "text_delta", text: "hi" } } };
+      throw new Error("stream died");
+    },
+  }));
+  const { analyst } = await session({ onEvent: (event) => events.push(event) }, sdk);
+  await analyst.start();
+  await expect(analyst.send("hello")).rejects.toThrow("stream died");
+  expect(events).toEqual([
+    { type: "chunk", text: "hi" },
+    { type: "error", error: { code: "analysis_error", message: "stream died" } },
+  ]);
+  await analyst.dispose();
 });
 
 it("reports a failed turn as an error event rather than a silent completion", async () => {
@@ -155,27 +253,122 @@ it("reports a failed turn as an error event rather than a silent completion", as
   await analyst.dispose();
 });
 
+it("falls a result error without detail back to Analysis turn failed", async () => {
+  const events: AnalystEvent[] = [];
+  const sdk = new FakeSdk([{ type: "result", is_error: true }]);
+  const { analyst } = await session({ onEvent: (event) => events.push(event) }, sdk);
+  await analyst.start();
+  await analyst.send("hello");
+  expect(events).toEqual([{ type: "error", error: { code: "analysis_error", message: "Analysis turn failed" } }]);
+  await analyst.dispose();
+});
+
+it("separates thinking from text and maps tools through the common loop", async () => {
+  const events: AnalystEvent[] = [];
+  const sdk = new FakeSdk([
+    { type: "stream_event", event: { type: "content_block_delta", delta: { type: "text_delta", text: "hi" } } },
+    { type: "stream_event", event: { type: "content_block_delta", delta: { type: "thinking_delta", thinking: "hmm" } } },
+    { type: "assistant", message: { content: [{ type: "tool_use", id: "t1", name: "session_outline", input: {} }] } },
+    { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "t1", is_error: false }] } },
+    resultMessage(),
+  ]);
+  const { analyst } = await session({ onEvent: (event) => events.push(event) }, sdk);
+  await analyst.start();
+  await analyst.send("hello");
+  expect(events).toEqual([
+    { type: "chunk", text: "hi" },
+    { type: "thought", text: "hmm" },
+    { type: "tool", title: "session_outline", status: "running" },
+    { type: "tool", title: "session_outline", status: "done" },
+    { type: "complete" },
+  ]);
+  await analyst.dispose();
+});
+
 it("redacts text, thought, and tool titles on the way out", () => {
-  const names = new Map<string, string>();
-  const redact = (value: string) => value.replace(/chunk-secret|thought-secret-value|ses_tool-secret/g, "[redacted]");
   const emitted = [
-    ...toAnalystEvents(delta("text_delta", { text: "MY_APP_PASSWORD=chunk-secret" }), names, redact),
-    ...toAnalystEvents(delta("thinking_delta", { thinking: "Bearer thought-secret-value" }), names, redact),
-    ...toAnalystEvents({ type: "assistant", message: { content: [{ type: "tool_use", id: "t1", name: "ses_tool-secret" }] } }, names, redact),
+    ...toAnalystEvents({ kind: "text", text: "MY_APP_PASSWORD=chunk-secret" }),
+    ...toAnalystEvents({ kind: "thinking", text: "Bearer thought-secret-value" }),
+    ...toAnalystEvents({ kind: "tool-start", name: "ses_tool-secret", input: {} }),
+    ...toAnalystEvents({ kind: "tool-end", name: "ses_tool-secret", isError: true }),
   ];
   const exposed = JSON.stringify(emitted);
   for (const secret of ["chunk-secret", "thought-secret-value", "ses_tool-secret"]) {
     expect(exposed).not.toContain(secret);
   }
-  expect(emitted.map((event) => event.type)).toEqual(["chunk", "thought", "tool"]);
+  expect(emitted.map((event) => event.type)).toEqual(["chunk", "thought", "tool", "tool"]);
 });
 
 it("keeps assistant text and reasoning on separate event kinds", () => {
-  const identity = (value: string): string => value;
-  expect(toAnalystEvents(delta("text_delta", { text: "hi" }), new Map(), identity)).toEqual([{ type: "chunk", text: "hi" }]);
-  expect(toAnalystEvents(delta("thinking_delta", { thinking: "hmm" }), new Map(), identity)).toEqual([{ type: "thought", text: "hmm" }]);
+  expect(toAnalystEvents({ kind: "text", text: "hi" })).toEqual([{ type: "chunk", text: "hi" }]);
+  expect(toAnalystEvents({ kind: "thinking", text: "hmm" })).toEqual([{ type: "thought", text: "hmm" }]);
 });
 
-function delta(type: string, payload: Record<string, unknown>): ClaudeGatewayMessage {
-  return { type: "stream_event", event: { type: "content_block_delta", delta: { type, ...payload } } };
+it("maps result errors without detail to the analysis fallback and success to complete", () => {
+  expect(toAnalystEvents(resultEvent(true))).toEqual([
+    { type: "error", error: { code: "analysis_error", message: "Analysis turn failed" } },
+  ]);
+  expect(toAnalystEvents(resultEvent(true, "denied"))).toEqual([
+    { type: "error", error: { code: "analysis_error", message: "denied" } },
+  ]);
+  expect(toAnalystEvents(resultEvent(false, "ok"))).toEqual([{ type: "complete" }]);
+  expect(toAnalystEvents({ kind: "result", isError: true, source: "watchdog" })).toEqual([
+    { type: "error", error: { code: "analysis_error", message: "Analysis turn failed" } },
+  ]);
+  expect(toAnalystEvents({ kind: "result", isError: false, source: "incomplete" })).toEqual([{ type: "complete" }]);
+});
+
+it("falls a tool-end without a name back to tool", () => {
+  expect(toAnalystEvents({ kind: "tool-end", isError: false })).toEqual([
+    { type: "tool", title: "tool", status: "done" },
+  ]);
+});
+
+function resultMessage(): ClaudeGatewayMessage {
+  return { type: "result", subtype: "success", is_error: false, session_id: "child-session" };
+}
+
+function resultEvent(isError: boolean, detail?: string): ClaudeExecutionEvent {
+  return {
+    kind: "result",
+    isError,
+    source: "message",
+    ...(detail === undefined ? {} : { detail }),
+  };
+}
+
+function hangingRun(): {
+  readonly close: (() => void) & { readonly mock: { readonly calls: readonly unknown[] } };
+  readonly started: Promise<void>;
+  [Symbol.asyncIterator](): AsyncGenerator<ClaudeGatewayMessage, void, unknown>;
+} {
+  let closed = false;
+  const gate = deferred<void>();
+  const started = deferred<void>();
+  const close = vi.fn((): void => {
+    closed = true;
+    gate.resolve();
+  });
+  return {
+    close,
+    started: started.promise,
+    async *[Symbol.asyncIterator]() {
+      started.resolve();
+      if (!closed) await gate.promise;
+    },
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }

--- a/packages/fleet-wiki/src/cowork/service.ts
+++ b/packages/fleet-wiki/src/cowork/service.ts
@@ -22,9 +22,8 @@ export function createCoworkMcpRuntime(store: CoworkStore, workspaceId: string, 
   // The session-token snapshot scopes tools/list, but the executor call router still
   // invokes through the registry — the same seven specs must be registered there too.
   for (const spec of specs) registry.registerAgentTool(spec);
-  // 스코프 강제는 승인 게이트가 아니라 전용 MCP 도구 주입 + 시스템 프롬프트가 담당한다.
-  // yolo/autoApprove가 없으면 백엔드별 승인 프로토콜(claude/cursor)마다 브릿지가 필요해진다.
-  return { registry, snapshots, server, manager, specs, allowedToolIds, connection: { strictMcp: true, yoloMode: true, autoApprove: true } };
+  // 스코프 강제는 전용 MCP 도구 집합과 현재 게이트웨이 턴 정책이 담당한다.
+  return { registry, snapshots, server, manager, specs, allowedToolIds };
 }
 
 /**
@@ -44,16 +43,12 @@ export interface CoworkAgentClient {
 
 export interface CoworkConnectOptions {
   cwd: string;
-  cli?: string;
   model?: string;
   effort?: string;
   systemPrompt: string;
   mcpServers: readonly unknown[];
   /** 이 세션에 노출되는 도구 id. 도메인이 정하고 호스트가 사전승인에 쓴다. */
   allowedToolIds: readonly string[];
-  strictMcp: boolean;
-  yoloMode: boolean;
-  autoApprove: boolean;
 }
 
 export interface CoworkConnector { connect(options: CoworkConnectOptions): Promise<CoworkAgentClient>; }
@@ -101,9 +96,9 @@ export class CoworkService {
       const mcp = await runtime.manager.createExecutorMcpSession({ serverName: "cowork", specs: runtime.specs, cwd: this.cwd });
       // Provider cwd is the session's own directory — minimizes what a backend CLI can read on its own.
       // 원샷 실행: provider 세션을 resume하지 않고 매 프롬프트마다 새로 연결한다.
-      // 스코프 강제는 yolo + 전용 MCP 도구 주입 + 시스템 프롬프트가 담당한다.
+      // 스코프 강제는 전용 MCP 도구 집합과 현재 게이트웨이 턴 정책이 담당한다.
       const providerCwd = await this.store.sessionDir(workspaceId, id);
-      const client = await this.connector.connect({ cwd: providerCwd, cli: session.cli, model: session.model, effort: session.effort, systemPrompt: COWORK_SYSTEM_PROMPT, mcpServers: [mcp.mcpServer], allowedToolIds: [...runtime.allowedToolIds], ...runtime.connection });
+      const client = await this.connector.connect({ cwd: providerCwd, model: session.model, effort: session.effort, systemPrompt: COWORK_SYSTEM_PROMPT, mcpServers: [mcp.mcpServer], allowedToolIds: [...runtime.allowedToolIds] });
       this.releaseLive(id);
       this.live.set(id, { workspaceId, client, annotations, cleanup: () => { try { mcp.cleanup(); } catch { /* already released */ } } });
       client.on("toolCall", (title, status) => { void this.emit(workspaceId, id, "tool", `${String(title).slice(0, 80)} · ${String(status).slice(0, 24)}`, false); });

--- a/packages/fleet-wiki/tests/cowork-runtime.test.ts
+++ b/packages/fleet-wiki/tests/cowork-runtime.test.ts
@@ -5,15 +5,46 @@ import { join } from "node:path";
 import { createMemoryPaths, ensureMemoryRoot, readWikiEntry, writeWikiEntry } from "../src/index.js";
 import { describe, expect, it } from "vitest";
 import { createCoworkMcpRuntime } from "../src/cowork/index.js";
-import { CoworkService, CoworkStore, type CoworkAgentClient, type CoworkConnector } from "../src/cowork/index.js";
+import { CoworkService, CoworkStore, type CoworkAgentClient, type CoworkConnectOptions, type CoworkConnector } from "../src/cowork/index.js";
+
+const SCOPED_TOOL_IDS = [
+  "wiki_draft_read",
+  "wiki_draft_edit",
+  "wiki_draft_write",
+  "wiki_briefing",
+  "wiki_orient",
+  "wiki_read",
+  "wiki_resolve",
+] as const;
 
 describe("Cowork MCP runtime", () => {
-  it("runs one-shot yolo with only the seven scoped MCP tools", async () => {
+  it("exposes only the seven scoped MCP tools", async () => {
     const store = new CoworkStore(); const session = await store.create("workspace", "entry", "draft");
     const runtime = createCoworkMcpRuntime(store, "workspace", session.id);
-    expect(runtime.allowedToolIds).toHaveLength(7);
-    expect(runtime.specs.map(spec => spec.id).sort()).toEqual([...runtime.allowedToolIds].sort());
-    expect(runtime.connection).toEqual({ strictMcp: true, yoloMode: true, autoApprove: true });
+    expect([...runtime.allowedToolIds]).toEqual([...SCOPED_TOOL_IDS]);
+    expect(runtime.specs.map(spec => spec.id).sort()).toEqual([...SCOPED_TOOL_IDS].sort());
+    expect(runtime).not.toHaveProperty("connection");
+  });
+
+  it("reconnects each prompt without cli or approval-bridge flags", async () => {
+    const connector = new FakeConnector();
+    const { service } = await fixture(connector);
+    const session = await service.create("workspace", "entry", { cli: "claude", model: "sonnet", effort: "high" });
+    await service.prompt("workspace", session.id, "first");
+    connector.client.emit("promptComplete");
+    await until(async () => (await service.get("workspace", session.id))?.state === "idle");
+    await service.prompt("workspace", session.id, "second");
+
+    expect(connector.connected).toHaveLength(2);
+    for (const options of connector.connected) {
+      expect(options).not.toHaveProperty("cli");
+      expect(options).not.toHaveProperty("strictMcp");
+      expect(options).not.toHaveProperty("yoloMode");
+      expect(options).not.toHaveProperty("autoApprove");
+      expect(options.model).toBe("sonnet");
+      expect(options.effort).toBe("high");
+      expect(options.allowedToolIds).toEqual([...SCOPED_TOOL_IDS]);
+    }
   });
 
   it("preserves draft and session when the Wiki base has gone stale", async () => {
@@ -77,8 +108,20 @@ async function fixture(connector: CoworkConnector = new FakeConnector()) {
 }
 function entry() { return { id: "entry", title: "Entry", tags: ["test"], created: "2026-01-01T00:00:00.000Z", updated: "2026-01-01T00:00:00.000Z", version: 1, body: "Original" }; }
 function draft(value: { body: string; version: number; templateId?: string }) { const e = { ...entry(), ...value }; return `---\nid: ${e.id}\ntitle: ${e.title}\ntags: ["test"]\ncreated: ${e.created}\nupdated: ${e.updated}\nversion: ${e.version}\n${value.templateId ? `template_id: ${value.templateId}\n` : ""}---\n${e.body}`; }
+async function until(condition: () => Promise<boolean>, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise<void>(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error("condition not met within timeout");
+}
 class FakeConnector implements CoworkConnector {
+  readonly connected: CoworkConnectOptions[] = [];
   readonly client = new EventEmitter() as EventEmitter & { getConnectionInfo(): { sessionId: string }; sendMessage(content: string): Promise<{}>; cancelPrompt(): Promise<void>; disconnect(): Promise<void> };
   constructor() { this.client.getConnectionInfo = () => ({ sessionId: "provider-session-only" }); this.client.sendMessage = async () => ({}); this.client.cancelPrompt = async () => {}; this.client.disconnect = async () => {}; }
-  async connect(): Promise<CoworkAgentClient> { return this.client as unknown as CoworkAgentClient; }
+  async connect(options: CoworkConnectOptions): Promise<CoworkAgentClient> {
+    this.connected.push(options);
+    return this.client as unknown as CoworkAgentClient;
+  }
 }

--- a/runtime/fleet-console/core/host/codex/cowork/gateway-adapter.ts
+++ b/runtime/fleet-console/core/host/codex/cowork/gateway-adapter.ts
@@ -1,6 +1,14 @@
 import { EventEmitter } from "node:events";
 
-import { createClaudeGatewaySdk, type ClaudeGatewayEffort, type ClaudeGatewayRun, type ClaudeGatewaySdk, type ClaudeGatewayServedMcpServer } from "@dotobokuri/core-agent/claude";
+import {
+  createClaudeExecutionLoop,
+  createClaudeGatewaySdk,
+  type ClaudeExecutionEvent,
+  type ClaudeExecutionLoop,
+  type ClaudeGatewayEffort,
+  type ClaudeGatewaySdk,
+  type ClaudeGatewayServedMcpServer,
+} from "@dotobokuri/core-agent/claude";
 import type { CoworkAgentClient, CoworkConnectOptions, CoworkConnector } from "@dotobokuri/fleet-wiki/cowork";
 
 /** 게이트웨이 강도 사다리. 여기 없는 값은 싣지 않는다 — 사용자가 고르지 않은 강도로 도는 것보다 낫다. */
@@ -9,8 +17,7 @@ const GATEWAY_EFFORTS = new Set<ClaudeGatewayEffort>(["low", "medium", "high", "
 /**
  * 한 턴이 아무 종료 신호 없이 늘어지는 것을 끊는 상한.
  *
- * 이터레이터가 결과 없이 끝나거나 이 시간을 넘기면 오류로 올린다. 조용히 멈춘 대화는 사용자에게
- * "생각 중"과 구별되지 않아 영원히 기다리게 되므로, 판정은 시끄러워야 한다.
+ * 공통 루프가 이 시간 안에 결과를 보지 못하면 워치독으로 정산한다.
  */
 const TURN_WATCHDOG_MS = 10 * 60 * 1000;
 
@@ -33,13 +40,20 @@ const COWORK_DISALLOWED_TOOLS = [
 export interface CoworkGatewayAdapterDeps {
   /** Console이 서빙 중인 AI Gateway의 절대 URL. 리슨 전이면 null. */
   readonly baseUrl: () => string | null;
+  /**
+   * 테스트 seam. 커넥터가 조립한 생성 인자를 그대로 받는다 — 인자 없이 받으면 조립 자체가 검증
+   * 밖으로 나간다.
+   */
+  readonly createSdk?: (options: {
+    readonly baseUrl: string;
+    readonly models: readonly string[];
+  }) => Promise<ClaudeGatewaySdk>;
 }
 
 /**
  * Cowork를 Console의 AI Gateway 위에서 돌리는 커넥터.
  *
- * 예전에는 ACP 클라이언트를 그대로 넘겼다. fleet-wiki는 그때도 provider 조립을 몰랐고 지금도
- * 모른다 — 바뀐 것은 호스트가 조립하는 대상뿐이다.
+ * fleet-wiki는 provider 조립을 모른다 — 커넥터는 반드시 호스트가 소유한다.
  */
 export function createCoworkGatewayConnector(deps: CoworkGatewayAdapterDeps): CoworkConnector {
   return {
@@ -48,124 +62,109 @@ export function createCoworkGatewayConnector(deps: CoworkGatewayAdapterDeps): Co
       // 포트를 추측해 자식을 띄우면 첫 턴에서야 알 수 없는 이유로 죽는다.
       if (!baseUrl) throw new Error("cowork_gateway_unavailable");
       const model = options.model && options.model.length > 0 ? options.model : "sonnet";
-      const sdk = await createClaudeGatewaySdk({ baseUrl, models: [model] });
-      return new CoworkGatewayClient(sdk, options, model);
+      const client = new CoworkGatewayClient();
+      const loop = createClaudeExecutionLoop({
+        createSdk: () => {
+          const create = { baseUrl, models: [model] };
+          return deps.createSdk?.(create) ?? createClaudeGatewaySdk(create);
+        },
+        buildTurn: () => {
+          const effort = options.effort;
+          const served = toServedMcpServers(options.mcpServers);
+          return {
+            model,
+            systemPrompt: { mode: "replace" as const, text: options.systemPrompt },
+            cwd: options.cwd,
+            disallowedTools: COWORK_DISALLOWED_TOOLS,
+            // 위키 도구는 호스트가 이미 띄운 HTTP MCP 엔드포인트로 온다. 이것을 싣지 않으면 자식은
+            // 시스템 프롬프트가 말하는 도구 이름을 부르지만 그런 도구가 없어 그대로 턴이 끝난다.
+            servedMcpServers: served,
+            // dontAsk는 사전승인되지 않은 도구를 묻지 않고 거부한다 — 노출한 도구는 전부 승인해 둔다.
+            allowedTools: served.flatMap((server) => options.allowedToolIds.map((id) => `mcp__${server.name}__${id}`)),
+            permissionMode: "dontAsk" as const,
+            includePartialMessages: true,
+            ...(effort && GATEWAY_EFFORTS.has(effort as ClaudeGatewayEffort) ? { effort: effort as ClaudeGatewayEffort } : {}),
+          };
+        },
+        continuation: { kind: "oneshot" },
+        settlement: { kind: "result-required", watchdogMs: TURN_WATCHDOG_MS },
+        onEvent: (event) => client.publish(event),
+      });
+      client.bind(loop);
+      await loop.start();
+      return client;
     },
   };
 }
 
 class CoworkGatewayClient extends EventEmitter implements CoworkAgentClient {
-  private run: ClaudeGatewayRun | null = null;
-  private resumeId: string | null = null;
-  private disposed = false;
+  private loop: ClaudeExecutionLoop | null = null;
+  /** 이번 턴을 취소한 뒤에 루프가 내는 종점 정산·이터레이터 거절은 조용히 삼킨다. */
+  private canceledTurn = false;
 
-  constructor(
-    private readonly sdk: ClaudeGatewaySdk,
-    private readonly options: CoworkConnectOptions,
-    private readonly model: string,
-  ) {
-    super();
+  bind(loop: ClaudeExecutionLoop): void {
+    this.loop = loop;
+  }
+
+  publish(event: ClaudeExecutionEvent): void {
+    if (this.canceledTurn && event.kind === "result") return;
+    if (event.kind === "text") {
+      this.emit("messageChunk", event.text);
+      return;
+    }
+    if (event.kind === "thinking") return;
+    if (event.kind === "tool-start") {
+      this.emit("toolCall", event.name, "running");
+      return;
+    }
+    if (event.kind === "tool-end") {
+      this.emit("toolCallUpdate", event.name ?? "tool", event.isError ? "error" : "done");
+      return;
+    }
+    if (event.source === "incomplete") {
+      this.emit("error", { message: "cowork_turn_incomplete" });
+      return;
+    }
+    if (event.source === "watchdog") {
+      this.emit("error", { message: "cowork_turn_timeout" });
+      return;
+    }
+    if (event.isError) {
+      this.emit("error", { message: event.detail ?? "cowork_turn_failed" });
+      return;
+    }
+    this.emit("promptComplete");
   }
 
   async sendMessage(content: string): Promise<void> {
-    if (this.disposed) throw new Error("cowork_session_disposed");
-    const effort = this.options.effort;
-    const served = toServedMcpServers(this.options.mcpServers);
-    const run = await this.sdk.startTurn({
-      prompt: content,
-      model: this.model,
-      systemPrompt: { mode: "replace", text: this.options.systemPrompt },
-      cwd: this.options.cwd,
-      disallowedTools: COWORK_DISALLOWED_TOOLS,
-      // 위키 도구는 호스트가 이미 띄운 HTTP MCP 엔드포인트로 온다. 이것을 싣지 않으면 자식은
-      // 시스템 프롬프트가 말하는 도구 이름을 부르지만 그런 도구가 없어 그대로 턴이 끝난다.
-      servedMcpServers: served,
-      // dontAsk는 사전승인되지 않은 도구를 묻지 않고 거부한다 — 노출한 도구는 전부 승인해 둔다.
-      allowedTools: served.flatMap((server) => this.options.allowedToolIds.map((id) => `mcp__${server.name}__${id}`)),
-      permissionMode: "dontAsk",
-      includePartialMessages: true,
-      ...(effort && GATEWAY_EFFORTS.has(effort as ClaudeGatewayEffort) ? { effort: effort as ClaudeGatewayEffort } : {}),
-      ...(this.resumeId === null ? {} : { resume: this.resumeId }),
-    });
-    this.run = run;
-    await this.consume(run);
+    this.canceledTurn = false;
+    try {
+      await this.requireLoop().run(content);
+    } catch (error) {
+      if (this.canceledTurn) return;
+      throw disposedError(error);
+    }
   }
 
   async cancelPrompt(): Promise<void> {
-    this.run?.close();
-    this.run = null;
+    this.canceledTurn = true;
+    this.loop?.cancel();
   }
 
   async disconnect(): Promise<void> {
-    this.disposed = true;
-    this.run?.close();
-    this.run = null;
-    await this.sdk.dispose().catch(() => undefined);
+    await this.loop?.dispose();
   }
 
-  /**
-   * 한 턴을 소비하고 정확히 한 번 결말을 낸다.
-   *
-   * 이터레이터가 끝났다는 사실만으로 성공을 알리지 않는다. 인식 가능한 종료 결과를 보지 못한 채
-   * 끝나면 그것은 조용한 실패이고, 조용한 실패는 사용자에게 멈춘 화면으로만 보인다.
-   */
-  private async consume(run: ClaudeGatewayRun): Promise<void> {
-    const toolNames = new Map<string, string>();
-    let settled = false;
-    const finish = (error?: string): void => {
-      if (settled) return;
-      settled = true;
-      if (error) this.emit("error", { message: error });
-      else this.emit("promptComplete");
-    };
-    const watchdog = setTimeout(() => { run.close(); finish("cowork_turn_timeout"); }, TURN_WATCHDOG_MS);
-    watchdog.unref?.();
-    try {
-      for await (const event of run) {
-        if (typeof event.session_id === "string" && this.resumeId === null) this.resumeId = event.session_id;
-        this.publish(event, toolNames, finish);
-      }
-      finish(settled ? undefined : "cowork_turn_incomplete");
-    } catch (error) {
-      if (!this.disposed) finish(error instanceof Error ? error.message : String(error));
-    } finally {
-      clearTimeout(watchdog);
-      if (this.run === run) this.run = null;
-    }
+  private requireLoop(): ClaudeExecutionLoop {
+    if (this.loop === null) throw new Error("cowork_session_disposed");
+    return this.loop;
   }
+}
 
-  private publish(event: Record<string, unknown>, toolNames: Map<string, string>, finish: (error?: string) => void): void {
-    const type = event.type;
-    if (type === "stream_event") {
-      const inner = record(event.event);
-      if (inner.type !== "content_block_delta") return;
-      const delta = record(inner.delta);
-      if (delta.type === "text_delta" && typeof delta.text === "string" && delta.text.length > 0) {
-        this.emit("messageChunk", delta.text);
-      }
-      return;
-    }
-    if (type === "assistant") {
-      for (const block of blocks(event.message)) {
-        if (block.type !== "tool_use") continue;
-        const name = typeof block.name === "string" ? block.name : "tool";
-        if (typeof block.id === "string") toolNames.set(block.id, name);
-        this.emit("toolCall", name, "running");
-      }
-      return;
-    }
-    if (type === "user") {
-      for (const block of blocks(event.message)) {
-        if (block.type !== "tool_result") continue;
-        const name = typeof block.tool_use_id === "string" ? toolNames.get(block.tool_use_id) ?? "tool" : "tool";
-        this.emit("toolCallUpdate", name, block.is_error === true ? "error" : "done");
-      }
-      return;
-    }
-    if (type === "result") {
-      finish(event.is_error === true ? (typeof event.result === "string" ? event.result : "cowork_turn_failed") : undefined);
-    }
-  }
+function disposedError(error: unknown): unknown {
+  return error instanceof Error && error.message === "Session disposed"
+    ? new Error("cowork_session_disposed")
+    : error;
 }
 
 /**
@@ -187,11 +186,6 @@ function toServedMcpServers(values: readonly unknown[]): readonly ClaudeGatewayS
       ...(typeof server.toolTimeoutSeconds === "number" ? { toolTimeoutSeconds: server.toolTimeoutSeconds } : {}),
     }];
   });
-}
-
-function blocks(message: unknown): readonly Record<string, unknown>[] {
-  const content = record(message).content;
-  return Array.isArray(content) ? content.map(record) : [];
 }
 
 function record(value: unknown): Record<string, unknown> {

--- a/runtime/fleet-console/tests/codex-cowork-gateway-adapter.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-gateway-adapter.test.ts
@@ -1,0 +1,415 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ClaudeGatewayMessage, ClaudeGatewayRun, ClaudeGatewaySdk, ClaudeGatewayTurn } from "@dotobokuri/core-agent/claude";
+import type { CoworkAgentClient, CoworkConnectOptions } from "@dotobokuri/fleet-wiki/cowork";
+
+import { createCoworkGatewayConnector } from "../core/host/codex/cowork/gateway-adapter.js";
+
+const BASE_URL = "http://127.0.0.1:43210/plugins/terminal/ai-gateway";
+const TURN_WATCHDOG_MS = 10 * 60 * 1000;
+const COWORK_DISALLOWED_TOOLS = [
+  "Bash", "BashOutput", "KillShell",
+  "Read", "Write", "Edit", "NotebookEdit", "Glob", "Grep",
+  "WebFetch", "WebSearch",
+  "Task", "Agent", "Workflow", "Skill", "SendMessage",
+  "EnterWorktree", "ExitWorktree",
+  "TodoWrite", "SlashCommand", "Artifact",
+];
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("createCoworkGatewayConnector", () => {
+  it("throws before SDK creation when the gateway is not listening", async () => {
+    const createSdk = vi.fn();
+    const connector = createCoworkGatewayConnector({ baseUrl: () => null, createSdk });
+    await expect(connector.connect(connectOptions())).rejects.toThrow("cowork_gateway_unavailable");
+    expect(createSdk).not.toHaveBeenCalled();
+  });
+
+  it("starts the common loop during connect and binds the SDK to the host gateway", async () => {
+    const sdk = new FakeSdk();
+    const { client } = await connectClient(sdk, { model: "opus" });
+    expect(sdk.createArgs).toEqual({ baseUrl: BASE_URL, models: ["opus"] });
+    await client.sendMessage("hello");
+    expect(sdk.startTurn).toHaveBeenCalledOnce();
+    await client.disconnect();
+  });
+
+  it("falls the model back to sonnet and forwards only a valid gateway effort", async () => {
+    const sdk = new FakeSdk();
+    const { client } = await connectClient(sdk, { model: "", effort: "high" });
+    await client.sendMessage("hello");
+    expect(sdk.createArgs).toEqual({ baseUrl: BASE_URL, models: ["sonnet"] });
+    expect(sdk.startTurn.mock.calls[0]?.[0].model).toBe("sonnet");
+    expect(sdk.startTurn.mock.calls[0]?.[0].effort).toBe("high");
+    await client.disconnect();
+
+    const other = new FakeSdk();
+    const second = await connectClient(other, { effort: "turbo" });
+    await second.client.sendMessage("hello");
+    expect(other.startTurn.mock.calls[0]?.[0].effort).toBeUndefined();
+    await second.client.disconnect();
+  });
+
+  it("preserves the local turn policy and never resumes a child session", async () => {
+    const sdk = new FakeSdk([
+      { type: "system", subtype: "init", session_id: "child-session" },
+      resultMessage(),
+    ]);
+    const { client } = await connectClient(sdk, {
+      effort: "low",
+      mcpServers: [
+        {
+          name: "cowork",
+          url: "http://127.0.0.1:9/mcp",
+          headers: [{ name: "Authorization", value: "Bearer x" }, { name: 1, value: "drop" }],
+          toolTimeoutSeconds: 30,
+        },
+        { name: "broken" },
+        null,
+      ],
+      allowedToolIds: ["wiki_draft_read", "wiki_read"],
+    });
+    await client.sendMessage("first");
+    await client.sendMessage("second");
+    expect(sdk.startTurn).toHaveBeenCalledTimes(2);
+    for (const [turn] of sdk.startTurn.mock.calls) {
+      expect(turn.resume).toBeUndefined();
+      expect(Object.hasOwn(turn, "resume")).toBe(false);
+      expect(turn.prompt).toBe(turn === sdk.startTurn.mock.calls[0]?.[0] ? "first" : "second");
+      expect(turn.systemPrompt).toEqual({ mode: "replace", text: "You are Fleet Wiki Cowork" });
+      expect(turn.cwd).toBe("/tmp/cowork");
+      expect(turn.disallowedTools).toEqual(COWORK_DISALLOWED_TOOLS);
+      expect(turn.permissionMode).toBe("dontAsk");
+      expect(turn.includePartialMessages).toBe(true);
+      expect(turn.effort).toBe("low");
+      expect(turn.servedMcpServers).toEqual([{
+        name: "cowork",
+        url: "http://127.0.0.1:9/mcp",
+        headers: [{ name: "Authorization", value: "Bearer x" }],
+        toolTimeoutSeconds: 30,
+      }]);
+      expect(turn.allowedTools).toEqual([
+        "mcp__cowork__wiki_draft_read",
+        "mcp__cowork__wiki_read",
+      ]);
+    }
+    await client.disconnect();
+  });
+
+  it("streams text, ignores thinking, and never exposes a child session id", async () => {
+    const sdk = new FakeSdk([
+      { type: "system", subtype: "init", session_id: "child-session" },
+      thinkingDelta("hmm"),
+      textDelta("hi"),
+      thinkingDelta(""),
+      textDelta(""),
+      resultMessage(),
+    ]);
+    const { client, events } = await connectClient(sdk);
+    await client.sendMessage("hello");
+    expect(events).toEqual([
+      { type: "messageChunk", text: "hi" },
+      { type: "promptComplete" },
+    ]);
+    expect(JSON.stringify(events)).not.toContain("child-session");
+    await client.disconnect();
+  });
+
+  it("pairs tool ids and falls the name back to tool on done and error", async () => {
+    const sdk = new FakeSdk([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "t1", name: "wiki_draft_read", input: {} },
+            { type: "tool_use", id: "t2", input: {} },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "t1", is_error: false },
+            { type: "tool_result", tool_use_id: "t2", is_error: true },
+            { type: "tool_result", tool_use_id: "missing", is_error: true },
+            { type: "tool_result", is_error: false },
+          ],
+        },
+      },
+      resultMessage(),
+    ]);
+    const { client, events } = await connectClient(sdk);
+    await client.sendMessage("hello");
+    expect(events).toEqual([
+      { type: "toolCall", title: "wiki_draft_read", status: "running" },
+      { type: "toolCall", title: "tool", status: "running" },
+      { type: "toolCallUpdate", title: "wiki_draft_read", status: "done" },
+      { type: "toolCallUpdate", title: "tool", status: "error" },
+      { type: "toolCallUpdate", title: "tool", status: "error" },
+      { type: "toolCallUpdate", title: "tool", status: "done" },
+      { type: "promptComplete" },
+    ]);
+    await client.disconnect();
+  });
+
+  it("emits promptComplete on success and the failed detail or cowork_turn_failed exactly once", async () => {
+    const success = new FakeSdk([resultMessage(), textDelta("late"), resultMessage("again")]);
+    const { client, events } = await connectClient(success);
+    await client.sendMessage("hello");
+    expect(events).toEqual([{ type: "promptComplete" }]);
+    await client.disconnect();
+
+    const failed = new FakeSdk([{ type: "result", is_error: true, result: "denied" }, { type: "result", is_error: true, result: "again" }]);
+    const second = await connectClient(failed);
+    await second.client.sendMessage("hello");
+    expect(second.events).toEqual([{ type: "error", error: { message: "denied" } }]);
+    await second.client.disconnect();
+
+    const fallback = new FakeSdk([{ type: "result", is_error: true, result: { nested: true } }]);
+    const third = await connectClient(fallback);
+    await third.client.sendMessage("hello");
+    expect(third.events).toEqual([{ type: "error", error: { message: "cowork_turn_failed" } }]);
+    await third.client.disconnect();
+  });
+
+  it("emits cowork_turn_incomplete when the stream ends without a result", async () => {
+    const sdk = new FakeSdk([textDelta("hi")]);
+    const { client, events } = await connectClient(sdk);
+    await client.sendMessage("hello");
+    expect(events).toEqual([
+      { type: "messageChunk", text: "hi" },
+      { type: "error", error: { message: "cowork_turn_incomplete" } },
+    ]);
+    await client.disconnect();
+  });
+
+  it("closes the active run and emits cowork_turn_timeout exactly once after ten minutes", async () => {
+    vi.useFakeTimers();
+    const hanging = hangingRun({ throwOnClose: true });
+    const sdk = new FakeSdk();
+    sdk.startTurn.mockImplementation(async () => hanging);
+    const { client, events } = await connectClient(sdk);
+    const sending = client.sendMessage("hello");
+    await hanging.started;
+    await vi.advanceTimersByTimeAsync(TURN_WATCHDOG_MS - 1);
+    expect(events).toEqual([]);
+    expect(hanging.close).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await sending;
+    expect(events).toEqual([{ type: "error", error: { message: "cowork_turn_timeout" } }]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await client.disconnect();
+    expect(hanging.close).toHaveBeenCalledOnce();
+  });
+
+  it("cancels a hanging run as a quiet control path and resets before the next send", async () => {
+    const hanging = hangingRun();
+    const sdk = new FakeSdk();
+    sdk.startTurn
+      .mockImplementationOnce(async () => hanging)
+      .mockImplementationOnce(async () => immediateRun([resultMessage()]));
+    const { client, events } = await connectClient(sdk);
+    const sending = client.sendMessage("hello");
+    await hanging.started;
+    await client.cancelPrompt();
+    await expect(sending).resolves.toBeUndefined();
+    expect(events).toEqual([]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+
+    await client.sendMessage("again");
+    expect(events).toEqual([{ type: "promptComplete" }]);
+    expect(sdk.startTurn.mock.calls[0]?.[0].resume).toBeUndefined();
+    expect(sdk.startTurn.mock.calls[1]?.[0].resume).toBeUndefined();
+    expect(sdk.startTurn.mock.calls[1]?.[0].prompt).toBe("again");
+    await client.disconnect();
+    await client.disconnect();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("swallows a close-induced iterator throw on cancel without a terminal event", async () => {
+    const hanging = hangingRun({ throwOnClose: true });
+    const sdk = new FakeSdk();
+    sdk.startTurn
+      .mockImplementationOnce(async () => hanging)
+      .mockImplementationOnce(async () => immediateRun([resultMessage()]));
+    const { client, events } = await connectClient(sdk);
+    const sending = client.sendMessage("hello");
+    await hanging.started;
+    await client.cancelPrompt();
+    await expect(sending).resolves.toBeUndefined();
+    expect(events).toEqual([]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+
+    await client.sendMessage("again");
+    expect(events).toEqual([{ type: "promptComplete" }]);
+    expect(sdk.startTurn.mock.calls[1]?.[0].resume).toBeUndefined();
+    await client.disconnect();
+  });
+
+  it("cancels the active run and disconnects the SDK idempotently with disposed send vocabulary", async () => {
+    const hanging = hangingRun();
+    const sdk = new FakeSdk();
+    sdk.startTurn.mockImplementation(async () => hanging);
+    const { client, events } = await connectClient(sdk);
+    const sending = client.sendMessage("hello");
+    await hanging.started;
+    await client.cancelPrompt();
+    await sending;
+    expect(events).toEqual([]);
+    expect(hanging.close).toHaveBeenCalledOnce();
+    await client.disconnect();
+    await client.disconnect();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+    await expect(client.sendMessage("too late")).rejects.toThrow("cowork_session_disposed");
+  });
+
+  it("rejects iterator and startTurn failures without a duplicate terminal event", async () => {
+    const streamDied = new FakeSdk();
+    streamDied.startTurn.mockImplementation(async () => immediateRun([textDelta("hi")], new Error("stream died")));
+    const first = await connectClient(streamDied);
+    await expect(first.client.sendMessage("hello")).rejects.toThrow("stream died");
+    expect(first.events).toEqual([{ type: "messageChunk", text: "hi" }]);
+    await first.client.disconnect();
+
+    const startFailed = new FakeSdk();
+    startFailed.startTurn.mockImplementation(async () => {
+      throw new Error("start failed");
+    });
+    const second = await connectClient(startFailed);
+    await expect(second.client.sendMessage("hello")).rejects.toThrow("start failed");
+    expect(second.events).toEqual([]);
+    await second.client.disconnect();
+  });
+
+  it("rejects SDK creation during connect so the service can map provider unavailability", async () => {
+    const connector = createCoworkGatewayConnector({
+      baseUrl: () => BASE_URL,
+      createSdk: async () => {
+        throw new Error("sdk boom");
+      },
+    });
+    await expect(connector.connect(connectOptions())).rejects.toThrow("sdk boom");
+  });
+});
+
+async function connectClient(
+  sdk: FakeSdk,
+  options?: Partial<CoworkConnectOptions>,
+  baseUrl: string | null = BASE_URL,
+): Promise<{ client: CoworkAgentClient; events: unknown[] }> {
+  const connector = createCoworkGatewayConnector({
+    baseUrl: () => baseUrl,
+    createSdk: async (args) => sdk.create(args),
+  });
+  const client = await connector.connect(connectOptions(options));
+  const events: unknown[] = [];
+  listen(client, events);
+  return { client, events };
+}
+
+function listen(client: CoworkAgentClient, events: unknown[]): void {
+  client.on("messageChunk", (text) => { events.push({ type: "messageChunk", text }); });
+  client.on("toolCall", (title, status) => { events.push({ type: "toolCall", title, status }); });
+  client.on("toolCallUpdate", (title, status) => { events.push({ type: "toolCallUpdate", title, status }); });
+  client.on("promptComplete", () => { events.push({ type: "promptComplete" }); });
+  client.on("error", (error) => { events.push({ type: "error", error }); });
+}
+
+function connectOptions(overrides: Partial<CoworkConnectOptions> = {}): CoworkConnectOptions {
+  return {
+    cwd: "/tmp/cowork",
+    systemPrompt: "You are Fleet Wiki Cowork",
+    mcpServers: [{ name: "cowork", url: "http://127.0.0.1:9/mcp" }],
+    allowedToolIds: ["wiki_draft_read", "wiki_read"],
+    ...overrides,
+  };
+}
+
+class FakeSdk {
+  createArgs: unknown = null;
+  readonly configDir = "/tmp/fake";
+  readonly models = ["sonnet"];
+  readonly dispose = vi.fn(async () => undefined);
+  readonly startTurn: ReturnType<typeof vi.fn>;
+
+  constructor(stream: readonly ClaudeGatewayMessage[] = [resultMessage()]) {
+    this.startTurn = vi.fn(async (_turn: ClaudeGatewayTurn) => immediateRun(stream));
+  }
+
+  create(args: unknown): ClaudeGatewaySdk {
+    this.createArgs = args;
+    return this as unknown as ClaudeGatewaySdk;
+  }
+}
+
+function immediateRun(
+  messages: readonly ClaudeGatewayMessage[],
+  iterateError?: unknown,
+): ClaudeGatewayRun & { readonly close: ReturnType<typeof vi.fn> } {
+  const close = vi.fn();
+  return {
+    close,
+    async *[Symbol.asyncIterator]() {
+      for (const message of messages) yield message;
+      if (iterateError !== undefined) throw iterateError;
+    },
+  };
+}
+
+function hangingRun(options: { throwOnClose?: boolean } = {}): ClaudeGatewayRun & {
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly started: Promise<void>;
+} {
+  let closed = false;
+  const gate = deferred<void>();
+  const started = deferred<void>();
+  const close = vi.fn(() => {
+    closed = true;
+    gate.resolve();
+  });
+  return {
+    close,
+    started: started.promise,
+    async *[Symbol.asyncIterator]() {
+      started.resolve();
+      if (!closed) await gate.promise;
+      if (options.throwOnClose) throw new Error("run closed");
+    },
+  };
+}
+
+function resultMessage(result?: string): ClaudeGatewayMessage {
+  return {
+    type: "result",
+    is_error: false,
+    session_id: "child-session",
+    ...(result === undefined ? {} : { result }),
+  };
+}
+
+function textDelta(text: string): ClaudeGatewayMessage {
+  return { type: "stream_event", event: { type: "content_block_delta", delta: { type: "text_delta", text } } };
+}
+
+function thinkingDelta(thinking: string): ClaudeGatewayMessage {
+  return { type: "stream_event", event: { type: "content_block_delta", delta: { type: "thinking_delta", thinking } } };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/runtime/fleet-console/tests/codex-cowork-gateway-adapter.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-gateway-adapter.test.ts
@@ -231,6 +231,28 @@ describe("createCoworkGatewayConnector", () => {
     expect(sdk.dispose).toHaveBeenCalledOnce();
   });
 
+  it("remembers cancelPrompt while startTurn is pending and resets before the next send", async () => {
+    const starting = deferred<ClaudeGatewayRun>();
+    const canceled = immediateRun([textDelta("late"), resultMessage()]);
+    const sdk = new FakeSdk();
+    sdk.startTurn
+      .mockImplementationOnce(async () => starting.promise)
+      .mockImplementationOnce(async () => immediateRun([resultMessage()]));
+    const { client, events } = await connectClient(sdk);
+    const sending = client.sendMessage("hello");
+    await vi.waitFor(() => expect(sdk.startTurn).toHaveBeenCalledOnce());
+    await client.cancelPrompt();
+    starting.resolve(canceled);
+    await expect(sending).resolves.toBeUndefined();
+    expect(events).toEqual([]);
+    expect(canceled.close).toHaveBeenCalledOnce();
+
+    await client.sendMessage("again");
+    expect(events).toEqual([{ type: "promptComplete" }]);
+    expect(sdk.startTurn.mock.calls[1]?.[0].prompt).toBe("again");
+    await client.disconnect();
+  });
+
   it("swallows a close-induced iterator throw on cancel without a terminal event", async () => {
     const hanging = hangingRun({ throwOnClose: true });
     const sdk = new FakeSdk();

--- a/runtime/fleet-plugins/scuttlebutt/server/chat-session.ts
+++ b/runtime/fleet-plugins/scuttlebutt/server/chat-session.ts
@@ -1,7 +1,8 @@
 import {
+  createClaudeExecutionLoop,
   createClaudeGatewaySdk,
-  type ClaudeGatewayMessage,
-  type ClaudeGatewayRun,
+  type ClaudeExecutionEvent,
+  type ClaudeExecutionLoop,
   type ClaudeGatewaySdk,
 } from "@dotobokuri/core-agent/claude";
 
@@ -21,8 +22,7 @@ export const SCUTTLEBUTT_AGENT = {
  *
  * `tools`가 내장 툴의 기본 집합을 이 둘로 잘라내므로 파일·셸 도구는 아예 존재하지 않게 된다.
  * `allowedTools`는 그 둘을 물어보지 않고 쓰게 하고, `dontAsk`는 그 밖의 무엇이든 승인을 기다리지
- * 않고 거부한다 — 헤드리스에서 승인 대기는 곧 멈춘 대화다. 세 값은 하나의 경계이며, 앞선 ACP
- * 권한 분류기가 도구 이름 없이 `kind`와 입력 모양으로 추측하던 것을 구조로 대체한다.
+ * 않고 거부한다 — 헤드리스에서 승인 대기는 곧 멈춘 대화다. 세 값은 하나의 경계다.
  */
 export const PET_TOOLS = ["WebSearch", "WebFetch"] as const;
 
@@ -181,57 +181,17 @@ export interface ChatSessionLike {
 
 export class ChatSession implements ChatSessionLike {
   private readonly options: ChatSessionOptions;
-  private sdk: ClaudeGatewaySdk | null = null;
-  private run: ClaudeGatewayRun | null = null;
-  /** 같은 대화를 이어 가기 위한 자식 세션 id. 첫 턴이 알려 준다. */
-  private resumeId: string | null = null;
-  private started = false;
-  private disposed = false;
-  private turn: Promise<void> = Promise.resolve();
-  private disposeFlight: Promise<void> | null = null;
+  private readonly loop: ClaudeExecutionLoop;
 
   constructor(options: ChatSessionOptions) {
     this.options = { ...options };
-  }
-
-  async start(): Promise<void> {
-    if (this.disposed) throw new Error("Session disposed");
-    if (this.started) return;
-    const create = { baseUrl: this.options.baseUrl, models: [SCUTTLEBUTT_AGENT.model] };
-    const sdk = await (this.options.createSdk?.(create) ?? createClaudeGatewaySdk(create));
-    if (this.disposed) {
-      await sdk.dispose().catch(() => undefined);
-      throw new Error("Session disposed");
-    }
-    this.sdk = sdk;
-    this.started = true;
-  }
-
-  send(text: string): Promise<void> {
-    if (this.disposed) return Promise.reject(new Error("Session disposed"));
-    if (!this.started || !this.sdk) return Promise.reject(new Error("Session not started"));
-    if (!text.trim()) return Promise.reject(new Error("Message required"));
-    const run = this.turn.then(() => this.runTurn(text));
-    this.turn = run.catch(() => undefined);
-    return run;
-  }
-
-  dispose(): Promise<void> {
-    if (this.disposeFlight) return this.disposeFlight;
-    this.disposed = true;
-    this.disposeFlight = this.disposeResources();
-    return this.disposeFlight;
-  }
-
-  private async runTurn(text: string): Promise<void> {
-    const sdk = this.sdk;
-    if (!sdk) throw new Error("Session not started");
-    const emit = (event: ChatEvent): void => this.options.onEvent?.(event);
     const redact = (value: string) => redactScratchPath(value, this.options.cwd);
-    let run: ClaudeGatewayRun;
-    try {
-      run = await sdk.startTurn({
-        prompt: text,
+    this.loop = createClaudeExecutionLoop({
+      createSdk: () => {
+        const create = { baseUrl: this.options.baseUrl, models: [SCUTTLEBUTT_AGENT.model] };
+        return this.options.createSdk?.(create) ?? createClaudeGatewaySdk(create);
+      },
+      buildTurn: () => ({
         model: SCUTTLEBUTT_AGENT.model,
         effort: SCUTTLEBUTT_AGENT.effort,
         systemPrompt: { mode: "replace", text: ADMIRAL_SYSTEM_PROMPTS[this.options.admiral] },
@@ -241,82 +201,66 @@ export class ChatSession implements ChatSessionLike {
         permissionMode: "dontAsk",
         // 텍스트를 흘려 보내려면 부분 메시지가 필요하다. SSE `chunk` 계약이 그것으로 만들어진다.
         includePartialMessages: true,
-        ...(this.resumeId === null ? {} : { resume: this.resumeId }),
-      });
-    } catch (error) {
-      emit({ type: "error", error: { code: "chat_error", message: redact(message(error)) } });
-      throw error;
-    }
-    this.run = run;
-    const toolNames = new Map<string, string>();
-    try {
-      for await (const event of run) {
-        if (typeof event.session_id === "string" && this.resumeId === null) this.resumeId = event.session_id;
-        for (const mapped of toChatEvents(event, toolNames, redact)) emit(mapped);
-      }
-    } catch (error) {
-      if (this.disposed) return;
-      emit({ type: "error", error: { code: "chat_error", message: redact(message(error)) } });
-      throw error;
-    } finally {
-      if (this.run === run) this.run = null;
-    }
+      }),
+      continuation: { kind: "resume-child" },
+      settlement: { kind: "result" },
+      onEvent: (event) => {
+        for (const mapped of toChatEvents(event, redact)) this.options.onEvent?.(mapped);
+      },
+    });
   }
 
-  private async disposeResources(): Promise<void> {
-    this.run?.close();
-    this.run = null;
-    await this.turn.catch(() => undefined);
-    const sdk = this.sdk;
-    this.sdk = null;
-    this.started = false;
-    await sdk?.dispose().catch(() => undefined);
+  start(): Promise<void> {
+    return this.loop.start();
+  }
+
+  send(text: string): Promise<void> {
+    return this.loop.run(text).catch((error: unknown) => {
+      if (!isLifecycleError(error)) {
+        const redact = (value: string) => redactScratchPath(value, this.options.cwd);
+        this.options.onEvent?.({
+          type: "error",
+          error: { code: "chat_error", message: redact(message(error)) },
+        });
+      }
+      throw error;
+    });
+  }
+
+  dispose(): Promise<void> {
+    return this.loop.dispose();
   }
 }
 
 /**
- * 자식이 흘리는 메시지를 이 플러그인의 SSE 계약(chunk/tool/complete/error)으로 옮긴다.
+ * 공통 실행 이벤트를 이 플러그인의 SSE 계약(chunk/tool/complete/error)으로 옮긴다.
  *
- * 모양은 실측으로 고정했다. 텍스트는 `stream_event`의 `content_block_delta` 중 `text_delta`로만
- * 오고, 같은 자리에 `thinking_delta`도 섞여 온다 — 그것까지 흘리면 펫이 생각을 소리내어 말하게
- * 되므로 텍스트만 고른다. 도구는 assistant 메시지의 `tool_use` 블록으로 시작해 user 메시지의
- * `tool_result`로 끝나고, 이름은 앞쪽에만 실려 있어 id로 짝지어 둔다.
+ * 텍스트만 흘린다. 사고는 같은 채널로 오지만 펫이 생각을 소리내어 말하게 되므로 버린다.
+ * 도구 시작은 기존 제목 규칙을 쓰고, 끝은 디코더가 짝지은 이름(없으면 `tool`)을 쓴다.
+ * 실패한 결과는 상세가 없으면 "Chat turn failed"다. 세션 id는 실리지 않는다.
  */
 export function toChatEvents(
-  event: ClaudeGatewayMessage,
-  toolNames: Map<string, string>,
+  event: ClaudeExecutionEvent,
   redact: (value: string) => string,
 ): readonly ChatEvent[] {
-  if (event.type === "stream_event") {
-    const inner = record(event.event);
-    if (inner.type !== "content_block_delta") return [];
-    const delta = record(inner.delta);
-    if (delta.type !== "text_delta" || typeof delta.text !== "string" || delta.text.length === 0) return [];
-    return [{ type: "chunk", text: redact(delta.text) }];
+  if (event.kind === "text") return [{ type: "chunk", text: redact(event.text) }];
+  if (event.kind === "thinking") return [];
+  if (event.kind === "tool-start") {
+    return [{ type: "tool", title: redact(toolTitle(event.name, event.input)), status: "running" }];
   }
-  if (event.type === "assistant") {
-    const events: ChatEvent[] = [];
-    for (const block of blocks(event.message)) {
-      if (block.type !== "tool_use") continue;
-      const name = typeof block.name === "string" ? block.name : "tool";
-      if (typeof block.id === "string") toolNames.set(block.id, name);
-      events.push({ type: "tool", title: redact(toolTitle(name, block.input)), status: "running" });
-    }
-    return events;
+  if (event.kind === "tool-end") {
+    return [{
+      type: "tool",
+      title: redact(event.name ?? "tool"),
+      status: event.isError ? "error" : "done",
+    }];
   }
-  if (event.type === "user") {
-    const events: ChatEvent[] = [];
-    for (const block of blocks(event.message)) {
-      if (block.type !== "tool_result") continue;
-      const name = typeof block.tool_use_id === "string" ? toolNames.get(block.tool_use_id) ?? "tool" : "tool";
-      events.push({ type: "tool", title: redact(name), status: block.is_error === true ? "error" : "done" });
-    }
-    return events;
-  }
-  if (event.type === "result") {
-    if (event.is_error === true) {
-      const detail = typeof event.result === "string" ? event.result : "Chat turn failed";
-      return [{ type: "error", error: { code: "chat_error", message: redact(detail) } }];
+  if (event.kind === "result") {
+    if (event.isError) {
+      return [{
+        type: "error",
+        error: { code: "chat_error", message: redact(event.detail ?? "Chat turn failed") },
+      }];
     }
     return [{ type: "complete" }];
   }
@@ -332,9 +276,9 @@ function toolTitle(name: string, input: unknown): string {
   return name;
 }
 
-function blocks(message: unknown): readonly Record<string, unknown>[] {
-  const content = record(message).content;
-  return Array.isArray(content) ? content.map(record) : [];
+function isLifecycleError(error: unknown): boolean {
+  const text = message(error);
+  return text === "Session disposed" || text === "Session not started" || text === "Message required";
 }
 
 function message(error: unknown): string {

--- a/runtime/fleet-plugins/scuttlebutt/tests/chat-session.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/chat-session.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { ClaudeGatewayMessage, ClaudeGatewaySdk, ClaudeGatewayTurn } from "@dotobokuri/core-agent/claude";
+import type {
+  ClaudeExecutionEvent,
+  ClaudeGatewayMessage,
+  ClaudeGatewayRun,
+  ClaudeGatewaySdk,
+  ClaudeGatewayTurn,
+} from "@dotobokuri/core-agent/claude";
 
 import {
   ADMIRAL_SYSTEM_PROMPTS,
@@ -16,15 +22,14 @@ const BASE_URL = "http://127.0.0.1:43210/plugins/terminal/ai-gateway";
 
 describe("Scuttlebutt tool boundary", () => {
   it("cuts the built-in tool set down to the two web tools and never waits for approval", async () => {
-    // 오늘의 ACP 권한 분류기는 도구 이름 없이 kind와 입력 모양으로 추측했다. 이제는 파일·셸 도구가
-    // 아예 존재하지 않는다 — 실측하면 자식의 system/init이 여기 준 목록 그대로를 보고한다.
     const { session, sdk } = fakeSession();
     await session.start();
     await session.send("hello");
     const turn = sdk.startTurn.mock.calls[0]?.[0] as ClaudeGatewayTurn;
     expect(turn.tools).toEqual(["WebSearch", "WebFetch"]);
     expect(turn.allowedTools).toEqual(["WebSearch", "WebFetch"]);
-    // 승인 대기는 헤드리스에서 멈춘 대화와 같다. 미승인 도구는 물어보지 않고 거부한다.
+    expect(turn.tools).not.toBe(PET_TOOLS);
+    expect(turn.allowedTools).not.toBe(PET_TOOLS);
     expect(turn.permissionMode).toBe("dontAsk");
     expect(PET_TOOLS).toEqual(["WebSearch", "WebFetch"]);
   });
@@ -37,11 +42,17 @@ describe("ChatSession", () => {
     expect(sdk.createArgs).toEqual({ baseUrl: BASE_URL, models: ["sonnet"] });
 
     await session.send("hello");
-    const turn = sdk.startTurn.mock.calls[0]?.[0] as ClaudeGatewayTurn;
-    expect(turn.model).toBe("sonnet");
-    expect(turn.effort).toBe("low");
-    expect(turn.cwd).toBe(CWD);
-    expect(turn.systemPrompt).toEqual({ mode: "replace", text: ADMIRAL_SYSTEM_PROMPTS.bori });
+    expect(sdk.startTurn.mock.calls[0]?.[0]).toEqual({
+      prompt: "hello",
+      model: "sonnet",
+      effort: "low",
+      systemPrompt: { mode: "replace", text: ADMIRAL_SYSTEM_PROMPTS.bori },
+      cwd: CWD,
+      tools: ["WebSearch", "WebFetch"],
+      allowedTools: ["WebSearch", "WebFetch"],
+      permissionMode: "dontAsk",
+      includePartialMessages: true,
+    });
   });
 
   it("continues the same conversation by resuming the child's session", async () => {
@@ -84,9 +95,184 @@ describe("ChatSession", () => {
     ]);
   });
 
-  it("disposes the SDK instance and its isolated directory", async () => {
+  it("falls a failed result without detail back to Chat turn failed", async () => {
+    const events: ChatEvent[] = [];
+    const { session } = fakeSession({
+      onEvent: (event) => events.push(event),
+      stream: [{ type: "result", is_error: true }],
+    });
+    await session.start();
+    await session.send("hello");
+    expect(events).toEqual([
+      { type: "error", error: { code: "chat_error", message: "Chat turn failed" } },
+    ]);
+  });
+
+  it("drops thinking from the session stream and keeps only assistant text", async () => {
+    const events: ChatEvent[] = [];
+    const { session } = fakeSession({
+      onEvent: (event) => events.push(event),
+      stream: [
+        thinkingDelta("hmm"),
+        textDelta("hi"),
+        { type: "result", is_error: false },
+      ],
+    });
+    await session.start();
+    await session.send("hello");
+    expect(events).toEqual([{ type: "chunk", text: "hi" }, { type: "complete" }]);
+  });
+
+  it("correlates a tool result name through the common decoder id", async () => {
+    const events: ChatEvent[] = [];
+    const { session } = fakeSession({
+      onEvent: (event) => events.push(event),
+      stream: [
+        {
+          type: "assistant",
+          message: { content: [{ type: "tool_use", id: "t1", name: "WebSearch", input: { query: "fleet console" } }] },
+        },
+        {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "t1", is_error: false }] },
+        },
+        { type: "result", is_error: false },
+      ],
+    });
+    await session.start();
+    await session.send("hello");
+    expect(events).toEqual([
+      { type: "tool", title: "WebSearch: fleet console", status: "running" },
+      { type: "tool", title: "WebSearch", status: "done" },
+      { type: "complete" },
+    ]);
+  });
+
+  it("emits nothing for message kinds the SSE contract has no event for", async () => {
+    const events: ChatEvent[] = [];
+    const { session } = fakeSession({
+      onEvent: (event) => events.push(event),
+      stream: [
+        { type: "system", subtype: "init", session_id: "child-session" },
+        { type: "rate_limit_event" },
+        { type: "stream_event" },
+        { type: "result", is_error: false },
+      ],
+    });
+    await session.start();
+    await session.send("hello");
+    expect(events).toEqual([{ type: "complete" }]);
+  });
+
+  it("runs queued prompts in call order and recovers after a failed turn", async () => {
+    const order: string[] = [];
+    const firstTurn = deferred<void>();
+    const events: ChatEvent[] = [];
+    const { session, sdk } = fakeSession({
+      onEvent: (event) => events.push(event),
+      startTurn: async (turn) => {
+        order.push(turn.prompt);
+        if (turn.prompt === "first") await firstTurn.promise;
+        if (turn.prompt === "bad") throw new Error(`denied at ${CWD}`);
+        return immediateRun([
+          { type: "system", subtype: "init", session_id: "child-session" },
+          { type: "result", is_error: false, session_id: "child-session" },
+        ]);
+      },
+    });
+    await session.start();
+    const first = session.send("first");
+    const second = session.send("second");
+    await vi.waitFor(() => expect(order).toEqual(["first"]));
+    firstTurn.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first", "second"]);
+
+    await expect(session.send("bad")).rejects.toThrow(`denied at ${CWD}`);
+    await session.send("good");
+    expect(order).toEqual(["first", "second", "bad", "good"]);
+    expect(events.filter((event) => event.type === "error")).toEqual([
+      { type: "error", error: { code: "chat_error", message: "denied at [workspace]" } },
+    ]);
+    expect(sdk.startTurn.mock.calls.map((call) => call[0].prompt)).toEqual([
+      "first",
+      "second",
+      "bad",
+      "good",
+    ]);
+  });
+
+  it("emits one redacted chat_error and rejects send when the iterator fails", async () => {
+    const events: ChatEvent[] = [];
+    const { session } = fakeSession({
+      onEvent: (event) => events.push(event),
+      startTurn: async () => immediateRun(
+        [textDelta(`See ${CWD}/result.md`)],
+        new Error(`stream died at ${CWD}`),
+      ),
+    });
+    await session.start();
+    await expect(session.send("hello")).rejects.toThrow(`stream died at ${CWD}`);
+    expect(events).toEqual([
+      { type: "chunk", text: "See [workspace]/result.md" },
+      { type: "error", error: { code: "chat_error", message: "stream died at [workspace]" } },
+    ]);
+  });
+
+  it("emits one redacted chat_error and rejects send when onEvent throws", async () => {
+    const events: ChatEvent[] = [];
+    const { session } = fakeSession({
+      onEvent: (event) => {
+        events.push(event);
+        if (event.type === "chunk") throw new Error(`listener failed at ${CWD}`);
+      },
+      stream: [textDelta("hi"), { type: "result", is_error: false }],
+    });
+    await session.start();
+    await expect(session.send("hello")).rejects.toThrow(`listener failed at ${CWD}`);
+    expect(events).toEqual([
+      { type: "chunk", text: "hi" },
+      { type: "error", error: { code: "chat_error", message: "listener failed at [workspace]" } },
+    ]);
+  });
+
+  it("suppresses a disposal-induced turn failure and disposes the SDK once", async () => {
+    const events: ChatEvent[] = [];
+    const hanging = hangingRun({ throwOnClose: true });
+    const { session, sdk } = fakeSession({
+      onEvent: (event) => events.push(event),
+      startTurn: async () => hanging,
+    });
+    await session.start();
+    const sending = session.send("hello");
+    await hanging.started;
+    await session.dispose();
+    await expect(sending).resolves.toBeUndefined();
+    expect(events).toEqual([]);
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+    await session.dispose();
+    expect(sdk.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("keeps public start and send error strings and does not emit for them", async () => {
+    const events: ChatEvent[] = [];
+    const { session } = fakeSession({ onEvent: (event) => events.push(event) });
+    await expect(session.send("hello")).rejects.toThrow("Session not started");
+    await session.start();
+    await expect(session.send("")).rejects.toThrow("Message required");
+    await expect(session.send("   \n\t")).rejects.toThrow("Message required");
+    await session.dispose();
+    await expect(session.send("hello")).rejects.toThrow("Session disposed");
+    await expect(session.start()).rejects.toThrow("Session disposed");
+    expect(events).toEqual([]);
+  });
+
+  it("creates the SDK once across idempotent start and dispose", async () => {
     const { session, sdk } = fakeSession();
     await session.start();
+    await session.start();
+    expect(sdk.createCalls).toBe(1);
+    await session.dispose();
     await session.dispose();
     expect(sdk.dispose).toHaveBeenCalledOnce();
     await expect(session.send("hello")).rejects.toThrow(/disposed/i);
@@ -128,37 +314,53 @@ describe("toChatEvents", () => {
   const identity = (value: string): string => value;
 
   it("streams assistant text and drops thinking from the same delta channel", () => {
-    // 두 종류가 같은 자리로 온다. 생각까지 흘리면 펫이 혼잣말을 소리내어 하게 된다.
-    expect(toChatEvents(textDelta("hi"), new Map(), identity)).toEqual([{ type: "chunk", text: "hi" }]);
-    expect(toChatEvents(thinkingDelta("hmm"), new Map(), identity)).toEqual([]);
+    expect(toChatEvents({ kind: "text", text: "hi" }, identity)).toEqual([{ type: "chunk", text: "hi" }]);
+    expect(toChatEvents({ kind: "thinking", text: "hmm" }, identity)).toEqual([]);
   });
 
-  it("pairs a tool call with its result through the id the start block carries", () => {
-    const names = new Map<string, string>();
-    const started = toChatEvents({
-      type: "assistant",
-      message: { content: [{ type: "tool_use", id: "t1", name: "WebSearch", input: { query: "fleet console" } }] },
-    }, names, identity);
-    expect(started).toEqual([{ type: "tool", title: "WebSearch: fleet console", status: "running" }]);
-
-    const finished = toChatEvents({
-      type: "user",
-      message: { content: [{ type: "tool_result", tool_use_id: "t1", is_error: false }] },
-    }, names, identity);
-    expect(finished).toEqual([{ type: "tool", title: "WebSearch", status: "done" }]);
-  });
-
-  it("marks a failed tool result rather than reporting it as done", () => {
-    const names = new Map([["t1", "WebFetch"]]);
+  it("maps a tool start through the existing title rule", () => {
     expect(toChatEvents({
-      type: "user",
-      message: { content: [{ type: "tool_result", tool_use_id: "t1", is_error: true }] },
-    }, names, identity)).toEqual([{ type: "tool", title: "WebFetch", status: "error" }]);
+      kind: "tool-start",
+      id: "t1",
+      name: "WebSearch",
+      input: { query: "fleet console" },
+    }, identity)).toEqual([{ type: "tool", title: "WebSearch: fleet console", status: "running" }]);
   });
 
-  it("ignores the message kinds the SSE contract has no event for", () => {
-    for (const type of ["system", "rate_limit_event", "stream_event"]) {
-      expect(toChatEvents({ type }, new Map(), identity)).toEqual([]);
+  it("maps a tool end using the name the common decoder correlated", () => {
+    expect(toChatEvents({
+      kind: "tool-end",
+      id: "t1",
+      name: "WebSearch",
+      isError: false,
+    }, identity)).toEqual([{ type: "tool", title: "WebSearch", status: "done" }]);
+  });
+
+  it("falls a missing tool-end name back to tool and marks a failed result", () => {
+    expect(toChatEvents({ kind: "tool-end", isError: true }, identity)).toEqual([
+      { type: "tool", title: "tool", status: "error" },
+    ]);
+  });
+
+  it("completes a successful result and uses the exact failure fallback", () => {
+    expect(toChatEvents({ kind: "result", isError: false, source: "message" }, identity)).toEqual([
+      { type: "complete" },
+    ]);
+    expect(toChatEvents({ kind: "result", isError: true, source: "message" }, identity)).toEqual([
+      { type: "error", error: { code: "chat_error", message: "Chat turn failed" } },
+    ]);
+    expect(toChatEvents({ kind: "result", isError: true, detail: `denied at ${CWD}`, source: "message" }, identity))
+      .toEqual([{ type: "error", error: { code: "chat_error", message: `denied at ${CWD}` } }]);
+  });
+
+  it("maps synthetic failed results through the same fallback", () => {
+    for (const event of [
+      { kind: "result", isError: true, source: "incomplete" },
+      { kind: "result", isError: true, source: "watchdog" },
+    ] satisfies ClaudeExecutionEvent[]) {
+      expect(toChatEvents(event, identity)).toEqual([
+        { type: "error", error: { code: "chat_error", message: "Chat turn failed" } },
+      ]);
     }
   });
 });
@@ -175,12 +377,13 @@ function fakeSession(overrides: {
   admiral?: "tori" | "bori" | "dori";
   onEvent?: (event: ChatEvent) => void;
   stream?: readonly ClaudeGatewayMessage[];
+  startTurn?: (turn: ClaudeGatewayTurn) => Promise<ClaudeGatewayRun>;
 } = {}): { session: ChatSession; sdk: FakeSdk } {
   const stream = overrides.stream ?? [
     { type: "system", subtype: "init", session_id: "child-session" },
     { type: "result", subtype: "success", is_error: false, session_id: "child-session" },
   ];
-  const sdk = new FakeSdk(stream);
+  const sdk = new FakeSdk(overrides.startTurn ?? (async () => immediateRun(stream)));
   const session = new ChatSession({
     cwd: CWD,
     admiral: overrides.admiral ?? "tori",
@@ -194,22 +397,66 @@ function fakeSession(overrides: {
 class FakeSdk {
   /** 세션이 조립해 넘긴 생성 인자. 관측 대상이므로 지어내지 않는다. */
   createArgs: unknown = null;
+  createCalls = 0;
   readonly configDir = "/tmp/fake";
   readonly models = ["sonnet"];
   readonly dispose = vi.fn(async () => undefined);
   readonly startTurn: ReturnType<typeof vi.fn>;
 
-  constructor(stream: readonly ClaudeGatewayMessage[]) {
-    this.startTurn = vi.fn(async (_turn: ClaudeGatewayTurn) => ({
-      [Symbol.asyncIterator]: async function* () {
-        for (const message of stream) yield message;
-      },
-      close: () => {},
-    }));
+  constructor(startTurn: (turn: ClaudeGatewayTurn) => Promise<ClaudeGatewayRun>) {
+    this.startTurn = vi.fn(startTurn);
   }
 
   create(args: unknown): ClaudeGatewaySdk {
+    this.createCalls += 1;
     this.createArgs = args;
     return this as unknown as ClaudeGatewaySdk;
   }
+}
+
+function immediateRun(
+  messages: readonly ClaudeGatewayMessage[],
+  iterateError?: unknown,
+): ClaudeGatewayRun {
+  return {
+    close() {},
+    async *[Symbol.asyncIterator]() {
+      for (const message of messages) yield message;
+      if (iterateError !== undefined) throw iterateError;
+    },
+  };
+}
+
+function hangingRun(options: { throwOnClose?: boolean } = {}): ClaudeGatewayRun & {
+  readonly started: Promise<void>;
+} {
+  let closed = false;
+  const gate = deferred<void>();
+  const started = deferred<void>();
+  return {
+    started: started.promise,
+    close() {
+      closed = true;
+      gate.resolve();
+    },
+    async *[Symbol.asyncIterator]() {
+      started.resolve();
+      if (!closed) await gate.promise;
+      if (options.throwOnClose) throw new Error("run closed");
+    },
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }

--- a/scripts/check-claude-agent-sdk-boundary.mjs
+++ b/scripts/check-claude-agent-sdk-boundary.mjs
@@ -30,8 +30,9 @@ const REFERENCE = new RegExp(`["']${VENDOR_SDK.replace(/[.*+?^${}()|[\]\\]/g, "\
  * 죽은 예외가 남아 있으면 다음 사람이 그 경로를 "이미 허용된 곳"으로 읽고 창구를 되살린다.
  */
 const ALLOWED = [
-  // 이 리포가 vendor SDK를 부르는 유일한 신규 지점.
+  // 이 리포가 vendor SDK를 부르는 유일한 production 지점과 그 wrapper-only 단위 테스트.
   "packages/core-agent/src/claude/vendor-sdk.ts",
+  "packages/core-agent/tests/claude-vendor-sdk.test.ts",
   "packages/core-agent/package.json",
   // 선존: Console은 소스에서 부르지 않지만 게시 매니페스트 external 해석을 위해 선언한다.
   "runtime/fleet-console/package.json",

--- a/scripts/check-claude-agent-sdk-boundary.test.mjs
+++ b/scripts/check-claude-agent-sdk-boundary.test.mjs
@@ -49,10 +49,22 @@ test("a consumer declaring the vendor SDK in its manifest is reported", () => {
   ]);
 });
 
-test("an allowed path is not reported", () => {
+test("an allowed production path is not reported", () => {
   const allowed = "packages/core-agent/src/claude/vendor-sdk.ts";
   const root = fixture({ [allowed]: `import { query } from "${VENDOR_SDK}";\n` });
   assert.deepEqual(findVendorSdkBoundaryViolations(root, [allowed]), []);
+});
+
+test("an exact wrapper test mock is allowed without opening consumer tests", () => {
+  const allowed = "packages/core-agent/tests/claude-vendor-sdk.test.ts";
+  const consumer = "packages/some-consumer/tests/vendor.test.ts";
+  const root = fixture({
+    [allowed]: `vi.mock("${VENDOR_SDK}", () => ({}));\n`,
+    [consumer]: `vi.mock("${VENDOR_SDK}", () => ({}));\n`,
+  });
+  assert.deepEqual(findVendorSdkBoundaryViolations(root, [allowed]), [
+    { kind: "unexpected", path: `${consumer}:1` },
+  ]);
 });
 
 test("an allowlist entry that no longer references the vendor SDK is reported as stale", () => {


### PR DESCRIPTION
## Summary

- centralize Claude SDK ownership, queued turns, continuation, settlement, cancellation, cleanup, and normalized execution events under `@dotobokuri/core-agent/claude`
- migrate Session Analyst, Scuttlebutt, and Cowork while preserving each product's prompt, tool, permission, event, redaction, and durability policies
- remove duplicate stream parsers and retired ACP connection flags, with regression coverage for lifecycle races and package boundaries

## Type of Change

- [ ] feat — new feature or carrier capability
- [ ] fix — bug fix
- [ ] docs — documentation only
- [x] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `packages/core-agent`
- [x] `packages/fleet-analyst`
- [x] `packages/fleet-wiki`
- [x] Fleet Console and Scuttlebutt host adapters
- [x] Repository boundary gates

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-agent test` — 117 passed
- [x] Analyst, Scuttlebutt, and Fleet Wiki test/typecheck/build suites
- [x] Terminal plugin test suite — 684 passed
- [x] Fleet Console Cowork-targeted suite — 45 passed
- [x] Fleet Console full suite — 2,085 passed, 24 skipped
- [x] repository `build` followed by `typecheck`
- [x] Claude SDK boundary, core boundary, retired core-unified-agent absence, and 53 script tests

## Notes for Reviewers

The newer Terminal Chat Mode has a distinct transcript copy-in/write-back and durable provider-session contract, so this refactor intentionally limits migration to Session Analyst, Scuttlebutt, and Cowork.