### PR TITLE
feat(core-ai-gateway): log raw provider response events

### DIFF
--- a/packages/core-ai-gateway/src/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/codex/responses/adapter.ts
@@ -25,7 +25,7 @@ import {
   type FetchLike,
   type UpstreamReadOptions,
 } from "../../transport/upstream-sse.js";
-import { wireLog } from "../../transport/wire-log.js";
+import { logRawWireEvent, wireLog } from "../../transport/wire-log.js";
 
 // 전송 계층은 upstream-sse.ts와 공유한다. 기존 배럴 소비자를 위해 그대로 재수출한다.
 export { UpstreamBodyLimitError, UpstreamIdleTimeoutError, UpstreamProtocolError };
@@ -687,6 +687,8 @@ function parseEventFrame(frame: string): CanonicalResponseEvent | undefined {
       `OpenAI SSE contained invalid JSON: ${error instanceof Error ? error.message : String(error)}`
     );
   }
+  // Raw provider payload before the event-name type fallback and canonical filtering.
+  logRawWireEvent("openai.wire.event", eventName, parsed);
   if (isRecord(parsed) && typeof parsed.type !== "string" && eventName !== undefined) {
     parsed = { ...parsed, type: eventName };
   }

--- a/packages/core-ai-gateway/src/cursor/native/adapter.ts
+++ b/packages/core-ai-gateway/src/cursor/native/adapter.ts
@@ -40,7 +40,7 @@ import {
   isCursorNativeRedirectToolName,
   type CursorNativeRedirectResultType,
 } from "./exec-redirect.js";
-import { wireLog } from "../../transport/wire-log.js";
+import { logRawWireEvent, wireLog } from "../../transport/wire-log.js";
 import {
   AgentClientMessageSchema,
   AgentServerMessageSchema,
@@ -3093,6 +3093,8 @@ function createCursorLiveRun(options: CursorLiveRunOptions): CursorLiveRun {
           continue;
         }
         const decodedFrame = decodeCursorServerMessage(frame.payload);
+        // Raw provider frame before heartbeat filtering and canonical assembly.
+        logRawWireEvent("cursor.wire.event", undefined, decodedFrame);
         if (!isCursorHeartbeatFrame(decodedFrame)) noteSemanticProgress();
         handleFrame(decodedFrame);
       }

--- a/packages/core-ai-gateway/src/gateway-router/opencode.ts
+++ b/packages/core-ai-gateway/src/gateway-router/opencode.ts
@@ -62,5 +62,6 @@ export async function proxyToOpencode(
     headers,
     signal,
     url: OPENCODE_GO_MESSAGES_URL,
+    wireEventLabel: "opencode-go-anthropic.wire.event",
   });
 }

--- a/packages/core-ai-gateway/src/gateway-router/proxy.ts
+++ b/packages/core-ai-gateway/src/gateway-router/proxy.ts
@@ -2,6 +2,7 @@ import { projectAnthropicResponseUsage } from "../anthropic/claude-context.js";
 import { eagerAnthropicRequestBody } from "../anthropic/passthrough.js";
 import { withSseKeepAlive } from "../transport/sse-keepalive.js";
 import { findCauseCode } from "../transport/upstream-sse.js";
+import { logRawPassthroughBody } from "../transport/wire-log.js";
 import type { AnthropicMessagesRequest } from "../anthropic/protocol.js";
 
 // 도구 eager 정규화는 core-ai-gateway 소유로 이전됐다. 기존 런타임 소비자(ai-gateway-routes)를
