### PR TITLE
fix(fleet-console): restore hover-reveal on the rail header

### DIFF
--- a/.changelog.d/window-caption-b.md
+++ b/.changelog.d/window-caption-b.md
@@ -4,5 +4,5 @@ branch: window-caption-b
 
 ### fleet-console
 #### Changed
-- Operation panels now carry a 32px window caption above the existing body, so the PTY keeps its previous size. The Activity Rail uses the same caption inside its slot. Tactical packs each row with that 32px caption in the stride so stacked captions stay in their cells. War Room and maximize keep the caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click.
-  ko: Operation 패널은 기존 본문 위에 32px 창 캡션을 붙여 PTY 크기를 유지합니다. Activity Rail은 같은 캡션을 슬롯 안에 둡니다. Tactical은 행 보폭에 32px 캡션을 넣어 쌓인 캡션이 칸 안에 머물게 합니다. War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다.
+- Operation panels now carry a 32px window caption above the existing body, so the PTY keeps its previous size. Tactical packs each row with that 32px caption in the stride so stacked captions stay in their cells. War Room and maximize keep the caption outside the body by shifting the slot down. Dragging uses the whole caption, including the title; rename stays on double-click. The Activity Rail keeps its hover-reveal header so the panel body uses the full slot.
+  ko: Operation 패널은 기존 본문 위에 32px 창 캡션을 붙여 PTY 크기를 유지합니다. Tactical은 행 보폭에 32px 캡션을 넣어 쌓인 캡션이 칸 안에 머물게 합니다. War Room·최대화는 슬롯을 내려 캡션을 본문 밖에 둡니다. 제목을 포함한 캡션 전체에서 패널을 움직이고, 이름 변경은 더블클릭입니다. Activity Rail은 호버-리빌 헤더를 유지해 본문이 슬롯 전체를 씁니다.

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -25,6 +25,14 @@ interface RightRailProps {
 
 const MIN_PANEL_WIDTH = 240;
 const DEFAULT_PANEL_WIDTH = 312;
+// 호버-리빌 헤더 입력 계약: 진입은 pointermove로만 판정하고(스크롤-언더-포인터 오발화 방지)
+// 의도 지연을 거친다. 진입 띠와 64px 이탈 경계 사이는 히스테리시스 중립 지대다.
+// 진입 띠는 패널 본문 상단 컨트롤(저장소 동기화·Skills 탭 등)의 클릭을 방해하지 않도록
+// 가장자리 12px로 좁게 잡는다 — 24px에서는 상단 첫 줄 컨트롤로 향하는 호버가 헤더를 오발화했다.
+const HEAD_REVEAL_ZONE_PX = 12;
+const HEAD_REVEAL_TOUCH_ZONE_PX = 28;
+const HEAD_HIDE_BOUNDARY_PX = 64;
+const HEAD_REVEAL_INTENT_DELAY_MS = 120;
 const PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
 const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
 
@@ -130,6 +138,86 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
+  const [headRevealed, setHeadRevealed] = useState(false);
+  const headRevealedRef = useRef(headRevealed);
+  headRevealedRef.current = headRevealed;
+  const revealIntentTimerRef = useRef<number | null>(null);
+
+  const cancelRevealIntent = useCallback(() => {
+    if (revealIntentTimerRef.current === null) return;
+    window.clearTimeout(revealIntentTimerRef.current);
+    revealIntentTimerRef.current = null;
+  }, []);
+
+  const holdHeadOpen = useCallback(() => {
+    cancelRevealIntent();
+    if (!headRevealedRef.current) setHeadRevealed(true);
+  }, [cancelRevealIntent]);
+
+  const hideHeadUnlessFocused = useCallback(() => {
+    // 키보드 포커스(:focus-visible)가 헤더 안에 남아 있는 동안만 숨기지 않는다 — 숨기면
+    // 포커스가 투명한 컨트롤에 갇힌다. 마우스 클릭·드래그가 남긴 잔류 포커스는 리빌을
+    // 붙잡는 근거가 아니므로, 블러로 걷어내고 즉시 숨긴다.
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && active.closest(".right-rail-panel-head-reveal") !== null) {
+      if (active.matches(":focus-visible")) return;
+      active.blur();
+    }
+    setHeadRevealed(false);
+  }, []);
+
+  // 이탈은 지연 없이 즉시 숨긴다 — 리빌 진입만 의도 지연을 거친다.
+  const releaseHead = useCallback(() => {
+    cancelRevealIntent();
+    if (!headRevealedRef.current) return;
+    hideHeadUnlessFocused();
+  }, [cancelRevealIntent, hideHeadUnlessFocused]);
+
+  // 패널이 바뀌거나 닫히면 리빌 상태를 초기화한다.
+  useLayoutEffect(() => {
+    cancelRevealIntent();
+    setHeadRevealed(false);
+  }, [activeId, cancelRevealIntent]);
+
+  useLayoutEffect(() => () => {
+    cancelRevealIntent();
+  }, [cancelRevealIntent]);
+
+  const handleSlotPointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    // 진입 판정은 hover 포인터에만 적용한다. 터치는 pointerdown 폴백이 담당한다.
+    if (event.pointerType === "touch") return;
+    const slotTop = event.currentTarget.getBoundingClientRect().top;
+    const y = event.clientY - slotTop;
+    if (y <= HEAD_REVEAL_ZONE_PX) {
+      if (headRevealedRef.current || revealIntentTimerRef.current !== null) return;
+      revealIntentTimerRef.current = window.setTimeout(() => {
+        revealIntentTimerRef.current = null;
+        setHeadRevealed(true);
+      }, HEAD_REVEAL_INTENT_DELAY_MS);
+      return;
+    }
+    cancelRevealIntent();
+    if (y > HEAD_HIDE_BOUNDARY_PX) releaseHead();
+  }, [cancelRevealIntent, releaseHead]);
+
+  const handleSlotPointerLeave = useCallback(() => {
+    releaseHead();
+  }, [releaseHead]);
+
+  const handleSlotPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== "touch") return;
+    const slotTop = event.currentTarget.getBoundingClientRect().top;
+    const y = event.clientY - slotTop;
+    if (!headRevealedRef.current) {
+      // 상단 가장자리 탭 = 리빌. preventDefault 없이 콘텐츠 탭도 그대로 통과시킨다.
+      if (y <= HEAD_REVEAL_TOUCH_ZONE_PX) holdHeadOpen();
+      return;
+    }
+    const target = event.target instanceof Element ? event.target : null;
+    if (target?.closest(".right-rail-panel-head-reveal") === null) {
+      hideHeadUnlessFocused();
+    }
+  }, [hideHeadUnlessFocused, holdHeadOpen]);
 
   useLayoutEffect(() => {
     const onResize = () => {
@@ -274,6 +362,9 @@ export function RightRail({ theaterId, api }: RightRailProps) {
         style={panelBehavior === "overlay"
           ? { "--right-rail-overlay-alpha": overlayAlpha / 100 } as CSSProperties
           : undefined}
+        onPointerMove={hasPanel ? handleSlotPointerMove : undefined}
+        onPointerLeave={hasPanel ? handleSlotPointerLeave : undefined}
+        onPointerDown={hasPanel ? handleSlotPointerDown : undefined}
       >
         {activePanel && (
           <div
@@ -296,7 +387,11 @@ export function RightRail({ theaterId, api }: RightRailProps) {
               activePanelTitle={activePanelTitle}
               panelBehavior={panelBehavior}
               overlayAlpha={overlayAlpha}
+              revealed={headRevealed}
+              onHoldOpen={holdHeadOpen}
+              onRelease={releaseHead}
             />
+            <div className="right-rail-panel-peek" aria-hidden="true" />
             <RailPanelBody activePanel={activePanel} activeId={activeId} ctx={ctx} connection={connection} connectionLostAt={connectionLostAt} language={language} />
           </>
         )}
@@ -322,56 +417,81 @@ interface RailPanelHeadProps {
   readonly activePanelTitle: string;
   readonly panelBehavior: "push" | "overlay";
   readonly overlayAlpha: RailOverlayAlpha;
+  readonly revealed: boolean;
+  readonly onHoldOpen: () => void;
+  readonly onRelease: () => void;
 }
 
-// 캡션은 본문 높이를 빼지 않고 슬롯 위에 붙는 패널 속성이다. Esc는 헤더 포커스 범위로만 닫는다.
-function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha }: RailPanelHeadProps) {
+// 헤더의 세 통제(타이틀·플로팅·닫기)는 전부 저빈도라 상주 캡션 대신 호버-리빌
+// 오버레이로 소환한다. 숨김 상태에서도 DOM에 남아 Tab 진입(focus)이 리빌 경로가 된다.
+function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha, revealed, onHoldOpen, onRelease }: RailPanelHeadProps) {
   const t = useT();
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    // slot의 진입/이탈 판정으로 버블되면 32px 헤더 하단부(y>12px)가 이탈로 오판된다.
+    event.stopPropagation();
+    onHoldOpen();
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
+    onRelease();
+  };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "Escape") return;
+    // Esc 닫기는 헤더 포커스 범위로 한정한다 — 패널 본문(Shell PTY 등)의 Esc 어휘를 뺏지 않는다.
     event.stopPropagation();
     closeRailPanel();
   };
 
   return (
-    <div className="right-rail-panel-head" onKeyDown={handleKeyDown}>
-      <span className="right-rail-panel-title">{activePanelTitle}</span>
-      <button
-        className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
-        type="button"
-        aria-pressed={panelBehavior === "overlay"}
-        aria-label={t("rail.chrome.floatToggle")}
-        title={t("rail.chrome.floatLabel")}
-        onClick={toggleRailPanelBehavior}
-      >
-        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
-      </button>
-      {panelBehavior === "overlay" ? (
-        <div className="right-rail-alpha">
-          <input
-            className="right-rail-alpha-slider"
-            type="range"
-            min={RAIL_OVERLAY_ALPHA_MIN}
-            max={RAIL_OVERLAY_ALPHA_MAX}
-            step={1}
-            value={overlayAlpha}
-            aria-label={t("rail.chrome.opacityAria")}
-            onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
-            onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
-            style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
-          />
-          <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
-        </div>
-      ) : null}
-      <button
-        className="right-rail-close-btn"
-        type="button"
-        aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
-        onClick={closeRailPanel}
-      >
-        <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" /></svg>
-      </button>
+    <div
+      className={`right-rail-panel-head-reveal${revealed ? " is-revealed" : ""}`}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={onRelease}
+      onFocusCapture={onHoldOpen}
+      onBlurCapture={handleBlur}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="right-rail-panel-head">
+        <span className="right-rail-panel-title">{activePanelTitle}</span>
+        <button
+          className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
+          type="button"
+          aria-pressed={panelBehavior === "overlay"}
+          aria-label={t("rail.chrome.floatToggle")}
+          title={t("rail.chrome.floatLabel")}
+          onClick={toggleRailPanelBehavior}
+        >
+          <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
+        </button>
+        {panelBehavior === "overlay" ? (
+          <div className="right-rail-alpha">
+            <input
+              className="right-rail-alpha-slider"
+              type="range"
+              min={RAIL_OVERLAY_ALPHA_MIN}
+              max={RAIL_OVERLAY_ALPHA_MAX}
+              step={1}
+              value={overlayAlpha}
+              aria-label={t("rail.chrome.opacityAria")}
+              onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
+              onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
+              style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
+            />
+            <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
+          </div>
+        ) : null}
+        <button
+          className="right-rail-close-btn"
+          type="button"
+          aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
+          onClick={closeRailPanel}
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" /></svg>
+        </button>
+      </div>
     </div>
   );
 }

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -200,7 +200,10 @@ export function RightRail({ theaterId, api }: RightRailProps) {
     if (y > HEAD_HIDE_BOUNDARY_PX) releaseHead();
   }, [cancelRevealIntent, releaseHead]);
 
