### PR TITLE
perf(ai-gateway): compress Cursor grep redirects

### DIFF
--- a/.changelog.d/cursor-auto-loop-optimization.md
+++ b/.changelog.d/cursor-auto-loop-optimization.md
@@ -1,0 +1,8 @@
+---
+branch: cursor-auto-loop-optimization
+---
+
+### fleet-console
+#### Changed
+- Reduced the repeated command and result payloads used when Cursor searches run through caller-approved shell tools, while preserving bounded search results and permission checks.
+  ko: Cursor 검색이 호출자 승인 셸 도구를 거칠 때 반복되는 명령과 결과 페이로드를 줄이면서 제한된 검색 결과와 권한 검사를 유지합니다.

--- a/packages/core-ai-gateway/src/cursor/native/exec-redirect.ts
+++ b/packages/core-ai-gateway/src/cursor/native/exec-redirect.ts
@@ -1,3 +1,5 @@
+import { deflateRawSync, inflateRawSync } from "node:zlib";
+
 type ExecMessage = Record<string, unknown>;
 
 export type CursorNativeRedirectResultType =
@@ -385,18 +387,19 @@ function grepShellArguments(
   ) {
     return null;
   }
-  const script = Buffer.from(CURSOR_GREP_RECEIPT_SCRIPT, "utf8").toString("base64url");
   const payload = Buffer.from(JSON.stringify(input), "utf8").toString("base64url");
-  const bootstrap = `eval(Buffer.from(process.argv.splice(1,1)[0],'base64url').toString('utf8'))`;
-  const command = `node -e "${bootstrap}" ${script} ${payload}`;
+  const bootstrap = `eval(require('node:zlib').inflateRawSync(Buffer.from(process.argv.splice(1,1)[0],'base64url')).toString('utf8'))`;
+  const command = `node -e "${bootstrap}" ${CURSOR_GREP_RECEIPT_SCRIPT_BASE64} ${payload}`;
   return shellArguments(schema, command, undefined, undefined);
 }
 
-const CURSOR_GREP_RECEIPT_PREFIX = "FLEET_CURSOR_GREP_V1:";
+const CURSOR_GREP_RECEIPT_PREFIX = "FLEET_CURSOR_GREP_V2:";
+const CURSOR_GREP_RECEIPT_MAX_BYTES = 128 * 1024;
 const CURSOR_GREP_RECEIPT_SCRIPT = String.raw`
 const {spawn}=require("node:child_process");
 const {TextDecoder}=require("node:util");
-const emit=(value)=>process.stdout.write("${CURSOR_GREP_RECEIPT_PREFIX}"+Buffer.from(JSON.stringify(value)).toString("base64url"));
+const {deflateRawSync}=require("node:zlib");
+const emit=(value)=>process.stdout.write("${CURSOR_GREP_RECEIPT_PREFIX}"+deflateRawSync(Buffer.from(JSON.stringify(value))).toString("base64url"));
 (async()=>{try {
   const input=JSON.parse(Buffer.from(process.argv[1],"base64url").toString("utf8"));
   const matchSeparator=30;
@@ -482,6 +485,7 @@ const emit=(value)=>process.stdout.write("${CURSOR_GREP_RECEIPT_PREFIX}"+Buffer.
   emit({ok:true,outputMode:input.outputMode,files,counts,matches,totalFiles,totalLines,totalMatchedLines,clientTruncated});
 }catch(error){emit({ok:false,error:error instanceof Error?error.message:String(error)});}})();
 `.trim();
