### PR TITLE
feat(fleet-console): attach a 28px window caption above panels

### DIFF
--- a/.changelog.d/window-caption-b.md
+++ b/.changelog.d/window-caption-b.md
@@ -4,5 +4,5 @@ branch: window-caption-b
 
 ### fleet-console
 #### Changed
-- Operation and Activity Rail panels now carry a 28px window caption above the existing body. Tactical, War Room, and maximize keep that caption outside the body by shifting the slot down. Dragging moves from the caption, not a strip inside the panel. The body and PTY keep their previous size.
-  ko: Operation과 Activity Rail 패널이 기존 본문 위에 28px 창 캡션을 붙입니다. Tactical·War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 패널 이동은 본문 안 띠가 아니라 캡션에서 합니다. 본문과 PTY 크기는 그대로입니다.
+- Operation and Activity Rail panels now carry a 28px window caption above the existing body. Tactical, War Room, and maximize keep that caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click. The body and PTY keep their previous size.
+  ko: Operation과 Activity Rail 패널이 기존 본문 위에 28px 창 캡션을 붙입니다. Tactical·War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다. 본문과 PTY 크기는 그대로입니다.

--- a/.changelog.d/window-caption-b.md
+++ b/.changelog.d/window-caption-b.md
@@ -4,5 +4,5 @@ branch: window-caption-b
 
 ### fleet-console
 #### Changed
-- Operation and Activity Rail panels now carry a 28px window caption above the existing body. Tactical, War Room, and maximize keep that caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click. The body and PTY keep their previous size.
-  ko: Operation과 Activity Rail 패널이 기존 본문 위에 28px 창 캡션을 붙입니다. Tactical·War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다. 본문과 PTY 크기는 그대로입니다.
+- Operation panels now carry a 28px window caption above the existing body, so the PTY keeps its previous size. The Activity Rail uses the same caption inside its slot. Tactical, War Room, and maximize keep the Operation caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click.
+  ko: Operation 패널은 기존 본문 위에 28px 창 캡션을 붙여 PTY 크기를 유지합니다. Activity Rail은 같은 캡션을 슬롯 안에 둡니다. Tactical·War Room·최대화는 슬롯을 내려 Operation 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다.

--- a/.changelog.d/window-caption-b.md
+++ b/.changelog.d/window-caption-b.md
@@ -1,0 +1,8 @@
+---
+branch: window-caption-b
+---
+
+### fleet-console
+#### Changed
+- Operation and Activity Rail panels now carry a 28px window caption above the existing body. Minimize, maximize, and close stay visible; the body and PTY keep their previous size.
+  ko: Operation과 Activity Rail 패널이 기존 본문 위에 28px 창 캡션을 붙입니다. 최소화·최대화·닫기는 항상 보이고, 본문과 PTY 크기는 그대로입니다.

--- a/.changelog.d/window-caption-b.md
+++ b/.changelog.d/window-caption-b.md
@@ -4,5 +4,5 @@ branch: window-caption-b
 
 ### fleet-console
 #### Changed
