### PR TITLE
fix(fleet-console): fill the War Room stage to the mode inset

### DIFF
--- a/.changelog.d/war-room-empty-bottom.md
+++ b/.changelog.d/war-room-empty-bottom.md
@@ -1,0 +1,8 @@
+---
+branch: war-room-empty-bottom
+---
+
+### fleet-console
+#### Fixed
+- A staged War Room panel now fills the canvas down to the same 18px inset Tactical already uses. The old bottom waiting rail is gone, but the stage still reserved that band, so activating one panel left an empty strip under the frame.
+  ko: War Room에 올린 패널이 Tactical과 같은 18px 인셋까지 캔버스를 채웁니다. 하단 대기 레일은 이미 없는데 무대가 그 자리를 계속 비워 두어, 패널 하나를 활성화하면 프레임 아래가 빈 띠로 남았습니다.

--- a/runtime/fleet-console/core/client/src/canvas/coordinates.ts
+++ b/runtime/fleet-console/core/client/src/canvas/coordinates.ts
@@ -1,4 +1,4 @@
-import type { OperationGeometry } from "./canvas-store.js";
+import { OPERATION_WINDOW_CAPTION_HEIGHT, type OperationGeometry } from "./canvas-store.js";
 
 export interface CanvasPoint {
   readonly x: number;
@@ -79,10 +79,12 @@ export function triageStageGeometryFor(
   slotIndex = 0,
   slotCount = 1,
 ): OperationGeometry {
+  // 무대는 Tactical 슬롯과 같은 18px 인셋이다. 하단 대기 레일이 있던 자리(옛 height-84)는
+  // 레일 제거 이후 비워 두지 않는다 — 사이드바 '대기'가 그 순서를 쥐고 있다.
   return modeSlotGeometryFor({
     x: 18,
-    y: 18 + 32,
+    y: 18 + OPERATION_WINDOW_CAPTION_HEIGHT,
     width: Math.max(320, canvasSize.width - 36),
-    height: Math.max(240, canvasSize.height - 84 - 32),
+    height: Math.max(240, canvasSize.height - 36 - OPERATION_WINDOW_CAPTION_HEIGHT),
   }, slotIndex, slotCount, 8, zIndex);
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1732,7 +1732,8 @@ describe("Instrument core design contract", () => {
     expect(source("canvas/canvas.tsx")).toContain("const TITLEBAR_OUTSET_PX = OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/canvas.tsx")).toContain("y: TITLEBAR_OUTSET_PX");
     expect(source("canvas/canvas.tsx")).toContain("TITLEBAR_OUTSET_PX * effectiveZoom");
-    expect(source("canvas/coordinates.ts")).toContain("y: 18 + 32");
+    expect(source("canvas/coordinates.ts")).toContain("y: 18 + OPERATION_WINDOW_CAPTION_HEIGHT");
+    expect(source("canvas/coordinates.ts")).toContain("canvasSize.height - 36 - OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/operation-frame.tsx")).not.toContain("canvas-operation-drag-edge");
     expect(source("canvas/operation-frame.tsx")).not.toContain('className="canvas-operation-cli"');
     expect(components).toContain(".canvas-operation-beacon-button {");

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -753,9 +753,9 @@ describe("triage store", () => {
 
     for (const geometry of geometries) {
       expect(geometry.x).toBeGreaterThanOrEqual(18);
-      expect(geometry.y).toBeGreaterThanOrEqual(46);
+      expect(geometry.y).toBeGreaterThanOrEqual(18 + 32);
       expect(geometry.x + geometry.width).toBeLessThanOrEqual(canvasSize.width - 18);
-      expect(geometry.y + geometry.height).toBeLessThanOrEqual(canvasSize.height - 66);
+      expect(geometry.y + geometry.height).toBe(canvasSize.height - 18);
     }
     expect(geometries[0]!.x + geometries[0]!.width).toBeLessThan(geometries[1]!.x);
     expect(geometries[1]!.x + geometries[1]!.width).toBeLessThan(geometries[2]!.x);


### PR DESCRIPTION
## Summary
- War Room에서 패널을 활성화하면 프레임 아래가 비던 원인을 고칩니다. 무대 높이가 이미 제거된 하단 대기 레일(66px)을 계속 비워 두고 있었습니다.
- `triageStageGeometryFor`를 Tactical과 같은 18px 인셋으로 맞추고, 캡션 오프셋은 `OPERATION_WINDOW_CAPTION_HEIGHT`를 씁니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/triage-store.test.ts tests/instrument-design-contract.test.ts` — 137 passed
- [ ] War Room에서 패널 하나를 활성화했을 때 무대가 모드 프레임 아랫변까지 채워지는지 확인
- [ ] companion 슬롯이 겹치지 않고 같은 인셋 안에 머무는지 확인