### PR TITLE
feat(gateway): restore Cursor Opus 5 and Fable 5 Max Mode 1M

### DIFF
--- a/.changelog.d/cursor-opus-fable-1m.md
+++ b/.changelog.d/cursor-opus-fable-1m.md
@@ -1,0 +1,13 @@
+---
+branch: cursor-opus-fable-1m
+---
+
+### fleet-cli
+#### Added
+- Offer Cursor Opus 5 and Fable 5 through the AI Gateway, including Max Mode 1M variants billed against the Cursor API pool.
+  ko: AI Gateway를 통해 Cursor Opus 5와 Fable 5, 그리고 API 풀로 청구되는 Max Mode 1M 변형을 제공합니다.
+
+### fleet-console
+#### Added
+- Offer Cursor Opus 5 and Fable 5 in AI Gateway model selection, including Max Mode 1M variants billed against the Cursor API pool.
+  ko: AI Gateway 모델 선택에 Cursor Opus 5와 Fable 5, 그리고 API 풀로 청구되는 Max Mode 1M 변형을 제공합니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -51,7 +51,7 @@ Operation의 주인은 브라우저가 아니라 로컬 Fleet Console 서버입�
 | 프로바이더 | 자격증명 | 모델 |
 |---|---|---|
 | **Codex** | ChatGPT 구독 | GPT-5.6 Sol · Terra · Luna, 각각 Fast 변형 |
-| **Cursor** | Cursor 구독 | Auto · Composer 2.5 · Grok 4.5, Fast 변형 포함 |
+| **Cursor** | Cursor 구독 | Auto · Composer 2.5 · Grok 4.5 · Grok 4.6, Fast 변형 포함 · Opus 5 · Fable 5, 각각 Max Mode 1M 변형 |
 | **Moonshot-Kimi** | API 키 | Kimi K3 1M · K3 256K |
 | **OpenCode Go** | API 키 | MiniMax M3 · Qwen3.8 Max · DeepSeek V4 Flash / Pro · GLM-5.2 · Kimi K3 · MiMo V2.5 / Pro · HY3 · Grok 4.5 · GPT-5.6 Luna |
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Right-click the canvas and launch Claude Code on any model you have enabled — 
 | Provider | Credential | Models |
 |---|---|---|
 | **Codex** | ChatGPT subscription | GPT-5.6 Sol · Terra · Luna, each with a Fast variant |
-| **Cursor** | Cursor subscription | Auto · Composer 2.5 · Grok 4.5, with Fast variants |
+| **Cursor** | Cursor subscription | Auto · Composer 2.5 · Grok 4.5 · Grok 4.6, with Fast variants · Opus 5 · Fable 5, each with a Max Mode 1M variant |
 | **Moonshot-Kimi** | API key | Kimi K3 1M · K3 256K |
 | **OpenCode Go** | API key | MiniMax M3 · Qwen3.8 Max · DeepSeek V4 Flash / Pro · GLM-5.2 · Kimi K3 · MiMo V2.5 / Pro · HY3 · Grok 4.5 · GPT-5.6 Luna |
 