-- Operation and Activity Rail panels now carry a 28px window caption above the existing body. Minimize, maximize, and close stay visible; the body and PTY keep their previous size.
-  ko: Operation과 Activity Rail 패널이 기존 본문 위에 28px 창 캡션을 붙입니다. 최소화·최대화·닫기는 항상 보이고, 본문과 PTY 크기는 그대로입니다.
+- Operation and Activity Rail panels now carry a 28px window caption above the existing body. Tactical, War Room, and maximize keep that caption outside the body by shifting the slot down. Dragging moves from the caption, not a strip inside the panel. The body and PTY keep their previous size.
+  ko: Operation과 Activity Rail 패널이 기존 본문 위에 28px 창 캡션을 붙입니다. Tactical·War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 패널 이동은 본문 안 띠가 아니라 캡션에서 합니다. 본문과 PTY 크기는 그대로입니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -722,13 +722,13 @@ export function OperationsCanvas({
     : formationOperationIds.length;
   const formationSlotArea = {
     x: 18,
-    y: 18,
+    y: 18 + TITLEBAR_OUTSET_PX,
     width: Math.max(0, canvasSize.width - 36),
-    height: Math.max(0, canvasSize.height - 36),
+    height: Math.max(0, canvasSize.height - 36 - TITLEBAR_OUTSET_PX),
   };
   const allFormationSlots = formationView
     ? calculateGridSlots(
-        { x: 0, y: 0, width: canvasSize.width, height: canvasSize.height },
+        { x: 0, y: TITLEBAR_OUTSET_PX, width: canvasSize.width, height: canvasSize.height - TITLEBAR_OUTSET_PX },
         formationCellCount,
         undefined,
         undefined,
@@ -874,8 +874,8 @@ export function OperationsCanvas({
               ? modeSlotGeometryFor(formationSlotArea, 0, companionSlotCount, 8, topPanelZIndex)
               : companionGeometryFor(canvasSize, 0, companionSlotCount, topPanelZIndex)
             : formationSlot ? { ...baseGeometry, ...formationSlot } : baseGeometry;
-          // 보더 위 캡션(top: -28px)이 캔버스 상단 클립에 잘리는 뷰포트-상대 위치면 본문 위 오버레이로 전환한다.
-          // 최대화/Formation은 전용 CSS 오버레이 규칙이 이미 소유한다. 어느 쪽이든 본문·PTY geometry는 그대로다.
+          // 보더 위 캡션(top: -28px)이 캔버스 상단 클립에 잘리는 뷰포트-상대 위치.
+          // Tactical/War Room/최대화는 슬롯을 28px 내려 캡션을 밖에 둔다. 본문·PTY geometry는 그대로다.
           const topEdge = !operationTriageStage && !operationMaximized && !operationCompanion && !formationSlot
             && canvas.viewport.y + frameGeometry.y * effectiveZoom < TITLEBAR_OUTSET_PX * effectiveZoom;
           return renderPluginOperation(operation, {
@@ -1139,9 +1139,9 @@ function ensurePluginGeometry(operation: OperationNode): OperationGeometry {
 function maximizedGeometryFor(canvasSize: { readonly width: number; readonly height: number }, zIndex: number): OperationGeometry {
   return {
     x: 0,
-    y: 0,
+    y: TITLEBAR_OUTSET_PX,
     width: Math.max(320, canvasSize.width),
-    height: Math.max(240, canvasSize.height),
+    height: Math.max(240, canvasSize.height - TITLEBAR_OUTSET_PX),
     zIndex,
   };
 }
@@ -1154,9 +1154,9 @@ function companionGeometryFor(canvasSize: { readonly width: number; readonly hei
   const width = Math.max(0, (canvasSize.width - gap * (count - 1)) / count);
   return {
     x: slotIndex * (width + gap),
-    y: 0,
+    y: TITLEBAR_OUTSET_PX,
     width,
-    height: Math.max(0, canvasSize.height),
+    height: Math.max(0, canvasSize.height - TITLEBAR_OUTSET_PX),
     zIndex,
   };
 }

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -74,8 +74,9 @@ interface PluginOperationRendererProps {
 
 const DEFAULT_SHELL_WIDTH = 560;
 const DEFAULT_SHELL_HEIGHT = 360;
-/* components.css의 .canvas-operation-titlebar top(-1 * --space-3)과 짝을 이루는 상수. */
-const TITLEBAR_OUTSET_PX = 12;
+/* components.css의 .canvas-operation-titlebar top(-28px)과 짝을 이루는 상수.
+   캡션은 본문·PTY geometry 밖에 붙는 패널 속성이라, 이 높이만큼만 캔버스 클립을 본다. */
+const TITLEBAR_OUTSET_PX = 28;
 // 프리뷰 config는 identity 비교로 재발행이 억제되므로 공유 불변 배열을 쓴다.
 const EMPTY_HIDDEN_COMPANION_IDS: readonly string[] = [];
 
@@ -873,8 +874,8 @@ export function OperationsCanvas({
               ? modeSlotGeometryFor(formationSlotArea, 0, companionSlotCount, 8, topPanelZIndex)
               : companionGeometryFor(canvasSize, 0, companionSlotCount, topPanelZIndex)
             : formationSlot ? { ...baseGeometry, ...formationSlot } : baseGeometry;
-          // 보더 위 명판(top: -space-3)이 캔버스 상단 클립에 잘리는 뷰포트-상대 위치면 내부 인셋으로 전환한다.
-          // 최대화/Formation은 전용 CSS 인셋 규칙이 이미 소유한다.
+          // 보더 위 캡션(top: -28px)이 캔버스 상단 클립에 잘리는 뷰포트-상대 위치면 본문 위 오버레이로 전환한다.
+          // 최대화/Formation은 전용 CSS 오버레이 규칙이 이미 소유한다. 어느 쪽이든 본문·PTY geometry는 그대로다.
           const topEdge = !operationTriageStage && !operationMaximized && !operationCompanion && !formationSlot
             && canvas.viewport.y + frameGeometry.y * effectiveZoom < TITLEBAR_OUTSET_PX * effectiveZoom;
           return renderPluginOperation(operation, {

--- a/runtime/fleet-console/core/client/src/canvas/coordinates.ts
+++ b/runtime/fleet-console/core/client/src/canvas/coordinates.ts
@@ -81,8 +81,8 @@ export function triageStageGeometryFor(
 ): OperationGeometry {
   return modeSlotGeometryFor({
     x: 18,
-    y: 18,
+    y: 18 + 28,
     width: Math.max(320, canvasSize.width - 36),
-    height: Math.max(240, canvasSize.height - 84),
+    height: Math.max(240, canvasSize.height - 84 - 28),
   }, slotIndex, slotCount, 8, zIndex);
 }

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -351,18 +351,6 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
       inert={minimized || renderHidden ? true : undefined}
     >
       {accentColor ? <span className="canvas-operation-spine" aria-hidden="true" /> : null}
-      {!maximized && !interactionDisabled ? (
-        <div
-          className="canvas-operation-drag-edge"
-          onPointerDown={beginDrag}
-          onPointerMove={updateDrag}
-          onPointerUp={endDrag}
-          onPointerCancel={endDrag}
-          onLostPointerCapture={abortPointerManipulation}
-          data-canvas-blocker
-          aria-hidden="true"
-        />
-      ) : null}
       <div
         className="canvas-operation-titlebar"
         onPointerDown={beginDrag}

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -45,11 +45,17 @@ interface DragState {
   readonly startX: number;
   readonly startY: number;
   readonly geometry: OperationGeometry;
+  capturing: boolean;
   latest: OperationGeometry;
 }
 
-interface ResizeState extends DragState {
+interface ResizeState {
+  readonly pointerId: number;
+  readonly startX: number;
+  readonly startY: number;
+  readonly geometry: OperationGeometry;
   readonly direction: ResizeDirection;
+  latest: OperationGeometry;
 }
 
 type ResizeDirection = "n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "nw";
@@ -58,6 +64,7 @@ const RESIZE_DIRECTIONS: readonly ResizeDirection[] = ["n", "ne", "e", "se", "s"
 const MIN_OPERATION_WIDTH = 320;
 const MIN_OPERATION_HEIGHT = 200;
 const CLOSE_ARM_DURATION_MS = 1500;
+const DRAG_THRESHOLD_PX = 3;
 
 export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, glanceHud, formationSlotIndex, accentKey = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onSetAccent, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
   const t = useT();
@@ -174,24 +181,30 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
     disarmClose();
     if (maximized || interactionDisabled) return;
     if (event.button !== 0) return;
-    event.preventDefault();
     event.stopPropagation();
     onActivate();
-    dragRef.current = { pointerId: event.pointerId, startX: event.clientX, startY: event.clientY, geometry, latest: geometry };
-    setDragging(true);
-    event.currentTarget.setPointerCapture(event.pointerId);
+    // 제자리 클릭·더블클릭은 캡처하지 않는다 — 캡처하면 제목 버튼의 dblclick이 캡션으로 간다.
+    dragRef.current = { pointerId: event.pointerId, startX: event.clientX, startY: event.clientY, geometry, latest: geometry, capturing: false };
   };
 
   const updateDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (maximized || interactionDisabled) return;
     const drag = dragRef.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
+    const dx = event.clientX - drag.startX;
+    const dy = event.clientY - drag.startY;
+    if (!drag.capturing) {
+      if (dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) return;
+      drag.capturing = true;
+      setDragging(true);
+      event.currentTarget.setPointerCapture(event.pointerId);
+    }
     event.preventDefault();
     event.stopPropagation();
     const next = {
       ...drag.geometry,
-      x: drag.geometry.x + (event.clientX - drag.startX) / zoom,
-      y: drag.geometry.y + (event.clientY - drag.startY) / zoom,
+      x: drag.geometry.x + dx / zoom,
+      y: drag.geometry.y + dy / zoom,
     };
     drag.latest = next;
     onGeometryChange(next);
@@ -205,12 +218,15 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
     }
     const drag = dragRef.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
-    event.preventDefault();
-    event.stopPropagation();
+    const moved = drag.capturing;
     dragRef.current = null;
     setDragging(false);
-    event.currentTarget.releasePointerCapture(event.pointerId);
-    onGeometryCommit(drag.latest);
+    if (moved) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.currentTarget.releasePointerCapture(event.pointerId);
+      onGeometryCommit(drag.latest);
+    }
   };
 
   const beginResize = (direction: ResizeDirection, event: ReactPointerEvent<HTMLDivElement>) => {

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -255,7 +255,8 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
   };
 
   const stopIdentityPointer = (event: ReactPointerEvent<HTMLButtonElement | HTMLInputElement>) => {
-    event.stopPropagation();
+    // 이름 입력 중만 드래그를 막는다. 제목 버튼은 캡션과 같이 창을 움직인다.
+    if (rename.renaming) event.stopPropagation();
     disarmClose();
   };
 

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -44,7 +44,7 @@ export const canvasEn = {
 
   "canvas.frame.operationAria": "Operation {title}",
   "canvas.frame.renameAria": "Rename operation {title}",
-  "canvas.frame.renameTitle": "{title} — Double-click, Enter, or F2 to rename",
+  "canvas.frame.renameTitle": "{title} — Drag to move. Double-click, Enter, or F2 to rename",
   "canvas.frame.setAccentAria": "Set accent for operation {title}",
   "canvas.frame.setAccentTitle": "Set accent",
   "canvas.frame.minimizeAria": "Minimize operation {title}",
@@ -250,7 +250,7 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
 
   "canvas.frame.operationAria": "Operation {title}",
   "canvas.frame.renameAria": "Operation {title} 이름 바꾸기",
-  "canvas.frame.renameTitle": "{title} — 더블클릭, Enter 또는 F2로 이름 변경",
+  "canvas.frame.renameTitle": "{title} — 드래그로 이동. 더블클릭, Enter 또는 F2로 이름 변경",
   "canvas.frame.setAccentAria": "Operation {title} 액센트 설정",
   "canvas.frame.setAccentTitle": "액센트 설정",
   "canvas.frame.minimizeAria": "Operation {title} 최소화",

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -25,14 +25,6 @@ interface RightRailProps {
 
 const MIN_PANEL_WIDTH = 240;
 const DEFAULT_PANEL_WIDTH = 312;
-// 호버-리빌 헤더 입력 계약: 진입은 pointermove로만 판정하고(스크롤-언더-포인터 오발화 방지)
-// 의도 지연을 거친다. 진입 띠와 64px 이탈 경계 사이는 히스테리시스 중립 지대다.
-// 진입 띠는 패널 본문 상단 컨트롤(Skills 탭 등)의 클릭을 방해하지 않도록 가장자리
-// 12px로 좁게 잡는다 — 24px에서는 상단 첫 줄 컨트롤로 향하는 호버가 헤더를 오발화했다.
-const HEAD_REVEAL_ZONE_PX = 12;
-const HEAD_REVEAL_TOUCH_ZONE_PX = 28;
-const HEAD_HIDE_BOUNDARY_PX = 64;
-const HEAD_REVEAL_INTENT_DELAY_MS = 120;
 const PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
 const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
 
@@ -138,86 +130,6 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
-  const [headRevealed, setHeadRevealed] = useState(false);
-  const headRevealedRef = useRef(headRevealed);
-  headRevealedRef.current = headRevealed;
-  const revealIntentTimerRef = useRef<number | null>(null);
-
-  const cancelRevealIntent = useCallback(() => {
-    if (revealIntentTimerRef.current === null) return;
-    window.clearTimeout(revealIntentTimerRef.current);
-    revealIntentTimerRef.current = null;
-  }, []);
-
-  const holdHeadOpen = useCallback(() => {
-    cancelRevealIntent();
-    if (!headRevealedRef.current) setHeadRevealed(true);
-  }, [cancelRevealIntent]);
-
-  const hideHeadUnlessFocused = useCallback(() => {
-    // 키보드 포커스(:focus-visible)가 헤더 안에 남아 있는 동안만 숨기지 않는다 — 숨기면
-    // 포커스가 투명한 컨트롤에 갇힌다. 마우스 클릭·드래그가 남긴 잔류 포커스는 리빌을
-    // 붙잡는 근거가 아니므로, 블러로 걷어내고 즉시 숨긴다.
-    const active = document.activeElement;
-    if (active instanceof HTMLElement && active.closest(".right-rail-panel-head-reveal") !== null) {
-      if (active.matches(":focus-visible")) return;
-      active.blur();
-    }
-    setHeadRevealed(false);
-  }, []);
-
-  // 이탈은 지연 없이 즉시 숨긴다 — 리빌 진입만 의도 지연을 거친다.
-  const releaseHead = useCallback(() => {
-    cancelRevealIntent();
-    if (!headRevealedRef.current) return;
-    hideHeadUnlessFocused();
-  }, [cancelRevealIntent, hideHeadUnlessFocused]);
-
-  // 패널이 바뀌거나 닫히면 리빌 상태를 초기화한다.
-  useLayoutEffect(() => {
-    cancelRevealIntent();
-    setHeadRevealed(false);
-  }, [activeId, cancelRevealIntent]);
-
-  useLayoutEffect(() => () => {
-    cancelRevealIntent();
-  }, [cancelRevealIntent]);
-
-  const handleSlotPointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    // 진입 판정은 hover 포인터에만 적용한다. 터치는 pointerdown 폴백이 담당한다.
-    if (event.pointerType === "touch") return;
-    const slotTop = event.currentTarget.getBoundingClientRect().top;
-    const y = event.clientY - slotTop;
-    if (y <= HEAD_REVEAL_ZONE_PX) {
-      if (headRevealedRef.current || revealIntentTimerRef.current !== null) return;
-      revealIntentTimerRef.current = window.setTimeout(() => {
-        revealIntentTimerRef.current = null;
-        setHeadRevealed(true);
-      }, HEAD_REVEAL_INTENT_DELAY_MS);
-      return;
-    }
-    cancelRevealIntent();
-    if (y > HEAD_HIDE_BOUNDARY_PX) releaseHead();
-  }, [cancelRevealIntent, releaseHead]);
-
-  const handleSlotPointerLeave = useCallback(() => {
-    releaseHead();
-  }, [releaseHead]);
-
-  const handleSlotPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    if (event.pointerType !== "touch") return;
-    const slotTop = event.currentTarget.getBoundingClientRect().top;
-    const y = event.clientY - slotTop;
-    if (!headRevealedRef.current) {
-      // 상단 가장자리 탭 = 리빌. preventDefault 없이 콘텐츠 탭도 그대로 통과시킨다.
-      if (y <= HEAD_REVEAL_TOUCH_ZONE_PX) holdHeadOpen();
-      return;
-    }
-    const target = event.target instanceof Element ? event.target : null;
-    if (target?.closest(".right-rail-panel-head-reveal") === null) {
-      hideHeadUnlessFocused();
-    }
-  }, [hideHeadUnlessFocused, holdHeadOpen]);
 
   useLayoutEffect(() => {
     const onResize = () => {
@@ -362,9 +274,6 @@ export function RightRail({ theaterId, api }: RightRailProps) {
         style={panelBehavior === "overlay"
           ? { "--right-rail-overlay-alpha": overlayAlpha / 100 } as CSSProperties
           : undefined}
-        onPointerMove={hasPanel ? handleSlotPointerMove : undefined}
-        onPointerLeave={hasPanel ? handleSlotPointerLeave : undefined}
-        onPointerDown={hasPanel ? handleSlotPointerDown : undefined}
       >
         {activePanel && (
           <div
@@ -387,11 +296,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
               activePanelTitle={activePanelTitle}
               panelBehavior={panelBehavior}
               overlayAlpha={overlayAlpha}
-              revealed={headRevealed}
-              onHoldOpen={holdHeadOpen}
-              onRelease={releaseHead}
             />
-            <div className="right-rail-panel-peek" aria-hidden="true" />
             <RailPanelBody activePanel={activePanel} activeId={activeId} ctx={ctx} connection={connection} connectionLostAt={connectionLostAt} language={language} />
           </>
         )}
@@ -417,81 +322,56 @@ interface RailPanelHeadProps {
   readonly activePanelTitle: string;
   readonly panelBehavior: "push" | "overlay";
   readonly overlayAlpha: RailOverlayAlpha;
-  readonly revealed: boolean;
-  readonly onHoldOpen: () => void;
-  readonly onRelease: () => void;
 }
 
-// 헤더의 세 통제(타이틀·플로팅·닫기)는 전부 저빈도라 상시 46px 대신 호버-리빌
-// 오버레이로 소환한다. 숨김 상태에서도 DOM에 남아 Tab 진입(focus)이 리빌 경로가 된다.
-function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha, revealed, onHoldOpen, onRelease }: RailPanelHeadProps) {
+// 캡션은 본문 높이를 빼지 않고 슬롯 위에 붙는 패널 속성이다. Esc는 헤더 포커스 범위로만 닫는다.
+function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha }: RailPanelHeadProps) {
   const t = useT();
-
-  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
-    // slot의 진입/이탈 판정으로 버블되면 46px 헤더 하단부(y>24px)가 이탈로 오판된다.
-    event.stopPropagation();
-    onHoldOpen();
-  };
-
-  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
-    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
-    onRelease();
-  };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "Escape") return;
-    // Esc 닫기는 헤더 포커스 범위로 한정한다 — 패널 본문(Shell PTY 등)의 Esc 어휘를 뺏지 않는다.
     event.stopPropagation();
     closeRailPanel();
   };
 
   return (
-    <div
-      className={`right-rail-panel-head-reveal${revealed ? " is-revealed" : ""}`}
-      onPointerMove={handlePointerMove}
-      onPointerLeave={onRelease}
-      onFocusCapture={onHoldOpen}
-      onBlurCapture={handleBlur}
-      onKeyDown={handleKeyDown}
-    >
-      <div className="right-rail-panel-head">
-        <span className="right-rail-panel-title">{activePanelTitle}</span>
-        <button
-          className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
-          type="button"
-          aria-pressed={panelBehavior === "overlay"}
-          aria-label={t("rail.chrome.floatToggle")}
-          title={t("rail.chrome.floatLabel")}
-          onClick={toggleRailPanelBehavior}
-        >
-          <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
-        </button>
-        {panelBehavior === "overlay" ? (
-          <div className="right-rail-alpha">
-            <input
-              className="right-rail-alpha-slider"
-              type="range"
-              min={RAIL_OVERLAY_ALPHA_MIN}
-              max={RAIL_OVERLAY_ALPHA_MAX}
-              step={1}
-              value={overlayAlpha}
-              aria-label={t("rail.chrome.opacityAria")}
-              onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
-              onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
-              style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
-            />
-            <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
-          </div>
-        ) : null}
-        <button
-          className="right-rail-close-btn"
-          type="button"
-          aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
-          onClick={closeRailPanel}
-        >
-          ✕
-        </button>
-      </div>
+    <div className="right-rail-panel-head" onKeyDown={handleKeyDown}>
+      <span className="right-rail-panel-title">{activePanelTitle}</span>
+      <button
+        className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
+        type="button"
+        aria-pressed={panelBehavior === "overlay"}
+        aria-label={t("rail.chrome.floatToggle")}
+        title={t("rail.chrome.floatLabel")}
+        onClick={toggleRailPanelBehavior}
+      >
+        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
+      </button>
+      {panelBehavior === "overlay" ? (
+        <div className="right-rail-alpha">
+          <input
+            className="right-rail-alpha-slider"
+            type="range"
+            min={RAIL_OVERLAY_ALPHA_MIN}
+            max={RAIL_OVERLAY_ALPHA_MAX}
+            step={1}
+            value={overlayAlpha}
+            aria-label={t("rail.chrome.opacityAria")}
+            onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
+            onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
+            style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
+          />
+          <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
+        </div>
+      ) : null}
+      <button
+        className="right-rail-close-btn"
+        type="button"
+        aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
+        onClick={closeRailPanel}
+      >
+        <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" /></svg>
+      </button>
     </div>
   );
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5860,7 +5860,7 @@
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   background: transparent;
-  cursor: text;
+  cursor: inherit;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -6509,7 +6509,8 @@
 
 .canvas-operation-resize {
   position: absolute;
-  z-index: 5;
+  /* 캡션(z 7)보다 위에 두어 북쪽 가장자리는 리사이즈, 캡션 안은 드래그가 받는다. */
+  z-index: 8;
   touch-action: none;
 }
 
@@ -6522,7 +6523,8 @@
 }
 
 .canvas-operation-resize--n {
-  top: -4px;
+  /* 캡션이 본문 위 28px에 붙으므로 북쪽 리사이즈도 그 상단에 둔다. */
+  top: -32px;
 }
 
 .canvas-operation-resize--s {
@@ -6554,7 +6556,7 @@
 }
 
 .canvas-operation-resize--ne {
-  top: -5px;
+  top: -33px;
   right: -5px;
   cursor: nesw-resize;
 }
@@ -6572,7 +6574,7 @@
 }
 
 .canvas-operation-resize--nw {
-  top: -5px;
+  top: -33px;
   left: -5px;
   cursor: nwse-resize;
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6589,6 +6589,16 @@
   cursor: nwse-resize;
 }
 
+/* 캡션이 본문 위로 접히면 북쪽 리사이즈도 그 가장자리를 따른다. */
+.canvas-operation.is-top-edge .canvas-operation-resize--n {
+  top: -4px;
+}
+
+.canvas-operation.is-top-edge .canvas-operation-resize--ne,
+.canvas-operation.is-top-edge .canvas-operation-resize--nw {
+  top: -5px;
+}
+
 .canvas-rubber-band {
   position: absolute;
   z-index: 20;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4458,6 +4458,16 @@
   animation-delay: calc(var(--li, 0) * 40ms + 1180ms);
 }
 
+/* Cruise에서 캡션이 캔버스 클립 밖으로 나가면 본문 위 오버레이로 접는다.
+   Tactical/War Room/최대화는 슬롯을 28px 내려 이 경로를 타지 않는다. */
+.canvas-operation.is-top-edge .canvas-operation-titlebar {
+  top: 0;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid var(--surface-rim);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+}
+
 .operations-canvas.is-companion-layout .canvas-operation-titlebar {
   cursor: default;
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4403,7 +4403,8 @@
 }
 
 .canvas-operation.is-maximized .canvas-operation-titlebar {
-  top: var(--space-2);
+  top: 0;
+  border-bottom: 1px solid var(--ink-rim);
   cursor: default;
 }
 
@@ -4425,7 +4426,8 @@
 }
 
 .canvas-operation.is-triage-stage .canvas-operation-titlebar {
-  top: var(--space-2);
+  top: 0;
+  border-bottom: 1px solid var(--ink-rim);
   cursor: default;
 }
 
@@ -4459,11 +4461,12 @@
 }
 
 /* Formation 슬롯은 y=0에서 시작하고, 일반 맵 뷰에서도 뷰포트-상대 상단 밀착(is-top-edge) 패널은
-   캔버스 클립(overflow:hidden)이 보더 위 명판을 잘라낸다 — 최대화와 동일하게 내부 인셋으로 전환한다. */
+   캔버스 클립이 보더 위 캡션을 잘라낸다 — 본문·PTY geometry는 그대로 두고 캡션만 본문 위 오버레이로 옮긴다. */
 .operations-canvas.is-formation-view .canvas-operation-titlebar,
 .operations-canvas.is-companion-layout .canvas-operation-titlebar,
 .canvas-operation.is-top-edge .canvas-operation-titlebar {
-  top: var(--space-2);
+  top: 0;
+  border-bottom: 1px solid var(--ink-rim);
 }
 
 .operations-canvas.is-companion-layout .canvas-operation-titlebar {
@@ -5816,18 +5819,22 @@
 
 .canvas-operation-titlebar {
   position: absolute;
-  top: calc(-1 * var(--space-3));
-  right: var(--space-3);
+  /* 본문·PTY geometry 밖에 붙는 패널 속성 — 인라인 height는 본문만 소유한다. */
+  top: -28px;
+  left: 0;
+  right: 0;
   z-index: 7;
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  width: fit-content;
-  max-width: calc(100% - (var(--space-3) * 2));
-  min-height: 24px;
-  padding: 3px var(--space-2) 3px var(--space-2);
+  width: 100%;
+  max-width: none;
+  min-height: 28px;
+  height: 28px;
+  padding: 0 var(--space-2);
   border: 1px solid var(--ink-rim);
-  border-radius: var(--radius-sm);
+  border-bottom: none;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   overflow: visible;
   background: var(--surface-frame);
   box-shadow: var(--shadow-soft);
@@ -5857,7 +5864,7 @@
 }
 
 .canvas-operation-identity-name {
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   overflow: hidden;
   padding: 3px 0;
   border: 0;
@@ -6187,59 +6194,41 @@
   display: flex;
   align-items: center;
   flex: none;
-  /* 버튼 focus/hover 링이 outline 2px + offset 2px로 보더 밖 4px까지 나온다 —
-     gap이 그보다 좁으면 이웃 칩과 링이 겹쳐 외곽선이 이중으로 보인다. */
-  gap: var(--space-2);
-  max-width: 0;
-  overflow-x: clip;
-  overflow-y: visible;
-  opacity: 0;
-  pointer-events: none;
-  transition:
-    max-width var(--duration-base) var(--ease-spring),
-    opacity var(--duration-base) var(--ease-spring);
+  margin-left: auto;
+  gap: 2px;
+  max-width: none;
+  overflow: visible;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .canvas-operation-window-controls > .canvas-operation-icon-button:last-child {
-  margin-inline-end: var(--space-1);
+  margin-inline-end: 0;
 }
 
 .canvas-operation-controls-divider {
   flex: none;
   width: 1px;
-  height: var(--space-3);
-  /* 좌측만 보정: titlebar gap(space-1)과 합쳐 beacon–divider 간격을 버튼 간 gap(space-2)과 맞춘다. */
-  margin: 0 0 0 var(--space-1);
+  height: 12px;
+  margin: 0 6px 0 4px;
   background: var(--hairline-strong);
-}
-
-.canvas-operation:hover .canvas-operation-window-controls,
-.canvas-operation-titlebar:focus-within .canvas-operation-window-controls {
-  /* gap(2×8px) + armed "Close?" 확장폭까지 수용해야 한다 — 120px에서는 armed 상태가 잘린다. */
-  max-width: calc(var(--space-3) * 12);
-  opacity: 1;
-  pointer-events: auto;
 }
 
 .canvas-operation-icon-button {
   display: grid;
   place-items: center;
-  flex: 0 0 0;
-  width: 0;
-  height: 0;
+  flex: none;
+  width: 20px;
+  height: 20px;
   padding: 0;
   overflow: hidden;
-  border: 0 solid transparent;
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  color: transparent;
+  color: var(--text-tertiary);
   background: transparent;
-  opacity: 0;
-  pointer-events: none;
+  opacity: 1;
+  pointer-events: auto;
   transition:
-    width var(--duration-base) var(--ease-spring),
-    height var(--duration-base) var(--ease-spring),
-    padding var(--duration-base) var(--ease-spring),
-    opacity var(--duration-base) var(--ease-spring),
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
     background var(--duration-fast) var(--ease-spring);
@@ -6263,30 +6252,14 @@
 
 .canvas-operation-icon-button svg {
   display: block;
-  width: 15px;
-  height: 15px;
+  width: 12px;
+  height: 12px;
 }
 
-.canvas-operation:hover .canvas-operation-window-controls .canvas-operation-icon-button,
-.canvas-operation-titlebar:focus-within .canvas-operation-window-controls .canvas-operation-icon-button {
-  flex: none;
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: 1px solid var(--surface-rim);
-  color: var(--text-tertiary);
-  background: color-mix(in oklch, var(--surface-glass) 58%, transparent);
-  opacity: 1;
-  pointer-events: auto;
-}
-
-/* .canvas-operation-window-controls 프리픽스 필수 — hover 전개 규칙(.canvas-operation:hover
-   .canvas-operation-window-controls .canvas-operation-icon-button, 0-4-0)이 armed의 width/padding을
-   24px로 되누르지 않도록 armed를 같은 특이도(0-4-0)의 후순위로 둔다. */
 .canvas-operation .canvas-operation-window-controls .canvas-operation-icon-button.is-armed-close {
   flex: none;
   width: auto;
-  height: 24px;
+  height: 20px;
   padding: 0 6px;
   border: 1px solid color-mix(in oklch, var(--coral) 50%, transparent);
   background: color-mix(in oklch, var(--coral) 20%, transparent);
@@ -6306,8 +6279,7 @@
   outline: none;
 }
 
-/* 명판은 name → beacon → collapsed controls 순서다. hover/focus에서 컨트롤은 beacon 오른쪽으로
-   전개되며, status 색은 beacon 도트만 소유한다. */
+/* 캡션은 name → beacon → 상시 컨트롤 순서다. 창 컨트롤은 패널 속성이라 호버 전개하지 않는다. */
 
 @media (prefers-reduced-motion: reduce) {
   .canvas-operation-titlebar,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4344,7 +4344,8 @@
   min-height: 200px;
   overflow: visible;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  /* 상단 모서리는 캡션이 잇는다 — 본문이 따로 둥글면 두 개의 창처럼 읽힌다. */
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   /* 창 프레임은 --surface-frame — 라이트에서 최암면이 되지 않도록 밴드와 같은 크롬 패밀리를 탄다. */
   background: var(--surface-frame);
   box-shadow: var(--shadow-soft);
@@ -4399,17 +4400,16 @@
    클립과 일치해 검은 갭 없이 단일 표면을 유지한다.
    드래그/리사이즈가 차단된 상태이므로 코너 필의 grab 어포던스 커서도 기본값으로 되돌린다. */
 .canvas-operation.is-maximized {
-  border-radius: calc(var(--radius-xl) - 1px);
+  border-radius: 0 0 calc(var(--radius-xl) - 1px) calc(var(--radius-xl) - 1px);
 }
 
 .canvas-operation.is-maximized .canvas-operation-titlebar {
-  top: 0;
-  border-bottom: 1px solid var(--ink-rim);
   cursor: default;
+  border-radius: calc(var(--radius-xl) - 1px) calc(var(--radius-xl) - 1px) 0 0;
 }
 
 .canvas-operation.is-maximized .canvas-operation-terminal {
-  border-radius: calc(var(--radius-xl) - 2px);
+  border-radius: 0 0 calc(var(--radius-xl) - 2px) calc(var(--radius-xl) - 2px);
 }
 
 .canvas-operation.is-triage-stage {
@@ -4426,8 +4426,6 @@
 }
 
 .canvas-operation.is-triage-stage .canvas-operation-titlebar {
-  top: 0;
-  border-bottom: 1px solid var(--ink-rim);
   cursor: default;
 }
 
@@ -4458,15 +4456,6 @@
 .operations-canvas.is-formation-entering .canvas-operation {
   animation: formation-tile-land 420ms cubic-bezier(0.2, 0.9, 0.25, 1) both;
   animation-delay: calc(var(--li, 0) * 40ms + 1180ms);
-}
-
-/* Formation 슬롯은 y=0에서 시작하고, 일반 맵 뷰에서도 뷰포트-상대 상단 밀착(is-top-edge) 패널은
-   캔버스 클립이 보더 위 캡션을 잘라낸다 — 본문·PTY geometry는 그대로 두고 캡션만 본문 위 오버레이로 옮긴다. */
-.operations-canvas.is-formation-view .canvas-operation-titlebar,
-.operations-canvas.is-companion-layout .canvas-operation-titlebar,
-.canvas-operation.is-top-edge .canvas-operation-titlebar {
-  top: 0;
-  border-bottom: 1px solid var(--ink-rim);
 }
 
 .operations-canvas.is-companion-layout .canvas-operation-titlebar {
@@ -4568,9 +4557,9 @@
   overflow: auto;
 }
 
-/* 포커스는 단일 location accent로만 표시한다. */
+/* 포커스는 단일 location accent로만 표시한다. 캡션과 본문이 같은 보더 선을 잇는다. */
 .canvas-operation.is-active {
-  border-color: var(--brass);
+  border-color: color-mix(in oklch, var(--brass) 62%, var(--ink-rim));
   box-shadow: var(--shadow-soft);
 }
 
@@ -5819,25 +5808,25 @@
 
 .canvas-operation-titlebar {
   position: absolute;
-  /* 본문·PTY geometry 밖에 붙는 패널 속성 — 인라인 height는 본문만 소유한다. */
+  /* 본문·PTY geometry 밖에 붙는 패널 속성 — 인라인 height는 본문만 소유한다.
+     left/right -1px는 본문 보더 바깥선과 같은 사각형을 그린다. */
   top: -28px;
-  left: 0;
-  right: 0;
+  left: -1px;
+  right: -1px;
   z-index: 7;
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  width: 100%;
+  width: auto;
   max-width: none;
   min-height: 28px;
   height: 28px;
   padding: 0 var(--space-2);
-  border: 1px solid var(--ink-rim);
+  border: 1px solid var(--surface-rim);
   border-bottom: none;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   overflow: visible;
   background: var(--surface-frame);
-  box-shadow: var(--shadow-soft);
   cursor: grab;
   touch-action: none;
   transition:
@@ -5903,21 +5892,6 @@
 .canvas-operation-identity-input:focus {
   border-color: var(--brass);
   box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 32%, transparent);
-}
-
-.canvas-operation-drag-edge {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  z-index: 4;
-  height: 14px;
-  cursor: grab;
-  touch-action: none;
-}
-
-.canvas-operation-drag-edge:active {
-  cursor: grabbing;
 }
 
 /* 좌측 상태 인디케이터(beacon)를 감싼 클릭 어포던스 — 누르면 accent 설정 모달을 연다.
@@ -6397,7 +6371,7 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  border-radius: calc(var(--radius-lg) - 1px);
+  border-radius: 0 0 calc(var(--radius-lg) - 1px) calc(var(--radius-lg) - 1px);
   background: color-mix(in oklch, var(--ink-deep) 64%, var(--surface-pillar));
 }
 

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -762,8 +762,7 @@ html[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-le
 .console-body.is-canvas {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  /* 레일 캡션이 슬롯 위로 28px 붙으므로 세로 클립을 열다. 가로 넘침은 셸이 막는다. */
-  overflow: visible;
+  overflow: hidden;
 }
 
 /* 명시적 열 고정 — 접힌 크롬이 display:none으로 슬롯을 비워도(auto-placement 시프트)

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -762,7 +762,8 @@ html[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-le
 .console-body.is-canvas {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  overflow: hidden;
+  /* 레일 캡션이 슬롯 위로 28px 붙으므로 세로 클립을 열다. 가로 넘침은 셸이 막는다. */
+  overflow: visible;
 }
 
 /* 명시적 열 고정 — 접힌 크롬이 display:none으로 슬롯을 비워도(auto-placement 시프트)

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -67,6 +67,13 @@
   grid-template-rows: 28px minmax(0, 1fr);
 }
 
+/* 언독 풀스크린은 밴드가 흐름에서 빠져 .console-route-content가 뷰포트 최상단이다.
+   그 조상이 overflow:hidden이라 -28px 연장은 캡션을 잘라낸다 — 슬롯 안으로 접는다. */
+.console-shell:has(.command-band.is-fullscreen:not(.is-docked)) .right-rail.is-open .right-rail-panel-slot {
+  margin-top: 0;
+  height: 100%;
+}
+
 .right-rail.is-overlay .right-rail-panel-slot {
   position: absolute;
   right: 44px;

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -26,7 +26,9 @@
     radial-gradient(130% 60% at 100% 0%, color-mix(in oklch, var(--brass) 7%, transparent), transparent 56%),
     color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
   box-shadow: var(--shadow-floating);
-  overflow: hidden;
+  /* 캡션은 슬롯 위 28px에 붙는다. hidden이면 잘리므로 펼친 레일은 세로만 연다.
+     접힘은 is-closed가 다시 클립한다. */
+  overflow: visible;
   transition: width 200ms ease, border-color 200ms ease, visibility 0s linear 0s;
 }
 
@@ -42,29 +44,37 @@
 }
 
 /* ── 패널 슬롯 ─────────────────────────────────────────────────────
-   overflow:hidden + width 전환으로 spring 펼침/접힘을 구현한다.
-   min-width는 애니메이션 중 내부 레이아웃 흔들림을 방지한다.        */
+   폭 전환으로 spring 펼침/접힘을 구현한다. 캡션은 슬롯을 위로 28px
+   연장해 붙이고, 본문 1fr은 원래 높이를 유지한다. */
 .right-rail-panel-slot {
   position: relative;
   width: 0;
   /* 요청 시점 클램프(rail-store) 이후 뷰포트가 줄어도 슬롯이 캔버스를 밀어내지 않도록 렌더 시점 상한 — 드래그 클램프(148px 여유)와 동일 시맨틱 */
   max-width: calc(100vw - 148px);
-  overflow: hidden;
+  overflow: visible;
   display: grid;
-  /* 헤더는 호버-리빌 오버레이(absolute)로 빠져 본문이 슬롯 전체 높이를 쓴다. */
+  /* 캡션은 슬롯 위(-28px)에 붙는다. 본문 그리드 행·마진으로 높이를 빼지 않는다. */
   grid-template-rows: minmax(0, 1fr);
   transition: width var(--duration-base) var(--ease-spring);
 }
 
 .right-rail.is-open .right-rail-panel-slot {
   width: var(--right-rail-panel-width, 312px);
+  /* 캡션 28px는 슬롯을 커맨드 밴드 쪽으로 연장해 붙인다. 1fr 본문은 원래 슬롯 높이다. */
+  align-self: start;
+  margin-top: -28px;
+  height: calc(100% + 28px);
+  grid-template-rows: 28px minmax(0, 1fr);
 }
 
 .right-rail.is-overlay .right-rail-panel-slot {
   position: absolute;
   right: 44px;
-  top: 0;
+  top: -28px;
   bottom: 0;
+  margin-top: 0;
+  height: auto;
+  grid-template-rows: 28px minmax(0, 1fr);
   width: var(--right-rail-panel-width, 0px);
   border-left: 1px solid var(--surface-rim);
   /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
@@ -93,64 +103,23 @@
   pointer-events: none;
 }
 
-/* ── 호버-리빌 헤더 ─────────────────────────────────────────────────
-   세 통제(타이틀·플로팅·닫기)는 전부 저빈도 set-and-forget이라 46px 상주 대신
-   상단 접근 시에만 본문 위 오버레이로 소환한다(진입 판정은 right-rail.tsx의
-   pointermove+의도 지연 계약). 숨김은 opacity+transform으로만 처리해 Tab
-   포커스 진입이 리빌 경로로 남는다. */
-.right-rail-panel-head-reveal {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 3;
-  transform: translateY(-100%);
-  opacity: 0;
-  pointer-events: none;
-  border-bottom: 1px solid var(--surface-rim);
-  /* 본문 위에 얹히는 오버레이라 glass 카드와 같은 불투명 언더레이가 필요하다. */
-  background: color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
-  /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
-  box-shadow: 0 10px 26px oklch(0% 0 0 / 40%);
-  transition: transform 180ms var(--ease-spring), opacity 140ms ease;
-}
-
-.right-rail-panel-head-reveal.is-revealed {
-  transform: none;
-  opacity: 1;
-  pointer-events: auto;
-}
-
-/* 리빌 힌트 — 헤더가 숨어 있음을 알리는 유일한 상주 크롬(3px 대시). */
-.right-rail-panel-peek {
-  position: absolute;
-  top: 5px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 30px;
-  height: 3px;
-  border-radius: 2px;
-  z-index: 2;
-  background: var(--text-tertiary);
-  opacity: 0.32;
-  pointer-events: none;
-  transition: opacity 140ms ease;
-}
-
-.right-rail-panel-head-reveal.is-revealed + .right-rail-panel-peek {
-  opacity: 0;
-}
-
+/* ── 패널 캡션 ─────────────────────────────────────────────────────
+   슬롯이 위로 28px 연장한 첫 행. 본문 1fr은 원래 높이다. 호버-리빌이 아니다. */
 .right-rail-panel-head {
   position: relative;
-  z-index: 1;
+  z-index: 3;
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
   gap: 6px;
-  padding: 9px 44px 9px 10px;
-  min-height: 46px;
-  min-width: 240px;
+  height: 28px;
+  min-height: 28px;
+  min-width: 0;
+  padding: 0 8px;
+  border: 1px solid var(--surface-rim);
+  border-bottom: none;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  background: color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
 }
 
 .right-rail-panel-title {
@@ -168,8 +137,8 @@
 
 .right-rail-float-toggle {
   flex: none;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   display: inline-grid;
   place-items: center;
   padding: 0;
@@ -182,8 +151,8 @@
 }
 
 .right-rail-float-toggle svg {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   display: block;
 }
 
@@ -213,8 +182,8 @@
   gap: 6px;
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-sm);
-  padding: 0 7px;
-  height: 24px;
+  padding: 0 6px;
+  height: 20px;
 }
 
 .right-rail-alpha-slider {
@@ -223,7 +192,7 @@
   flex: 1 1 44px;
   width: 64px;
   min-width: 44px;
-  height: 20px;
+  height: 16px;
   background: transparent;
   cursor: pointer;
 }
@@ -296,25 +265,33 @@
 }
 
 .right-rail-close-btn {
-  position: absolute;
-  top: 9px;
-  right: 10px;
-  width: 24px;
-  height: 24px;
+  margin-left: auto;
+  width: 20px;
+  height: 20px;
   flex: none;
   display: inline-grid;
   place-items: center;
-  border-radius: var(--radius-xs);
+  border-radius: var(--radius-sm);
   background: none;
-  border: none;
+  border: 1px solid transparent;
   color: var(--text-tertiary);
   cursor: pointer;
-  transition: color 140ms, background 140ms;
+  transition: color 140ms, background 140ms, border-color 140ms;
 }
 
-.right-rail-close-btn:hover {
-  color: var(--text-primary);
-  background: var(--surface-glass);
+.right-rail-close-btn svg {
+  width: 12px;
+  height: 12px;
+  display: block;
+}
+
+.right-rail-close-btn:hover,
+.right-rail-close-btn:focus-visible {
+  color: var(--brass-bright);
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
+  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
+  outline-offset: 2px;
 }
 
 .right-rail-panel-body {
@@ -490,6 +467,7 @@
   width: 0;
   border-color: transparent;
   visibility: hidden;
+  overflow: hidden;
   transition: width 200ms ease, border-color 200ms ease, visibility 0s linear 200ms;
 }
 
@@ -497,8 +475,7 @@
 @media (prefers-reduced-motion: reduce) {
   .right-rail,
   .right-rail-panel-slot,
-  .right-rail-panel-head-reveal,
-  .right-rail-panel-peek {
+  .right-rail-panel-head {
     transition: none !important;
   }
 

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -26,9 +26,7 @@
     radial-gradient(130% 60% at 100% 0%, color-mix(in oklch, var(--brass) 7%, transparent), transparent 56%),
     color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
   box-shadow: var(--shadow-floating);
-  /* 캡션은 슬롯 위 28px에 붙는다. hidden이면 잘리므로 펼친 레일은 세로만 연다.
-     접힘은 is-closed가 다시 클립한다. */
-  overflow: visible;
+  overflow: hidden;
   transition: width 200ms ease, border-color 200ms ease, visibility 0s linear 0s;
 }
 
@@ -51,33 +49,23 @@
   width: 0;
   /* 요청 시점 클램프(rail-store) 이후 뷰포트가 줄어도 슬롯이 캔버스를 밀어내지 않도록 렌더 시점 상한 — 드래그 클램프(148px 여유)와 동일 시맨틱 */
   max-width: calc(100vw - 148px);
-  overflow: visible;
+  overflow: hidden;
   display: grid;
-  /* 캡션은 슬롯 위(-28px)에 붙는다. 본문 그리드 행·마진으로 높이를 빼지 않는다. */
   grid-template-rows: minmax(0, 1fr);
   transition: width var(--duration-base) var(--ease-spring);
 }
 
 .right-rail.is-open .right-rail-panel-slot {
   width: var(--right-rail-panel-width, 312px);
-  /* 캡션 28px는 슬롯을 커맨드 밴드 쪽으로 연장해 붙인다. 1fr 본문은 원래 슬롯 높이다. */
-  align-self: start;
-  margin-top: -28px;
-  height: calc(100% + 28px);
+  /* 캡션은 슬롯 첫 행. 조상 route-content가 overflow:hidden이라 밴드 쪽으로
+     연장하면 잘리거나 밴드를 덮는다. Operation PTY와 달리 Rail 본문은 28px를 내준다. */
   grid-template-rows: 28px minmax(0, 1fr);
-}
-
-/* 언독 풀스크린은 밴드가 흐름에서 빠져 .console-route-content가 뷰포트 최상단이다.
-   그 조상이 overflow:hidden이라 -28px 연장은 캡션을 잘라낸다 — 슬롯 안으로 접는다. */
-.console-shell:has(.command-band.is-fullscreen:not(.is-docked)) .right-rail.is-open .right-rail-panel-slot {
-  margin-top: 0;
-  height: 100%;
 }
 
 .right-rail.is-overlay .right-rail-panel-slot {
   position: absolute;
   right: 44px;
-  top: -28px;
+  top: 0;
   bottom: 0;
   margin-top: 0;
   height: auto;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -997,6 +997,9 @@ describe("Instrument core design contract", () => {
     expect(rail).toContain(".right-rail-panel-head {");
     expect(rail).toContain("height: calc(100% + 28px);");
     expect(rail).toContain("grid-template-rows: 28px minmax(0, 1fr);");
+    expect(rail).toContain(".console-shell:has(.command-band.is-fullscreen:not(.is-docked)) .right-rail.is-open .right-rail-panel-slot");
+    expect(source("canvas/operation-frame.tsx")).toContain("DRAG_THRESHOLD_PX");
+    expect(source("canvas/operation-frame.tsx")).toContain("capturing: false");
     expect(rail).toContain("height: 28px;");
     expect(rail).not.toContain(".right-rail-panel-head-reveal");
     expect(rail).not.toContain(".right-rail-panel-peek");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -991,15 +991,16 @@ describe("Instrument core design contract", () => {
     expect(rightRail).toContain("right-rail-alpha-slider");
     expect(rightRail).toContain("is-switching");
     expect(railStore).toContain("fleet-console.rail.panelBehavior");
-    // Doctrine: the panel head is hover-reveal chrome, not resident chrome — it hides
-    // with opacity+transform only (never display/visibility) so keyboard focus can
-    // still enter and reveal it, and its reveal entry stays pointermove-gated with an
-    // intent delay so scroll-under-pointer never triggers it.
-    expect(rail).toContain(".right-rail-panel-head-reveal");
-    expect(rail).toMatch(/\.right-rail-panel-head-reveal \{[^}]*pointer-events:\s*none/);
-    expect(rail).toMatch(/\.right-rail-panel-head-reveal\.is-revealed \{[^}]*pointer-events:\s*auto/);
-    expect(rail).toMatch(/@media \(prefers-reduced-motion: reduce\) \{[^{]*\.right-rail-panel-head-reveal/);
-    expect(rightRail).toContain("HEAD_REVEAL_INTENT_DELAY_MS");
+    // Doctrine: the panel head is a 28px caption attached above the slot. It does
+    // not take a body row and does not hover-reveal. The body keeps the full slot
+    // height; PTY/plugin geometry is unaware of the caption.
+    expect(rail).toContain(".right-rail-panel-head {");
+    expect(rail).toContain("height: calc(100% + 28px);");
+    expect(rail).toContain("grid-template-rows: 28px minmax(0, 1fr);");
+    expect(rail).toContain("height: 28px;");
+    expect(rail).not.toContain(".right-rail-panel-head-reveal");
+    expect(rail).not.toContain(".right-rail-panel-peek");
+    expect(rightRail).not.toContain("HEAD_REVEAL_INTENT_DELAY_MS");
     expect(rightRail).not.toMatch(/onPointerEnter=\{(?:handleSlotPointerMove|holdHeadOpen)/);
   });
 
@@ -1660,7 +1661,7 @@ describe("Instrument core design contract", () => {
     const identityInputBlock = components.match(/^\.canvas-operation-identity-input \{\n  flex: 1 1 auto;[^}]*\}/m)?.[0] ?? "";
     expect(identityInputBlock).toContain("width: min(28ch, 34vw);");
     expect(identityInputBlock).not.toContain("width: 0;");
-    expect(components).toContain("top: calc(-1 * var(--space-3));");
+    expect(components).toContain("top: -28px;");
     expect(components).toContain("border-radius: 999px;");
     // 활성 타이틀바는 brass 7% 틴트를 frame 위에 얹는다 — ink-mid 재결합 회귀를 여기서 잡는다.
     expect(components).toContain("color-mix(in oklch, var(--brass) 7%, var(--surface-frame))");
@@ -1668,29 +1669,29 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".canvas-operation.is-active .canvas-operation-titlebar {");
     expect(components).toContain("color-mix(in oklch, var(--brass) 62%, var(--ink-rim))");
     expect(components).toContain(".canvas-operation-window-controls {");
-    expect(components).toContain("max-width: 0;");
     const windowControlsBlock = components.match(/\.canvas-operation-window-controls \{[^}]*\}/)?.[0] ?? "";
-    expect(windowControlsBlock).toContain("overflow-x: clip;");
-    expect(windowControlsBlock).toContain("overflow-y: visible;");
+    expect(windowControlsBlock).toContain("margin-left: auto;");
+    expect(windowControlsBlock).toContain("max-width: none;");
+    expect(windowControlsBlock).not.toContain("max-width: 0;");
     const windowControlsLastButtonBlock = components.match(/\.canvas-operation-window-controls > \.canvas-operation-icon-button:last-child \{[^}]*\}/)?.[0] ?? "";
-    expect(windowControlsLastButtonBlock).toContain("margin-inline-end: var(--space-1);");
+    expect(windowControlsLastButtonBlock).toContain("margin-inline-end: 0;");
     expect(components).toContain(".operations-canvas.is-glance .canvas-operation-glance-hud {");
     expect(components).not.toContain(".canvas-triage-rail-arm {");
     expect(components).toContain(".canvas-operation-glance-hud-arm {");
     // 무장 안내는 Alt 홀드와 무관하게 떠 있어야 한다 — 확인 기한이 1.5초뿐이다.
     expect(components).toContain(".canvas-operation-glance-hud.is-armed-set-aside {");
     expect(components).toContain("/* 두 번 눌러 확정 중인 위험 상태만 coral 채널을 쓰며");
-    // armed-close는 hover 전개 규칙(0-4-0)과 같은 특이도의 후순위여야 Close? 라벨이 잘리지 않는다.
     expect(components).toContain(".canvas-operation .canvas-operation-window-controls .canvas-operation-icon-button.is-armed-close {");
-    // Formation(y=0 슬롯)과 일반 맵 뷰의 뷰포트-상대 상단 밀착 패널은 명판을 내부 인셋으로 전환한다.
+    // Formation(y=0 슬롯)과 일반 맵 뷰의 뷰포트-상대 상단 밀착 패널은 캡션을 본문 위 오버레이로 옮긴다.
+    // 본문·PTY geometry는 그대로다.
     expect(components).toContain(".operations-canvas.is-formation-view .canvas-operation-titlebar,");
     expect(components).toContain(".canvas-operation.is-top-edge .canvas-operation-titlebar {");
     expect(source("canvas/canvas.tsx")).toContain("TITLEBAR_OUTSET_PX * effectiveZoom");
     expect(source("canvas/operation-frame.tsx")).not.toContain('className="canvas-operation-cli"');
     expect(components).toContain(".canvas-operation-beacon-button {");
     expect(components).toContain("border: 1px solid var(--surface-rim);");
-    expect(components).toContain("right: var(--space-3);");
-    expect(components).toContain("name → beacon → collapsed controls");
+    expect(components).toContain("left: 0;");
+    expect(components).toContain("name → beacon → 상시 컨트롤");
     const canvas = source("canvas/canvas.tsx");
     expect(canvas).toContain("export function useGlanceHold(): boolean");
     expect(canvas).toContain('event.code === "AltLeft" || event.code === "AltRight"');

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -998,6 +998,7 @@ describe("Instrument core design contract", () => {
     expect(rail).toContain("grid-template-rows: 28px minmax(0, 1fr);");
     expect(rail).not.toContain("height: calc(100% + 28px);");
     expect(source("styles/components.css")).toContain(".canvas-operation.is-top-edge .canvas-operation-titlebar");
+    expect(source("styles/components.css")).toContain(".canvas-operation.is-top-edge .canvas-operation-resize--n");
     expect(source("canvas/operation-frame.tsx")).toContain("DRAG_THRESHOLD_PX");
     expect(source("canvas/operation-frame.tsx")).toContain("capturing: false");
     expect(rail).toContain("height: 28px;");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1682,15 +1682,15 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".canvas-operation-glance-hud.is-armed-set-aside {");
     expect(components).toContain("/* 두 번 눌러 확정 중인 위험 상태만 coral 채널을 쓰며");
     expect(components).toContain(".canvas-operation .canvas-operation-window-controls .canvas-operation-icon-button.is-armed-close {");
-    // Formation(y=0 슬롯)과 일반 맵 뷰의 뷰포트-상대 상단 밀착 패널은 캡션을 본문 위 오버레이로 옮긴다.
-    // 본문·PTY geometry는 그대로다.
-    expect(components).toContain(".operations-canvas.is-formation-view .canvas-operation-titlebar,");
-    expect(components).toContain(".canvas-operation.is-top-edge .canvas-operation-titlebar {");
+    // Tactical/War Room/최대화는 슬롯을 28px 내려 캡션을 본문 밖에 둔다.
+    expect(source("canvas/canvas.tsx")).toContain("y: TITLEBAR_OUTSET_PX");
     expect(source("canvas/canvas.tsx")).toContain("TITLEBAR_OUTSET_PX * effectiveZoom");
+    expect(source("canvas/coordinates.ts")).toContain("y: 18 + 28");
+    expect(source("canvas/operation-frame.tsx")).not.toContain("canvas-operation-drag-edge");
     expect(source("canvas/operation-frame.tsx")).not.toContain('className="canvas-operation-cli"');
     expect(components).toContain(".canvas-operation-beacon-button {");
     expect(components).toContain("border: 1px solid var(--surface-rim);");
-    expect(components).toContain("left: 0;");
+    expect(components).toContain("left: -1px;");
     expect(components).toContain("name → beacon → 상시 컨트롤");
     const canvas = source("canvas/canvas.tsx");
     expect(canvas).toContain("export function useGlanceHold(): boolean");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -995,9 +995,9 @@ describe("Instrument core design contract", () => {
     // not take a body row and does not hover-reveal. The body keeps the full slot
     // height; PTY/plugin geometry is unaware of the caption.
     expect(rail).toContain(".right-rail-panel-head {");
-    expect(rail).toContain("height: calc(100% + 28px);");
     expect(rail).toContain("grid-template-rows: 28px minmax(0, 1fr);");
-    expect(rail).toContain(".console-shell:has(.command-band.is-fullscreen:not(.is-docked)) .right-rail.is-open .right-rail-panel-slot");
+    expect(rail).not.toContain("height: calc(100% + 28px);");
+    expect(source("styles/components.css")).toContain(".canvas-operation.is-top-edge .canvas-operation-titlebar");
     expect(source("canvas/operation-frame.tsx")).toContain("DRAG_THRESHOLD_PX");
     expect(source("canvas/operation-frame.tsx")).toContain("capturing: false");
     expect(rail).toContain("height: 28px;");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1639,6 +1639,7 @@ describe("Instrument core design contract", () => {
     expect(operationFrame).toContain("onPointerDown={stopIdentityPointer}");
     expect(operationFrame).toContain("onBegin: () => {\n      disarmClose();\n    },");
     const identityPointerBlock = operationFrame.match(/const stopIdentityPointer = \([^]*?\n  };/)?.[0] ?? "";
+    expect(identityPointerBlock).toContain("if (rename.renaming) event.stopPropagation();");
     expect(identityPointerBlock).toContain("disarmClose();");
     expect(identityPointerBlock).not.toContain("onActivate();");
     expect(operationFrame).toContain('event.key !== "Enter" && event.key !== "F2"');

--- a/runtime/fleet-console/tests/operation-frame-identity.test.ts
+++ b/runtime/fleet-console/tests/operation-frame-identity.test.ts
@@ -97,7 +97,9 @@ describe("OperationFrame identity rename", () => {
 
     act(() => {
       if (action === "double-click") {
-        trigger.dispatchEvent(new Event("pointerdown", { bubbles: true, cancelable: true }));
+        const titlebar = document.querySelector(".canvas-operation-titlebar")!;
+        trigger.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true, pointerId: 1, clientX: 10, clientY: 10, button: 0 }));
+        titlebar.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, cancelable: true, pointerId: 1, clientX: 10, clientY: 10, button: 0 }));
         trigger.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
         return;
       }
@@ -107,6 +109,23 @@ describe("OperationFrame identity rename", () => {
     expect(identityInput()).not.toBeNull();
     expect(document.activeElement).toBe(identityInput());
     expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("does not capture the pointer on a stationary title click so dblclick stays on the button", () => {
+    const onRename = vi.fn();
+    renderFrame(onRename, true);
+    const trigger = identityTrigger();
+    const titlebar = document.querySelector(".canvas-operation-titlebar") as HTMLElement;
+    titlebar.setPointerCapture = vi.fn();
+    const capture = titlebar.setPointerCapture as ReturnType<typeof vi.fn>;
+
+    act(() => {
+      trigger.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true, pointerId: 7, clientX: 12, clientY: 12, button: 0 }));
+      titlebar.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, cancelable: true, pointerId: 7, clientX: 12, clientY: 12, button: 0 }));
+    });
+
+    expect(capture).not.toHaveBeenCalled();
+    expect(identityInput()).toBeNull();
   });
 
   it("marks the frame with is-top-edge when the canvas would clip the attached caption", () => {

--- a/runtime/fleet-console/tests/operation-frame-identity.test.ts
+++ b/runtime/fleet-console/tests/operation-frame-identity.test.ts
@@ -109,7 +109,7 @@ describe("OperationFrame identity rename", () => {
     expect(onRename).not.toHaveBeenCalled();
   });
 
-  it("marks the frame with is-top-edge so the nameplate insets under the canvas clip", () => {
+  it("marks the frame with is-top-edge so the caption overlays when the canvas would clip it", () => {
     renderFrame(vi.fn(), false, true);
     expect(document.querySelector(".canvas-operation")!.className).toContain("is-top-edge");
   });

--- a/runtime/fleet-console/tests/operation-frame-identity.test.ts
+++ b/runtime/fleet-console/tests/operation-frame-identity.test.ts
@@ -109,7 +109,7 @@ describe("OperationFrame identity rename", () => {
     expect(onRename).not.toHaveBeenCalled();
   });
 
-  it("marks the frame with is-top-edge so the caption overlays when the canvas would clip it", () => {
+  it("marks the frame with is-top-edge when the canvas would clip the attached caption", () => {
     renderFrame(vi.fn(), false, true);
     expect(document.querySelector(".canvas-operation")!.className).toContain("is-top-edge");
   });

--- a/runtime/fleet-console/tests/operation-frame-identity.test.ts
+++ b/runtime/fleet-console/tests/operation-frame-identity.test.ts
@@ -87,7 +87,7 @@ describe("OperationFrame identity rename", () => {
     expect(children[1]?.className).toBe("canvas-operation-beacon-button");
     expect(children[2]?.className).toBe("canvas-operation-window-controls");
     expect(document.querySelectorAll(".canvas-operation-window-controls .canvas-operation-icon-button")).toHaveLength(3);
-    expect(identityTrigger().title).toBe("A deliberately long Operation title — Double-click, Enter, or F2 to rename");
+    expect(identityTrigger().title).toBe("A deliberately long Operation title — Drag to move. Double-click, Enter, or F2 to rename");
   });
 
   it.each(["double-click", "Enter", "F2"])("renders active identity and begins rename with %s", (action) => {
@@ -139,9 +139,14 @@ describe("OperationFrame identity rename", () => {
       trigger.dispatchEvent(new KeyboardEvent("keydown", { key: action, bubbles: true, cancelable: true }));
     });
 
-    expect(onActivate).not.toHaveBeenCalled();
+    if (action === "double-click") {
+      // 제목은 캡션 드래그 면이라 pointerdown이 창을 활성화한다. 이름 변경은 더블클릭이 연다.
+      expect(onActivate).toHaveBeenCalled();
+    } else {
+      expect(onActivate).not.toHaveBeenCalled();
+      expect(document.querySelector(".canvas-operation")?.classList.contains("is-active")).toBe(false);
+    }
     expect(identityInput()).not.toBeNull();
-    expect(document.querySelector(".canvas-operation")?.classList.contains("is-active")).toBe(false);
   });
 });
 

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -753,7 +753,7 @@ describe("triage store", () => {
 
     for (const geometry of geometries) {
       expect(geometry.x).toBeGreaterThanOrEqual(18);
-      expect(geometry.y).toBeGreaterThanOrEqual(18);
+      expect(geometry.y).toBeGreaterThanOrEqual(46);
       expect(geometry.x + geometry.width).toBeLessThanOrEqual(canvasSize.width - 18);
       expect(geometry.y + geometry.height).toBeLessThanOrEqual(canvasSize.height - 66);
     }


### PR DESCRIPTION
## Summary
- Operation과 Activity Rail 패널에 본문·PTY 밖에 붙는 28px 창 캡션을 둡니다. 최소화·최대화·닫기는 항상 보입니다.
- Tactical·War Room·최대화는 슬롯을 28px 내려 캡션이 본문 안으로 들어가지 않게 합니다. 캡션과 본문은 한 프레임입니다.
- 패널 이동은 제목을 포함한 캡션 전체에서 하고, 이름 변경은 더블클릭입니다. 북쪽 리사이즈는 캡션 상단에 있습니다.

## Test Plan
- [ ] Cruise에서 캡션이 본문 위에 붙고, 본문 높이가 이전과 같은지 확인
- [ ] Tactical / War Room / 최대화에서 캡션이 본문 안에 들어가지 않는지 확인
- [ ] 제목을 드래그하면 패널이 움직이고, 더블클릭만 이름 변경인지 확인
- [ ] 최소화·최대화·닫기(1.5s 무장)가 캡션에서 동작하는지 확인
- [ ] Activity Rail 캡션이 본문 높이를 빼지 않는지 확인