### PR TITLE
style(fleet-console): keep window captions on the default frame fill

### DIFF
--- a/.changelog.d/window-caption-b.md
+++ b/.changelog.d/window-caption-b.md
@@ -4,5 +4,5 @@ branch: window-caption-b
 
 ### fleet-console
 #### Changed
-- Operation panels now carry a 28px window caption above the existing body, so the PTY keeps its previous size. The Activity Rail uses the same caption inside its slot. Tactical, War Room, and maximize keep the Operation caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click.
-  ko: Operation 패널은 기존 본문 위에 28px 창 캡션을 붙여 PTY 크기를 유지합니다. Activity Rail은 같은 캡션을 슬롯 안에 둡니다. Tactical·War Room·최대화는 슬롯을 내려 Operation 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다.
+- Operation panels now carry a 28px window caption above the existing body, so the PTY keeps its previous size. The caption keeps the default frame fill; focus is the shared panel outline. The Activity Rail uses the same caption inside its slot. Tactical, War Room, and maximize keep the Operation caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click.
+  ko: Operation 패널은 기존 본문 위에 28px 창 캡션을 붙여 PTY 크기를 유지합니다. 캡션은 기본 프레임 칠을 유지하고, 포커스는 패널과 이어진 아웃라인만 씁니다. Activity Rail은 같은 캡션을 슬롯 안에 둡니다. Tactical·War Room·최대화는 슬롯을 내려 Operation 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5832,8 +5832,10 @@
   min-height: 28px;
   height: 28px;
   padding: 0 var(--space-2);
-  /* 보더는 패널 아웃라인을 잇는다 — 활성 전용 틴트는 같은 신호를 캡션에 한 번 더 칠한다. */
-  border: 1px solid inherit;
+  /* 보더는 패널 아웃라인을 잇는다 — inherit은 단축 전체가 아니라 색만 받는다. */
+  border-width: 1px;
+  border-style: solid;
+  border-color: inherit;
   border-bottom: none;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   overflow: visible;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5832,7 +5832,8 @@
   min-height: 28px;
   height: 28px;
   padding: 0 var(--space-2);
-  border: 1px solid var(--surface-rim);
+  /* 보더는 패널 아웃라인을 잇는다 — 활성 전용 틴트는 같은 신호를 캡션에 한 번 더 칠한다. */
+  border: 1px solid inherit;
   border-bottom: none;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   overflow: visible;
@@ -5846,11 +5847,6 @@
 
 .canvas-operation-titlebar:active {
   cursor: grabbing;
-}
-
-.canvas-operation.is-active .canvas-operation-titlebar {
-  border-color: color-mix(in oklch, var(--brass) 62%, var(--ink-rim));
-  background: color-mix(in oklch, var(--brass) 7%, var(--surface-frame));
 }
 
 .canvas-operation-identity-name,
@@ -5876,10 +5872,6 @@
 }
 
 .canvas-operation-identity-name:hover {
-  color: var(--text-primary);
-}
-
-.canvas-operation.is-active .canvas-operation-identity-name {
   color: var(--text-primary);
 }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1668,11 +1668,13 @@ describe("Instrument core design contract", () => {
     expect(identityInputBlock).not.toContain("width: 0;");
     expect(components).toContain("top: -28px;");
     expect(components).toContain("border-radius: 999px;");
-    // 활성 타이틀바는 brass 7% 틴트를 frame 위에 얹는다 — ink-mid 재결합 회귀를 여기서 잡는다.
-    expect(components).toContain("color-mix(in oklch, var(--brass) 7%, var(--surface-frame))");
     expect(components).toContain("color: var(--text-secondary);");
-    expect(components).toContain(".canvas-operation.is-active .canvas-operation-titlebar {");
-    expect(components).toContain("color-mix(in oklch, var(--brass) 62%, var(--ink-rim))");
+    // 활성은 패널 아웃라인만 말한다 — 캡션 brass 틴트와 이름 재채색은 같은 신호를 중복한다.
+    expect(components).toContain("border: 1px solid inherit;");
+    expect(components).not.toContain(".canvas-operation.is-active .canvas-operation-titlebar");
+    expect(components).not.toContain(".canvas-operation.is-active .canvas-operation-identity-name");
+    expect(components).not.toContain("color-mix(in oklch, var(--brass) 7%, var(--surface-frame))");
+    expect(components).toContain(".canvas-operation.is-active {\n  border-color: color-mix(in oklch, var(--brass) 62%, var(--ink-rim));");
     expect(components).toContain(".canvas-operation-window-controls {");
     const windowControlsBlock = components.match(/\.canvas-operation-window-controls \{[^}]*\}/)?.[0] ?? "";
     expect(windowControlsBlock).toContain("margin-left: auto;");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1670,7 +1670,11 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("border-radius: 999px;");
     expect(components).toContain("color: var(--text-secondary);");
     // 활성은 패널 아웃라인만 말한다 — 캡션 brass 틴트와 이름 재채색은 같은 신호를 중복한다.
-    expect(components).toContain("border: 1px solid inherit;");
+    // inherit은 단축 전체가 아니라 border-color만 받는다. 1px solid inherit은 선언이 버려진다.
+    expect(components).toContain("border-width: 1px;");
+    expect(components).toContain("border-style: solid;");
+    expect(components).toContain("border-color: inherit;");
+    expect(components).not.toContain("border: 1px solid inherit;");
     expect(components).not.toContain(".canvas-operation.is-active .canvas-operation-titlebar");
     expect(components).not.toContain(".canvas-operation.is-active .canvas-operation-identity-name");
     expect(components).not.toContain("color-mix(in oklch, var(--brass) 7%, var(--surface-frame))");


### PR DESCRIPTION
## Summary
- 활성 Operation 캡션의 brass 틴트와 제목 재채색을 제거합니다. 기본 프레임 칠을 유지하고, 포커스는 패널과 이어진 아웃라인만 씁니다.
- 캡션 보더는 패널 `border-color`를 inherit 해서 창 프레임이 한 줄로 남습니다.
- 아직 미릴리스인 창 캡션 노트를 그 동작에 맞게 고칩니다.

Changelog-Amend: window-caption-b.md

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts` (57 passed)
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] 활성/비활성 패널을 나란히 두고 캡션 채움이 같고 아웃라인만 brass인지 확인
- [ ] 대기(aurora)·미확인(positive) 패널에서도 캡션 보더가 본문과 이어지는지 확인