### PR TITLE
fix(fleet-console): show Ctrl+Space on the docked Quick Launch bar

### DIFF
--- a/.changelog.d/quick-launch-ctrl-space-hint.md
+++ b/.changelog.d/quick-launch-ctrl-space-hint.md
@@ -1,0 +1,8 @@
+---
+branch: quick-launch-ctrl-space-hint
+---
+
+### fleet-console
+#### Fixed
+- The docked Quick Launch bar now shows Ctrl+Space next to Mod+J, matching the shortcut that already opens it.
+  ko: 하단 고정 Quick Launch 바가 이미 동작하던 Ctrl+Space를 Mod+J 옆에 함께 보여 줍니다.

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -11,6 +11,7 @@ import { usePluginRegistry } from "../plugin-registry.js";
 import { QUICK_LAUNCH_ULTRACODE_NOTICE_LIMIT, readQuickLaunchSelection, readUltracodeNoticeSeen, writeQuickLaunchMentionFocused, writeQuickLaunchModelEffort, writeQuickLaunchSelection, writeQuickLaunchTheater, writeUltracodeNoticeSeen } from "../quick-launch-preferences.js";
 import { buildQuickLaunchEffortOptions, buildQuickLaunchMentionGroups, findVariantLaunchKind, isMentionSelectable, isQuickLaunchAttachmentCandidate, isUltracodeDisarmCaret, nextUltracodeIgnored, QUICK_LAUNCH_ATTACHMENT_MAX_BYTES, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_MAX_ATTACHMENTS, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchAttachmentErrorMessageKey, quickLaunchErrorMessageKey, quickLaunchMentionErrorMessageKey, readCommandInput, readMentionToken, readUltracodeTokens, resolveFocusedMention, resolveMentionEntry, resolveSelection, shouldApplyFocusedMention, stripMentionToken, type QuickLaunchCommandInput, type QuickLaunchMentionToken, type UltracodeToken } from "../quick-launch.js";
 import { FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
+import { formatShortcutCombo, QUICK_LAUNCH_TOGGLE_COMBOS } from "../shortcuts-catalog.js";
 import type { QuickLaunchDraftAttachment } from "../types.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { isTriageActive } from "../canvas/triage-store.js";
@@ -22,6 +23,18 @@ import { EffortTrack, resolveRowEffort } from "./effort-track.js";
 const CARD_WIDTH_FALLBACK = 760;
 const POPOVER_GAP = 8;
 const FOCUSABLE_SELECTOR = "a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex='-1'])";
+
+interface NavigatorWithUserAgentData extends Navigator {
+  readonly userAgentData?: {
+    readonly platform?: string;
+  };
+}
+
+function resolveModLabel(): string {
+  const userAgentDataPlatform = (navigator as NavigatorWithUserAgentData).userAgentData?.platform;
+  const platform = userAgentDataPlatform ?? navigator.platform;
+  return /mac|iphone|ipad|ipod/i.test(platform) ? "⌘" : "Ctrl";
+}
 
 /**
  * War Room 무대 id. 전 Theater가 마운트되므로 지목이 Theater를 바꾸지 않고
@@ -1194,6 +1207,7 @@ export function QuickLaunch() {
     : (target
       ? registry.plugins.find((plugin) => plugin.id === target.pluginId)?.renderLaunchIcon?.(target.kind) ?? null
       : null);
+  const modLabel = resolveModLabel();
 
   return (
     <div
@@ -1235,7 +1249,14 @@ export function QuickLaunch() {
             <span className={`quick-launch-strip-trace${draftTrace.length === 0 ? " is-idle" : ""}`}>
               {draftTrace.length === 0 ? t("chrome.quickLaunch.placeholder") : draftTrace}
             </span>
-            <kbd className="quick-launch-strip-key" aria-hidden="true">⌘J</kbd>
+            <span className="quick-launch-strip-keys" aria-hidden="true">
+              {QUICK_LAUNCH_TOGGLE_COMBOS.map((combo, index) => (
+                <span key={combo.join("+")}>
+                  {index > 0 ? <span className="quick-launch-strip-or">{t("chrome.shortcuts.or")}</span> : null}
+                  <kbd className="quick-launch-strip-key">{formatShortcutCombo(combo, modLabel)}</kbd>
+                </span>
+              ))}
+            </span>
           </button>
         ) : null}
 

--- a/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
@@ -19,6 +19,21 @@ export interface CompanionShortcutEntry {
 
 type T = Translate<CoreMessageKey>;
 
+/** Quick Launch 토글. 전역 단축키와 접힌 바 힌트가 같은 목록을 쓴다. */
+export const QUICK_LAUNCH_TOGGLE_COMBOS = [
+  ["Mod", "J"],
+  ["Ctrl", "Space"],
+] as const;
+
+/**
+ * 접힌 바처럼 한 덩어리로 읽는 힌트. Mod는 플랫폼 글쇠(⌘/Ctrl)로 바꾸고,
+ * ⌘ 조합만 붙여 쓴다(⌘J). 그 밖은 +로 잇는다(Ctrl+J, Ctrl+Space).
+ */
+export function formatShortcutCombo(combo: readonly string[], modLabel: string): string {
+  const keys = combo.map((key) => (key === "Mod" ? modLabel : key));
+  return keys.join(keys[0] === "⌘" ? "" : "+");
+}
+
 export function buildShortcutGroups(
   t: T,
   companionShortcuts: readonly CompanionShortcutEntry[] = [],
@@ -29,7 +44,7 @@ export function buildShortcutGroups(
       entries: [
         { combos: [["Mod", "K"]], description: t("shortcuts.console.searchOps") },
         { combos: [["Mod", "P"]], description: t("shortcuts.console.commandPalette") },
-        { combos: [["Mod", "J"], ["Ctrl", "Space"]], description: t("shortcuts.console.quickLaunch") },
+        { combos: [...QUICK_LAUNCH_TOGGLE_COMBOS], description: t("shortcuts.console.quickLaunch") },
         { combos: [["Mod", "B"]], description: t("shortcuts.console.toggleSidebar") },
         { combos: [["Mod", "Alt", "B"]], description: t("shortcuts.console.toggleRail") },
       ],

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -12048,10 +12048,13 @@ body[data-codex-reading="true"] .operations-side-bar {
   color: var(--text-tertiary);
 }
 
+/* 각 조합이 flex 아이템이라 번역문(" or "/" 또는 ")의 앞 공백이 줄 앞에서 사라진다.
+   간격을 번역 공백에 맡기면 ⌘Jor Ctrl+Space로 붙는다. */
 .quick-launch-strip-keys {
   display: inline-flex;
   align-items: center;
   flex: none;
+  gap: var(--space-1);
   color: var(--brass);
   font-family: var(--font-mono);
   font-size: 10px;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -12048,12 +12048,26 @@ body[data-codex-reading="true"] .operations-side-bar {
   color: var(--text-tertiary);
 }
 
-.quick-launch-strip-key {
+.quick-launch-strip-keys {
+  display: inline-flex;
+  align-items: center;
   flex: none;
   color: var(--brass);
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.quick-launch-strip-key {
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+}
+
+.quick-launch-strip-or {
+  color: var(--text-tertiary);
+  letter-spacing: 0;
 }
 
 /* 고정·포커스 멘션 토글 — 켜지면 brass로 자기 상태를 말한다(위치/행선지 채널). */

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -132,6 +132,8 @@ describe("Quick Launch docking", () => {
     expect(quickLaunch).toMatch(/QUICK_LAUNCH_TOGGLE_COMBOS\.map/u);
     expect(quickLaunch).toMatch(/formatShortcutCombo\(combo, modLabel\)/u);
     expect(ruleFor(".quick-launch-strip-keys")).toMatch(/white-space:\s*nowrap;/u);
+    // flex 아이템은 번역문 앞 공백을 버리므로, 대안 사이 간격은 gap이 맡는다.
+    expect(ruleFor(".quick-launch-strip-keys")).toMatch(/gap:\s*var\(--space-1\);/u);
     // 펼친 동안에는 접근성 트리와 탭 순서 어디에도 없어야 한다.
     expect(ruleFor(".quick-launch-strip")).toMatch(/display:\s*none;/u);
     expect(ruleFor(".quick-launch-card.is-collapsed .quick-launch-strip")).toMatch(/display:\s*flex;/u);

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -128,6 +128,10 @@ describe("Quick Launch docking", () => {
     expect(quickLaunch).toMatch(/className="quick-launch-strip"/u);
     // 접힌 줄의 빈 상태는 컴포저 플레이스홀더와 같은 초대 문구다 — 키를 나누면 둘이 어긋난다.
     expect(quickLaunch).toMatch(/draftTrace\.length === 0 \? t\("chrome\.quickLaunch\.placeholder"\) : draftTrace/u);
+    // 토글이 두 개면 힌트도 두 개다 — ⌘J만 박으면 Ctrl+Space가 없는 단축키가 된다.
+    expect(quickLaunch).toMatch(/QUICK_LAUNCH_TOGGLE_COMBOS\.map/u);
+    expect(quickLaunch).toMatch(/formatShortcutCombo\(combo, modLabel\)/u);
+    expect(ruleFor(".quick-launch-strip-keys")).toMatch(/white-space:\s*nowrap;/u);
     // 펼친 동안에는 접근성 트리와 탭 순서 어디에도 없어야 한다.
     expect(ruleFor(".quick-launch-strip")).toMatch(/display:\s*none;/u);
     expect(ruleFor(".quick-launch-card.is-collapsed .quick-launch-strip")).toMatch(/display:\s*flex;/u);

--- a/runtime/fleet-console/tests/shortcuts-catalog.test.ts
+++ b/runtime/fleet-console/tests/shortcuts-catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { getT } from "../core/client/src/i18n/index.js";
-import { buildShortcutGroups } from "../core/client/src/shortcuts-catalog.js";
+import { buildShortcutGroups, formatShortcutCombo, QUICK_LAUNCH_TOGGLE_COMBOS } from "../core/client/src/shortcuts-catalog.js";
 
 describe("shortcut catalog", () => {
   it("lists the command palette immediately after operation search, then Quick Launch", () => {
@@ -11,8 +11,16 @@ describe("shortcut catalog", () => {
     expect(consoleGroup.entries.slice(0, 3)).toEqual([
       { combos: [["Mod", "K"]], description: "Search Operations across Theaters" },
       { combos: [["Mod", "P"]], description: "Open Command Palette" },
-      { combos: [["Mod", "J"], ["Ctrl", "Space"]], description: "Toggle Quick Launch" },
+      { combos: [...QUICK_LAUNCH_TOGGLE_COMBOS], description: "Toggle Quick Launch" },
     ]);
+    expect(QUICK_LAUNCH_TOGGLE_COMBOS).toEqual([["Mod", "J"], ["Ctrl", "Space"]]);
+  });
+
+  it("formats Quick Launch toggle hints as one chord each", () => {
+    expect(formatShortcutCombo(["Mod", "J"], "⌘")).toBe("⌘J");
+    expect(formatShortcutCombo(["Mod", "J"], "Ctrl")).toBe("Ctrl+J");
+    expect(formatShortcutCombo(["Ctrl", "Space"], "⌘")).toBe("Ctrl+Space");
+    expect(formatShortcutCombo(["Ctrl", "Space"], "Ctrl")).toBe("Ctrl+Space");
   });
 
   it("appends active companion shortcuts to the end of Operations", () => {


### PR DESCRIPTION
## Summary
- 접힌 Quick Launch 바가 `⌘J`만 보여 이미 동작하던 `Ctrl+Space`가 없는 단축키처럼 읽혔습니다.
- 토글 목록을 단축키 카탈로그와 공유해, 접힌 바가 Mod+J와 Ctrl+Space를 함께 표시합니다.
- macOS는 `⌘J or Ctrl+Space`, 그 밖은 `Ctrl+J or Ctrl+Space`로 플랫폼 글쇠를 맞춥니다.

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/shortcuts-catalog.test.ts tests/quick-launch-layout.test.tsx tests/keyboard-shortcuts-dialog.test.ts tests/global-shortcuts.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [ ] 하단 고정 Quick Launch를 접어 두고, 바에 `⌘J`(또는 `Ctrl+J`)와 `Ctrl+Space`가 함께 보이는지 확인
- [ ] Ctrl+Space와 Mod+J가 이전과 같이 컴포저를 여닫는지 확인