### PR TITLE
fix(fleet-console): put the rail Shell card on the panel surface

### DIFF
--- a/.changelog.d/terminal-ground.md
+++ b/.changelog.d/terminal-ground.md
@@ -1,0 +1,8 @@
+---
+branch: terminal-ground
+---
+
+### fleet-console
+#### Fixed
+- The rail Shell panel now sits on the same surface as the terminal inside it, so the framed step around that terminal is gone in every theme.
+  ko: 레일 Shell 패널이 그 안의 터미널과 같은 면에 놓여, 모든 테마에서 터미널을 감싸던 액자 테가 사라집니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8575,7 +8575,11 @@
   flex-direction: column;
   gap: var(--space-2);
   padding: var(--space-3);
-  background: var(--surface-glass);
+  /* 이 기본 규칙의 소비처는 레일 Shell 하나다(캔버스 Operation은 아래에서 transparent로 덮는다).
+     카드 면은 그 안의 xterm과 같은 --surface-panel이어야 한다 — 유리(--surface-glass)는 뒤에
+     오는 것에 따라 유효색이 흔들리는데 xterm 배경은 불투명 한 값이라 맞출 수가 없고, Maritime
+     5.3%p·Carbon 6.6%p의 계단으로 남는다. 카드의 정체는 테두리가 지고 면은 터미널에 넘긴다. */
+  background: var(--surface-panel);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-soft);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1246,6 +1246,10 @@ describe("Instrument core design contract", () => {
     expect(titlebarBlock).toContain("background: var(--surface-panel);");
     const panelBodyBlock = components.match(/^\.canvas-operation-terminal \{[^}]*\}/m)?.[0] ?? "";
     expect(panelBodyBlock).toContain("background: var(--surface-panel);");
+    // 레일 Shell 카드도 같은 면이다 — 이 기본 규칙의 소비처는 레일 하나뿐이고, 유리로 되돌리면
+    // 카드가 자기 안의 xterm과 갈린다(불투명 xterm 배경은 반투명 유리를 따라갈 수 없다).
+    const terminalShellBlock = components.match(/^\.terminal-shell \{[^}]*\}/m)?.[0] ?? "";
+    expect(terminalShellBlock).toContain("background: var(--surface-panel);");
     // 휴면은 패널 면 위의 상태다 — 톤을 낮추는 베이스 레이어가 돌아오면 창 안에 다른 면이 생긴다.
     const dormantBlock = components.match(/^\.canvas-operation-dormant \{[^}]*\}/m)?.[0] ?? "";
     expect(dormantBlock).toContain("background: radial-gradient(");


### PR DESCRIPTION
## Summary
- #704가 Operation 패널을 `--surface-panel` 하나로 통일했지만 우측 레일은 범위 밖이었습니다. 레일 Shell 카드는 여전히 `--surface-glass`(반투명 유리)를 칠하고 그 안의 xterm만 `--surface-panel`을 받아, Operation 창에서 사라진 액자 테가 레일에 남아 있었습니다 — 실측 Maritime 5.28%p · Carbon 6.60%p. Instrument가 0인 건 `--surface-glass`가 `--ink-deep` 별칭이라 우연히 겹친 것입니다.
- `.terminal-shell` 기본 규칙의 배경을 `--surface-panel`로 바꿉니다. 반투명 유리는 애초에 반대편에서 맞출 수 없습니다 — 뒤에 오는 것에 따라 유효색이 흔들리는데 xterm 배경은 불투명 한 값입니다. 카드는 테두리로 계속 패널로 읽힙니다.
- 이 기본 규칙의 소비처는 레일 하나입니다(캔버스 Operation은 `.canvas-operation-terminal .terminal-shell`이 `transparent`로 덮습니다).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 172 파일 / 2103 테스트 통과
- [x] `pnpm --filter "./runtime/fleet-plugins/**" test` — terminal 684 포함 전 플러그인 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 17 항목 검증
- [x] 격리 콘솔 헤디드 실측(1600×1000, DPR 1): 4테마 레일 카드/PTY 도색 픽셀 ΔL 0.00 (변경 전 Maritime −5.28 · Carbon −6.60), Operation 패널은 #704 값 그대로 유지