+const CURSOR_GREP_RECEIPT_SCRIPT_BASE64 = deflateRawSync(CURSOR_GREP_RECEIPT_SCRIPT).toString("base64url");
 
 function shellArguments(
   schema: Record<string, unknown>,
@@ -533,10 +537,13 @@ function parseGrepShellReceipt(
     return { ok: false, error: "The caller Bash result did not contain a complete Fleet Grep receipt." };
   }
   try {
-    const decoded = JSON.parse(Buffer.from(
+    const compressed = Buffer.from(
       output.slice(CURSOR_GREP_RECEIPT_PREFIX.length).trim(),
       "base64url",
-    ).toString("utf8")) as unknown;
+    );
+    const decoded = JSON.parse(inflateRawSync(compressed, {
+      maxOutputLength: CURSOR_GREP_RECEIPT_MAX_BYTES,
+    }).toString("utf8")) as unknown;
     if (!isRecord(decoded)) throw new Error("receipt is not an object");
     if (decoded.ok === false && typeof decoded.error === "string") {
       return { ok: false, error: decoded.error };

--- a/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import http2 from "node:http2";
+import { deflateRawSync } from "node:zlib";
 
 import { fromBinary, fromJson, toBinary, toJson, type JsonValue } from "@bufbuild/protobuf";
 import { ValueSchema } from "@bufbuild/protobuf/wkt";
@@ -1809,7 +1810,7 @@ function cursorCall(callId: string, messageId: number): CursorCallSpec {
 }
 
 function cursorGrepReceipt(value: unknown): string {
-  return `FLEET_CURSOR_GREP_V1:${Buffer.from(JSON.stringify(value), "utf8").toString("base64url")}`;
+  return `FLEET_CURSOR_GREP_V2:${deflateRawSync(Buffer.from(JSON.stringify(value), "utf8")).toString("base64url")}`;
 }
 
 function cursorResult(

--- a/packages/core-ai-gateway/tests/cursor/native/tool-stream.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/tool-stream.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import http2 from "node:http2";
+import { deflateRawSync, inflateRawSync } from "node:zlib";
 
 import { fromBinary, fromJson, toBinary, toJson, type JsonValue } from "@bufbuild/protobuf";
 import { ValueSchema } from "@bufbuild/protobuf/wkt";
@@ -508,10 +509,11 @@ describe("Cursor client tool suspension", () => {
       call: { name: "Bash", toolCallId: "native-grep-shell-5" },
     });
     const grepShellCommand = JSON.parse(grepShell?.call.arguments ?? "{}").command as string;
-    expect(grepShellCommand).toContain("process.argv.splice(1,1)");
+    expect(grepShellCommand).toContain("inflateRawSync");
     const encodedScript = grepShellCommand.split(" ").at(-2);
     expect(encodedScript).toBeDefined();
-    const grepShellScript = Buffer.from(encodedScript ?? "", "base64url").toString("utf8");
+    const grepShellScript = inflateRawSync(Buffer.from(encodedScript ?? "", "base64url")).toString("utf8");
+    expect(grepShellCommand.length).toBeLessThan(2_600);
     expect(grepShellScript).toContain('"--sort","path","--max-columns",String(maxContentBytes)');
     expect(grepShellScript).toContain("maxRecordBytes=64*1024");
     expect(grepShellScript).not.toContain("new Map()");
@@ -587,7 +589,7 @@ describe("Cursor client tool suspension", () => {
   });
 
   it("accepts only complete caller Bash receipts as native Grep success", () => {
-    const receipt = `FLEET_CURSOR_GREP_V1:${Buffer.from(JSON.stringify({
+    const receipt = `FLEET_CURSOR_GREP_V2:${deflateRawSync(Buffer.from(JSON.stringify({
       ok: true,
       outputMode: "content",
       files: [],
@@ -604,7 +606,7 @@ describe("Cursor client tool suspension", () => {
       totalMatchedLines: 1,
       totalMatches: 1,
       clientTruncated: false,
-    }), "utf8").toString("base64url")}`;
+    }), "utf8")).toString("base64url")}`;
     const success = cursorNativeRedirectResultReplies(
       {
         messageId: 2,
@@ -641,7 +643,7 @@ describe("Cursor client tool suspension", () => {
         nativeResultType: "grepShellResult",
         nativeArgs: { pattern: "Fleet", path: "packages", outputMode: "content" },
       },
-      "FLEET_CURSOR_GREP_V1:truncated",
+      "FLEET_CURSOR_GREP_V2:truncated",
       false,
     );
     expect(incomplete).toContainEqual(expect.objectContaining({
@@ -649,7 +651,23 @@ describe("Cursor client tool suspension", () => {
         grepResult: { error: { error: expect.stringContaining("invalid Fleet Grep receipt") } },
       }),
     }));
-    for (const reply of [...success, ...incomplete]) {
+
+    const oversized = cursorNativeRedirectResultReplies(
+      {
+        messageId: 4,
+        execId: "grep-shell-4",
+        nativeResultType: "grepShellResult",
+        nativeArgs: { pattern: "Fleet", path: "packages", outputMode: "content" },
+      },
+      `FLEET_CURSOR_GREP_V2:${deflateRawSync(Buffer.alloc(128 * 1024 + 1)).toString("base64url")}`,
+      false,
+    );
+    expect(oversized).toContainEqual(expect.objectContaining({
+      execClientMessage: expect.objectContaining({
+        grepResult: { error: { error: expect.stringContaining("invalid Fleet Grep receipt") } },
+      }),
+    }));
+    for (const reply of [...success, ...incomplete, ...oversized]) {
       expect(() => fromJson(AgentClientMessageSchema, reply as JsonValue)).not.toThrow();
     }
   });


### PR DESCRIPTION
## Summary
- compress the generated Cursor-native grep shell script and typed result receipt with raw deflate
- bound receipt decompression at 128 KiB while preserving caller permissions, search limits, and native result correlation
- reduce repeated command bytes by 61.0% and result bytes by 67.7% across five successful Cursor `auto` trials

## Test Plan
- [x] `pnpm --dir packages/core-ai-gateway test` (661 tests)
- [x] `pnpm --dir packages/core-ai-gateway typecheck`
- [x] `pnpm --dir packages/core-ai-gateway build`
- [x] `pnpm --dir runtime/fleet-console typecheck`
- [x] `pnpm --dir runtime/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Cursor `auto` controlled before/after workload, five successful trials per variant
- [x] malformed and oversized receipt fail-closed checks