### PR TITLE
fix(fleet-console): drop Bori's warning hop and flap

### DIFF
--- a/.changelog.d/worktree-bori-warning-anim-off.md
+++ b/.changelog.d/worktree-bori-warning-anim-off.md
@@ -1,0 +1,8 @@
+---
+branch: worktree-bori-warning-anim-off
+---
+
+### fleet-console
+#### Changed
+- Admiral Bori still shows the alert mark, but no longer hops or flaps through a warning.
+  ko: 보리 제독은 경보 때 느낌표만 켜고 뛰어오르거나 퍼덕이지 않습니다.

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -306,17 +306,21 @@
   animation: scuttlebutt-qk-salute 1.7s ease-in-out infinite;
 }
 
-.scuttlebutt-bird.is-alert .scuttlebutt-qk {
+/* 보리는 경보 담당이라 도약·퍼덕임이 상시 소음이 된다. 느낌표만 켠다. */
+.scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) {
   animation: scuttlebutt-qk-hop 0.58s cubic-bezier(0.3, 0.7, 0.3, 1) infinite;
 }
 
-.scuttlebutt-bird.is-alert .scuttlebutt-qk-wing-l,
-.scuttlebutt-bird.is-alert .scuttlebutt-qk-wing-r {
+.scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) .scuttlebutt-qk-wing-l,
+.scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) .scuttlebutt-qk-wing-r {
   animation-duration: 0.22s;
 }
 
 .scuttlebutt-bird.is-alert .scuttlebutt-qk-mark {
   opacity: 1;
+}
+
+.scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) .scuttlebutt-qk-mark {
   animation: scuttlebutt-qk-markpop 0.58s ease-in-out infinite;
 }
 

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -316,6 +316,11 @@
   animation-duration: 0.22s;
 }
 
+.scuttlebutt-bird.is-alert .scuttlebutt-qk[data-morph="bori"] .scuttlebutt-qk-wing-l,
+.scuttlebutt-bird.is-alert .scuttlebutt-qk[data-morph="bori"] .scuttlebutt-qk-wing-r {
+  animation: none;
+}
+
 .scuttlebutt-bird.is-alert .scuttlebutt-qk-mark {
   opacity: 1;
 }

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-quaker-figure.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-quaker-figure.test.ts
@@ -96,6 +96,9 @@ describe("Quaker admiral figures", () => {
       /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk:not\(\[data-morph="bori"\]\) \.scuttlebutt-qk-wing-l/,
     );
     expect(styles).toMatch(
+      /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk\[data-morph="bori"\] \.scuttlebutt-qk-wing-l[\s\S]*?animation: none;/,
+    );
+    expect(styles).toMatch(
       /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk-mark\s*\{\s*opacity: 1;/,
     );
     expect(styles).toMatch(

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-quaker-figure.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-quaker-figure.test.ts
@@ -88,6 +88,21 @@ describe("Quaker admiral figures", () => {
     expect(qkPalette).not.toMatch(/var\(--(?:ink|id|brass)(?:-[a-z-]+)?\)/);
   });
 
+  it("holds Bori's alert on the mark without hop or mark-pop", () => {
+    expect(styles).toMatch(
+      /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk:not\(\[data-morph="bori"\]\)\s*\{\s*animation: scuttlebutt-qk-hop/,
+    );
+    expect(styles).toMatch(
+      /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk:not\(\[data-morph="bori"\]\) \.scuttlebutt-qk-wing-l/,
+    );
+    expect(styles).toMatch(
+      /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk-mark\s*\{\s*opacity: 1;/,
+    );
+    expect(styles).toMatch(
+      /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk:not\(\[data-morph="bori"\]\) \.scuttlebutt-qk-mark\s*\{\s*animation: scuttlebutt-qk-markpop/,
+    );
+  });
+
   it("preserves the four reduced-motion pose fallbacks", () => {
     const reducedMotion = styles.slice(
       styles.indexOf("@media (prefers-reduced-motion: reduce)"),


### PR DESCRIPTION
## Summary
- 보리 제독은 경보(승인 대기·연결 끊김)에서도 도약·퍼덕임·느낌표 팝을 하지 않고, 느낌표만 켭니다.
- 토리·도리의 경보 연출은 그대로입니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/scuttlebutt test` — 120 passed
- [ ] Console에서 보리를 켠 뒤 승인 대기 또는 연결 끊김을 만들고, 보리가 뛰거나 퍼덕이지 않고 `!`만 보이는지 확인
- [ ] 같은 장면에서 토리/도리 자기 챗 오류 경보는 기존처럼 도약·퍼덕임이 남는지 확인