### PR TITLE
feat(fleet-console): move panel state onto the window caption

### DIFF
--- a/.changelog.d/panel-state-caption.md
+++ b/.changelog.d/panel-state-caption.md
@@ -1,0 +1,8 @@
+---
+branch: panel-state-caption
+---
+
+### fleet-console
+#### Changed
+- Operation panel state now reads on the window caption instead of the panel outline. The caption's top edge carries focus and its bottom edge carries a status rail, so a focused panel still shows whether it is running or waiting for you, and a panel working in the background finally shows anything at all. The panel outline stays a neutral rim in every state, and the unseen-completion glow becomes an arrival flash on that rail.
+  ko: Operation 패널의 상태를 패널 아웃라인이 아니라 창 캡션이 표시합니다. 캡션 윗변이 포커스를, 아랫변 레일이 상태를 나르므로 포커스한 패널도 진행 중인지 입력을 기다리는지 계속 알리고, 배경에서 도는 패널도 비로소 드러납니다. 패널 아웃라인은 모든 상태에서 중립 테두리로 남고, 미확인 완료의 글로우는 그 레일의 도착 플래시로 바뀝니다.

--- a/.changelog.d/panel-state-caption.md
+++ b/.changelog.d/panel-state-caption.md
@@ -4,5 +4,5 @@ branch: panel-state-caption
 
 ### fleet-console
 #### Changed
-- Operation panel state now reads on the window caption instead of the panel outline. The caption's top edge carries focus and its bottom edge carries a status rail, so a focused panel still shows whether it is running or waiting for you, and a panel working in the background finally shows anything at all. The panel outline stays a neutral rim in every state, and the unseen-completion glow becomes an arrival flash on that rail.
-  ko: Operation 패널의 상태를 패널 아웃라인이 아니라 창 캡션이 표시합니다. 캡션 윗변이 포커스를, 아랫변 레일이 상태를 나르므로 포커스한 패널도 진행 중인지 입력을 기다리는지 계속 알리고, 배경에서 도는 패널도 비로소 드러납니다. 패널 아웃라인은 모든 상태에서 중립 테두리로 남고, 미확인 완료의 글로우는 그 레일의 도착 플래시로 바뀝니다.
+- Operation panel state now reads on the window caption instead of the panel outline. A focused panel lifts its caption fill and title, and a status rail runs along the caption's lower edge, so a focused panel still shows whether it is running or waiting for you, and a panel working in the background finally shows anything at all. The panel outline stays a neutral rim in every state, and the unseen-completion glow becomes an arrival flash on that rail.
+  ko: Operation 패널의 상태를 패널 아웃라인이 아니라 창 캡션이 표시합니다. 포커스한 패널은 캡션 채움과 제목이 밝아지고, 상태 레일이 캡션 아랫변을 따라 흐릅니다. 그래서 포커스한 패널도 진행 중인지 입력을 기다리는지 계속 알리고, 배경에서 도는 패널도 비로소 드러납니다. 패널 아웃라인은 모든 상태에서 중립 테두리로 남고, 미확인 완료의 글로우는 그 레일의 도착 플래시로 바뀝니다.

--- a/.changelog.d/window-caption-b.md
+++ b/.changelog.d/window-caption-b.md
@@ -4,5 +4,5 @@ branch: window-caption-b
 
 ### fleet-console
 #### Changed
-- Operation panels now carry a 32px window caption above the existing body, so the PTY keeps its previous size. The caption keeps the default frame fill; focus is the shared panel outline. The Activity Rail uses the same caption inside its slot. Tactical packs each row with that 32px caption in the stride so stacked captions stay in their cells. War Room and maximize keep the caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click.
-  ko: Operation 패널은 기존 본문 위에 32px 창 캡션을 붙여 PTY 크기를 유지합니다. 캡션은 기본 프레임 칠을 유지하고, 포커스는 패널과 이어진 아웃라인만 씁니다. Activity Rail은 같은 캡션을 슬롯 안에 둡니다. Tactical은 행 보폭에 32px 캡션을 넣어 쌓인 캡션이 칸 안에 머물게 합니다. War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다.
+- Operation panels now carry a 32px window caption above the existing body, so the PTY keeps its previous size. The Activity Rail uses the same caption inside its slot. Tactical packs each row with that 32px caption in the stride so stacked captions stay in their cells. War Room and maximize keep the caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click.
+  ko: Operation 패널은 기존 본문 위에 32px 창 캡션을 붙여 PTY 크기를 유지합니다. Activity Rail은 같은 캡션을 슬롯 안에 둡니다. Tactical은 행 보폭에 32px 캡션을 넣어 쌓인 캡션이 칸 안에 머물게 합니다. War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다.

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -65,6 +65,8 @@ const MIN_OPERATION_WIDTH = 320;
 const MIN_OPERATION_HEIGHT = 200;
 const CLOSE_ARM_DURATION_MS = 1500;
 const DRAG_THRESHOLD_PX = 3;
