### PR TITLE
feat(fleet-console): show Operation marks on War Room cards

### DIFF
--- a/.changelog.d/war-room-card-glyphs.md
+++ b/.changelog.d/war-room-card-glyphs.md
@@ -1,0 +1,8 @@
+---
+branch: war-room-card-glyphs
+---
+
+### fleet-console
+#### Added
+- War Room cards show the same Operation mark as the sidebar, to the left of the title.
+  ko: War Room 카드 제목 왼쪽에 사이드바와 같은 Operation 마크가 보입니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -1065,6 +1065,8 @@ export function OperationsCanvas({
         }}
         onOperationContextMenu={onOpenOperationMenu}
         onTheaterContextMenu={openTriageTheaterLaunchMenu}
+        catalog={catalog}
+        renderKindIcon={renderKindIcon}
       />
       {cruiseEntering ? (
         <div className="canvas-mode-curtain canvas-cruise-curtain" aria-hidden="true">

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -1,9 +1,11 @@
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent } from "react";
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent, type ReactNode } from "react";
+import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { useT } from "../i18n/index.js";
 import { getIdleArrivalIds } from "../operation-idle-arrival.js";
 import { OperationBodySlot, useOperationBodyPoolAvailable, type OperationBodyConfig } from "../mobile/operation-body-pool.js";
+import { resolveOperationMark } from "../operation-mark.js";
 import { operationActivityLabel, operationActivityVisual, resolveOperationActivity, resolveOperationDisplayActivity } from "../operation-activity.js";
 import { getOperationStatusDetailSnapshot, useOperationStatusDetails } from "../operation-status-detail-store.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