-  const handleSlotPointerLeave = useCallback(() => {
+  const handleSlotPointerLeave = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    // 터치 탭은 pointerup 뒤에 pointerleave가 따라온다. 그걸 숨김으로 받으면
+    // 방금 연 헤더가 접혀 두 번째 탭(플로팅·닫기)이 닿지 않는다.
+    if (event.pointerType === "touch") return;
     releaseHead();
   }, [releaseHead]);
 
@@ -433,6 +436,11 @@ function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha, revealed
     onHoldOpen();
   };
 
+  const handlePointerLeave = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "touch") return;
+    onRelease();
+  };
+
   const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
     if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
     onRelease();
@@ -449,7 +457,7 @@ function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha, revealed
     <div
       className={`right-rail-panel-head-reveal${revealed ? " is-revealed" : ""}`}
       onPointerMove={handlePointerMove}
-      onPointerLeave={onRelease}
+      onPointerLeave={handlePointerLeave}
       onFocusCapture={onHoldOpen}
       onBlurCapture={handleBlur}
       onKeyDown={handleKeyDown}

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -42,8 +42,8 @@
 }
 
 /* ── 패널 슬롯 ─────────────────────────────────────────────────────
-   폭 전환으로 spring 펼침/접힘을 구현한다. 캡션은 슬롯을 위로 32px
-   연장해 붙이고, 본문 1fr은 원래 높이를 유지한다. */
+   폭 전환으로 spring 펼침/접힘을 구현한다. 헤더는 호버-리빌 오버레이
+   (absolute)로 빠져 본문이 슬롯 전체 높이를 쓴다. */
 .right-rail-panel-slot {
   position: relative;
   width: 0;
@@ -57,9 +57,6 @@
 
 .right-rail.is-open .right-rail-panel-slot {
   width: var(--right-rail-panel-width, 312px);
-  /* 캡션은 슬롯 첫 행. 조상 route-content가 overflow:hidden이라 밴드 쪽으로
-     연장하면 잘리거나 밴드를 덮는다. Operation PTY와 달리 Rail 본문은 32px를 내준다. */
-  grid-template-rows: 32px minmax(0, 1fr);
 }
 
 .right-rail.is-overlay .right-rail-panel-slot {
@@ -69,7 +66,7 @@
   bottom: 0;
   margin-top: 0;
   height: auto;
-  grid-template-rows: 32px minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   width: var(--right-rail-panel-width, 0px);
   border-left: 1px solid var(--surface-rim);
   /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
@@ -98,11 +95,57 @@
   pointer-events: none;
 }
 
-/* ── 패널 캡션 ─────────────────────────────────────────────────────
-   슬롯이 위로 32px 연장한 첫 행. 본문 1fr은 원래 높이다. 호버-리빌이 아니다. */
+/* ── 호버-리빌 헤더 ─────────────────────────────────────────────────
+   세 통제(타이틀·플로팅·닫기)는 전부 저빈도 set-and-forget이라 상주 캡션 대신
+   상단 접근 시에만 본문 위 오버레이로 소환한다(진입 판정은 right-rail.tsx의
+   pointermove+의도 지연 계약). 숨김은 opacity+transform으로만 처리해 Tab
+   포커스 진입이 리빌 경로로 남는다. */
+.right-rail-panel-head-reveal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 3;
+  transform: translateY(-100%);
+  opacity: 0;
+  pointer-events: none;
+  border-bottom: 1px solid var(--surface-rim);
+  /* 본문 위에 얹히는 오버레이라 glass 카드와 같은 불투명 언더레이가 필요하다. */
+  background: color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
+  /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
+  box-shadow: 0 10px 26px oklch(0% 0 0 / 40%);
+  transition: transform 180ms var(--ease-spring), opacity 140ms ease;
+}
+
+.right-rail-panel-head-reveal.is-revealed {
+  transform: none;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* 리빌 힌트 — 헤더가 숨어 있음을 알리는 유일한 상주 크롬(3px 대시). */
+.right-rail-panel-peek {
+  position: absolute;
+  top: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 30px;
+  height: 3px;
+  border-radius: 2px;
+  z-index: 2;
+  background: var(--text-tertiary);
+  opacity: 0.32;
+  pointer-events: none;
+  transition: opacity 140ms ease;
+}
+
+.right-rail-panel-head-reveal.is-revealed + .right-rail-panel-peek {
+  opacity: 0;
+}
+
 .right-rail-panel-head {
   position: relative;
-  z-index: 3;
+  z-index: 1;
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
@@ -111,10 +154,6 @@
   min-height: 32px;
   min-width: 0;
   padding: 0 8px;
-  border: 1px solid var(--surface-rim);
-  border-bottom: none;
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  background: color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
 }
 
 .right-rail-panel-title {
@@ -470,7 +509,8 @@
 @media (prefers-reduced-motion: reduce) {
   .right-rail,
   .right-rail-panel-slot,
-  .right-rail-panel-head {
+  .right-rail-panel-head-reveal,
+  .right-rail-panel-peek {
     transition: none !important;
   }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1009,23 +1009,23 @@ describe("Instrument core design contract", () => {
     expect(rightRail).toContain("right-rail-alpha-slider");
     expect(rightRail).toContain("is-switching");
     expect(railStore).toContain("fleet-console.rail.panelBehavior");
-    // Doctrine: the panel head is a 32px caption attached above the slot. It does
-    // not take a body row and does not hover-reveal. The body keeps the full slot
-    // height; PTY/plugin geometry is unaware of the caption.
-    expect(rail).toContain(".right-rail-panel-head {");
-    expect(rail).toContain("grid-template-rows: 32px minmax(0, 1fr);");
-    expect(rail).not.toContain("height: calc(100% + 32px);");
+    // Doctrine: Operation panels keep a 32px attached caption. The Activity Rail
+    // does not — its head is hover-reveal chrome so the body uses the full slot.
+    // Hide with opacity+transform only (never display/visibility) so keyboard
+    // focus can still enter and reveal it; reveal entry stays pointermove-gated
+    // with an intent delay so scroll-under-pointer never triggers it.
+    expect(rail).toContain(".right-rail-panel-head-reveal");
+    expect(rail).toMatch(/\.right-rail-panel-head-reveal \{[^}]*pointer-events:\s*none/);
+    expect(rail).toMatch(/\.right-rail-panel-head-reveal\.is-revealed \{[^}]*pointer-events:\s*auto/);
+    expect(rail).toMatch(/@media \(prefers-reduced-motion: reduce\) \{[^{]*\.right-rail-panel-head-reveal/);
+    expect(rail).toContain(".right-rail-panel-peek");
+    expect(rail).not.toContain("grid-template-rows: 32px minmax(0, 1fr);");
+    expect(rightRail).toContain("HEAD_REVEAL_INTENT_DELAY_MS");
+    expect(rightRail).not.toMatch(/onPointerEnter=\{(?:handleSlotPointerMove|holdHeadOpen)/);
     expect(source("styles/components.css")).toContain(".canvas-operation.is-top-edge .canvas-operation-titlebar");
     expect(source("styles/components.css")).toContain(".canvas-operation.is-top-edge .canvas-operation-resize--n");
     expect(source("canvas/operation-frame.tsx")).toContain("DRAG_THRESHOLD_PX");
     expect(source("canvas/operation-frame.tsx")).toContain("capturing: false");
-    const railHead = rail.match(/^\.right-rail-panel-head \{[^}]*\}/m)?.[0] ?? "";
-    expect(railHead).toContain("height: 32px;");
-    expect(railHead).toContain("min-height: 32px;");
-    expect(rail).not.toContain(".right-rail-panel-head-reveal");
-    expect(rail).not.toContain(".right-rail-panel-peek");
-    expect(rightRail).not.toContain("HEAD_REVEAL_INTENT_DELAY_MS");
-    expect(rightRail).not.toMatch(/onPointerEnter=\{(?:handleSlotPointerMove|holdHeadOpen)/);
   });
 
   it("pins the popup opacity underlay contract", () => {

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -444,6 +444,26 @@ describe("Right Rail hover-reveal header", () => {
     expect(panelHeadReveal().classList.contains("is-revealed")).toBe(false);
   });
 
+  it("keeps a touch reveal open through the lift so a second tap can reach the chrome", () => {
+    renderRail();
+    dispatchSlotPointer("pointerdown", { clientY: 120, pointerType: "touch" });
+    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
+
+    dispatchSlotPointer("pointerleave", { clientY: 120, pointerType: "touch" });
+    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
+
+    act(() => {
+      panelHeadReveal().dispatchEvent(new PointerEvent("pointerleave", {
+        bubbles: true,
+        cancelable: true,
+        clientX: 980,
+        clientY: 110,
+        pointerType: "touch",
+      }));
+    });
+    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
+  });
+
   it("resets the reveal when the active panel changes", () => {
     renderRail();
     dispatchSlotPointer("pointermove", { clientY: 104 });

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -394,6 +394,69 @@ describe("Right Rail panel width", () => {
   });
 });
 
+describe("Right Rail hover-reveal header", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the header hidden until a delayed pointer approach, then hides immediately on leave", () => {
+    renderRail();
+    const reveal = panelHeadReveal();
+    expect(reveal.classList.contains("is-revealed")).toBe(false);
+    expect(container.querySelector(".right-rail-panel-peek")).not.toBeNull();
+
+    dispatchSlotPointer("pointermove", { clientY: 104 });
+    expect(reveal.classList.contains("is-revealed")).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(119);
+    });
+    expect(reveal.classList.contains("is-revealed")).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(reveal.classList.contains("is-revealed")).toBe(true);
+
+    dispatchSlotPointer("pointermove", { clientY: 180 });
+    expect(reveal.classList.contains("is-revealed")).toBe(false);
+  });
+
+  it("does not start a reveal from a touch pointermove", () => {
+    renderRail();
+    dispatchSlotPointer("pointermove", { clientY: 104, pointerType: "touch" });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(false);
+  });
+
+  it("reveals from a touch on the top edge and hides when the body is tapped", () => {
+    renderRail();
+    dispatchSlotPointer("pointerdown", { clientY: 120, pointerType: "touch" });
+    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
+
+    dispatchSlotPointer("pointerdown", { clientY: 240, pointerType: "touch" });
+    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(false);
+  });
+
+  it("resets the reveal when the active panel changes", () => {
+    renderRail();
+    dispatchSlotPointer("pointermove", { clientY: 104 });
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
+
+    act(() => setActiveRailPanel("codex"));
+    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(false);
+  });
+});
+
 function renderRail(): void {
   act(() => {
     root.render(<RightRail theaterId={null} api={{} as never} />);
@@ -404,6 +467,39 @@ function panelSlot(): HTMLDivElement {
   const slot = container.querySelector<HTMLDivElement>(".right-rail-panel-slot");
   expect(slot).not.toBeNull();
   return slot!;
+}
+
+function panelHeadReveal(): HTMLDivElement {
+  const reveal = container.querySelector<HTMLDivElement>(".right-rail-panel-head-reveal");
+  expect(reveal).not.toBeNull();
+  return reveal!;
+}
+
+function dispatchSlotPointer(
+  type: "pointermove" | "pointerdown" | "pointerleave",
+  init: { readonly clientY: number; readonly pointerType?: string },
+): void {
+  const slot = panelSlot();
+  vi.spyOn(slot, "getBoundingClientRect").mockReturnValue({
+    x: 800,
+    y: 100,
+    top: 100,
+    left: 800,
+    right: 1160,
+    bottom: 700,
+    width: 360,
+    height: 600,
+    toJSON: () => ({}),
+  });
+  act(() => {
+    slot.dispatchEvent(new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: 980,
+      clientY: init.clientY,
+      pointerType: init.pointerType ?? "mouse",
+    }));
+  });
 }
 
 function panelBody(): HTMLDivElement {


### PR DESCRIPTION
## Summary
- Activity Rail 헤더를 #659 호버-리빌로 되돌립니다. 창 캡션(#689)이 레일 슬롯에 32px 상주 캡션을 넣으면서 본문 높이를 빼 갔고, 상단 접근 시에만 옵션이 나오던 계약이 사라졌습니다.
- Operation 패널의 32px 창 캡션은 그대로 둡니다. 레일 본문은 다시 슬롯 전체 높이를 쓰고, 타이틀·플로팅·닫기는 상단 12px 접근(120ms 의도 지연) 또는 키보드 포커스에서만 오버레이로 소환됩니다.
- 아직 미릴리스인 `window-caption-b` 프래그먼트에서 "Activity Rail도 같은 캡션을 슬롯 안에 둔다"는 문장을 회수합니다.

Changelog-Amend: window-caption-b.md

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/right-rail.test.tsx tests/instrument-design-contract.test.ts` — 84 passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] 저장소 패널을 연 뒤 상단 가장자리에 마우스를 가져가면 120ms 후 헤더(타이틀·플로팅·닫기)가 본문 위에 나타나고, 본문 쪽으로 벗어나면 즉시 숨는지 확인
- [ ] 헤더가 숨은 동안 저장소 본문(이름·브랜치·동기화)이 슬롯 최상단까지 올라와 있는지 확인
- [ ] Tab으로 헤더 컨트롤에 들어가면 리빌이 유지되고, Esc는 헤더 포커스 범위에서만 패널을 닫는지 확인