### PR TITLE
fix(fleet-console): include the window caption in Tactical row stride

### DIFF
--- a/.changelog.d/window-caption-b.md
+++ b/.changelog.d/window-caption-b.md
@@ -4,5 +4,5 @@ branch: window-caption-b
 
 ### fleet-console
 #### Changed
-- Operation panels now carry a 28px window caption above the existing body, so the PTY keeps its previous size. The caption keeps the default frame fill; focus is the shared panel outline. The Activity Rail uses the same caption inside its slot. Tactical, War Room, and maximize keep the Operation caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click.
-  ko: Operation 패널은 기존 본문 위에 28px 창 캡션을 붙여 PTY 크기를 유지합니다. 캡션은 기본 프레임 칠을 유지하고, 포커스는 패널과 이어진 아웃라인만 씁니다. Activity Rail은 같은 캡션을 슬롯 안에 둡니다. Tactical·War Room·최대화는 슬롯을 내려 Operation 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다.
+- Operation panels now carry a 28px window caption above the existing body, so the PTY keeps its previous size. The caption keeps the default frame fill; focus is the shared panel outline. The Activity Rail uses the same caption inside its slot. Tactical packs each row with that 28px caption in the stride so stacked captions stay in their cells. War Room and maximize keep the caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click.
+  ko: Operation 패널은 기존 본문 위에 28px 창 캡션을 붙여 PTY 크기를 유지합니다. 캡션은 기본 프레임 칠을 유지하고, 포커스는 패널과 이어진 아웃라인만 씁니다. Activity Rail은 같은 캡션을 슬롯 안에 둡니다. Tactical은 행 보폭에 28px 캡션을 넣어 쌓인 캡션이 칸 안에 머물게 합니다. War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -68,6 +68,9 @@ export const MIN_OPERATION_WIDTH = 320;
 export const MIN_OPERATION_HEIGHT = 200;
 export const OPERATION_GRID_GAP = 8;
 export const OPERATION_GRID_PADDING = 0;
+// 본문 위에 붙는 창 캡션 높이. CSS top:-28px / height:28px 와 한 값이다.
+// grid/rows 행 보폭에 넣어 아래 행 캡션이 위 행 본문을 침범하지 않게 한다.
+export const OPERATION_WINDOW_CAPTION_HEIGHT = 28;
 const OPERATION_FOCUS_PADDING = 96;
 const FOCUS_MIN_ZOOM = 0.25;
 // fit-all의 하한은 사용성 경계가 아니라 수치 안전 epsilon이다 — fit은 "전체를 담는" 계약이라
@@ -417,6 +420,9 @@ export function getTheaterMinimizedIds(theaterIds: readonly string[]): readonly 
 // 균형 그리드의 열은 ceil(sqrt(n)), 행은 ceil(n / cols)로 정한다. 마지막 행에 슬롯이 모자라면
 // 남은 패널들이 그 행의 전체 폭을 나눠 채워 빈 셀을 남기지 않는다. 최소 크기는 실제 가용 폭·높이로
 // 캡해, 좁은 Formation 캔버스에서도 panel chrome이 clip되지 않게 한다.
