### PR TITLE
fix(fleet-console): hide the launch menu when no Theater is registered

### DIFF
--- a/.changelog.d/empty-theater-context-menu.md
+++ b/.changelog.d/empty-theater-context-menu.md
@@ -1,0 +1,8 @@
+---
+branch: empty-theater-context-menu
+---
+
+### fleet-console
+#### Changed
+- Right-click no longer opens the operation launcher when no Theater is registered.
+  ko: 등록된 Theater가 없으면 우클릭으로 실행 메뉴가 열리지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -283,6 +283,12 @@ export function OperationsCanvas({
     }
     if (target?.closest("[data-canvas-blocker]")) return;
     event.preventDefault();
+    // 등록된 Theater가 없으면 실행할 대상이 없다 — 메뉴를 띄워도 고를 자리가 없으니
+    // 브라우저 메뉴만 막고 우리 상자는 열지 않는다. War Room은 위에서 같은 이유로 막는다.
+    if (state.theaters.length === 0) {
+      setContextMenu(null);
+      return;
+    }
     const rect = canvasRef.current?.getBoundingClientRect();
     const anchor = rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : null;
     if (!anchor) return;

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -249,6 +249,12 @@ export function OperationsCanvas({
     onClick: clearTerminalFocus,
   });
 
+  // 우클릭 가드는 다음 우클릭에서만 돈다. 마지막 Theater를 잊는 동안 이미 열린 상자는
+  // 목록이 비워져도 그대로 남으므로, 그 전환에서 걷는다.
+  useEffect(() => {
+    if (state.theaters.length === 0) setContextMenu(null);
+  }, [state.theaters.length]);
+
   const handleContextMenuLaunchKind = (
     pluginId: string,
     kind: OperationLaunchKind,

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -373,6 +373,11 @@ export function OperationsSideBar({
   const [activeContextMenu, setActiveContextMenu] = useState<ActiveContextMenu | null>(null);
   const [newMenu, setNewMenu] = useState<NewMenuState | null>(null);
   const [browserOpen, setBrowserOpen] = useState(false);
+  // 우클릭 가드는 다음 우클릭에서만 돈다. 마지막 Theater를 잊는 동안 이미 열린 상자는
+  // 목록이 비워져도 그대로 남으므로, 그 전환에서 걷는다.
+  useEffect(() => {
+    if (theaters.length === 0) setNewMenu(null);
+  }, [theaters.length]);
   const { resizing, onPointerDown: onResizePointerDown, onDoubleClick: onResizeDoubleClick } = useSideBarResize();
   const collapsedGroups = useCollapsedGroups();
   const collapsedTheaters = useCollapsedTheaters();

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -809,6 +809,7 @@ export function OperationsSideBar({
   // 사이드바 빈 영역 우클릭 = ＋New 버튼과 동일한 launch 오버레이를 커서 위치에 연다.
   // chip/그룹 헤더는 자체 우클릭 핸들러가 preventDefault()를 호출하므로(버블로 도달 시
   // defaultPrevented=true), 그쪽 우클릭은 accent/그룹 메뉴를 유지하고 여기서는 무시한다.
+  // 등록된 Theater가 없으면 실행할 대상이 없다 — 브라우저 메뉴만 막고 상자는 열지 않는다.
   const openNewMenuAtCursor = (event: React.MouseEvent<HTMLElement>) => {
     if (event.defaultPrevented) return;
     event.preventDefault();
@@ -816,6 +817,10 @@ export function OperationsSideBar({
     // 캔버스(Map) 쪽에 이미 열린 캔버스 제어 메뉴는 사이드바 <aside> 안에 있지 않아
     // 포털의 mousedown 외부-클릭 닫기가 안 잡는다 — 포털이 구독하는 닫기 신호를 함께 본다.
     window.dispatchEvent(new Event("canvas-context-menu-close"));
+    if (theaters.length === 0) {
+      setNewMenu(null);
+      return;
+    }
     setNewMenu({
       anchor: { x: event.clientX, y: event.clientY },
       viewportBounds: { width: window.innerWidth, height: window.innerHeight },

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -101,12 +101,17 @@ export function TriageSideBar({
   // 사이드바 빈 영역 우클릭 = 캔버스의 주인 없는 자리와 같은 '캔버스 제어'를 커서 자리에 연다.
   // 칩과 휴면 선반은 자기 우클릭에서 preventDefault()를 부르므로(버블로 도달 시 defaultPrevented=true)
   // 그쪽 계약은 그대로 유지되고 여기서는 무시된다.
+  // 등록된 Theater가 없으면 실행할 대상이 없다 — 브라우저 메뉴만 막고 상자는 열지 않는다.
   const openLaunchMenuAtCursor = (event: MouseEvent<HTMLElement>) => {
     if (event.defaultPrevented) return;
     event.preventDefault();
     // 캔버스가 소유한 메뉴는 이 <aside> 안에 없어 포털의 mousedown 외부-클릭 닫기가 못 잡는다 —
     // 포털이 구독하는 닫기 신호를 함께 보낸다.
     window.dispatchEvent(new Event("canvas-context-menu-close"));
+    if (theaters.length === 0) {
+      setLaunchMenu(null);
+      return;
+    }
     setLaunchMenu({
       anchor: { x: event.clientX, y: event.clientY },
       viewportBounds: { width: window.innerWidth, height: window.innerHeight },

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -98,6 +98,11 @@ export function TriageSideBar({
   useEffect(() => {
     if (sideBar.collapsed) setLaunchMenu(null);
   }, [sideBar.collapsed]);
+  // 우클릭 가드는 다음 우클릭에서만 돈다. 마지막 Theater를 잊는 동안 이미 열린 상자는
+  // 목록이 비워져도 그대로 남으므로, 그 전환에서 걷는다.
+  useEffect(() => {
+    if (theaters.length === 0) setLaunchMenu(null);
+  }, [theaters.length]);
   // 사이드바 빈 영역 우클릭 = 캔버스의 주인 없는 자리와 같은 '캔버스 제어'를 커서 자리에 연다.
   // 칩과 휴면 선반은 자기 우클릭에서 preventDefault()를 부르므로(버블로 도달 시 defaultPrevented=true)
   // 그쪽 계약은 그대로 유지되고 여기서는 무시된다.

--- a/runtime/fleet-console/tests/canvas-context-menu-formation-launch.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-formation-launch.test.tsx
@@ -107,6 +107,22 @@ describe("canvas controls launch parity across canvas modes", () => {
     expect(item!.disabled).toBe(true);
     act(() => { window.dispatchEvent(new Event("canvas-context-menu-close")); });
   });
+
+  it("opens nothing when no Theater is registered", () => {
+    // 실행 대상이 없으면 메뉴를 띄워도 고를 자리가 없다 — 브라우저 메뉴만 막고 상자는 열지 않는다.
+    // canLaunch:false + Theater가 있는 위 경우와 반대: 거기는 항목을 회색으로 남기고, 여기는 상자 자체다.
+    renderCanvas({
+      state: { ...STATE, theaters: [], operations: [], activeTheaterId: null, activeOperationId: null },
+      canLaunch: false,
+    });
+
+    const canvas = container!.querySelector<HTMLElement>("main.operations-canvas")!;
+    const menu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 120, clientY: 240 });
+    act(() => canvas.dispatchEvent(menu));
+
+    expect(menu.defaultPrevented).toBe(true);
+    expect(container!.querySelector(".canvas-context-menu")).toBeNull();
+  });
 });
 
 function renderCanvas(overrides: Partial<Parameters<typeof OperationsCanvas>[0]> = {}) {

--- a/runtime/fleet-console/tests/canvas-context-menu-formation-launch.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-formation-launch.test.tsx
@@ -123,6 +123,19 @@ describe("canvas controls launch parity across canvas modes", () => {
     expect(menu.defaultPrevented).toBe(true);
     expect(container!.querySelector(".canvas-context-menu")).toBeNull();
   });
+
+  it("closes an already-open launcher when the last Theater disappears", () => {
+    renderCanvas();
+    const canvas = container!.querySelector<HTMLElement>("main.operations-canvas")!;
+    act(() => canvas.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 120, clientY: 240 })));
+    expect(container!.querySelector(".canvas-context-menu")).not.toBeNull();
+
+    renderCanvas({
+      state: { ...STATE, theaters: [], operations: [], activeTheaterId: null, activeOperationId: null },
+      canLaunch: false,
+    });
+    expect(container!.querySelector(".canvas-context-menu")).toBeNull();
+  });
 });
 
 function renderCanvas(overrides: Partial<Parameters<typeof OperationsCanvas>[0]> = {}) {

--- a/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
@@ -219,6 +219,21 @@ describe("sidebar context menu keyboard path", () => {
     expect(document.querySelector(".canvas-context-menu")).toBeNull();
   });
 
+  it("closes an already-open launch overlay when the last Theater disappears", () => {
+    renderSideBar();
+    const sideBar = required<HTMLElement>(".operations-side-bar");
+    act(() => sideBar.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 120,
+      clientY: 80,
+    })));
+    expect(document.querySelector(".canvas-context-menu")).not.toBeNull();
+
+    renderSideBar([], vi.fn(), { theaters: [], activeTheaterId: null, operations: [], groups: [], activeOperationId: null });
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
+  });
+
 });
 
 function renderSideBar(

--- a/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
@@ -203,11 +203,28 @@ describe("sidebar context menu keyboard path", () => {
     expect(document.activeElement).toBe(chip);
   });
 
+  it("does not open the launch overlay when no Theater is registered", () => {
+    renderSideBar([], vi.fn(), { theaters: [], activeTheaterId: null, operations: [], groups: [], activeOperationId: null });
+    const sideBar = required<HTMLElement>(".operations-side-bar");
+    const menu = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 120,
+      clientY: 80,
+    });
+
+    act(() => sideBar.dispatchEvent(menu));
+
+    expect(menu.defaultPrevented).toBe(true);
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
+  });
+
 });
 
 function renderSideBar(
   catalog: readonly OperationCatalogPlugin[] = [],
   onLaunchKind = vi.fn(),
+  overrides: Partial<Parameters<typeof OperationsSideBar>[0]> = {},
 ): void {
   act(() => root?.render(createElement(MemoryRouter, null, createElement(OperationsSideBar, {
     theaters: [THEATER],
@@ -240,6 +257,7 @@ function renderSideBar(
     onAddTheater: vi.fn(),
     onCancelAddTheater: vi.fn(),
     onForgetTheater: vi.fn(),
+    ...overrides,
   }))));
 }
 

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -1467,6 +1467,34 @@ describe("triage store", () => {
     expect(document.querySelector(".canvas-context-menu")).toBeNull();
   });
 
+  it("opens nothing from bare sidebar space when no Theater is registered", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    triagePlateRoot = createRoot(container);
+    setTriageActive(true);
+
+    act(() => triagePlateRoot?.render(createElement(TriageSideBar, {
+      theaters: [],
+      operations: [],
+      operationStatus: {},
+      operationNotifications: {},
+      catalog: [{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }],
+      plugins: [],
+      renderKindIcon: () => null,
+      canLaunch: false,
+      onLaunchKind: () => {},
+      onPick: () => {},
+      onClose: () => {},
+      onRename: () => {},
+    })));
+
+    const aside = container.querySelector<HTMLElement>(".triage-side-bar")!;
+    const menu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 24, clientY: 48 });
+    act(() => aside.dispatchEvent(menu));
+    expect(menu.defaultPrevented).toBe(true);
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
+  });
+
   it("renders live previews only for active-Theater cards and the detail fallback for foreign ones", () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -1495,6 +1495,42 @@ describe("triage store", () => {
     expect(document.querySelector(".canvas-context-menu")).toBeNull();
   });
 
+  it("closes an already-open sidebar launcher when the last Theater disappears", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    triagePlateRoot = createRoot(container);
+    setTriageActive(true);
+    const catalog = [{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }];
+    const props = {
+      operations: [],
+      operationStatus: {},
+      operationNotifications: {},
+      catalog,
+      plugins: [],
+      renderKindIcon: () => null,
+      onLaunchKind: () => {},
+      onPick: () => {},
+      onClose: () => {},
+      onRename: () => {},
+    };
+
+    act(() => triagePlateRoot?.render(createElement(TriageSideBar, {
+      ...props,
+      theaters: THEATERS,
+      canLaunch: true,
+    })));
+    const aside = container.querySelector<HTMLElement>(".triage-side-bar")!;
+    act(() => aside.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 24, clientY: 48 })));
+    expect(document.querySelector(".canvas-context-menu")).not.toBeNull();
+
+    act(() => triagePlateRoot?.render(createElement(TriageSideBar, {
+      ...props,
+      theaters: [],
+      canLaunch: false,
+    })));
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
+  });
+
   it("renders live previews only for active-Theater cards and the detail fallback for foreign ones", () => {
     const container = document.createElement("div");
     document.body.append(container);


### PR DESCRIPTION
## Summary
- 등록된 Theater가 없으면 캔버스·사이드바 빈 자리 우클릭이 실행 런처를 열지 않습니다.
- 브라우저 기본 메뉴는 계속 막습니다. Theater가 있으면 기존처럼 메뉴가 열립니다.
- Theater는 있는데 실행이 막힌 경우(`canLaunch: false`)는 이전과 같이 메뉴가 열리고 항목만 비활성입니다.

## Test Plan
- [x] `pnpm exec vitest run tests/canvas-context-menu-formation-launch.test.tsx tests/operations-side-bar-keyboard-context-menu.test.tsx tests/triage-store.test.ts tests/warroom-canvas-context-menu.test.tsx` (97 passed)
- [ ] Theater가 0개인 콘솔에서 캔버스·사이드바 우클릭 시 드롭다운이 안 뜨는지 확인
- [ ] Theater가 있을 때 우클릭 런처가 그대로 열리는지 확인