@@ -82,6 +84,14 @@ interface TriageWatchDeckProps {
       상태 변경은 canvas가 단일 소유하므로 deck는 의도만 올려보낸다. */
   readonly onMinimizeOperation?: (operationId: string) => void;
   readonly onCloseOperation?: (operationId: string) => void;
+  /** 사이드바와 같은 Operation 마크를 제목 왼쪽에 그리기 위한 재료. 없으면 마크를 생략한다. */
+  readonly catalog?: readonly OperationCatalogPlugin[];
+  readonly renderKindIcon?: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
+}
+
+const EMPTY_OPERATION_CATALOG: readonly OperationCatalogPlugin[] = [];
+function renderMissingKindIcon(_pluginId: string, _kind: OperationLaunchKind): ReactNode {
+  return null;
 }
 
 export interface TriageDeckArrivalDwell {
@@ -514,6 +524,8 @@ export function TriageWatchDeck({
   onTheaterContextMenu,
   onMinimizeOperation,
   onCloseOperation,
+  catalog = EMPTY_OPERATION_CATALOG,
+  renderKindIcon = renderMissingKindIcon,
 }: TriageWatchDeckProps) {
   const t = useT();
   const gridRef = useRef<HTMLDivElement | null>(null);
@@ -1116,8 +1128,9 @@ export function TriageWatchDeck({
                         onClick={(event) => pick(operation.id, event.currentTarget)}
                       >
                         <TriageDeckCardFace
-                          operationId={operation.id}
-                          title={operation.title}
+                          operation={operation}
+                          catalog={catalog}
+                          renderKindIcon={renderKindIcon}
                           label={label}
                           detail={statusDetail.detail}
                           accentColor={accentColor}
@@ -1247,8 +1260,9 @@ export function TriageWatchDeck({
             aria-hidden="true"
           >
             <TriageDeckCardFace
-              operationId={mapQuicklookOperation.operation.id}
-              title={mapQuicklookOperation.operation.title}
+              operation={mapQuicklookOperation.operation}
+              catalog={catalog}
+              renderKindIcon={renderKindIcon}
               label={mapQuicklookOperation.label}
               detail={mapQuicklookOperation.detail}
               accentColor={mapQuicklookOperation.accentColor}
@@ -1416,10 +1430,12 @@ function renderTriageMapDots(
 }
 
 // 카드 얼굴 — 덱 카드와 지도 점의 확대창이 같은 조각(스파인·상태줄·제목·프리뷰/tail)을 공유한다.
-// 두 표면이 각자 얼굴을 조립하면 같은 Operation이 밀도에 따라 다르게 읽힌다.
-function TriageDeckCardFace({ operationId, title, label, detail, accentColor, preview, surfaceScale = 0 }: {
-  readonly operationId: string;
-  readonly title: string;
+// 두 표면이 각자 얼굴을 조립하면 같은 Operation이 밀도에 따라 다르게 읽힌다. 제목 왼쪽 마크도
+// 이 얼굴이 해석한다 — 사이드바와 같은 resolveOperationMark라 밀도만 달라도 같은 Operation으로 읽힌다.
+function TriageDeckCardFace({ operation, catalog, renderKindIcon, label, detail, accentColor, preview, surfaceScale = 0 }: {
+  readonly operation: OperationNode;
+  readonly catalog: readonly OperationCatalogPlugin[];
+  readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
   readonly label: string;
   readonly detail: string | null | undefined;
   readonly accentColor: string | null;
@@ -1427,6 +1443,7 @@ function TriageDeckCardFace({ operationId, title, label, detail, accentColor, pr
   /** 이 얼굴을 담은 표면의 화면상 확대 배율 — 확대창만 넘긴다(기본 0 = 확대창 아님). */
   readonly surfaceScale?: number;
 }) {
+  const { icon, launchProvider } = resolveOperationMark(operation, catalog, renderKindIcon);
   return (
     <>
       {accentColor ? <span className="canvas-triage-deck-card-spine" style={{ backgroundColor: accentColor } as CSSProperties} aria-hidden="true" /> : null}
@@ -1434,12 +1451,22 @@ function TriageDeckCardFace({ operationId, title, label, detail, accentColor, pr
         <span className="canvas-triage-deck-card-dot" aria-hidden="true" />
         <span>{label}</span>
       </span>
-      <strong title={title}>{title}</strong>
+      <span className="canvas-triage-deck-card-title">
+        {icon ? (
+          <span
+            className={`canvas-triage-deck-card-mark${launchProvider ? ` operation-provider-mark is-${launchProvider}` : ""}`}
+            aria-hidden="true"
+          >
+            {icon}
+          </span>
+        ) : null}
+        <strong title={operation.title}>{operation.title}</strong>
+      </span>
       {preview ? (
         <TriageDeckCardPreview
           config={preview.config}
           bottomChrome={preview.bottomChrome}
-          operationId={operationId}
+          operationId={operation.id}
           surfaceScale={surfaceScale}
         />
       ) : (

--- a/runtime/fleet-console/core/client/src/operation-mark.ts
+++ b/runtime/fleet-console/core/client/src/operation-mark.ts
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
+
+import { launchProviderFromOperationPayload, launchProviderGlyph, type LaunchProviderGlyphId } from "./components/launch-provider-glyphs.js";
+import { resolveOperationLaunchKind } from "./sidebar/interaction.js";
+import type { OperationNode } from "./types.js";
+
+export interface OperationMark {
+  readonly icon: ReactNode;
+  readonly launchProvider: LaunchProviderGlyphId | null;
+}
+
+/**
+ * 칩·커맨드 밴드·팔레트·War Room 카드가 쓸 마크. 실행된 공급자가 기록된 Operation은 그
+ * 공급자의 글리프가 실행 종류 아이콘을 대신한다 — 같은 실행 종류라도 어느 공급자의 모델이
+ * 돌았는지가 목록에서 먼저 읽혀야 한다. 공급자를 기록하지 않는 플러그인은 그대로 자기
+ * 아이콘을 그린다.
+ */
+export function resolveOperationMark(
+  operation: OperationNode,
+  catalog: readonly OperationCatalogPlugin[],
+  renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode,
+): OperationMark {
+  const launchProvider = launchProviderFromOperationPayload(operation.payload);
+  if (launchProvider) return { icon: launchProviderGlyph(launchProvider), launchProvider };
+  const kind = resolveOperationLaunchKind(catalog, operation);
+  return { icon: kind ? renderKindIcon(operation.pluginId, kind) : null, launchProvider: null };
+}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -11,8 +11,8 @@ import type { OperationGroup, OperationNode, OperationNotification, TheaterInfo 
 import { CanvasContextMenu } from "../canvas/canvas-context-menu.js";
 import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../focus-guards.js";
 import { DirectoryBrowserModal } from "../components/directory-browser-modal.js";
-import { launchProviderFromOperationPayload, launchProviderGlyph, type LaunchProviderGlyphId } from "../components/launch-provider-glyphs.js";
 import { useConsoleState } from "../hooks/use-store.js";
+import { resolveOperationMark } from "../operation-mark.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
 import { getTheaterCanvasSnapshot, setOperationOrder, toggleGroupCollapsed, toggleTheaterGroupCollapsed, useCanvasState, useCollapsedGroups } from "../canvas/canvas-store.js";
@@ -41,7 +41,6 @@ import {
   useSideBarStatusSectionCollapsed,
   type SideBarStatus,
 } from "./operations-side-bar-store.js";
-import { resolveOperationLaunchKind } from "./interaction.js";
 import { SideBarResizeHandle, useSideBarResize } from "./side-bar-resize.js";
 
 interface OperationsSideBarProps {
@@ -1363,22 +1362,6 @@ export function buildTheaterEntries({
     status: resolveOperationActivity(operation, operationStatus),
     ...resolveOperationMark(operation, catalog, renderKindIcon),
   }));
-}
-
-/**
- * 칩이 쓸 마크. 실행된 공급자가 기록된 Operation은 그 공급자의 글리프가 실행 종류 아이콘을
- * 대신한다 — 같은 실행 종류라도 어느 공급자의 모델이 돌았는지가 목록에서 먼저 읽혀야 한다.
- * 공급자를 기록하지 않는 플러그인은 그대로 자기 아이콘을 그린다.
- */
-function resolveOperationMark(
-  operation: OperationNode,
-  catalog: readonly OperationCatalogPlugin[],
-  renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode,
-): { readonly icon: ReactNode; readonly launchProvider: LaunchProviderGlyphId | null } {
-  const launchProvider = launchProviderFromOperationPayload(operation.payload);
-  if (launchProvider) return { icon: launchProviderGlyph(launchProvider), launchProvider };
-  const kind = resolveOperationLaunchKind(catalog, operation);
-  return { icon: kind ? renderKindIcon(operation.pluginId, kind) : null, launchProvider: null };
 }
 
 function TheaterSectionHeader({

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3563,11 +3563,12 @@
   box-shadow: 0 18px 60px oklch(0% 0 0 / 55%), 0 0 0 1px var(--brass-glow);
 }
 
-/* 확대 시 카드 크롬(상태줄·제목)은 역보정해 프리뷰가 주인공으로 남게 한다. 역보정은 해상
+/* 확대 시 카드 크롬(상태줄·제목 줄)은 역보정해 프리뷰가 주인공으로 남게 한다. 제목 줄은
+   마크와 이름을 한 변환으로 묶어, 확대창에서만 마크가 커지는 일이 없게 한다. 역보정은 해상
    배율에 연동한다 — 1/scale 하한을 두어 캡이 배율을 1까지 깎은 좁은 창에서 크롬이 원본보다
    작아지는 일이 없게 한다(0.72 고정이면 확대 없는 카드의 제목만 줄어든다). */
 .canvas-triage-deck-card.is-quicklook .canvas-triage-deck-card-status,
-.canvas-triage-deck-card.is-quicklook > strong {
+.canvas-triage-deck-card.is-quicklook .canvas-triage-deck-card-title {
   transform: scale(max(0.72, calc(1 / var(--triage-quicklook-scale, 1.95))));
   transform-origin: left top;
 }
@@ -3712,7 +3713,23 @@
   box-shadow: 0 0 8px var(--activity-glow);
 }
 
-.canvas-triage-deck-card > strong,
+.canvas-triage-deck-card-title,
+.canvas-triage-deck-card-detail {
+  min-width: 0;
+}
+
+.canvas-triage-deck-card-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  align-self: end;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: var(--weight-bold);
+}
+
+.canvas-triage-deck-card-title > strong,
 .canvas-triage-deck-card-detail {
   min-width: 0;
   overflow: hidden;
@@ -3720,12 +3737,26 @@
   white-space: nowrap;
 }
 
-.canvas-triage-deck-card > strong {
-  align-self: end;
-  color: var(--text-primary);
-  font-family: var(--font-body);
-  font-size: 15px;
-  font-weight: var(--weight-bold);
+.canvas-triage-deck-card-title > strong {
+  font: inherit;
+  color: inherit;
+}
+
+/* 사이드바 칩과 같은 16px 슬롯·14px 글리프 — 카드만 치수를 바꾸면 같은 Operation이 두 크기로 읽힌다. */
+.canvas-triage-deck-card-mark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: none;
+  color: var(--text-secondary);
+}
+
+.canvas-triage-deck-card-mark svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
 }
 
 .canvas-triage-deck-card-detail {
@@ -3743,7 +3774,7 @@
   grid-template-rows: auto auto minmax(0, 1fr);
 }
 
-.canvas-triage-deck-card.has-preview > strong {
+.canvas-triage-deck-card.has-preview .canvas-triage-deck-card-title {
   align-self: start;
 }
 
@@ -7768,9 +7799,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .quick-launch-kind-icon.is-xai { --launch-provider-tone: var(--provider-xai); }
 
 /* 실행된 공급자 마크 — Operation 글리프는 어느 공급자의 모델로 돌았는지를 이름한다. Operation을
-   세는 세 크롬 표면(사이드바 칩·커맨드 밴드·팔레트)이 하나의 캐리어 시그니처 톤을 공유하므로
-   대조표는 여기 한 번만 적고, 각 표면은 자기 치수만 소유한다. 공급자는 정체성 축이라 마크의
-   잉크에만 머문다 — 테두리·상태 표면을 덧칠하지 않고, 포커스나 활성으로 다시 칠하지도 않는다. */
+   세는 크롬 표면(사이드바 칩·커맨드 밴드·팔레트·War Room 카드)이 하나의 캐리어 시그니처 톤을
+   공유하므로 대조표는 여기 한 번만 적고, 각 표면은 자기 치수만 소유한다. 공급자는 정체성 축이라
+   마크의 잉크에만 머문다 — 테두리·상태 표면을 덧칠하지 않고, 포커스나 활성으로 다시 칠하지도 않는다. */
 .operation-provider-mark.is-claude { color: var(--provider-claude); }
 .operation-provider-mark.is-codex { color: var(--provider-codex); }
 .operation-provider-mark.is-cursor { color: var(--provider-cursor); }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -648,8 +648,8 @@ describe("Instrument core design contract", () => {
   });
 
   it("pins the Operation provider mark grammar — one tone table, ink only, no state repaint", () => {
-    // 사이드바 칩·커맨드 밴드·팔레트는 같은 Operation을 세 곳에서 센다. 세 표면이 각자 톤을
-    // 적으면 한 곳만 고쳐도 컴파일은 되고 같은 Operation이 두 색으로 보인다 — 대조표는
+    // 사이드바 칩·커맨드 밴드·팔레트·War Room 카드는 같은 Operation을 네 곳에서 센다. 표면이
+    // 각자 톤을 적으면 한 곳만 고쳐도 컴파일은 되고 같은 Operation이 두 색으로 보인다 — 대조표는
     // .operation-provider-mark 한 곳에만 있어야 하고, 표면 클래스는 치수만 소유한다.
     const css = source("styles/components.css");
     for (const provider of ["claude", "codex", "cursor", "kimi", "opencode", "xai"]) {
@@ -665,10 +665,31 @@ describe("Instrument core design contract", () => {
     // 달리, 공급자 마크는 어느 상태에서도 같은 톤을 유지해야 같은 Operation으로 읽힌다.
     expect(css).not.toMatch(/\.is-active[^{}]*\.operation-provider-mark/);
 
-    // 세 표면 모두 공용 마크 클래스를 통해 톤을 받는다 — 하나라도 자기 색을 적으면 대조표가 갈라진다.
+    // 네 표면 모두 공용 마크 클래스를 통해 톤을 받는다 — 하나라도 자기 색을 적으면 대조표가 갈라진다.
     expect(source("sidebar/operations-side-bar-chip.tsx")).toContain("operation-provider-mark is-${entry.launchProvider}");
     expect(source("components/command-band.tsx")).toContain("operation-provider-mark is-${activeLaunchProvider}");
     expect(source("components/operation-search.tsx")).toContain("operation-provider-mark is-${entry.launchProvider}");
+    expect(source("canvas/triage-watch-deck.tsx")).toContain("operation-provider-mark is-${launchProvider}");
+    // 해석은 한 함수 — 카드가 사이드바와 다른 규칙을 적으면 같은 Operation이 두 마크를 갖는다.
+    expect(source("canvas/triage-watch-deck.tsx")).toContain('from "../operation-mark.js"');
+    expect(source("sidebar/operations-side-bar.tsx")).toContain('from "../operation-mark.js"');
+  });
+
+  it("pins the War Room card title mark — chip-sized slot, inverse-scaled with the title", () => {
+    const css = source("styles/components.css");
+    const mark = css.match(/\.canvas-triage-deck-card-mark \{[^}]*\}/)?.[0] ?? "";
+    expect(mark).toContain("width: 16px;");
+    expect(mark).toContain("height: 16px;");
+    const svg = css.match(/\.canvas-triage-deck-card-mark svg \{[^}]*\}/)?.[0] ?? "";
+    expect(svg).toContain("width: 14px;");
+    expect(svg).toContain("height: 14px;");
+    // 확대창에서 제목만 되돌리고 마크를 빼면 마크가 카드와 함께 커진다.
+    expect(css).toContain(".canvas-triage-deck-card.is-quicklook .canvas-triage-deck-card-title");
+    expect(css).not.toContain(".canvas-triage-deck-card.is-quicklook > strong");
+    // 상태 점은 활동 채널 — 마크가 점을 다시 칠하는 선택자를 두지 않는다.
+    const dot = css.match(/\.canvas-triage-deck-card-dot \{[^}]*\}/)?.[0] ?? "";
+    expect(dot).toContain("background: var(--activity-color);");
+    expect(css).not.toMatch(/\.canvas-triage-deck-card-dot[^{]*operation-provider-mark/);
   });
 
   it("pins the AI Gateway provider-priority toggle grammar — ink rank only, no signal colour, no brass", () => {

--- a/runtime/fleet-console/tests/resolve-operation-mark.test.ts
+++ b/runtime/fleet-console/tests/resolve-operation-mark.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { OperationCatalogPlugin } from "@fleet-console/sdk/operations";
+
+import { resolveOperationMark } from "../core/client/src/operation-mark.js";
+import type { OperationNode } from "../core/client/src/types.js";
+
+const CATALOG: readonly OperationCatalogPlugin[] = [
+  {
+    id: "terminal",
+    title: "Terminal",
+    kinds: [
+      { id: "claude", type: "agent", title: "Claude" },
+      { id: "shell", type: "shell", title: "Shell" },
+    ],
+  },
+];
+
+describe("resolveOperationMark", () => {
+  it("prefers the recorded provider glyph over the kind icon", () => {
+    const mark = resolveOperationMark(
+      operation({ type: "shell", launchProvider: "cursor" }),
+      CATALOG,
+      () => "kind",
+    );
+    expect(mark.launchProvider).toBe("cursor");
+    expect(mark.icon).not.toBe("kind");
+    expect(mark.icon).not.toBeNull();
+  });
+
+  it("uses the plugin kind icon when no provider is recorded", () => {
+    const mark = resolveOperationMark(operation({ type: "shell" }), CATALOG, () => "kind");
+    expect(mark.launchProvider).toBeNull();
+    expect(mark.icon).toBe("kind");
+  });
+
+  it("returns no mark when neither provider nor kind can be resolved", () => {
+    expect(resolveOperationMark(
+      operation({ pluginId: "missing", type: "other" }),
+      CATALOG,
+      () => "kind",
+    )).toEqual({ icon: null, launchProvider: null });
+  });
+
+  it("rejects a provider outside the glyph vocabulary", () => {
+    const mark = resolveOperationMark(
+      operation({ type: "shell", launchProvider: "gemini" }),
+      CATALOG,
+      () => "kind",
+    );
+    expect(mark.launchProvider).toBeNull();
+    expect(mark.icon).toBe("kind");
+  });
+});
+
+function operation(input: {
+  readonly pluginId?: string;
+  readonly type: string;
+  readonly launchProvider?: string;
+}): OperationNode {
+  return {
+    id: "op",
+    theaterId: "theater",
+    pluginId: input.pluginId ?? "terminal",
+    type: input.type,
+    title: "Operation",
+    payload: input.launchProvider ? { launchProvider: input.launchProvider } : {},
+    geometry: null,
+    ts: { createdAt: 1, updatedAt: 1 },
+  };
+}

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -846,6 +846,43 @@ describe("triage store", () => {
     expect(getTriagePick()).toBe("next");
   });
 
+  it("puts the sidebar Operation mark to the left of the card title", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    triagePlateRoot = createRoot(container);
+    const claude = { ...operation("claude-op", 1), payload: { launchProvider: "claude" } };
+    const shell = operation("shell-op", 2);
+    const unknown = { ...operation("unknown-op", 3), pluginId: "missing", type: "other" };
+
+    act(() => {
+      triagePlateRoot?.render(createElement(TriageWatchDeck, {
+        active: true,
+        entering: false,
+        theaters: THEATERS,
+        operations: [claude, shell, unknown],
+        operationStatus: { "claude-op": "running" },
+        operationAccent: {},
+        catalog: [{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }],
+        renderKindIcon: () => createElement("span", { "data-kind-icon": "shell" }),
+      }));
+    });
+
+    const claudeCard = container.querySelector('[data-triage-deck-card="claude-op"]');
+    const claudeMark = claudeCard?.querySelector(".canvas-triage-deck-card-mark");
+    expect(claudeMark?.classList.contains("operation-provider-mark")).toBe(true);
+    expect(claudeMark?.classList.contains("is-claude")).toBe(true);
+    expect(claudeMark?.querySelector("svg")).not.toBeNull();
+    expect(claudeCard?.querySelector(".canvas-triage-deck-card-title")?.textContent).toBe("claude-op");
+
+    const shellMark = container.querySelector('[data-triage-deck-card="shell-op"] .canvas-triage-deck-card-mark');
+    expect(shellMark?.classList.contains("operation-provider-mark")).toBe(false);
+    expect(shellMark?.querySelector("[data-kind-icon=\"shell\"]")).not.toBeNull();
+
+    expect(container.querySelector('[data-triage-deck-card="unknown-op"] .canvas-triage-deck-card-mark')).toBeNull();
+    // 정체성 마크는 상태 점을 다시 칠하지 않는다 — 점은 활동 채널만 쓴다.
+    expect(claudeCard?.querySelector(".canvas-triage-deck-card-dot")?.className).toBe("canvas-triage-deck-card-dot");
+  });
+
   it("routes card, map-dot, and owned empty-region context menus without guessing bare space", () => {
     const container = document.createElement("div");
     document.body.append(container);


### PR DESCRIPTION
## Summary
- War Room 카드 제목 왼쪽에 사이드바와 같은 Operation 마크를 붙입니다. 기록된 `launchProvider`가 있으면 그 공급자 글리프, 없으면 플러그인 kind 아이콘입니다.
- 덱 카드와 지도 Quick-Look이 같은 얼굴을 쓰므로 함께 바뀌고, 상태 점·림·스파인은 신호 채널에 남깁니다. 지도 점은 이번 범위가 아닙니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test tests/resolve-operation-mark.test.ts tests/launch-provider-glyphs.test.ts tests/triage-store.test.ts tests/triage-deck-quicklook.test.ts tests/instrument-design-contract.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Isolated console-e2e: Cursor/Grok 카드에 `operation-provider-mark is-cursor|is-xai`, 상태 점은 idle 초록 유지