@@ -33,6 +34,8 @@ export interface AnthropicProxyOptions {
   readonly responseModel?: string;
   /** Provider가 Anthropic 이벤트를 내지 않는 동안에도 gateway alias의 downstream 생존성을 유지한다. */
   readonly keepAlive?: boolean;
+  /** Raw response event label. Caller-owned so this shared proxy stays provider-neutral. */
+  readonly wireEventLabel?: string;
   readonly fetchImpl: typeof fetch;
   readonly headers: Readonly<Record<string, string>>;
   readonly signal: AbortSignal;
@@ -73,11 +76,19 @@ export async function proxyAnthropicMessages(
     return;
   }
   const rawBody = readResponseBody(upstream.body);
-  // contextWindow이 없어도 responseModel이 있으면 재작성이 필요하므로 변환기를 탄다.
   const contentType = upstream.headers.get("content-type");
-  const projectedBody = options.contextWindow === undefined && options.responseModel === undefined
+  // Observation tap: records provider response payloads before projection while passing the
+  // upstream bytes through unchanged. The label is caller-owned so this proxy stays neutral.
+  const observedBody = options.wireEventLabel === undefined
     ? rawBody
-    : projectAnthropicResponseUsage(rawBody, {
+    : logRawPassthroughBody(rawBody, {
+        label: options.wireEventLabel,
+        contentType,
+      });
+  // contextWindow이 없어도 responseModel이 있으면 재작성이 필요하므로 변환기를 탄다.
+  const projectedBody = options.contextWindow === undefined && options.responseModel === undefined
+    ? observedBody
+    : projectAnthropicResponseUsage(observedBody, {
         contentType,
         contextWindow: options.contextWindow,
         responseModel: options.responseModel,

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -444,6 +444,7 @@ async function proxyToAnthropic(
     headers,
     signal,
     url: ANTHROPIC_MESSAGES_URL,
+    wireEventLabel: "anthropic.wire.event",
   });
 }
 
@@ -469,6 +470,7 @@ async function proxyToKimi(
     headers,
     signal,
     url: KIMI_MESSAGES_URL,
+    wireEventLabel: "kimi-anthropic.wire.event",
   });
 }
 

--- a/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
@@ -22,7 +22,7 @@ import {
   type FetchLike,
   type UpstreamReadOptions,
 } from "../../transport/upstream-sse.js";
-import { wireLog } from "../../transport/wire-log.js";
+import { logRawWireEvent, wireLog, type RawWireEventPayload } from "../../transport/wire-log.js";
 
 /** OpenCode Go 구독이 노출하는 Chat Completions 네임스페이스 엔드포인트. */
 export const OPENCODE_GO_CHAT_COMPLETIONS_URL = "https://opencode.ai/zen/go/v1/chat/completions";
@@ -712,18 +712,21 @@ async function* translateChatCompletionsStream(
       while (boundary !== undefined) {
         const frame = buffer.slice(0, boundary.index);
         buffer = buffer.slice(boundary.index + boundary.length);
-        const data = chatFrameData(frame);
-        if (data !== undefined) {
-          yield* consumeChunk(data);
+        const frameData = chatFrameData(frame);
+        if (frameData !== undefined) {
+          // Raw provider payload before canonical consumeChunk assembly.
+          logRawWireEvent("openai-chat.wire.event", frameData.event, frameData.data);
+          yield* consumeChunk(frameData.data);
         }
         boundary = nextEventBoundary(buffer);
       }
     }
 
     if (buffer.trim().length > 0) {
-      const data = chatFrameData(buffer);
-      if (data !== undefined) {
-        yield* consumeChunk(data);
+      const frameData = chatFrameData(buffer);
+      if (frameData !== undefined) {
+        logRawWireEvent("openai-chat.wire.event", frameData.event, frameData.data);
+        yield* consumeChunk(frameData.data);
       }
     }
     yield* finish();
@@ -733,13 +736,16 @@ async function* translateChatCompletionsStream(
   }
 }
 
-function chatFrameData(frame: string): unknown | undefined {
-  const { data } = parseSseFrameFields(frame);
+function chatFrameData(frame: string): RawWireEventPayload | undefined {
+  const { event: eventName, data } = parseSseFrameFields(frame);
   if (data.length === 0 || data === "[DONE]") {
     return undefined;
   }
   try {
-    return JSON.parse(data);
+    return {
+      ...(eventName === undefined ? {} : { event: eventName }),
+      data: JSON.parse(data) as unknown,
+    };
   } catch (error) {
     throw new UpstreamProtocolError(
       `Chat Completions SSE contained invalid JSON: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/core-ai-gateway/src/opencode-go/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/opencode-go/responses/adapter.ts
@@ -23,7 +23,7 @@ import {
   type FetchLike,
   type UpstreamReadOptions,
 } from "../../transport/upstream-sse.js";
-import { wireLog } from "../../transport/wire-log.js";
+import { logRawWireEvent, wireLog } from "../../transport/wire-log.js";
 
 /** OpenCode Go 구독이 노출하는 Responses 네임스페이스 엔드포인트. */
 export const OPENCODE_GO_RESPONSES_URL = "https://opencode.ai/zen/go/v1/responses";
@@ -287,6 +287,8 @@ function parseEventFrame(frame: string): CanonicalResponseEvent | undefined {
       `OpenCode Go SSE contained invalid JSON: ${error instanceof Error ? error.message : String(error)}`
     );
   }
+  // Raw provider payload before the event-name type fallback and canonical filtering.
+  logRawWireEvent("opencode-go-responses.wire.event", eventName, parsed);
   if (isRecord(parsed) && typeof parsed.type !== "string" && eventName !== undefined) {
     parsed = { ...parsed, type: eventName };
   }

--- a/packages/core-ai-gateway/src/transport/upstream-sse.ts
+++ b/packages/core-ai-gateway/src/transport/upstream-sse.ts
@@ -195,6 +195,27 @@ export function nextEventBoundary(buffer: string): { index: number; length: numb
   return match === null ? undefined : { index: match.index, length: match[0].length };
 }
 
+/**
+ * Byte-level twin of `nextEventBoundary`. SSE separators are pure ASCII, so scanning the raw
+ * bytes is exact without decoding — a boundary never splits a multibyte sequence.
+ */
+export function nextEventBoundaryBytes(
+  buffer: Uint8Array,
+): { index: number; length: number } | undefined {
+  for (let index = 0; index < buffer.byteLength; index += 1) {
+    const first = buffer[index];
+    if (first === 10) {
+      if (buffer[index + 1] === 10) return { index, length: 2 };
+      continue;
+    }
+    if (first !== 13) continue;
+    if (buffer[index + 1] === 13) return { index, length: 2 };
+    if (buffer[index + 1] !== 10) continue;
+    if (buffer[index + 2] === 13 && buffer[index + 3] === 10) return { index, length: 4 };
+  }
+  return undefined;
+}
+
 export interface SseFrameFields {
   readonly event?: string;
   /** Joined `data:` lines. Comment-only or empty frames yield an empty string. */

--- a/packages/core-ai-gateway/src/transport/wire-log.ts
+++ b/packages/core-ai-gateway/src/transport/wire-log.ts
@@ -16,6 +16,7 @@ import {
   statSync,
 } from "node:fs";
 import { dirname } from "node:path";
+import { nextEventBoundaryBytes, parseSseFrameFields } from "./upstream-sse.js";
 
 export interface WireLogTarget {
   readonly path: string;
@@ -152,4 +153,141 @@ export async function* logCanonicalEvents<T>(
     wireLog(event, item);
     yield item;
   }
+}
+
+/**
+ * Raw provider event payload. `data` is the `JSON.parse` result verbatim — before
+ * event-name type fallback, canonical filtering, or tool assembly — and `event` is the SSE
+ * `event:` field when the frame carried one. `event` is omitted entirely when absent.
+ */
+export interface RawWireEventPayload {
+  readonly event?: string;
+  readonly data: unknown;
+}
+
+/** Log one raw provider event under the caller-owned label. Inert when no target is set. */
+export function logRawWireEvent(label: string, eventName: string | undefined, data: unknown): void {
+  if (!wireLogEnabled()) return;
+  wireLog(label, {
+    ...(eventName === undefined ? {} : { event: eventName }),
+    data,
+  } satisfies RawWireEventPayload);
+}
+
+// 진단 파싱 상한. wire log 타깃이 켜져 있을 때만 도달하고, 본문이 상한을 넘어도 원본 바이트는
+// 그대로 통과한다 — 기록 항목만 빠질 뿐이다.
+const RAW_EVENT_MAX_FRAME_BYTES = 1024 * 1024;
+const RAW_EVENT_MAX_JSON_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Observation tap for passthrough responses. Records each JSON payload exactly as parsed from
+ * the upstream body — before projection/model rewrite — then passes the original bytes through
+ * unchanged. Unsupported media types, malformed frames, and oversized diagnostics never fail
+ * or alter the request, only the diagnostic line is skipped. When no wire log target is set the
+ * tap is a pure pass-through with no buffering or parsing.
+ */
+export async function* logRawPassthroughBody(
+  chunks: AsyncIterable<Uint8Array>,
+  options: { readonly label: string; readonly contentType?: string | null },
+): AsyncGenerator<Uint8Array> {
+  if (!wireLogEnabled()) {
+    yield* chunks;
+    return;
+  }
+  const mediaType = options.contentType?.split(";", 1)[0]?.trim().toLowerCase();
+  if (mediaType === "text/event-stream") {
+    yield* tapPassthroughSse(chunks, options.label);
+    return;
+  }
+  if (mediaType === "application/json" || mediaType?.endsWith("+json")) {
+    yield* tapPassthroughJson(chunks, options.label);
+    return;
+  }
+  yield* chunks;
+}
+
+async function* tapPassthroughSse(
+  chunks: AsyncIterable<Uint8Array>,
+  label: string,
+): AsyncGenerator<Uint8Array> {
+  let pending: Uint8Array = new Uint8Array(0);
+  let oversizedFrame = false;
+  for await (const chunk of chunks) {
+    pending = concatBytes(pending, chunk);
+    let boundary = nextEventBoundaryBytes(pending);
+    while (boundary !== undefined) {
+      const frame = pending.slice(0, boundary.index);
+      pending = pending.slice(boundary.index + boundary.length);
+      if (!oversizedFrame && frame.byteLength <= RAW_EVENT_MAX_FRAME_BYTES) {
+        tapPassthroughFrameBytes(label, frame);
+      }
+      oversizedFrame = false;
+      boundary = nextEventBoundaryBytes(pending);
+    }
+    if (pending.byteLength > RAW_EVENT_MAX_FRAME_BYTES) {
+      // 상한을 넘긴 프레임은 진단만 skip한다. 경계가 청크에 걸쳐 나뉠 수 있으니 separator
+      // 길이만큼의 꼬리를 남겨 다음 청크에서 경계를 다시 찾고, 그 뒤 정상 프레임은 계속 기록한다.
+      pending = pending.slice(Math.max(0, pending.byteLength - 3));
+      oversizedFrame = true;
+    }
+    yield chunk;
+  }
+  if (!oversizedFrame && pending.byteLength > 0) {
+    tapPassthroughFrameBytes(label, pending);
+  }
+}
+
+function tapPassthroughFrameBytes(label: string, frameBytes: Uint8Array): void {
+  let frame: string;
+  try {
+    frame = new TextDecoder("utf-8", { fatal: true }).decode(frameBytes);
+  } catch {
+    return;
+  }
+  const { event: eventName, data } = parseSseFrameFields(frame);
+  if (data.length === 0 || data === "[DONE]") return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    // Malformed payloads flow through unchanged; only the diagnostic line is skipped.
+    return;
+  }
+  logRawWireEvent(label, eventName, parsed);
+}
+
+async function* tapPassthroughJson(
+  chunks: AsyncIterable<Uint8Array>,
+  label: string,
+): AsyncGenerator<Uint8Array> {
+  let pending: Uint8Array = new Uint8Array(0);
+  let oversized = false;
+  for await (const chunk of chunks) {
+    if (!oversized) {
+      if (pending.byteLength + chunk.byteLength > RAW_EVENT_MAX_JSON_BYTES) {
+        oversized = true;
+        pending = new Uint8Array(0);
+      } else {
+        pending = concatBytes(pending, chunk);
+      }
+    }
+    yield chunk;
+  }
+  if (oversized || pending.byteLength === 0) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(pending));
+  } catch {
+    return;
+  }
+  logRawWireEvent(label, undefined, parsed);
+}
+
+function concatBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
+  if (left.byteLength === 0) return right;
+  if (right.byteLength === 0) return left;
+  const combined = new Uint8Array(left.byteLength + right.byteLength);
+  combined.set(left, 0);
+  combined.set(right, left.byteLength);
+  return combined;
 }

--- a/packages/core-ai-gateway/src/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/xai/responses/adapter.ts
@@ -19,7 +19,7 @@ import {
   type FetchLike,
   type UpstreamReadOptions,
 } from "../../transport/upstream-sse.js";
-import { wireLog } from "../../transport/wire-log.js";
+import { logRawWireEvent, wireLog } from "../../transport/wire-log.js";
 
 /** Grok CLI 구독이 노출하는 Responses 네임스페이스 엔드포인트. */
 export const XAI_CLI_RESPONSES_URL = "https://cli-chat-proxy.grok.com/v1/responses";
@@ -384,6 +384,8 @@ function parseEventFrame(frame: string): CanonicalResponseEvent | undefined {
       `Grok CLI SSE contained invalid JSON: ${error instanceof Error ? error.message : String(error)}`
     );
   }
+  // Raw provider payload before the event-name type fallback and canonical filtering.
+  logRawWireEvent("xai-responses.wire.event", eventName, parsed);
   if (isRecord(parsed) && typeof parsed.type !== "string" && eventName !== undefined) {
     parsed = { ...parsed, type: eventName };
   }

--- a/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
@@ -786,6 +786,33 @@ describe("codex responses adapter", () => {
     });
   });
 
+  it("records the raw provider event before canonical type normalization", async () => {
+    const filePath = wireLogFile();
+    const fetchMock = vi.fn<typeof fetch>(async () => sse(
+      'event: response.reasoning_text.delta\ndata: {"item_id":"reasoning-raw","output_index":0,"delta":"checking"}\n\n',
+    ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events: CanonicalResponseEvent[] = [];
+    for await (const event of response.events) events.push(event);
+
+    expect(events).toEqual([{
+      type: "response.reasoning_summary_text.delta",
+      item_id: "reasoning-raw",
+      output_index: 0,
+      delta: "checking",
+    }]);
+    const raw = readWireLogLines(filePath).filter((entry) => entry.event === "openai.wire.event");
+    expect(raw).toEqual([expect.objectContaining({
+      payload: {
+        event: "response.reasoning_text.delta",
+        data: { item_id: "reasoning-raw", output_index: 0, delta: "checking" },
+      },
+    })]);
+    expect(JSON.stringify(raw)).not.toContain("sk-codex");
+  });
+
   it("preserves discarded failure evidence before the gateway canonical-event wrapper", async () => {
     const filePath = wireLogFile();
     const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"An error occurred while processing your request. Please include request ID req-1."}}}\n\n';

--- a/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
@@ -51,17 +51,43 @@ function wireLogFile(): string {
   return filePath;
 }
 
-function cursorWirePlanCount(filePath: string): number {
+function cursorWireEntries(filePath: string): Array<Record<string, unknown>> {
   return readFileSync(filePath, "utf8")
     .trim()
     .split("\n")
     .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line) as { readonly event?: unknown })
-    .filter((entry) => entry.event === "cursor.wire.plan")
-    .length;
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function cursorWirePlanCount(filePath: string): number {
+  return cursorWireEntries(filePath).filter((entry) => entry.event === "cursor.wire.plan").length;
 }
 
 describe("Cursor live client-tool Run bridge", () => {
+  it("records decoded Cursor server messages before canonical handling", async () => {
+    const wireLogPath = wireLogFile();
+    const stream = new BridgeCursorStream(cursorCompletionFrames("raw cursor event"));
+    const harness = cursorHarness([stream]);
+
+    try {
+      const events = await collectCursorResponse(
+        harness.adapter,
+        cursorRequest("session-raw-wire-event", "composer-2.5"),
+        "cursor-secret",
+      );
+
+      expect(canonicalText(events)).toBe("raw cursor event");
+      const raw = cursorWireEntries(wireLogPath).filter((entry) => entry.event === "cursor.wire.event");
+      expect(raw).toHaveLength(3);
+      expect(raw[0]?.payload).toEqual({
+        data: { interactionUpdate: { textDelta: { text: "raw cursor event" } } },
+      });
+      expect(JSON.stringify(raw)).not.toContain("cursor-secret");
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
   it.each([
     "grok-4.5",
     "grok-4.5-fast",

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -23,6 +23,7 @@ import {
   errorMessage,
 } from "../../src/index.js";
 import type { AiGatewayRouteDeps } from "../../src/index.js";
+import { wireLogFixture } from "../helpers/wire-log.js";
 
 function aiGatewaySettingsStub(settings: AiGatewayStoredSettings): () => AiGatewayStoredSettings {
   return () => settings;
@@ -700,6 +701,39 @@ describe("mid-stream failure", () => {
 });
 
 describe("OpenCode Go passthrough", () => {
+  it("records raw OpenCode Anthropic events without credentials", async () => {
+    const wireLog = wireLogFixture("fleet-opencode-anthropic-wire-log-");
+    try {
+      const upstream = 'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+      const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+        upstream,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ));
+      const router = createAiGatewayRouter({
+        fetch: fetchMock,
+        readAuth,
+        readOpencodeApiKey: async () => "opencode-secret",
+      });
+      const res = response();
+
+      await router.handle(ctx({
+        res,
+        token: ANTHROPIC_CRED,
+        model: "claude-gateway--opencode--minimax-m3[1m]",
+      }));
+
+      expect(res.body).toBe(upstream);
+      const raw = wireLog.read().filter((entry) => entry.event === "opencode-go-anthropic.wire.event");
+      expect(raw).toEqual([expect.objectContaining({
+        payload: { event: "message_stop", data: { type: "message_stop" } },
+      })]);
+      expect(JSON.stringify(raw)).not.toContain("opencode-secret");
+      expect(JSON.stringify(raw)).not.toContain(ANTHROPIC_CRED);
+    } finally {
+      wireLog.cleanup();
+    }
+  });
+
   it("rewrites the model, swaps in the stored key, and strips the unadvertised effort", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response(
       "event: message_stop\n\n",
@@ -914,6 +948,50 @@ describe("Grok CLI Responses", () => {
 });
 
 describe("Kimi passthrough", () => {
+  it("records raw Kimi Anthropic events before model projection", async () => {
+    const wireLog = wireLogFixture("fleet-kimi-anthropic-wire-log-");
+    try {
+      const upstream = [
+        "event: message_start\n",
+        `data: ${JSON.stringify({
+          type: "message_start",
+          message: { id: "msg-kimi-raw", model: "k3", usage: { input_tokens: 1, output_tokens: 0 } },
+        })}\n\n`,
+      ].join("");
+      const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+        upstream,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ));
+      const router = createAiGatewayRouter({
+        fetch: fetchMock,
+        readAuth,
+        readKimiApiKey: async () => "kimi-secret",
+      });
+      const res = response();
+
+      await router.handle(ctx({
+        res,
+        token: ANTHROPIC_CRED,
+        model: "claude-gateway--kimi--k3[1m]",
+      }));
+
+      expect(res.body).toContain('"model":"claude-gateway--kimi--k3[1m]"');
+      const raw = wireLog.read().filter((entry) => entry.event === "kimi-anthropic.wire.event");
+      expect(raw).toEqual([expect.objectContaining({
+        payload: {
+          event: "message_start",
+          data: {
+            type: "message_start",
+            message: { id: "msg-kimi-raw", model: "k3", usage: { input_tokens: 1, output_tokens: 0 } },
+          },
+        },
+      })]);
+      expect(JSON.stringify(raw)).not.toContain("kimi-secret");
+    } finally {
+      wireLog.cleanup();
+    }
+  });
+
   it("keeps Claude Code's downstream stream alive while the provider is silent", async () => {
     vi.useFakeTimers();
     try {
@@ -1298,6 +1376,30 @@ describe("Kimi passthrough", () => {
 });
 
 describe("anthropic passthrough", () => {
+  it("records raw native Anthropic events without caller credentials", async () => {
+    const wireLog = wireLogFixture("fleet-native-anthropic-wire-log-");
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ));
+    const router = createAiGatewayRouter({ fetch: fetchMock, readAuth });
+    try {
+      await router.handle(ctx({
+        res: response(),
+        token: ANTHROPIC_CRED,
+        model: "claude-sonnet-4-6",
+      }));
+
+      const raw = wireLog.read().filter((entry) => entry.event === "anthropic.wire.event");
+      expect(raw).toEqual([expect.objectContaining({
+        payload: { event: "message_stop", data: { type: "message_stop" } },
+      })]);
+      expect(JSON.stringify(raw)).not.toContain(ANTHROPIC_CRED);
+    } finally {
+      wireLog.cleanup();
+    }
+  });
+
   it("keeps Claude Code's downstream stream alive while Anthropic is silent", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core-ai-gateway/tests/helpers/wire-log.ts
+++ b/packages/core-ai-gateway/tests/helpers/wire-log.ts
@@ -1,0 +1,31 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { setWireLogTarget } from "../../src/transport/wire-log.js";
+
+export interface WireLogFixture {
+  readonly path: string;
+  read(): Array<Record<string, unknown>>;
+  cleanup(): void;
+}
+
+export function wireLogFixture(prefix: string): WireLogFixture {
+  const directory = mkdtempSync(path.join(tmpdir(), prefix));
+  const filePath = path.join(directory, "wire-log.jsonl");
+  setWireLogTarget({ path: filePath });
+  return {
+    path: filePath,
+    read() {
+      return readFileSync(filePath, "utf8")
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+    },
+    cleanup() {
+      setWireLogTarget(undefined);
+      rmSync(directory, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
@@ -11,6 +11,7 @@ import {
   opencodeGoWire,
 } from "../../../src/index.js";
 import type { CanonicalResponseEvent, CanonicalResponseRequest } from "../../../src/index.js";
+import { wireLogFixture } from "../../helpers/wire-log.js";
 
 const CHAT_URL = "https://chat.example/v1/chat/completions";
 
@@ -495,6 +496,31 @@ describe("chat completions request translation", () => {
 });
 
 describe("chat completions stream translation", () => {
+  it("records each raw chat chunk before canonical translation", async () => {
+    const wireLog = wireLogFixture("fleet-opencode-chat-wire-log-");
+    try {
+      const rawChunk = {
+        id: "chat-raw",
+        model: "deepseek-v4-flash",
+        choices: [{ index: 0, delta: { reasoning_content: "checking" } }],
+      };
+      const fetchMock = vi.fn<typeof fetch>(async () => sse(
+        `event: chat.completion.chunk\ndata: ${JSON.stringify(rawChunk)}\n\n`,
+      ));
+      const response = await adapter(fetchMock).stream(request(), { apiKey: "opencode-secret" });
+      if (!response.ok) throw new Error("expected ok");
+      await collect(response.events);
+
+      const raw = wireLog.read().filter((entry) => entry.event === "openai-chat.wire.event");
+      expect(raw).toEqual([expect.objectContaining({
+        payload: { event: "chat.completion.chunk", data: rawChunk },
+      })]);
+      expect(JSON.stringify(raw)).not.toContain("opencode-secret");
+    } finally {
+      wireLog.cleanup();
+    }
+  });
+
   it("translates reasoning_content into canonical reasoning events", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => sse(
       chunk({ id: "c-reason", model: "deepseek-v4-flash", choices: [{ index: 0, delta: { reasoning_content: "Inspecting " } }] }),

--- a/packages/core-ai-gateway/tests/opencode-go/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/opencode-go/responses/adapter.test.ts
@@ -6,6 +6,7 @@ import {
   createOpencodeGoAdapter,
 } from "../../../src/index.js";
 import type { CanonicalResponseEvent, CanonicalResponseRequest } from "../../../src/index.js";
+import { wireLogFixture } from "../../helpers/wire-log.js";
 
 function request(overrides: Partial<CanonicalResponseRequest> = {}): CanonicalResponseRequest {
   return {
@@ -59,6 +60,30 @@ describe("opencode go responses adapter", () => {
     expect(body.metadata).toEqual({ session: "s" });
     // No ChatGPT store:false coercion either.
     expect(body).not.toHaveProperty("store");
+  });
+
+  it("records raw response events that canonical translation drops", async () => {
+    const wireLog = wireLogFixture("fleet-opencode-responses-wire-log-");
+    try {
+      const rawDelta = {
+        type: "response.function_call_arguments.delta",
+        item_id: "call-raw",
+        output_index: 0,
+        delta: "{\"path\"",
+      };
+      const fetchMock = vi.fn<typeof fetch>(async () => sse(chunk(rawDelta)));
+      const response = await new OpencodeGoResponsesAdapter({ fetch: fetchMock }).stream(request(), {
+        apiKey: "opencode-secret",
+      });
+      if (!response.ok) throw new Error("expected ok");
+
+      expect(await collect(response.events)).toEqual([]);
+      const raw = wireLog.read().filter((entry) => entry.event === "opencode-go-responses.wire.event");
+      expect(raw).toEqual([expect.objectContaining({ payload: { data: rawDelta } })]);
+      expect(JSON.stringify(raw)).not.toContain("opencode-secret");
+    } finally {
+      wireLog.cleanup();
+    }
   });
 
   it("translates streamed output text into canonical events", async () => {

--- a/packages/core-ai-gateway/tests/transport/wire-log.test.ts
+++ b/packages/core-ai-gateway/tests/transport/wire-log.test.ts
@@ -11,9 +11,14 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { setWireLogTarget, wireLog, wireLogEnabled } from "../../src/transport/wire-log.js";
+import {
+  logRawPassthroughBody,
+  setWireLogTarget,
+  wireLog,
+  wireLogEnabled,
+} from "../../src/transport/wire-log.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -158,5 +163,143 @@ describe("managed wire log files", () => {
     setWireLogTarget({ path: path.join(parentFile, "wire-log.jsonl"), maxBytes: 1_024 });
 
     expect(() => wireLog("failed.event", {})).not.toThrow();
+  });
+});
+
+async function passthroughChunks(
+  chunks: readonly Uint8Array[],
+  options: { readonly label: string; readonly contentType?: string | null },
+): Promise<Uint8Array[]> {
+  const output: Uint8Array[] = [];
+  for await (const chunk of logRawPassthroughBody(
+    (async function* () {
+      yield* chunks;
+    })(),
+    options,
+  )) {
+    output.push(chunk);
+  }
+  return output;
+}
+
+describe("passthrough raw event tap", () => {
+  it("is a pure pass-through with no parsing when the wire log is off", async () => {
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      const chunk = new TextEncoder().encode('data: {"type":"message_start"}\n\n');
+      const output = await passthroughChunks([chunk], {
+        label: "off.wire.event",
+        contentType: "text/event-stream",
+      });
+      // Original chunk references flow through untouched — no buffering, no re-chunking.
+      expect(output).toEqual([chunk]);
+      expect(output[0]).toBe(chunk);
+    } finally {
+      parseSpy.mockRestore();
+    }
+    expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  it("records an SSE data frame split across network chunks exactly once", async () => {
+    const filePath = path.join(temporaryDirectory(), "split.jsonl");
+    setWireLogTarget({ path: filePath });
+    const frame = 'event: message_start\ndata: {"type":"message_start","message":{"id":"m1"}}\n\n';
+    const cut = 37;
+    const output = await passthroughChunks([
+      new TextEncoder().encode(frame.slice(0, cut)),
+      new TextEncoder().encode(frame.slice(cut)),
+    ], { label: "test.wire.event", contentType: "text/event-stream" });
+
+    // Downstream bytes are the original chunks in order.
+    expect(new TextDecoder().decode(Buffer.concat(output))).toBe(frame);
+    const entries = readLines(filePath).filter((entry) => entry.event === "test.wire.event");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.payload).toEqual({
+      event: "message_start",
+      data: { type: "message_start", message: { id: "m1" } },
+    });
+  });
+
+  it("skips an oversized frame's diagnostic and keeps recording later frames", async () => {
+    const filePath = path.join(temporaryDirectory(), "oversized.jsonl");
+    setWireLogTarget({ path: filePath });
+    // Frame exceeds the 1 MiB diagnostic cap in encoded bytes.
+    const oversized = `data: ${JSON.stringify({ type: "message_start", padding: "x".repeat(1024 * 1024) })}\n\n`;
+    const normal = 'data: {"type":"content_block_delta","delta":{"text":"ok"}}\n\n';
+    const encoder = new TextEncoder();
+    const output = await passthroughChunks([
+      encoder.encode(oversized),
+      encoder.encode(normal),
+    ], { label: "oversized.wire.event", contentType: "text/event-stream" });
+
+    expect(new TextDecoder().decode(Buffer.concat(output))).toBe(oversized + normal);
+    const entries = readLines(filePath).filter((entry) => entry.event === "oversized.wire.event");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.payload).toEqual({
+      data: { type: "content_block_delta", delta: { text: "ok" } },
+    });
+  });
+
+  it("records one non-streaming JSON envelope while preserving its original chunks", async () => {
+    const filePath = path.join(temporaryDirectory(), "json.jsonl");
+    setWireLogTarget({ path: filePath });
+    const first = new TextEncoder().encode('{"type":"message","content":');
+    const second = new TextEncoder().encode('[{"type":"text","text":"done"}]}');
+
+    const output = await passthroughChunks([first, second], {
+      label: "json.wire.event",
+      contentType: "application/json; charset=utf-8",
+    });
+
+    expect(output).toEqual([first, second]);
+    expect(readLines(filePath).filter((entry) => entry.event === "json.wire.event"))
+      .toEqual([expect.objectContaining({
+        payload: {
+          data: { type: "message", content: [{ type: "text", text: "done" }] },
+        },
+      })]);
+  });
+
+  it.each([
+    ["malformed SSE", "text/event-stream", 'event: message_start\ndata: {not-json}\n\n'],
+    ["malformed JSON", "application/json", '{not-json}'],
+    ["unsupported content type", "text/plain", '{"type":"message"}'],
+  ])("keeps %s byte-for-byte and writes no raw event", async (_case, contentType, input) => {
+    const filePath = path.join(temporaryDirectory(), "unchanged.jsonl");
+    setWireLogTarget({ path: filePath });
+    const chunk = new TextEncoder().encode(input);
+
+    const output = await passthroughChunks([chunk], {
+      label: "unchanged.wire.event",
+      contentType,
+    });
+
+    expect(output).toEqual([chunk]);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it("accounts the cap in encoded bytes, not string length", async () => {
+    const filePath = path.join(temporaryDirectory(), "multibyte.jsonl");
+    setWireLogTarget({ path: filePath });
+    // A multibyte payload whose char count is far under 1 MiB is still bounded by the byte cap
+    // (each `가` encodes to three bytes), and a byte-level split inside a multibyte char across
+    // chunks is reassembled correctly by the byte buffering.
+    const padding = "가".repeat(350 * 1024);
+    const oversized = `data: ${JSON.stringify({ type: "message_start", padding })}\n\n`;
+    const normal = 'data: {"type":"message_stop"}\n\n';
+    const encoder = new TextEncoder();
+    const oversizedBytes = encoder.encode(oversized);
+    const cut = 700 * 1024;
+    const output = await passthroughChunks([
+      oversizedBytes.slice(0, cut),
+      oversizedBytes.slice(cut),
+      encoder.encode(normal),
+    ], { label: "multibyte.wire.event", contentType: "text/event-stream" });
+
+    expect(new TextDecoder().decode(Buffer.concat(output))).toBe(oversized + normal);
+    const entries = readLines(filePath).filter((entry) => entry.event === "multibyte.wire.event");
+    // The oversized frame is skipped; the trailing normal frame is still recorded.
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.payload).toEqual({ data: { type: "message_stop" } });
   });
 });

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -17,6 +17,7 @@ import type {
   CanonicalResponseRequest,
   CredentialResolverDeps,
 } from "../src/index.js";
+import { wireLogFixture } from "./helpers/wire-log.js";
 
 function xaiRequest(overrides: Partial<CanonicalResponseRequest> = {}): CanonicalResponseRequest {
   return {
@@ -633,6 +634,37 @@ describe("Grok Responses tool loading", () => {
 });
 
 describe("Grok Responses adapter", () => {
+  it("records the raw xAI event before canonical reasoning normalization", async () => {
+    const wireLog = wireLogFixture("fleet-xai-wire-log-");
+    try {
+      const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+        'event: response.reasoning_text.delta\ndata: {"item_id":"reasoning-xai","output_index":0,"delta":"checking"}\n\n',
+      ));
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), {
+        apiKey: "xai-secret",
+      });
+      if (!response.ok) throw new Error("expected success");
+      const events = await collectXaiEvents(response.events);
+
+      expect(events).toEqual([{
+        type: "response.reasoning_summary_text.delta",
+        item_id: "reasoning-xai",
+        output_index: 0,
+        delta: "checking",
+      }]);
+      const raw = wireLog.read().filter((entry) => entry.event === "xai-responses.wire.event");
+      expect(raw).toEqual([expect.objectContaining({
+        payload: {
+          event: "response.reasoning_text.delta",
+          data: { item_id: "reasoning-xai", output_index: 0, delta: "checking" },
+        },
+      })]);
+      expect(JSON.stringify(raw)).not.toContain("xai-secret");
+    } finally {
+      wireLog.cleanup();
+    }
+  });
+
   it("uses the CLI proxy with subscription and model headers", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response("data: [DONE]\n\n", { status: 200 }));
     const request: CanonicalResponseRequest = {


### PR DESCRIPTION
## Summary
- record provider-decoded response events before canonical normalization across Codex, xAI, OpenCode, and Cursor wires
- tap Anthropic-compatible passthrough responses before projection while preserving the original downstream bytes
- bound diagnostic parsing and verify all eight wire labels without persisting credentials

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `pnpm check:core-boundary`
- [x] `git diff canary..HEAD --check`