+// grid/rows 행 보폭은 본문 높이 + gap + 캡션이다. 캡션은 본문 위(top: -28px)에 붙으므로
+// 피치에 넣지 않으면 아래 행이 위 행 본문을 침범한다. columns는 한 줄이라 첫 행 여백만
+// 호출부가 지고, 이 함수는 가로 gap만 쓴다.
 export function calculateGridSlots(
   rect: CanvasWorldRect,
   count: number,
@@ -448,20 +454,22 @@ export function calculateGridSlots(
     const naturalWidth = innerWidth;
     const effectiveMinWidth = Math.min(minimumWidth, naturalWidth);
     const width = Math.min(Math.max(effectiveMinWidth, naturalWidth), innerWidth);
-    const availableHeight = Math.max(0, innerHeight - gap * (count - 1));
+    const rowStride = gap + OPERATION_WINDOW_CAPTION_HEIGHT;
+    const availableHeight = Math.max(0, innerHeight - rowStride * (count - 1));
     const naturalHeight = availableHeight / count;
     const effectiveMinHeight = Math.min(minimumHeight, naturalHeight);
     const height = Math.min(Math.max(effectiveMinHeight, naturalHeight), availableHeight);
     return Array.from({ length: count }, (_, index) => ({
       x: rect.x + padding,
-      y: rect.y + padding + index * (height + gap),
+      y: rect.y + padding + index * (height + rowStride),
       width,
       height,
     }));
   }
   const columns = Math.ceil(Math.sqrt(count));
   const rows = Math.ceil(count / columns);
-  const availableHeight = Math.max(0, innerHeight - gap * (rows - 1));
+  const rowStride = gap + OPERATION_WINDOW_CAPTION_HEIGHT;
+  const availableHeight = Math.max(0, innerHeight - rowStride * (rows - 1));
   const naturalHeight = availableHeight / rows;
   const effectiveMinHeight = Math.min(minimumHeight, naturalHeight);
   const height = Math.min(Math.max(effectiveMinHeight, naturalHeight), availableHeight);
@@ -476,7 +484,7 @@ export function calculateGridSlots(
     const width = Math.min(Math.max(effectiveMinWidth, naturalWidth), availableWidth);
     return {
       x: rect.x + padding + column * (width + gap),
-      y: rect.y + padding + row * (height + gap),
+      y: rect.y + padding + row * (height + rowStride),
       width,
       height,
     };

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -18,7 +18,7 @@ import { resolveOperationActivity } from "../operation-activity.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
 import { OperationBodySlot, useOperationBodyPoolAvailable, type OperationBodyConfig } from "../mobile/operation-body-pool.js";
-import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, consumePendingFitAllOperations, enforceStationKeeping, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, getTheaterCanvasSnapshot, getTheaterMinimizedIds, minimizeOperation, prefersReducedMotion, resetCanvasViewportSize, restoreOperation, setCanvasViewportSize, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setTheaterOperationGeometry, setTheaterOperationMinimized, settleOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useCompanionPanelVisibilityOverrides, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
+import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, consumePendingFitAllOperations, enforceStationKeeping, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, getTheaterCanvasSnapshot, getTheaterMinimizedIds, minimizeOperation, OPERATION_WINDOW_CAPTION_HEIGHT, prefersReducedMotion, resetCanvasViewportSize, restoreOperation, setCanvasViewportSize, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setTheaterOperationGeometry, setTheaterOperationMinimized, settleOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useCompanionPanelVisibilityOverrides, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
 import { escapeSelectorValue, flyPanelMotionGhost, playMinimizeFlight } from "./panel-motion.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
@@ -75,8 +75,9 @@ interface PluginOperationRendererProps {
 const DEFAULT_SHELL_WIDTH = 560;
 const DEFAULT_SHELL_HEIGHT = 360;
 /* components.css의 .canvas-operation-titlebar top(-28px)과 짝을 이루는 상수.
-   캡션은 본문·PTY geometry 밖에 붙는 패널 속성이라, 이 높이만큼만 캔버스 클립을 본다. */
-const TITLEBAR_OUTSET_PX = 28;
+   캡션은 본문·PTY geometry 밖에 붙는 패널 속성이라, 이 높이만큼만 캔버스 클립을 본다.
+   행 보폭은 calculateGridSlots가 같은 상수를 쓴다. */
+const TITLEBAR_OUTSET_PX = OPERATION_WINDOW_CAPTION_HEIGHT;
 // 프리뷰 config는 identity 비교로 재발행이 억제되므로 공유 불변 배열을 쓴다.
 const EMPTY_HIDDEN_COMPANION_IDS: readonly string[] = [];
 

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { calculateGridSlots, clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, consumePendingFitAllOperations, ensureDefaultGeometry, fitAllOperations, forceDropCompanionOperationId, getCompanionOperationId, getCompanionPanelVisibilityOverrides, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getStationKeeping, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, requestFitAllOperations, resetCanvasViewportSize, resolveClearPosition, resolveLaunchGeometry, restoreOperation, selectFormationLayout, setCanvasViewportSize, setCompanionOperationId, setCompanionPanelVisible, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, setState, setStationKeeping, settleOperationGeometry, STATION_KEEPING_GAP, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { calculateGridSlots, clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, consumePendingFitAllOperations, ensureDefaultGeometry, fitAllOperations, forceDropCompanionOperationId, getCompanionOperationId, getCompanionPanelVisibilityOverrides, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getStationKeeping, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, OPERATION_WINDOW_CAPTION_HEIGHT, pruneOperations, requestFitAllOperations, resetCanvasViewportSize, resolveClearPosition, resolveLaunchGeometry, restoreOperation, selectFormationLayout, setCanvasViewportSize, setCompanionOperationId, setCompanionPanelVisible, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, setState, setStationKeeping, settleOperationGeometry, STATION_KEEPING_GAP, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 
 const GEOMETRY: OperationGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -570,17 +570,17 @@ describe("canvas store", () => {
     const slots = calculateGridSlots({ x: 10, y: 20, width: 100, height: 100 }, 3, 320, 200, 16, 24);
 
     expect(slots).toHaveLength(3);
-    expect(slots[0]).toEqual({ x: 34, y: 44, width: 18, height: 18 });
+    expect(slots[0]).toEqual({ x: 34, y: 44, width: 18, height: 4 });
     expect(slots[1]?.x).toBe(68);
-    expect(slots[2]).toEqual({ x: 34, y: 78, width: 52, height: 18 });
+    expect(slots[2]).toEqual({ x: 34, y: 92, width: 52, height: 4 });
   });
 
   it("stretches the last row across the full width so no empty cell remains", () => {
     const slots = calculateGridSlots({ x: 0, y: 0, width: 1000, height: 800 }, 3, 100, 100, 10, 0);
 
-    expect(slots[0]).toEqual({ x: 0, y: 0, width: 495, height: 395 });
-    expect(slots[1]).toEqual({ x: 505, y: 0, width: 495, height: 395 });
-    expect(slots[2]).toEqual({ x: 0, y: 405, width: 1000, height: 395 });
+    expect(slots[0]).toEqual({ x: 0, y: 0, width: 495, height: 381 });
+    expect(slots[1]).toEqual({ x: 505, y: 0, width: 495, height: 381 });
+    expect(slots[2]).toEqual({ x: 0, y: 419, width: 1000, height: 381 });
   });
 
   it("caps the effective minimum size to a narrow canvas", () => {
@@ -601,11 +601,11 @@ describe("canvas store", () => {
     const slots = calculateGridSlots({ x: 10, y: 20, width: 1000, height: 800 }, 5, 320, 200, 10, 20, "rows");
 
     expect(slots).toHaveLength(5);
-    expect(slots[0]).toEqual({ x: 30, y: 40, width: 960, height: 144 });
-    expect(slots[4]).toEqual({ x: 30, y: 656, width: 960, height: 144 });
+    expect(slots[0]).toEqual({ x: 30, y: 40, width: 960, height: 121.6 });
+    expect(slots[4]).toEqual({ x: 30, y: 678.4, width: 960, height: 121.6 });
   });
 
-  it("quantifies the Formation frame padding without a HUD reserve at 1280x720", () => {
+  it("quantifies the Formation frame padding and caption row stride at 1280x720", () => {
     const formationRect = { x: 0, y: 0, width: 1_280, height: 720 };
     const gridNine = calculateGridSlots(formationRect, 9, 320, 200, 8, 18, "grid");
     const gridTwelve = calculateGridSlots(formationRect, 12, 320, 200, 8, 18, "grid");
@@ -615,15 +615,17 @@ describe("canvas store", () => {
     const rowsFour = calculateGridSlots(formationRect, 4, 320, 200, 8, 18, "rows");
 
     expect(gridNine[0]).toMatchObject({ x: 18, y: 18, width: 409.3333333333333 });
-    expect(gridNine[0]?.height).toBeCloseTo(222.666667);
+    expect(gridNine[0]?.height).toBe(204);
     expect(gridTwelve[0]).toMatchObject({ x: 18, y: 18, width: 305 });
-    expect(gridTwelve[0]?.height).toBeCloseTo(222.666667);
+    expect(gridTwelve[0]?.height).toBe(204);
     expect(columnsThree[0]).toMatchObject({ width: 409.3333333333333, height: 684 });
     expect(columnsFour[0]).toMatchObject({ width: 305, height: 684 });
     expect(rowsThree[0]?.width).toBe(1_244);
-    expect(rowsThree[0]?.height).toBeCloseTo(222.666667);
+    expect(rowsThree[0]?.height).toBe(204);
     expect(rowsFour[0]?.width).toBe(1_244);
-    expect(rowsFour[0]?.height).toBe(165);
+    expect(rowsFour[0]?.height).toBe(144);
+    expect(gridNine[3]!.y - OPERATION_WINDOW_CAPTION_HEIGHT).toBeGreaterThanOrEqual(gridNine[0]!.y + gridNine[0]!.height + 8);
+    expect(rowsThree[1]!.y - OPERATION_WINDOW_CAPTION_HEIGHT).toBeGreaterThanOrEqual(rowsThree[0]!.y + rowsThree[0]!.height + 8);
   });
 
   it("defaults Formation layout to grid and persists the global selection", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1694,6 +1694,10 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("/* 두 번 눌러 확정 중인 위험 상태만 coral 채널을 쓰며");
     expect(components).toContain(".canvas-operation .canvas-operation-window-controls .canvas-operation-icon-button.is-armed-close {");
     // Tactical/War Room/최대화는 슬롯을 28px 내려 캡션을 본문 밖에 둔다.
+    // Tactical grid/rows 행 보폭은 같은 28px를 본문 피치에 넣어 아래 행 캡션이 위 칸을 침범하지 않는다.
+    expect(source("canvas/canvas-store.ts")).toContain("export const OPERATION_WINDOW_CAPTION_HEIGHT = 28");
+    expect(source("canvas/canvas-store.ts")).toContain("const rowStride = gap + OPERATION_WINDOW_CAPTION_HEIGHT");
+    expect(source("canvas/canvas.tsx")).toContain("const TITLEBAR_OUTSET_PX = OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/canvas.tsx")).toContain("y: TITLEBAR_OUTSET_PX");
     expect(source("canvas/canvas.tsx")).toContain("TITLEBAR_OUTSET_PX * effectiveZoom");
     expect(source("canvas/coordinates.ts")).toContain("y: 18 + 28");


### PR DESCRIPTION
## Summary
- Tactical grid/rows now include the 28px attached window caption in the row stride so stacked captions stay in their cells.
- Body and PTY geometry stay unchanged; the columns layout remains a single row.
- The shared caption constant, design-contract pins, and the unreleased caption note stay aligned.

Changelog-Amend: window-caption-b.md

## Test Plan
- [ ] Open Tactical with a multi-row grid and confirm each caption sits in its own cell without overlapping the row above
- [ ] Switch Tactical to rows and columns; columns stay a single full-height row, rows keep caption clearance
- [ ] Confirm War Room and maximize still shift the slot down and keep PTY size
- [ ] `pnpm exec vitest run tests/canvas-store.test.ts tests/instrument-design-contract.test.ts tests/operation-frame-identity.test.ts tests/canvas-minimap-formation.test.ts`