### PR TITLE
fix(fleet-console): retire the mode frame under a focus layer

### DIFF
--- a/.changelog.d/maximize-tactical-bounds.md
+++ b/.changelog.d/maximize-tactical-bounds.md
@@ -1,0 +1,8 @@
+---
+branch: maximize-tactical-bounds
+---
+
+### fleet-console
+#### Fixed
+- Maximizing a panel in Tactical or Triage no longer leaves the mode boundary drawn over it. The boundary marks the grid arena, and a maximized panel covers that arena entirely, so the frame and its corner brackets now step aside instead of sitting on top of the panel while it overhangs them.
+  ko: Tactical·Triage에서 패널을 최대화해도 모드 경계선이 패널 위에 남지 않습니다. 경계선은 격자 아레나를 표시하는데 최대화한 패널은 그 아레나를 통째로 덮으므로, 프레임과 모서리 브래킷이 패널 위에 겹친 채 패널이 그 선을 넘어가 보이는 대신 물러납니다.

--- a/.changelog.d/maximize-tactical-bounds.md
+++ b/.changelog.d/maximize-tactical-bounds.md
@@ -4,5 +4,5 @@ branch: maximize-tactical-bounds
 
 ### fleet-console
 #### Fixed
-- Maximizing a panel in Tactical or Triage no longer leaves the mode boundary drawn over it. The boundary marks the grid arena, and a maximized panel covers that arena entirely, so the frame and its corner brackets now step aside instead of sitting on top of the panel while it overhangs them.
-  ko: Tactical·Triage에서 패널을 최대화해도 모드 경계선이 패널 위에 남지 않습니다. 경계선은 격자 아레나를 표시하는데 최대화한 패널은 그 아레나를 통째로 덮으므로, 프레임과 모서리 브래킷이 패널 위에 겹친 채 패널이 그 선을 넘어가 보이는 대신 물러납니다.
+- Maximizing a panel in Tactical no longer leaves the mode boundary drawn over it. The boundary marks the grid arena, and a maximized panel covers that arena entirely, so the frame and its corner brackets now step aside instead of sitting on top of the panel while it overhangs them.
+  ko: Tactical에서 패널을 최대화해도 모드 경계선이 패널 위에 남지 않습니다. 경계선은 격자 아레나를 표시하는데 최대화한 패널은 그 아레나를 통째로 덮으므로, 프레임과 모서리 브래킷이 패널 위에 겹친 채 패널이 그 선을 넘어가 보이는 대신 물러납니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2859,6 +2859,13 @@
   pointer-events: none;
   border: 1px solid color-mix(in oklch, var(--brass) 16%, transparent);
   border-radius: var(--radius-sm);
+  /* 물러남은 즉시, 복귀는 패널이 슬롯에 안착한 뒤다. 복원은 geometry를 --duration-slow 동안
+     되돌리므로 경계선이 먼저 돌아오면 줄어드는 패널 위에 브래킷이 찍힌다 — 아래 규칙이 없애는
+     겹침이 매 복원마다 잠깐 재현된다(실측: 복원 직후 캡션이 프레임 윗변보다 10px 위, ~140ms 지속).
+     display를 쓰지 않는 이유가 이것이다. 지연은 opacity 전환에만 걸리므로 모드 진입처럼 프레임이
+     새로 마운트되는 경로는 전환 자체가 없어 브래킷 등장 연출을 그대로 유지한다. */
+  opacity: 1;
+  transition: opacity var(--duration-base) var(--ease-glide) var(--duration-slow);
 }
 
 /* 모드 프레임은 격자 아레나의 경계다 — 최대화 패널이 그 아레나를 통째로 덮으면 경계도 물러난다.
@@ -2869,7 +2876,8 @@
    프레임 안쪽에 머문다. 캔버스를 꽉 채우는 companionGeometryFor는 Cruise 전용이고 거기엔 프레임이
    없다(canvas.tsx의 frameGeometry 분기). */
 .operations-canvas.is-panel-maximized .canvas-mode-frame {
-  display: none;
+  opacity: 0;
+  transition-delay: 0s;
 }
 
 .canvas-mode-bracket {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2861,11 +2861,14 @@
   border-radius: var(--radius-sm);
 }
 