+// 캡션 상태 레일의 도착 플래시 길이 — CSS의 var(--duration-slow)와 한 값이다.
+const ARRIVAL_FLASH_DURATION_MS = 360;
 
 export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, glanceHud, formationSlotIndex, accentKey = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onSetAccent, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
   const t = useT();
@@ -74,10 +76,15 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
   const dragRef = useRef<DragState | null>(null);
   const resizeRef = useRef<ResizeState | null>(null);
   const closeArmTimeoutRef = useRef<number | null>(null);
+  const arrivalFlashTimeoutRef = useRef<number | null>(null);
+  // 마운트 시점의 unseen을 이전 값으로 삼는다 — 이미 미확인인 채로 되살아난 프레임(Theater 재진입 등)은
+  // 새 도착이 아니므로 플래시하지 않는다.
+  const previousUnseenRef = useRef(unseen);
   const lastVisibleGeometryRef = useRef(geometry);
   const restoreIdentityFocusRef = useRef(false);
   const [accentAnchor, setAccentAnchor] = useState<DOMRect | null>(null);
   const [isCloseArmed, setIsCloseArmed] = useState(false);
+  const [arrivalFlash, setArrivalFlash] = useState(false);
   const [dragging, setDragging] = useState(false);
   const displayTitle = operation.title;
   const rename = useInlineRename({
@@ -96,6 +103,7 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
   const className = [
     "canvas-operation",
     unseen ? "is-unseen" : "",
+    arrivalFlash ? "is-unseen-arriving" : "",
     active ? "is-active" : "",
     minimized ? "is-minimized" : "",
     maximized ? "is-maximized" : "",
@@ -107,7 +115,21 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
 
   useEffect(() => () => {
     if (closeArmTimeoutRef.current !== null) window.clearTimeout(closeArmTimeoutRef.current);
+    if (arrivalFlashTimeoutRef.current !== null) window.clearTimeout(arrivalFlashTimeoutRef.current);
   }, []);
+
+  // 도착은 상태의 전이이지 상태의 존재가 아니다 — false → true로 넘어가는 순간에만 플래시한다.
+  useEffect(() => {
+    const previous = previousUnseenRef.current;
+    previousUnseenRef.current = unseen;
+    if (previous || !unseen) return;
+    if (arrivalFlashTimeoutRef.current !== null) window.clearTimeout(arrivalFlashTimeoutRef.current);
+    setArrivalFlash(true);
+    arrivalFlashTimeoutRef.current = window.setTimeout(() => {
+      arrivalFlashTimeoutRef.current = null;
+      setArrivalFlash(false);
+    }, ARRIVAL_FLASH_DURATION_MS);
+  }, [unseen]);
 
   useEffect(() => {
     if (rename.renaming || !restoreIdentityFocusRef.current) return;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5847,12 +5847,11 @@
   border-top-style: none;
 }
 
-/* 포커스 = 캡션 채움 워시 + 보더 + 이름 티어. 본문 아웃라인이 상태를 놓았으므로 캡션 brass는
-   더 이상 아웃라인의 중복이 아니라 위치 채널의 유일한 운반체다.
+/* 포커스 = 캡션 채움 워시 + 이름 티어. 선(윗변 라인·캡션 아웃라인)은 쓰지 않는다 — 상태 레일과
+   같은 굵기의 선이 캡션 위아래에 겹치면 warn과 brass가 한 덩어리 금색으로 읽힌다.
    믹스는 oklab이다 — oklch는 hue를 극좌표 호로 보간해 brass(78)와 ink-rim(245)의 62% 믹스가
    hue 141(초록)에 착지했고, 위치 채널이 신호 채널 positive(160) 옆에 앉았다. */
 .canvas-operation.is-active > .canvas-operation-titlebar {
-  border-color: color-mix(in oklab, var(--brass) 45%, var(--surface-rim));
   background: color-mix(in oklab, var(--brass) 10%, var(--surface-frame));
   /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
   background-clip: padding-box;
@@ -5869,8 +5868,7 @@
   color: var(--text-primary);
 }
 
-/* 캡션 윗변 = 위치 채널, 아랫변 = 상태 채널. 서로 다른 기하라 어느 쪽도 상대를 덮지 않는다. */
-.canvas-operation-titlebar::before,
+/* 캡션 아랫변 = 상태 채널. 포커스는 채움이 말하므로 선은 상태 하나만 소유한다. */
 .canvas-operation-titlebar::after {
   content: "";
   position: absolute;
@@ -5878,21 +5876,6 @@
   right: -1px;
   height: 2px;
   pointer-events: none;
-}
-
-.canvas-operation-titlebar::before {
-  top: -1px;
-  /* 최대화 캡션은 라운드가 달라진다 — inherit이 두 모드를 한 선언으로 잇는다. */
-  border-radius: inherit;
-  background: transparent;
-  transition: background var(--duration-base) var(--ease-spring);
-}
-
-.canvas-operation.is-active > .canvas-operation-titlebar::before {
-  background: var(--brass);
-}
-
-.canvas-operation-titlebar::after {
   bottom: 0;
   background: var(--caption-rail, transparent);
   opacity: 0;
@@ -5904,13 +5887,15 @@
   opacity: 1;
 }
 
-/* turn은 진행을 색이 아니라 운동으로 말한다 — 한 방향 트래블. 작업 중 신호가 있는 동안만 도는
-   AGENTS.md 모션 규약의 sanctioned 예외이며, reduced-motion에서 정적 채움으로 단락한다. */
+/* turn은 진행을 색이 아니라 운동으로 말한다 — 좌우를 오가는 왕복 트래블. 한 방향 순환은 끝에서
+   되감기며 튀지만, 왕복은 양 끝에서 감속해 되돌아온다(그래서 ease-in-out을 두 구간에 건다).
+   작업 중 신호가 있는 동안만 도는 AGENTS.md 모션 규약의 sanctioned 예외이며,
+   reduced-motion에서 정적 채움으로 단락한다. */
 .canvas-operation.is-running--turn > .canvas-operation-titlebar::after {
   background: linear-gradient(90deg, transparent 0%, var(--warn) 30%, var(--warn) 70%, transparent 100%);
   background-size: 55% 100%;
   background-repeat: no-repeat;
-  animation: caption-rail-travel 1.9s var(--ease-glide) infinite;
+  animation: caption-rail-travel 3.8s ease-in-out infinite;
 }
 
 /* background는 턴이 끝나고 작업만 남은 상태 — 같은 warn을 낮은 광량의 정적 레일로 낮춘다. */
@@ -5924,8 +5909,11 @@
 }
 
 /* 미확인 완료는 도착 순간 1회 플래시로 시선을 부르고 그 뒤 상시 레일로 남는다 —
-   상시 aura(22px glow)를 순간 운동으로 교환한 자리다. */
-.canvas-operation.is-unseen > .canvas-operation-titlebar::after {
+   상시 aura(22px glow)를 순간 운동으로 교환한 자리다.
+   플래시를 is-unseen이 아니라 별도의 일시 클래스에 건다: is-unseen은 확인 전까지 계속 참이라
+   Theater를 오가며 프레임이 리마운트될 때마다 애니메이션이 다시 돈다. 도착은 상태의 전이이지
+   상태의 존재가 아니다. */
+.canvas-operation.is-unseen-arriving > .canvas-operation-titlebar::after {
   animation: caption-rail-arrive var(--duration-slow) var(--ease-spring) 1;
 }
 
@@ -5936,11 +5924,14 @@
 }
 
 @keyframes caption-rail-travel {
-  from {
+  0% {
     background-position: -60% 0;
   }
-  to {
+  50% {
     background-position: 160% 0;
+  }
+  100% {
+    background-position: -60% 0;
   }
 }
 
@@ -6379,7 +6370,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .canvas-operation-titlebar,
-  .canvas-operation-titlebar::before,
   .canvas-operation-titlebar::after,
   .canvas-operation-window-controls,
   .canvas-operation-icon-button {
@@ -6394,7 +6384,7 @@
      즉시 정착한 레일로 대체한다. 상태 자체는 계속 읽혀야 하므로 레일을 끄지는 않는다. */
   .canvas-operation.is-running--turn > .canvas-operation-titlebar::after,
   .canvas-operation.is-running--awaiting > .canvas-operation-titlebar::after,
-  .canvas-operation.is-unseen > .canvas-operation-titlebar::after {
+  .canvas-operation.is-unseen-arriving > .canvas-operation-titlebar::after {
     animation: none;
     background: var(--caption-rail);
     box-shadow: none;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4569,50 +4569,31 @@
   overflow: auto;
 }
 
-/* 포커스는 단일 location accent로만 표시한다. 캡션과 본문이 같은 보더 선을 잇는다. */
-.canvas-operation.is-active {
-  border-color: color-mix(in oklch, var(--brass) 62%, var(--ink-rim));
-  box-shadow: var(--shadow-soft);
-}
-
-/* Running state remains a static semantic indicator. */
-.canvas-operation.is-running {
-  box-shadow: var(--shadow-soft);
-}
-
-/* 인디케이터 색 추종 — turn: warn/amber(에이전트 턴 진행 또는 캐리어 스트리밍) */
-.canvas-operation.is-running--turn {
-  --uw-tint: var(--warn);
-  --uw-glow: var(--warn-glow);
-}
-
-/* 인디케이터 색 추종 — background: 턴은 끝났지만 백그라운드 작업 진행 중 */
-.canvas-operation.is-running--background {
-  --uw-tint: var(--warn);
-  --uw-glow: var(--warn-glow);
-}
-
-/* 인디케이터 색 추종 — awaiting: aurora(청록, 운영자 입력 대기) */
-.canvas-operation.is-running--awaiting {
-  --uw-tint: var(--aurora);
-  --uw-glow: var(--aurora-glow);
-  border-color: var(--aurora);
-}
-
-/* Selection retains the location accent while a status is active. */
-.canvas-operation.is-running.is-active {
-  border-color: var(--brass);
-}
-
-/* 미확인 완료 — 사이드바 칩과 같은 테두리 문법. 포커스는 항상 brass가 이긴다. */
+/* 패널 아웃라인은 어떤 상태에서도 중립 rim을 지킨다 — 위치도 상태도 캡션이 말한다.
+   한 선이 두 채널을 나르면 우선순위 규칙이 필요해지고 그 규칙이 상태를 지웠다: 포커스한 패널은
+   자기가 입력을 기다리는 중임을 알릴 수 없었고, 비포커스 패널의 진행은 0픽셀이었다.
+   위치(brass)는 캡션 윗변, 상태(신호 토큰)는 캡션 아랫변으로 갈라 서로를 덮지 않는다. */
+.canvas-operation.is-active,
+.canvas-operation.is-running,
 .canvas-operation.is-unseen {
-  border-color: var(--positive);
-  box-shadow: var(--shadow-soft), 0 0 0 1px color-mix(in oklch, var(--positive) 28%, transparent), 0 0 22px -4px var(--positive-glow);
+  border-color: var(--surface-rim);
+  box-shadow: var(--shadow-soft);
 }
 
-.canvas-operation.is-unseen.is-active {
-  border-color: var(--brass);
-  box-shadow: var(--shadow-soft);
+/* 상태 레일 색 — OperationActivity 매핑 축(.tenant-beacon 선언)과 같은 토큰을 쓴다.
+   turn/background: warn(에이전트 턴·백그라운드 작업) · awaiting: aurora(운영자 입력 대기)
+   · unseen: positive(미확인 완료). idle·dormant는 레일을 켜지 않는다. */
+.canvas-operation.is-running--turn,
+.canvas-operation.is-running--background {
+  --caption-rail: var(--warn);
+}
+
+.canvas-operation.is-running--awaiting {
+  --caption-rail: var(--aurora);
+}
+
+.canvas-operation.is-unseen {
+  --caption-rail: var(--positive);
 }
 
 /* Map에서 사용자 accent(정체성)는 좌측 스파인·명판 마크·명판 워시만 소유한다.
@@ -5866,6 +5847,128 @@
   border-top-style: none;
 }
 
+/* 포커스 = 캡션 채움 워시 + 보더 + 이름 티어. 본문 아웃라인이 상태를 놓았으므로 캡션 brass는
+   더 이상 아웃라인의 중복이 아니라 위치 채널의 유일한 운반체다.
+   믹스는 oklab이다 — oklch는 hue를 극좌표 호로 보간해 brass(78)와 ink-rim(245)의 62% 믹스가
+   hue 141(초록)에 착지했고, 위치 채널이 신호 채널 positive(160) 옆에 앉았다. */
+.canvas-operation.is-active > .canvas-operation-titlebar {
+  border-color: color-mix(in oklab, var(--brass) 45%, var(--surface-rim));
+  background: color-mix(in oklab, var(--brass) 10%, var(--surface-frame));
+  /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
+  background-clip: padding-box;
+}
+
+/* 정체성(--user-accent)은 캡션 채움을 계속 소유한다 — 포커스 워시는 그 위에 얹혀 두 채널이
+   같은 표면을 다투지 않는다. 이 결합 규칙이 없으면 accent가 있는 패널만 포커스를 잃는다. */
+.canvas-operation[style*="--user-accent"].is-active > .canvas-operation-titlebar {
+  background: color-mix(in oklab, var(--brass) 10%, color-mix(in oklch, var(--user-accent) 10%, var(--surface-frame)));
+  background-clip: padding-box;
+}
+
+.canvas-operation.is-active > .canvas-operation-titlebar .canvas-operation-identity-name {
+  color: var(--text-primary);
+}
+
+/* 캡션 윗변 = 위치 채널, 아랫변 = 상태 채널. 서로 다른 기하라 어느 쪽도 상대를 덮지 않는다. */
+.canvas-operation-titlebar::before,
+.canvas-operation-titlebar::after {
+  content: "";
+  position: absolute;
+  left: -1px;
+  right: -1px;
+  height: 2px;
+  pointer-events: none;
+}
+
+.canvas-operation-titlebar::before {
+  top: -1px;
+  /* 최대화 캡션은 라운드가 달라진다 — inherit이 두 모드를 한 선언으로 잇는다. */
+  border-radius: inherit;
+  background: transparent;
+  transition: background var(--duration-base) var(--ease-spring);
+}
+
+.canvas-operation.is-active > .canvas-operation-titlebar::before {
+  background: var(--brass);
+}
+
+.canvas-operation-titlebar::after {
+  bottom: 0;
+  background: var(--caption-rail, transparent);
+  opacity: 0;
+  transition: opacity var(--duration-base) var(--ease-spring);
+}
+
+.canvas-operation.is-running > .canvas-operation-titlebar::after,
+.canvas-operation.is-unseen > .canvas-operation-titlebar::after {
+  opacity: 1;
+}
+
+/* turn은 진행을 색이 아니라 운동으로 말한다 — 한 방향 트래블. 작업 중 신호가 있는 동안만 도는
+   AGENTS.md 모션 규약의 sanctioned 예외이며, reduced-motion에서 정적 채움으로 단락한다. */
+.canvas-operation.is-running--turn > .canvas-operation-titlebar::after {
+  background: linear-gradient(90deg, transparent 0%, var(--warn) 30%, var(--warn) 70%, transparent 100%);
+  background-size: 55% 100%;
+  background-repeat: no-repeat;
+  animation: caption-rail-travel 1.9s var(--ease-glide) infinite;
+}
+
+/* background는 턴이 끝나고 작업만 남은 상태 — 같은 warn을 낮은 광량의 정적 레일로 낮춘다. */
+.canvas-operation.is-running--background > .canvas-operation-titlebar::after {
+  opacity: 0.45;
+}
+
+/* awaiting은 사람을 기다리는 유일한 상태 — 호출 신호로 맥동한다. */
+.canvas-operation.is-running--awaiting > .canvas-operation-titlebar::after {
+  animation: caption-rail-pulse 2s var(--ease-glide) infinite;
+}
+
+/* 미확인 완료는 도착 순간 1회 플래시로 시선을 부르고 그 뒤 상시 레일로 남는다 —
+   상시 aura(22px glow)를 순간 운동으로 교환한 자리다. */
+.canvas-operation.is-unseen > .canvas-operation-titlebar::after {
+  animation: caption-rail-arrive var(--duration-slow) var(--ease-spring) 1;
+}
+
+/* 접힌 캡션(Cruise 상단 클리핑)은 아래에 자기 rim 보더를 갖는다 — 레일이 그 선을 삼켜야
+   한 줄로 읽힌다. */
+.canvas-operation.is-top-edge > .canvas-operation-titlebar::after {
+  bottom: -1px;
+}
+
+@keyframes caption-rail-travel {
+  from {
+    background-position: -60% 0;
+  }
+  to {
+    background-position: 160% 0;
+  }
+}
+
+@keyframes caption-rail-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.34;
+  }
+}
+
+@keyframes caption-rail-arrive {
+  0% {
+    opacity: 0;
+    box-shadow: none;
+  }
+  40% {
+    opacity: 1;
+    box-shadow: 0 0 12px 1px var(--positive-glow);
+  }
+  100% {
+    opacity: 1;
+    box-shadow: none;
+  }
+}
+
 .canvas-operation-identity-name,
 .canvas-operation-identity-input {
   min-width: 0;
@@ -6276,6 +6379,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .canvas-operation-titlebar,
+  .canvas-operation-titlebar::before,
+  .canvas-operation-titlebar::after,
   .canvas-operation-window-controls,
   .canvas-operation-icon-button {
     transition-duration: 0.01ms;
@@ -6283,6 +6388,16 @@
 
   .canvas-operation-icon-button.is-armed-close {
     animation: none;
+  }
+
+  /* 상태 레일은 색면으로 단락한다 — 트래블 그라디언트는 균일 채움으로 되돌리고, 도착 플래시는
+     즉시 정착한 레일로 대체한다. 상태 자체는 계속 읽혀야 하므로 레일을 끄지는 않는다. */
+  .canvas-operation.is-running--turn > .canvas-operation-titlebar::after,
+  .canvas-operation.is-running--awaiting > .canvas-operation-titlebar::after,
+  .canvas-operation.is-unseen > .canvas-operation-titlebar::after {
+    animation: none;
+    background: var(--caption-rail);
+    box-shadow: none;
   }
 }
 

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -624,14 +624,6 @@ a {
   }
 }
 
-/* 진행 중 Operation 패널/최소화 Dock 외곽의 "진행광(running light)" — conic 하이라이트 호(arc)가 테두리
-   링을 따라 한 방향으로 순환한다. 각도(--uw-angle)는 @property로 등록해야 커스텀 속성이 부드럽게
-   보간된다(미등록 시 이산 점프). 색(--uw-tint)은 인디케이터를 따른다. 작업 중 신호가 있는 동안만,
-   prefers-reduced-motion에선 정적 림으로 단락 — AGENTS.md 모션 규약의 sanctioned 예외(작업 중 신호). */
-
-
-
-
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1687,12 +1687,19 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("border-style: solid;");
     expect(components).toContain("border-color: inherit;");
     expect(components).not.toContain("border: 1px solid inherit;");
-    // 패널 아웃라인은 상태를 놓았다 — 위치는 캡션 윗변(brass), 상태는 캡션 아랫변(신호 토큰)이
-    // 나른다. 캡션 brass는 더 이상 아웃라인의 중복이 아니라 위치 채널의 유일한 운반체다.
+    // 패널 아웃라인은 상태를 놓았다 — 포커스는 캡션 채움 워시, 상태는 캡션 아랫변 레일이 나른다.
+    // 포커스는 선을 쓰지 않는다: 상태 레일과 같은 굵기의 brass 선이 캡션 위아래에 겹치면
+    // warn과 brass가 한 덩어리 금색으로 읽힌다.
     expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar {");
     expect(components).toContain("background: color-mix(in oklab, var(--brass) 10%, var(--surface-frame));");
-    expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar::before {");
+    expect(components).not.toContain(".canvas-operation-titlebar::before");
     expect(components).toContain("background: var(--caption-rail, transparent);");
+    // 도착 플래시는 지속 상태(is-unseen)가 아니라 전이를 표시하는 일시 클래스에만 건다 —
+    // is-unseen에 걸면 Theater 재진입 리마운트마다 다시 돈다.
+    expect(components).toContain(".canvas-operation.is-unseen-arriving > .canvas-operation-titlebar::after {");
+    expect(components).not.toMatch(/\.canvas-operation\.is-unseen > \.canvas-operation-titlebar::after \{\n\s*animation: caption-rail-arrive/);
+    expect(operationFrame).toContain('arrivalFlash ? "is-unseen-arriving" : ""');
+    expect(operationFrame).toContain("previousUnseenRef");
     // 정체성 워시와 포커스 워시는 같은 표면을 다투지 않는다 — 결합 규칙이 둘을 겹쳐 칠한다.
     expect(components).toContain('.canvas-operation[style*="--user-accent"].is-active > .canvas-operation-titlebar {');
     // oklch 믹스는 hue를 극좌표 호로 보간한다 — brass(78)+ink-rim(245) 62%는 hue 141(초록)에

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -592,7 +592,9 @@ describe("Instrument core design contract", () => {
     expect(chipAccentBlock).toContain("pointer-events: none;");
     expect(chipAccentBlock).not.toMatch(/animation/);
     expect(minimapDotBlock).toContain("background: var(--user-accent);");
-    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(5);
+    // 6번째 소비처는 정체성 워시 위에 포커스 워시를 겹치는 결합 규칙이다 — 새 채널이 아니라
+    // 같은 워시를 포커스 상태에서 다시 적는 자리이므로 accent는 여전히 spine+mark+wash에 머문다.
+    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(6);
     expect(accentSources).not.toMatch(/--op-accent|--chip-accent/);
   });
 
@@ -967,8 +969,9 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("background: var(--group-mark);");
     expect(components).toMatch(/\.side-bar-chip-unseen \{[^}]*background:\s*var\(--positive\)/);
     expect(components).toMatch(/\.side-bar-chip--unseen \{[^}]*border-color:\s*color-mix\(in oklch, var\(--positive\)/);
-    expect(components).toMatch(/\.canvas-operation\.is-unseen \{[^}]*border-color:\s*var\(--positive\)/);
-    expect(components).toContain(".canvas-operation.is-unseen.is-active {");
+    // 미확인 완료는 패널 아웃라인이 아니라 캡션 아랫변 레일이 나른다 — 상시 aura는 사라졌다.
+    expect(components).toMatch(/\.canvas-operation\.is-unseen \{[^}]*--caption-rail:\s*var\(--positive\)/);
+    expect(components).not.toContain(".canvas-operation.is-unseen.is-active {");
     expect(components).toMatch(/\.side-bar-status-header__unseen::before \{[^}]*background:\s*var\(--positive\)/);
     expect(components).toContain(".side-bar-status-axis-live-tick,");
     expect(components).toContain(".side-bar-status-header--awaiting .side-bar-status-header__dot {");
@@ -1679,16 +1682,28 @@ describe("Instrument core design contract", () => {
     expect(captionSeamBlock).not.toContain("border-top: none;");
     expect(components).toContain("border-radius: 999px;");
     expect(components).toContain("color: var(--text-secondary);");
-    // 활성은 패널 아웃라인만 말한다 — 캡션 brass 틴트와 이름 재채색은 같은 신호를 중복한다.
     // inherit은 단축 전체가 아니라 border-color만 받는다. 1px solid inherit은 선언이 버려진다.
     expect(components).toContain("border-width: 1px;");
     expect(components).toContain("border-style: solid;");
     expect(components).toContain("border-color: inherit;");
     expect(components).not.toContain("border: 1px solid inherit;");
-    expect(components).not.toContain(".canvas-operation.is-active .canvas-operation-titlebar");
-    expect(components).not.toContain(".canvas-operation.is-active .canvas-operation-identity-name");
-    expect(components).not.toContain("color-mix(in oklch, var(--brass) 7%, var(--surface-frame))");
-    expect(components).toContain(".canvas-operation.is-active {\n  border-color: color-mix(in oklch, var(--brass) 62%, var(--ink-rim));");
+    // 패널 아웃라인은 상태를 놓았다 — 위치는 캡션 윗변(brass), 상태는 캡션 아랫변(신호 토큰)이
+    // 나른다. 캡션 brass는 더 이상 아웃라인의 중복이 아니라 위치 채널의 유일한 운반체다.
+    expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar {");
+    expect(components).toContain("background: color-mix(in oklab, var(--brass) 10%, var(--surface-frame));");
+    expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar::before {");
+    expect(components).toContain("background: var(--caption-rail, transparent);");
+    // 정체성 워시와 포커스 워시는 같은 표면을 다투지 않는다 — 결합 규칙이 둘을 겹쳐 칠한다.
+    expect(components).toContain('.canvas-operation[style*="--user-accent"].is-active > .canvas-operation-titlebar {');
+    // oklch 믹스는 hue를 극좌표 호로 보간한다 — brass(78)+ink-rim(245) 62%는 hue 141(초록)에
+    // 착지해 위치 채널이 신호 채널 positive(160) 옆에 앉았다. 캡션 워시는 oklab으로 섞는다.
+    expect(components).not.toContain("color-mix(in oklch, var(--brass) 62%, var(--ink-rim))");
+    // 소비처가 사라진 진행광(running light) 변수는 함께 회수했다.
+    expect(components).not.toContain("--uw-tint");
+    expect(components).not.toContain("--uw-glow");
+    expect(source("styles/theme.css")).not.toContain("--uw-angle");
+    // 포커스가 상태를 덮던 우선순위 규칙은 채널이 갈린 뒤로 존재 이유가 없다.
+    expect(components).not.toContain(".canvas-operation.is-running.is-active {");
     expect(components).toContain(".canvas-operation-window-controls {");
     const windowControlsBlock = components.match(/\.canvas-operation-window-controls \{[^}]*\}/)?.[0] ?? "";
     expect(windowControlsBlock).toContain("margin-left: auto;");


### PR DESCRIPTION
## Summary
- 패널 아웃라인이 포커스·상태·미확인을 한 선에 겹쳐 나르던 구조를 캡션의 기하 분리로 대체합니다. 캡션 윗변 2px = 위치(brass), 채움 = 정체성(`--user-accent`), 아랫변 2px = 상태(신호 토큰). 본문 아웃라인은 모든 상태에서 `--surface-rim` 상수입니다.
- 소비처가 이미 삭제된 `--uw-tint`/`--uw-glow`를 회수하고, running·background를 처음으로 가시화합니다. `is-unseen`의 22px aura는 도착 1회 플래시 + 상시 레일로 대체합니다.
- 포커스 워시를 `oklab`으로 섞습니다. 기존 `color-mix(in oklch, brass 62%, ink-rim)`은 hue를 극좌표 호로 보간해 hue 141(초록)에 착지, 위치 채널이 신호 채널 `--positive`(160) 옆에 앉아 있었습니다(실측 `oklch(.6062 .0595 141.46)`).
- 접힌 캡션(`is-top-edge`)은 자기 rim 보더를 레일이 삼키도록 `bottom: -1px`로 분기하고, `prefers-reduced-motion`에서 트래블·펄스·플래시를 정적 채움으로 단락합니다.

Changelog-Amend: window-caption-b.md

`window-caption-b.md`는 아직 미릴리스 프래그먼트이고 "포커스는 패널과 이어진 아웃라인만 씁니다"라는 문장이 이 변경으로 사실이 아니게 되므로, 해당 문장만 회수하고 새 동작은 `panel-state-caption.md`에 기록했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 172 files / 2089 tests passed, 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` — exit 0
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공, 번들 CSS에 reduced-motion 단락 규칙 포함 확인
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 12 fragments validated
- [x] 격리 콘솔(worktree dist, 자체 dataDir) 실측 — 9개 상태 조합에서 본문 보더 `oklch(.29 .018 245)` 상수 유지, 캡션 윗변은 포커스에서만 brass, 아랫변 레일은 turn=warn 트래블 / awaiting=aurora 펄스 / background=warn 0.45 / unseen=positive 도착 플래시
- [x] 정체성 accent 합성 실측 — 비포커스 `oklch(.254 .022 239.5)` → 포커스 `oklab(.3086 …)`, 두 채널 모두 생존
- [x] Instrument·Whites 양 테마 스크린샷 확인, `is-top-edge` 접힘 모드 레일 `bottom: -1px` 확인