### PR TITLE
fix(ai-gateway): page Cursor read tools directly

### DIFF
--- a/.changelog.d/cursor-composer-compaction.md
+++ b/.changelog.d/cursor-composer-compaction.md
@@ -1,0 +1,13 @@
+---
+branch: cursor-composer-compaction
+---
+
+### fleet-cli
+#### Fixed
+- Let Cursor models page through the caller Read tool instead of repeatedly replaying whole files through failed native reads, reducing context growth and compaction during long gateway sessions.
+  ko: Cursor 모델이 실패한 네이티브 읽기로 전체 파일을 반복 재전송하는 대신 호출자 Read 도구로 페이지를 나눠 읽게 하여 장기 게이트웨이 세션의 컨텍스트 증가와 컴팩션을 줄였습니다.
+
+### fleet-console
+#### Fixed
+- Let Cursor models page through the caller Read tool instead of repeatedly replaying whole files through failed native reads, reducing context growth and compaction during long gateway Operations.
+  ko: Cursor 모델이 실패한 네이티브 읽기로 전체 파일을 반복 재전송하는 대신 호출자 Read 도구로 페이지를 나눠 읽게 하여 장기 게이트웨이 Operation의 컨텍스트 증가와 컴팩션을 줄였습니다.

--- a/packages/core-ai-gateway/src/cursor/native/adapter.ts
+++ b/packages/core-ai-gateway/src/cursor/native/adapter.ts
@@ -3476,13 +3476,11 @@ function isCursorClientToolFrame(
   if (call?.providerIdentifier === CURSOR_TOOL_PROVIDER_IDENTIFIER) return true;
   return cursorNativeExecRedirect(
     exec,
-    redirectTools
-      .filter((tool) => isCursorNativeRedirectToolName(tool.clientName))
-      .map((tool) => ({
-        clientName: tool.clientName,
-        wireName: tool.toolName,
-        inputSchemaValue: tool.inputSchemaValue,
-      })),
+    redirectTools.map((tool) => ({
+      clientName: tool.clientName,
+      wireName: tool.toolName,
+      inputSchemaValue: tool.inputSchemaValue,
+    })),
     CURSOR_TOOL_PROVIDER_IDENTIFIER,
   ) !== null;
 }