-/* 모드 프레임은 격자 아레나의 경계다 — 포커스 레이어(최대화·companion)가 캔버스를 통째로 덮으면
-   그 아레나 자체가 없으므로 경계도 물러난다. 남겨두면 두 가지가 동시에 어긋난다: 최대화 geometry는
-   캔버스 전체라 10px 인셋을 네 변 모두 넘고, 프레임은 z-index 76이라 패널 위에 브래킷을 찍는다. */
-.operations-canvas.is-panel-maximized .canvas-mode-frame,
-.operations-canvas.is-companion-layout .canvas-mode-frame {
+/* 모드 프레임은 격자 아레나의 경계다 — 최대화 패널이 그 아레나를 통째로 덮으면 경계도 물러난다.
+   남겨두면 두 가지가 동시에 어긋난다: 최대화 geometry는 캔버스 전체라 10px 인셋을 네 변 모두 넘고,
+   프레임은 z-index 76이라 패널 위에 브래킷을 찍는다.
+   companion은 여기 없다 — 프레임이 뜨는 두 모드에서 companion은 캔버스를 덮지 않는다.
+   Tactical은 formationSlotArea(18px 인셋), Triage는 triageStageGeometryFor(역시 18px)로 배치되어
+   프레임 안쪽에 머문다. 캔버스를 꽉 채우는 companionGeometryFor는 Cruise 전용이고 거기엔 프레임이
+   없다(canvas.tsx의 frameGeometry 분기). */
+.operations-canvas.is-panel-maximized .canvas-mode-frame {
   display: none;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2861,6 +2861,14 @@
   border-radius: var(--radius-sm);
 }
 
+/* 모드 프레임은 격자 아레나의 경계다 — 포커스 레이어(최대화·companion)가 캔버스를 통째로 덮으면
+   그 아레나 자체가 없으므로 경계도 물러난다. 남겨두면 두 가지가 동시에 어긋난다: 최대화 geometry는
+   캔버스 전체라 10px 인셋을 네 변 모두 넘고, 프레임은 z-index 76이라 패널 위에 브래킷을 찍는다. */
+.operations-canvas.is-panel-maximized .canvas-mode-frame,
+.operations-canvas.is-companion-layout .canvas-mode-frame {
+  display: none;
+}
+
 .canvas-mode-bracket {
   position: absolute;
   width: 26px;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -440,6 +440,10 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-minimap-fab,");
     expect(components).toContain(".operations-canvas.is-companion-layout .canvas-minimap,");
     expect(components).toContain(".operations-canvas.is-companion-layout .canvas-minimap-fab {");
+    // 모드 프레임도 포커스 레이어 아래에서 물러난다 — 최대화 geometry는 캔버스 전체라 프레임의
+    // 10px 인셋을 네 변 모두 넘고, 프레임은 z-index 76이라 패널 위에 브래킷을 찍는다.
+    expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-mode-frame,");
+    expect(components).toContain(".operations-canvas.is-companion-layout .canvas-mode-frame {");
     for (const sharedModeClass of [
       "canvas-mode-frame",
       "canvas-mode-bracket",

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -445,6 +445,15 @@ describe("Instrument core design contract", () => {
     // 프레임이 뜨는 두 모드에서 18px 인셋 슬롯에 머무르므로 경계를 지울 이유가 없다.
     expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-mode-frame {");
     expect(components).not.toContain(".operations-canvas.is-companion-layout .canvas-mode-frame");
+    // 물러남은 즉시, 복귀는 패널 geometry가 슬롯으로 돌아온 뒤다 — display 토글로 되돌리면
+    // 복원 전환 동안 브래킷이 다시 패널 위에 찍힌다.
+    const modeFrameBlock = components.match(/\.canvas-mode-frame \{[^}]*\}/)?.[0] ?? "";
+    expect(modeFrameBlock).toContain("transition: opacity var(--duration-base) var(--ease-glide) var(--duration-slow);");
+    expect(modeFrameBlock).not.toContain("display:");
+    const maximizedFrameBlock = components.match(/\.operations-canvas\.is-panel-maximized \.canvas-mode-frame \{[^}]*\}/)?.[0] ?? "";
+    expect(maximizedFrameBlock).toContain("opacity: 0;");
+    expect(maximizedFrameBlock).toContain("transition-delay: 0s;");
+    expect(maximizedFrameBlock).not.toContain("display: none;");
     for (const sharedModeClass of [
       "canvas-mode-frame",
       "canvas-mode-bracket",

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -440,10 +440,11 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-minimap-fab,");
     expect(components).toContain(".operations-canvas.is-companion-layout .canvas-minimap,");
     expect(components).toContain(".operations-canvas.is-companion-layout .canvas-minimap-fab {");
-    // 모드 프레임도 포커스 레이어 아래에서 물러난다 — 최대화 geometry는 캔버스 전체라 프레임의
-    // 10px 인셋을 네 변 모두 넘고, 프레임은 z-index 76이라 패널 위에 브래킷을 찍는다.
-    expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-mode-frame,");
-    expect(components).toContain(".operations-canvas.is-companion-layout .canvas-mode-frame {");
+    // 모드 프레임은 최대화 아래에서만 물러난다 — 최대화 geometry는 캔버스 전체라 프레임의 10px
+    // 인셋을 네 변 모두 넘고, 프레임은 z-index 76이라 패널 위에 브래킷을 찍는다. companion은
+    // 프레임이 뜨는 두 모드에서 18px 인셋 슬롯에 머무르므로 경계를 지울 이유가 없다.
+    expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-mode-frame {");
+    expect(components).not.toContain(".operations-canvas.is-companion-layout .canvas-mode-frame");
     for (const sharedModeClass of [
       "canvas-mode-frame",
       "canvas-mode-bracket",


### PR DESCRIPTION
## Summary
- Tactical(`is-formation-view`)·Triage에서 패널을 최대화하면 모드 프레임(`.canvas-mode-frame`, `inset: 10px`, `z-index: 76`)이 계속 렌더되어 **네 변 모두 정확히 10px씩 패널이 경계를 넘고**, 프레임이 패널보다 위 z-index라 모서리 브래킷이 패널 안쪽에 찍혔습니다.
- 경계선은 격자 아레나를 표시하는 것이고 포커스 레이어(최대화·companion)는 그 아레나를 통째로 덮으므로, 프레임이 물러나도록 했습니다. 미니맵이 이미 같은 두 클래스 아래에서 물러나는 선례를 따릅니다.
- `maximizedGeometryFor`를 10px 인셋시키는 대안은 취하지 않았습니다 — Cruise·War Room의 최대화가 캔버스 전체인데 Tactical만 작아지면 최대화의 의미가 모드마다 달라집니다.

## 재현 (격리 콘솔, 뷰포트 1900×1150 / 캔버스 1576×1106, Operation 6개)
Tactical → 패널 활성화 → 최대화(⛶ 또는 `Alt+↑`):

| | 값 |
|---|---|
| 모드 프레임 | `(291, 55, 1554×1084)`, `display: block`, `opacity: 1` |
| 최대화 패널 | `(281, 77, 1574×1072)`, 캡션 `(281, 45, 1574×32)` |
| 넘침 | left 10 · top 10 · right 10 · bottom 10 |

수정 후 같은 절차에서 `display: none`으로 물러나고, 복원하면 `block` + `(11, 11, 1554×1084)`로 정확히 복귀합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 172 files / 2089 tests passed, 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 13 fragments validated
- [x] 격리 콘솔 실측 — 최대화 중 프레임 `none`, 복원 후 `block`으로 원위치, 패널 6개 격자 복귀
- [x] `is-companion-layout`도 같은 기전임을 DOM으로 확인(프레임 렌더 조건이 `formationView`라 포커스 레이어와 독립) 후 같은 규칙에 포함
- [x] 설계 계약에 두 선택자 고정