--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -168,13 +168,16 @@ const PROVIDERS = [
     cred: "subscription",
     color: "#d4af37",
     mission: {
-      ko: "쓰던 Cursor 구독으로 Cursor의 에이전트 라인업에 닿는다. Auto는 작업에 맞는 모델을 Cursor가 스스로 고르는 좌석이고, Composer와 Grok은 Fast 변형까지 따로 선다.",
-      en: "Rides the Cursor subscription you already have into Cursor's agent lineup. Auto is the seat where Cursor picks the model for the task; Composer and Grok each stand with their own Fast variant.",
+      ko: "쓰던 Cursor 구독으로 Cursor의 에이전트 라인업에 닿는다. Auto는 작업에 맞는 모델을 Cursor가 스스로 고르는 좌석이고, Composer와 Grok은 Fast 변형까지 따로 선다. Opus 5와 Fable 5는 API 풀로 청구되며 각각 Max Mode 1M 창을 연다.",
+      en: "Rides the Cursor subscription you already have into Cursor's agent lineup. Auto is the seat where Cursor picks the model for the task; Composer and Grok each stand with their own Fast variant. Opus 5 and Fable 5 bill against the API pool and each open a Max Mode 1M window.",
     },
     models: [
       { ko: "Auto — Cursor가 모델을 선택", en: "Auto — Cursor picks the model" },
       { ko: "Composer 2.5 — Fast 변형 포함", en: "Composer 2.5 — Fast variant included" },
       { ko: "Grok 4.5 — Fast 변형 포함", en: "Grok 4.5 — Fast variant included" },
+      { ko: "Grok 4.6 — Fast 변형 포함", en: "Grok 4.6 — Fast variant included" },
+      { ko: "Opus 5 — Max Mode 1M 변형 포함", en: "Opus 5 — Max Mode 1M variant included" },
+      { ko: "Fable 5 — Max Mode 1M 변형 포함", en: "Fable 5 — Max Mode 1M variant included" },
     ],
   },
   {

--- a/packages/core-ai-gateway/benchmarks.json
+++ b/packages/core-ai-gateway/benchmarks.json
@@ -147,6 +147,26 @@
         }
       }
     },
+    "claude-opus-5": {
+      "source": "cursorbench",
+      "rungs": {
+        "low": { "score": 62.8, "tokensPerTask": 18529, "stepsPerTask": 37 },
+        "medium": { "score": 64.3, "tokensPerTask": 23612, "stepsPerTask": 44 },
+        "high": { "score": 66.7, "tokensPerTask": 27932, "stepsPerTask": 48 },
+        "xhigh": { "score": 69.3, "tokensPerTask": 54239, "stepsPerTask": 72 },
+        "max": { "score": 70.0, "tokensPerTask": 61838, "stepsPerTask": 78 }
+      }
+    },
+    "claude-fable-5": {
+      "source": "cursorbench",
+      "rungs": {
+        "low": { "score": 62.1, "tokensPerTask": 18182, "stepsPerTask": 31 },
+        "medium": { "score": 65.2, "tokensPerTask": 30366, "stepsPerTask": 41 },
+        "high": { "score": 66.5, "tokensPerTask": 43747, "stepsPerTask": 48 },
+        "xhigh": { "score": 68.4, "tokensPerTask": 64971, "stepsPerTask": 56 },
+        "max": { "score": 70.5, "tokensPerTask": 103525, "stepsPerTask": 72 }
+      }
+    },
     "kimi-k3": {
       "source": "cursorbench",
       "rungs": {

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-14T00:00:00Z",
+  "updatedAt": "2026-08-15T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
@@ -142,7 +142,7 @@
     "cursor": {
       "name": "Cursor",
       "defaultModel": "auto",
-      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); cursor-agent 2026.08.11-e8db854 observed 2026-08-13 for grok-4.6; quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
+      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); cursor-agent 2026.08.11-e8db854 observed 2026-08-13 for grok-4.6; claude-opus-5 and claude-fable-5 standard/Max Mode windows observed 2026-08-10; quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
       "models": [
         {
           "modelId": "auto",
@@ -236,6 +236,94 @@
             ],
             "upstreamModelIdTemplate": "cursor-grok-4.6-{effort}-fast"
           }
+        },
+        {
+          "modelId": "claude-opus-5",
+          "name": "Opus-5",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "contextWindow": 300000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "claude-opus-5-{effort}",
+            "upstreamModelIds": {
+              "xhigh": "claude-opus-5-thinking-xhigh",
+              "max": "claude-opus-5-thinking-max"
+            }
+          },
+          "benchmarkKey": "claude-opus-5"
+        },
+        {
+          "modelId": "claude-opus-5-1m",
+          "name": "Opus-5-1M",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "contextWindow": 1000000,
+          "cursorMaxMode": true,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "claude-opus-5-{effort}",
+            "upstreamModelIds": {
+              "xhigh": "claude-opus-5-thinking-xhigh",
+              "max": "claude-opus-5-thinking-max"
+            }
+          },
+          "benchmarkKey": "claude-opus-5"
+        },
+        {
+          "modelId": "claude-fable-5",
+          "name": "Fable-5",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "description": "NO ZDR",
+          "contextWindow": 300000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "claude-fable-5-{effort}"
+          },
+          "benchmarkKey": "claude-fable-5"
+        },
+        {
+          "modelId": "claude-fable-5-1m",
+          "name": "Fable-5-1M",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "description": "NO ZDR",
+          "contextWindow": 1000000,
+          "cursorMaxMode": true,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "claude-fable-5-{effort}"
+          },
+          "benchmarkKey": "claude-fable-5"
         }
       ]
     },