--- a/packages/core-ai-gateway/src/cursor/native/adapter.ts
+++ b/packages/core-ai-gateway/src/cursor/native/adapter.ts
@@ -1009,9 +1009,16 @@ function cursorClientToolDiscipline(
   nativeTools: readonly CanonicalNativeTool[],
 ): string {
   const nativeWebSearch = nativeTools.some((tool) => tool.type === "web_search");
-  const redirectLeaves = new Set(redirectTools.map((tool) => cursorToolLeafName(tool.clientName).replace(/[_-]/g, "").toLowerCase()));
+  const redirectLeaves = new Set(
+    redirectTools
+      .filter((tool) => isCursorNativeRedirectToolName(tool.clientName))
+      .map((tool) =>
+        cursorToolLeafName(tool.clientName)
+          .replace(/[_-]/g, "")
+          .toLowerCase()
+      ),
+  );
   const routed: string[] = [];
-  if (redirectLeaves.has("read")) routed.push("read");
   const hasShell = ["bash", "shellcommand", "execcommand"].some((leaf) => redirectLeaves.has(leaf));
   if (redirectLeaves.has("grep") || hasShell) routed.push("search");
   if (hasShell) routed.push("shell");
@@ -2732,11 +2739,13 @@ function createCursorLiveRun(options: CursorLiveRunOptions): CursorLiveRun {
       }
       const redirect = cursorNativeExecRedirect(
         frame.execServerMessage,
-        redirectTools.map((tool) => ({
-          clientName: tool.clientName,
-          wireName: tool.toolName,
-          inputSchemaValue: tool.inputSchemaValue,
-        })),
+        redirectTools
+          .filter((tool) => isCursorNativeRedirectToolName(tool.clientName))
+          .map((tool) => ({
+            clientName: tool.clientName,
+            wireName: tool.toolName,
+            inputSchemaValue: tool.inputSchemaValue,
+          })),
         CURSOR_TOOL_PROVIDER_IDENTIFIER,
       );
       if (redirect) {
@@ -3467,11 +3476,13 @@ function isCursorClientToolFrame(
   if (call?.providerIdentifier === CURSOR_TOOL_PROVIDER_IDENTIFIER) return true;
   return cursorNativeExecRedirect(
     exec,
-    redirectTools.map((tool) => ({
-      clientName: tool.clientName,
-      wireName: tool.toolName,
-      inputSchemaValue: tool.inputSchemaValue,
-    })),
+    redirectTools
+      .filter((tool) => isCursorNativeRedirectToolName(tool.clientName))
+      .map((tool) => ({
+        clientName: tool.clientName,
+        wireName: tool.toolName,
+        inputSchemaValue: tool.inputSchemaValue,
+      })),
     CURSOR_TOOL_PROVIDER_IDENTIFIER,
   ) !== null;
 }

--- a/packages/core-ai-gateway/src/cursor/native/exec-redirect.ts
+++ b/packages/core-ai-gateway/src/cursor/native/exec-redirect.ts
@@ -50,7 +50,7 @@ const READ_CANDIDATES = ["Read"] as const;
 const GREP_CANDIDATES = ["Grep"] as const;
 const SHELL_CANDIDATES = ["Bash", "shell_command", "exec_command"] as const;
 
-/** Tools needed to redirect the native operations whose result contract Fleet can preserve. */
+/** Caller tools kept eager because Cursor uses them directly or through a native redirect. */
 export const CURSOR_HOT_PATH_TOOL_LEAVES = [
   "read",
   "bash",
@@ -68,7 +68,7 @@ export function isCursorHotPathToolName(name: string): boolean {
 /** Caller tools whose Cursor-native equivalent is redirected without advertising a duplicate. */
 export function isCursorNativeRedirectToolName(name: string): boolean {
   const leaf = toolLeafName(name).replace(/[_-]/g, "").toLowerCase();
-  return ["read", "grep", "bash", "shellcommand", "execcommand"].includes(leaf);
+  return ["grep", "bash", "shellcommand", "execcommand"].includes(leaf);
 }
 
 /**

--- a/packages/core-ai-gateway/tests/cursor/native/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/adapter.test.ts
@@ -172,7 +172,8 @@ describe("Cursor request budgets", () => {
 
     for (const context of [prompt.action?.userMessageAction?.requestContext, resume.action?.resumeAction?.requestContext]) {
       const rule = context?.rules?.[0];
-      expect(rule?.content).toContain("Native read, search, shell requests are routed through the caller's tools and permissions");
+      expect(rule?.content).toContain("Native search, shell requests are routed through the caller's tools and permissions");
+      expect(rule?.content).not.toContain("Native read requests are routed through the caller's tools");
       expect(rule?.content).not.toContain("cannot preserve partial-file metadata");
       expect(rule?.content).toContain("Native mutation, fetch");
       expect(rule?.content).not.toContain("Do not invoke Cursor-native tools");
@@ -212,9 +213,26 @@ describe("Cursor request budgets", () => {
     }), "conversation-tool-alias");
     const wireTools = runRequest(plan).mcpTools?.mcpTools ?? [];
 
-    expect(wireTools.map((entry) => entry.toolName)).toEqual(["read_file"]);
+    expect(wireTools.map((entry) => entry.toolName)).toEqual([
+      expect.stringMatching(/^cc_read_[a-f0-9]{8}$/),
+      "read_file",
+    ]);
     expect(plan.redirectTools.find((tool) => tool.clientName === "Read")?.toolName)
       .toMatch(/^cc_read_[a-f0-9]{8}$/);
+  });
+
+  it("advertises Read directly without routing it as native, while routing Grep and Bash", () => {
+    const plan = buildCursorRunPlan(request({
+      tools: [tool("Read"), tool("Grep"), tool("Bash")],
+    }), "conversation-guidance-eligibility");
+    const names = runRequest(plan).mcpTools?.mcpTools.map((entry) => entry.toolName) ?? [];
+    const guidance = encodedRunRequest(plan).action?.userMessageAction?.requestContext?.rules?.[0]?.content ?? "";
+
+    expect(names).toContain(plan.redirectTools.find((tool) => tool.clientName === "Read")?.toolName);
+    expect(names).not.toContain(plan.redirectTools.find((tool) => tool.clientName === "Grep")?.toolName);
+    expect(names).not.toContain(plan.redirectTools.find((tool) => tool.clientName === "Bash")?.toolName);
+    expect(guidance).not.toContain("Native read requests are routed");
+    expect(guidance).toContain("Native search, shell requests are routed");
   });
 
   it("loads only ToolSearch-selected deferred tools into the next Cursor catalog", () => {
@@ -230,8 +248,8 @@ describe("Cursor request budgets", () => {
     const toolSearchWireName = initialNames.find((name) => name.startsWith("cc_tool_search_"));
 
     expect(toolSearchWireName).toMatch(/^cc_tool_search_[a-f0-9]{8}$/);
-    expect(initialNames).toHaveLength(1);
-    expect(initialNames.some((name) => name.startsWith("cc_read_"))).toBe(false);
+    expect(initialNames).toHaveLength(2);
+    expect(initialNames.some((name) => name.startsWith("cc_read_"))).toBe(true);
     expect(initialNames).not.toContain("mcp__fleet__wiki_read");
     const initialRule = encodedRunRequest(initialPlan).action?.userMessageAction?.requestContext?.rules?.[0]?.content;
     expect(initialRule).toContain(`Use \`${toolSearchWireName}\` for deferred tools.`);
@@ -329,8 +347,9 @@ describe("Cursor request budgets", () => {
     // The pre-flight sizing view must agree with the payload, not the declaration.
     expect(new CursorAdapter().wireTools(canonical).map((entry) => entry.name)).toEqual([
       "ToolSearch",
+      "Read",
     ]);
-    expect(runRequest(plan).mcpTools?.mcpTools).toHaveLength(1);
+    expect(runRequest(plan).mcpTools?.mcpTools).toHaveLength(2);
   });
 
   it("reports the capped survivors when the declared catalog overruns the byte budget", () => {

--- a/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
@@ -1651,6 +1651,71 @@ describe("Cursor live client-tool Run bridge", () => {
     }
   });
 
+  it("keeps a parked Run when native Read races past the seal", async () => {
+    const diagnostics: CursorDiagnosticEvent[] = [];
+    const first = cursorCall("call-native-read-race-first", 153);
+    const late = cursorCall("call-native-read-race-late", 154);
+    const stream = new BridgeCursorStream(
+      cursorToolFrames([first]),
+      cursorCompletionFrames("continued after native Read policy"),
+      2,
+    );
+    const harness = cursorHarness([stream], {
+      diagnostics: (event) => diagnostics.push(event),
+    });
+    const initial: CanonicalResponseRequest = {
+      ...cursorRequest("session-native-read-race", "composer-2.5"),
+      tools: [
+        ...(cursorRequest("unused", "composer-2.5").tools ?? []),
+        {
+          type: "function",
+          name: "Read",
+          description: "Read a file",
+          parameters: {
+            type: "object",
+            properties: { file_path: { type: "string" } },
+            required: ["file_path"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    };
+
+    try {
+      await collectCursorResponse(harness.adapter, initial);
+      await stream.emitFrames([{
+        execServerMessage: {
+          id: late.messageId,
+          execId: late.execId,
+          readArgs: { path: "README.md", toolCallId: late.callId },
+        },
+      }]);
+      expect(stream.closed).toBe(false);
+
+      const events = await collectCursorResponse(
+        harness.adapter,
+        cursorContinuation(initial, [first], [cursorResult(first, "first result")]),
+      );
+
+      expect(canonicalText(events)).toBe("continued after native Read policy");
+      expect(harness.openedStreams).toBe(1);
+      expect(cursorClientWrites(stream)).toContainEqual(expect.objectContaining({
+        execClientMessage: expect.objectContaining({
+          readResult: expect.objectContaining({
+            error: expect.objectContaining({ error: expect.stringContaining("cc_read_") }),
+          }),
+        }),
+      }));
+      expect(diagnostics).toContainEqual(expect.objectContaining({ event: "bridge.defer" }));
+      expect(diagnostics).toContainEqual(expect.objectContaining({
+        event: "bridge.attach",
+        outcome: "deferred_replay",
+      }));
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
   it.each<[string, (call: CursorCallSpec) => unknown[]]>([
     ["token accounting", () => [{ interactionUpdate: { tokenDelta: { tokens: 3 } } }]],
     ["the parked call's own tool update", (call) => [cursorToolCompletedFrame(call)]],

--- a/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
@@ -81,7 +81,7 @@ describe("Cursor live client-tool Run bridge", () => {
     },
   );
 
-  it("redirects native read through caller Read without inventing whole-file metadata", async () => {
+  it("rejects native Read with the advertised caller Read alias on the same Run", async () => {
     const call = cursorCall("native-read-redirect", 24);
     const stream = new BridgeCursorStream(
       [{
@@ -115,42 +115,40 @@ describe("Cursor live client-tool Run bridge", () => {
 
     try {
       const firstEvents = await collectCursorResponse(harness.adapter, initial);
-      expect(firstEvents).toContainEqual(expect.objectContaining({
+      expect(firstEvents).not.toContainEqual(expect.objectContaining({
         type: "response.output_item.done",
-        item: expect.objectContaining({
-          call_id: call.callId,
-          name: "Read",
-          arguments: JSON.stringify({ file_path: "README.md" }),
+        item: expect.objectContaining({ name: "Read" }),
+      }));
+      expect(cursorClientWrites(stream)).toContainEqual(expect.objectContaining({
+        execClientMessage: expect.objectContaining({
+          readResult: expect.objectContaining({
+            error: expect.objectContaining({
+              error: expect.stringContaining("cc_read_"),
+            }),
+          }),
         }),
       }));
-      const events = await collectCursorResponse(
-        harness.adapter,
-        cursorContinuation(initial, [{ ...call, name: "Read" }], [{
-          call_id: call.callId,
-          output: "1→first line\n2→second line",
-        }]),
-      );
-
-      expect(canonicalText(events)).toBe("native read continued");
-      expect(cursorClientWrites(stream)).toContainEqual(expect.objectContaining({
-        execClientMessage: {
-          id: call.messageId,
-          execId: call.execId,
-          readResult: {
-            error: {
-              path: "README.md",
-              error: expect.stringContaining("Caller output:\n1→first line\n2→second line"),
-            },
-          },
-        },
+      expect(cursorClientWrites(stream)).not.toContainEqual(expect.objectContaining({
+        execClientMessage: expect.objectContaining({ readResult: expect.objectContaining({ output: expect.anything() }) }),
       }));
-      expect(diagnostics).toEqual(expect.arrayContaining([
-        expect.objectContaining({ event: "exec.redirect.selected", adapter: "read-direct" }),
-        expect.objectContaining({ event: "exec.redirect.attached", adapter: "read-direct" }),
-        expect.objectContaining({ event: "exec.redirect.result_written", adapter: "read-direct" }),
-        expect.objectContaining({ event: "bridge.attach", outcome: "exact_match" }),
-      ]));
+      expect(canonicalText(firstEvents)).toBe("native read continued");
       expect(harness.openedStreams).toBe(1);
+      expect(diagnostics).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ event: "exec.redirect.selected", adapter: "read-direct" }),
+      ]));
+      expect(diagnostics).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ event: "exec.redirect.attached", adapter: "read-direct" }),
+      ]));
+      expect(diagnostics).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ event: "bridge.park" }),
+      ]));
+      expect(diagnostics).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ event: "bridge.attach" }),
+      ]));
+      expect(diagnostics).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ event: "exec.redirect.result_written", adapter: "read-direct" }),
+      ]));
+      expect(stream.closeCode).not.toBe(http2.constants.NGHTTP2_CANCEL);
     } finally {
       harness.adapter.dispose();
     }

--- a/packages/core-ai-gateway/tests/cursor/native/tool-stream.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/tool-stream.test.ts
@@ -30,6 +30,7 @@ import {
   cursorNativeExecRedirect,
   cursorNativeRedirectResultReplies,
   isCursorHotPathToolName,
+  isCursorNativeRedirectToolName,
 } from "../../../src/cursor/native/exec-redirect.js";
 
 afterEach(() => resetCursorWireModelMemory());
@@ -707,8 +708,13 @@ describe("Cursor client tool suspension", () => {
     }
   });
 
-  it("keeps hot-path tools eager under ToolSearch deferral", () => {
+  it("keeps hot-path tools eager while only redirecting search and shell", () => {
     expect(isCursorHotPathToolName("Read")).toBe(true);
+    expect(isCursorNativeRedirectToolName("Read")).toBe(false);
+    expect(isCursorNativeRedirectToolName("Grep")).toBe(true);
+    expect(isCursorNativeRedirectToolName("Bash")).toBe(true);
+    expect(isCursorNativeRedirectToolName("shell_command")).toBe(true);
+    expect(isCursorNativeRedirectToolName("exec_command")).toBe(true);
     expect(isCursorHotPathToolName("mcp__fleet__ToolSearch")).toBe(true);
     expect(isCursorHotPathToolName("mcp__fleet__wiki_read")).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Expose the caller `Read` schema directly to Cursor models so they can use bounded `offset` and `limit` paging.
- Keep `Grep` and shell native redirects, while rejecting native `Read` on the same Run with the advertised caller alias.
- Prevent repeated whole-file replay that measured 52 repeated reads and 10 compactions before the change, versus 1 repeated read and 2 compactions after it.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- `packages/core-ai-gateway/src/cursor/native/`
- Cursor adapter and live Run bridge tests
- `fleet-cli` and `fleet-console` release notes

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (30 files, 662 tests)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`
- [x] Run identical five-turn Cursor Composer 2.5 sessions before and after the change

## Changelog

- Let Cursor models page through caller-owned reads instead of repeatedly replaying whole files through failed native reads.
- Preserve caller permissions, fail-closed read semantics, and native search/shell redirects.

## Notes for Reviewers

The live comparison held the model, prompts, caller catalog, permissions, Theater, source revision, and logging constant. Exact duplicate Read output fell from 3,781,106 to 5,452 characters, workload replay bytes fell 27.4%, and automatic compactions fell from 10 to 2. Baseline turn 4 was queued while turn 3 was still running, so lifecycle-count deltas are not attributed solely to this patch; the exact Read duplication and direct paging evidence establish the tool-path effect.