### PR TITLE
fix(fleet-console): keep Quick Launch deck highlight in view

### DIFF
--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -552,6 +552,21 @@ export function QuickLaunch() {
   const activeCommandRow = commandRowsFlat.length === 0
     ? null
     : commandRowsFlat[Math.min(commandActiveIndex, commandRowsFlat.length - 1)] ?? null;
+  const activeCommandOptionId = commandDeckOpen && activeCommandRow
+    ? `quick-launch-command-${activeCommandRow.id}`
+    : undefined;
+  const activeMentionOptionId = mentionDeckOpen && activeMention
+    ? `quick-launch-mention-${activeMention.operationId}`
+    : undefined;
+
+  // 잘린 덱에서 하이라이트만 움직이면 활성 행이 화면 밖으로 나간다 — 팔레트·useSelect와
+  // 같은 nearest 스크롤을 방향키 인덱스와 짝으로 둔다. 옵션 id는 aria-activedescendant와 공유한다.
+  useEffect(() => {
+    const optionId = activeCommandOptionId ?? activeMentionOptionId;
+    if (!optionId) return;
+    document.getElementById(optionId)?.scrollIntoView({ block: "nearest" });
+  }, [activeCommandOptionId, activeMentionOptionId]);
+
   // 첨부 능력은 실행 대상 플러그인이 선언한다 — console-core는 어느 플러그인인지 모른 채
   // 능력의 존재로만 붙여넣기를 받는다(messageOperation과 같은 계약). 능력이 없으면 기존처럼 무반응.
   const attachmentPlugin = useMemo(
@@ -1172,11 +1187,7 @@ export function QuickLaunch() {
               : t("chrome.quickLaunch.placeholder")}
             aria-label={t("chrome.quickLaunch.promptLabel")}
             aria-controls={mentionDeckOpen ? "quick-launch-mention-deck" : commandDeckOpen ? "quick-launch-command-deck" : undefined}
-            aria-activedescendant={mentionDeckOpen && activeMention
-              ? `quick-launch-mention-${activeMention.operationId}`
-              : commandDeckOpen && activeCommandRow
-                ? `quick-launch-command-${activeCommandRow.id}`
-                : undefined}
+            aria-activedescendant={activeMentionOptionId ?? activeCommandOptionId}
             spellCheck={false}
           />
           {attachments.length > 0 ? (

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -195,6 +195,14 @@ describe("Quick Launch picker keyboard grammar", () => {
     expect(quickLaunch).toMatch(tabBranch);
   });
 
+  it("scrolls the active command or mention row into the clipped deck", () => {
+    // 방향키는 하이라이트만 옮기고 포커스는 textarea에 남는다 — 잘린 덱이 활성 행을
+    // 따라가지 않으면 /model·/effort·@ 목록에서 하이라이트가 화면 밖으로 걷는다.
+    expect(quickLaunch).toMatch(/scrollIntoView\(\{\s*block:\s*"nearest"\s*\}\)/u);
+    expect(quickLaunch).toMatch(/quick-launch-command-\$\{activeCommandRow\.id\}/u);
+    expect(quickLaunch).toMatch(/quick-launch-mention-\$\{activeMention\.operationId\}/u);
+  });
+
   it("gives every picker item a roving tabIndex and a typeahead label", () => {
     // tabIndex -1이 아니면 항목이 Tab 정지점으로 남고, data-menu-label이 없으면 typeahead가 침묵한다.
     const theaterItem = /role="menuitemradio"\s+aria-checked=\{theater\.id === theaterId\}\s+tabIndex=\{-1\}\s+data-menu-label=\{theater\.label\}/u;


### PR DESCRIPTION
## Summary
- Quick Launch `/model`·`/effort`·`@` 덱은 방향키로 하이라이트만 옮기고 포커스는 textarea에 남깁니다.
- 잘린 목록에서 활성 행이 화면 밖으로 걷지 않도록 `scrollIntoView({ block: "nearest" })`를 붙이고, 옵션 id는 `aria-activedescendant`와 공유합니다.
- 슬래시 명령은 아직 미릴리스라 별도 changelog는 쓰지 않았습니다.

## Test Plan
- [x] `pnpm exec vitest run tests/quick-launch-layout.test.tsx` (34/34)
- [ ] `/model` 또는 `/effort`에서 목록이 잘릴 때까지 방향키를 내려 하이라이트가 덱 안에 남는지 확인
- [ ] `@` 멘션 목록이 길 때도 같은지 확인