--- a/packages/core-ai-gateway/tests/cursor/native/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/adapter.test.ts
@@ -33,6 +33,10 @@ describe("Cursor request budgets", () => {
     ["grok-4.5", "low", "cursor-grok-4.5-low"],
     ["grok-4.5", "medium", "cursor-grok-4.5-medium"],
     ["grok-4.5-fast", "low", "cursor-grok-4.5-low-fast"],
+    ["claude-opus-5", "xhigh", "claude-opus-5-thinking-xhigh"],
+    ["claude-opus-5", "max", "claude-opus-5-thinking-max"],
+    ["claude-opus-5-1m", "xhigh", "claude-opus-5-thinking-xhigh"],
+    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
     ["composer-2.5", "high", "composer-2.5"],
   ] as const)("writes Cursor model %s with effort %s as %s", (model, effort, expected) => {
     const plan = buildCursorRunPlan(request({
@@ -54,6 +58,21 @@ describe("Cursor request budgets", () => {
 
     expect(encodedRunRequest(plan).modelDetails).toMatchObject({ modelId: "cursor-grok-4.5-high" });
     expect(encodedRunRequest(plan).modelDetails).not.toHaveProperty("maxMode");
+  });
+
+  it.each([
+    ["claude-opus-5-1m", "high", "claude-opus-5-high"],
+    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
+  ] as const)("encodes Cursor Max Mode for catalog model %s", (model, effort, wireModel) => {
+    const plan = buildCursorRunPlan(request({
+      model,
+      reasoning: { summary: "auto", effort },
+    }), `conversation-${model}`);
+
+    expect(encodedRunRequest(plan).modelDetails).toMatchObject({
+      modelId: wireModel,
+      maxMode: true,
+    });
   });
 
   it("encodes Cursor Max Mode when explicitly enabled", () => {

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -1701,7 +1701,7 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(27);
+    expect(list.data).toHaveLength(31);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--cursor--auto");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5");
@@ -1711,7 +1711,10 @@ describe("route surface", () => {
     expect(ids).toContain("claude-gateway--cursor--grok-4.6");
     expect(ids).toContain("claude-gateway--cursor--grok-4.6-fast");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-sol[1m]");
-    expect(ids).not.toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
+    expect(ids).toContain("claude-gateway--cursor--claude-opus-5");
+    expect(ids).toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
+    expect(ids).toContain("claude-gateway--cursor--claude-fable-5");
+    expect(ids).toContain("claude-gateway--cursor--claude-fable-5-1m[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -625,6 +625,8 @@ describe("model catalog", () => {
     // worthless for a panel that needs independent judgement.
     expect(constraintsFor("cursor--grok-4.5").homolineage).toBe(false);
     expect(constraintsFor("cursor--composer-2.5").homolineage).toBe(false);
+    expect(constraintsFor("cursor--claude-opus-5").homolineage).toBe(true);
+    expect(constraintsFor("cursor--claude-fable-5-1m").homolineage).toBe(true);
     expect(constraintsFor("kimi--k3").homolineage).toBe(false);
   });
 
@@ -725,6 +727,27 @@ describe("model catalog", () => {
     expect(findGatewayModel("cursor--grok-4.6-fast")?.benchmark).toBeUndefined();
     expect(grok46?.benchmark?.observedAt).toBe("2026-08-13T00:00:00Z");
 
+    const opus = findGatewayModel("cursor--claude-opus-5");
+    const opus1m = findGatewayModel("cursor--claude-opus-5-1m");
+    expect(opus?.benchmark?.source).toBe("CursorBench 3.2");
+    expect(opus1m?.benchmark).toEqual(opus?.benchmark);
+    expect(opus?.benchmark?.rungs && Object.keys(opus.benchmark.rungs).sort()).toEqual([
+      "high",
+      "low",
+      "max",
+      "medium",
+      "xhigh",
+    ]);
+    const fable = findGatewayModel("cursor--claude-fable-5");
+    expect(fable?.benchmark?.rungs && Object.keys(fable.benchmark.rungs).sort()).toEqual([
+      "high",
+      "low",
+      "max",
+      "medium",
+      "xhigh",
+    ]);
+    expect(findGatewayModel("cursor--claude-fable-5-1m")?.benchmark).toEqual(fable?.benchmark);
+
     const constraints = buildGatewayModelConstraints(findGatewayModel("codex--gpt-5.6-sol")!);
     expect(constraints.benchmark).toEqual(base?.benchmark);
   });
@@ -804,7 +827,7 @@ describe("model catalog", () => {
 
   it("contains only the approved provider families", () => {
     expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(6);
-    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(7);
+    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(11);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(11);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
@@ -817,6 +840,10 @@ describe("model catalog", () => {
       "grok-4.5-fast",
       "grok-4.6",
       "grok-4.6-fast",
+      "claude-opus-5",
+      "claude-opus-5-1m",
+      "claude-fable-5",
+      "claude-fable-5-1m",
     ]);
     expect(Object.fromEntries(CURSOR_SUBSCRIPTION_MODELS.map((model) => [
       model.upstreamId,
@@ -828,8 +855,16 @@ describe("model catalog", () => {
       "grok-4.5-fast": 256_000,
       "grok-4.6": 256_000,
       "grok-4.6-fast": 256_000,
+      "claude-opus-5": 300_000,
+      "claude-opus-5-1m": 1_000_000,
+      "claude-fable-5": 300_000,
+      "claude-fable-5-1m": 1_000_000,
       default: 256_000,
     });
+    for (const id of ["cursor--claude-opus-5-1m", "cursor--claude-fable-5-1m"]) {
+      expect(CURSOR_SUBSCRIPTION_MODELS.find((model) => model.id === id))
+        .toMatchObject({ cursorMaxMode: true });
+    }
     expect(KIMI_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual(["k3", "k3-256k"]);
     // OpenCode Go의 서비스 가능 전 모델(2026-08-03 라이브 프로브). wire 미선언 =
     // Anthropic passthrough, 그 외에는 선언된 네이티브 wire의 번역 경로를 탄다.
@@ -894,6 +929,22 @@ describe("model catalog", () => {
       levels: ["low", "medium", "high", "xhigh"],
       upstreamModelIdTemplate: "cursor-grok-4.6-{effort}-fast",
     });
+    expect(efforts["cursor--claude-opus-5"]).toEqual({
+      supported: true,
+      levels: ["low", "medium", "high", "xhigh", "max"],
+      upstreamModelIdTemplate: "claude-opus-5-{effort}",
+      upstreamModelIds: {
+        xhigh: "claude-opus-5-thinking-xhigh",
+        max: "claude-opus-5-thinking-max",
+      },
+    });
+    expect(efforts["cursor--claude-opus-5-1m"]).toEqual(efforts["cursor--claude-opus-5"]);
+    expect(efforts["cursor--claude-fable-5"]).toEqual({
+      supported: true,
+      levels: ["low", "medium", "high", "xhigh", "max"],
+      upstreamModelIdTemplate: "claude-fable-5-{effort}",
+    });
+    expect(efforts["cursor--claude-fable-5-1m"]).toEqual(efforts["cursor--claude-fable-5"]);
     expect(efforts["cursor--auto"]).toEqual({ supported: false });
     expect(efforts["cursor--composer-2.5"]).toEqual({ supported: false });
   });
@@ -908,6 +959,13 @@ describe("model catalog", () => {
     ["grok-4.6", "high", "cursor-grok-4.6-high"],
     ["grok-4.6", "xhigh", "cursor-grok-4.6-xhigh"],
     ["grok-4.6-fast", "xhigh", "cursor-grok-4.6-xhigh-fast"],
+    ["claude-opus-5", "high", "claude-opus-5-high"],
+    ["claude-opus-5", "xhigh", "claude-opus-5-thinking-xhigh"],
+    ["claude-opus-5", "max", "claude-opus-5-thinking-max"],
+    ["claude-opus-5-1m", "high", "claude-opus-5-high"],
+    ["claude-opus-5-1m", "xhigh", "claude-opus-5-thinking-xhigh"],
+    ["claude-opus-5-1m", "max", "claude-opus-5-thinking-max"],
+    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
     ["composer-2.5", "high", "composer-2.5"],
     ["unknown-model", "high", "unknown-model"],
   ] as const)("resolves Cursor base model %s at effort %s to %s", (model, effort, expected) => {
@@ -974,6 +1032,14 @@ describe("model catalog", () => {
     expect(list.data.find((entry) => entry.id.endsWith("cursor--composer-2.5"))).toMatchObject({
       display_name: "Cursor-Composer-2.5",
       max_input_tokens: 200_000,
+    });
+    expect(list.data.find((entry) => entry.id.endsWith("cursor--claude-opus-5-1m[1m]"))).toMatchObject({
+      display_name: "Cursor-Opus-5-1M (1M Context)",
+      max_input_tokens: 1_000_000,
+    });
+    expect(list.data.find((entry) => entry.id.endsWith("cursor--claude-fable-5-1m[1m]"))).toMatchObject({
+      display_name: "Cursor-Fable-5-1M (1M Context)",
+      max_input_tokens: 1_000_000,
     });
     expect(list.data.find((entry) => entry.id === "claude-gateway--kimi--k3[1m]")).toMatchObject({
       display_name: "Moonshot-Kimi-K3-1M (1M Context)",
@@ -1119,7 +1185,18 @@ describe("model catalog", () => {
       upstreamId: "composer-2.5",
       contextWindow: 200_000,
     });
-    expect(findGatewayModel("claude-gateway--cursor--claude-opus-5-1m[1m]")).toBeUndefined();
+    expect(findGatewayModel("claude-gateway--cursor--claude-opus-5-1m[1m]")).toMatchObject({
+      id: "cursor--claude-opus-5-1m",
+      upstreamId: "claude-opus-5-1m",
+      contextWindow: 1_000_000,
+      cursorMaxMode: true,
+    });
+    expect(findGatewayModel("claude-gateway--cursor--claude-fable-5-1m[1m]")).toMatchObject({
+      id: "cursor--claude-fable-5-1m",
+      upstreamId: "claude-fable-5-1m",
+      contextWindow: 1_000_000,
+      cursorMaxMode: true,
+    });
     expect(findGatewayModel("claude-gateway--cursor--kimi-k3")).toBeUndefined();
     expect(findGatewayModel("claude-gateway--cursor--glm-5.2[1m]")).toBeUndefined();
     expect(findGatewayModel("claude-gateway--k3[1m]")).toBeUndefined();

--- a/packages/core-ai-gateway/tests/settings/index.test.ts
+++ b/packages/core-ai-gateway/tests/settings/index.test.ts
@@ -127,7 +127,7 @@ describe("ai-gateway settings", () => {
   it("resolves stale ids out of the exposed selection", () => {
     const selection = resolveAiGatewaySelection({
       version: 1,
-      models: [{ id: "cursor--grok-4.5" }, { id: "cursor--claude-opus-5" }],
+      models: [{ id: "cursor--grok-4.5" }, { id: "cursor--kimi-k3" }],
     });
     expect(selection.models.map((model) => model.id)).toEqual(["cursor--grok-4.5"]);
   });

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -640,7 +640,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(27);
+    expect(cache.models).toHaveLength(31);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--cursor--auto");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5");
@@ -648,7 +648,10 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast");
     expect(ids).toContain("claude-gateway--cursor--grok-4.6");
     expect(ids).toContain("claude-gateway--cursor--grok-4.6-fast");
-    expect(ids).not.toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
+    expect(ids).toContain("claude-gateway--cursor--claude-opus-5");
+    expect(ids).toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
+    expect(ids).toContain("claude-gateway--cursor--claude-fable-5");
+    expect(ids).toContain("claude-gateway--cursor--claude-fable-5-1m[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-luna[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -48,7 +48,7 @@ describe("terminal settings routes", () => {
     const providers = body.aiGatewayCatalog.providers;
     expect(providers.map((provider) => provider.id)).toEqual(["codex", "xai", "cursor", "opencode", "kimi"]);
     const allIds = providers.flatMap((provider) => provider.models.map((model) => model.id));
-    // Cursor는 auto/composer/grok만 지원하고, Kimi 프로바이더는 별개 경로로 그대로 노출한다.
+    // Cursor 경유 Opus/Fable Max Mode와 Kimi 프로바이더는 다른 경로다 — 둘 다 노출한다.
     expect(allIds).toContain("kimi--k3");
     for (const id of [
       "cursor--auto",
@@ -56,14 +56,18 @@ describe("terminal settings routes", () => {
       "cursor--composer-2.5-fast",
       "cursor--grok-4.5",
       "cursor--grok-4.5-fast",
+      "cursor--claude-opus-5",
+      "cursor--claude-fable-5",
     ]) {
       expect(allIds).toContain(id);
     }
-    expect(allIds).not.toContain("cursor--claude-opus-5-1m");
-    expect(allIds).not.toContain("cursor--claude-fable-5-1m");
     expect(allIds).not.toContain("cursor--kimi-k3-1m");
-    // 남은 Cursor 라인업에는 Max Mode 경로가 없다 — 제거된 1M Max Mode 모델을 되살리지 않는다.
-    expect(providers.find((provider) => provider.id === "cursor")?.models.every((model) => model.maxMode === false)).toBe(true);
+    const cursorModels = providers.find((provider) => provider.id === "cursor")?.models;
+    for (const id of ["cursor--claude-opus-5-1m", "cursor--claude-fable-5-1m"]) {
+      expect(allIds).toContain(id);
+      expect(cursorModels?.find((model) => model.id === id)?.maxMode).toBe(true);
+    }
+    expect(cursorModels?.find((model) => model.id === "cursor--claude-opus-5")?.maxMode).toBe(false);
     const fastIds = allIds.filter((id) => id.endsWith("-fast"));
     expect(fastIds.length).toBeGreaterThan(0);
     // 등급은 이 응답으로만 브라우저에 닿는다 — 투영에서 잘리면 로스터 배지가 사라진다.


### PR DESCRIPTION
## Summary
- Cursor AI Gateway 카탈로그에 Opus 5·Fable 5와 Max Mode 1M 변형을 복원합니다. API 풀로 청구됩니다.
- CursorBench 3.2 수치를 함께 복구하고, Grok 4.6은 유지하며 Cursor GPT-5.6 Sol·Kimi 경유는 다시 넣지 않습니다.
- 픽커·설정·런치 캐시·문서 길이를 31개 카탈로그에 맞춥니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal test`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test -- tests/ai-gateway-model-loadout.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/launch.test.ts`
- [x] `node scripts/compile-changelog-fragments.mjs --check`