### PR TITLE
fix(fleet-console): size Tactical empty slots to the captioned window

### DIFF
--- a/.changelog.d/tactical-grid-empty-slot.md
+++ b/.changelog.d/tactical-grid-empty-slot.md
@@ -1,0 +1,8 @@
+---
+branch: tactical-grid-empty-slot
+---
+
+### fleet-console
+#### Fixed
+- Tactical Grid empty-slot boxes now match the occupied window, including the 32px caption, instead of drawing only the body.
+  ko: Tactical Grid 빈칸 상자가 본문만 그리지 않고 32px 캡션을 포함한 점유 창과 같은 크기로 맞춥니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -29,7 +29,7 @@ import { resolveGlanceHudModel, type GlanceHudModel } from "./glance-hud.js";
 import { OperationFrame } from "./operation-frame.js";
 import { hasVisibleCanvasContent, OperationsCanvasEmptyState } from "./operations-canvas-empty-state.js";
 import { useCanvasInteraction } from "./use-canvas-interaction.js";
-import { modeSlotGeometryFor, screenToCanvas, triageStageGeometryFor, type CanvasPoint, type CanvasRect } from "./coordinates.js";
+import { modeSlotGeometryFor, operationWindowFrameFor, screenToCanvas, triageStageGeometryFor, type CanvasPoint, type CanvasRect } from "./coordinates.js";
 import { disarmTriageSetAside, dismissTriageOperation, forgetTriageOperation, getTriageEnteredAt, getTriagePick, getTriageSetAsideArmedId, getTriageSnapshot, isTriageActive, isTriageClearedTransition, isTriageOperationDeferred, isTriageOperationDismissed, isTriageWaitingOperation, pickTriageOperation, reconcileTriageStageCompanion, recordTriageStageTheater, resolveTriageQueue, scheduleTriageClear, subscribeTriage, useTriageActive, useTriageSpotlightEnabled, type TriageQueueEntry, type TriageStageIdentity } from "./triage-store.js";
 
 interface OperationsCanvasProps {
@@ -829,24 +829,27 @@ export function OperationsCanvas({
         }}
         className="operations-canvas-world"
       >
-        {formationView ? formationGuideSlots.map((geometry, index) => (
-          <div
-            key={`formation-guide-${formationOperationIds.length + index + 1}`}
-            className="canvas-formation-guide"
-            style={{
-              left: Math.round(geometry.x),
-              top: Math.round(geometry.y),
-              width: Math.round(geometry.width),
-              height: Math.round(geometry.height),
-              "--gi": index,
-            } as CSSProperties}
-            aria-label={t("canvas.formation.slotAria", { index: formationOperationIds.length + index + 1 })}
-          >
-            <span className="canvas-formation-guide-index">
-              {String(formationOperationIds.length + index + 1).padStart(2, "0")}
-            </span>
-          </div>
-        )) : null}
+        {formationView ? formationGuideSlots.map((geometry, index) => {
+          const frame = operationWindowFrameFor(geometry);
+          return (
+            <div
+              key={`formation-guide-${formationOperationIds.length + index + 1}`}
+              className="canvas-formation-guide"
+              style={{
+                left: Math.round(frame.x),
+                top: Math.round(frame.y),
+                width: Math.round(frame.width),
+                height: Math.round(frame.height),
+                "--gi": index,
+              } as CSSProperties}
+              aria-label={t("canvas.formation.slotAria", { index: formationOperationIds.length + index + 1 })}
+            >
+              <span className="canvas-formation-guide-index">
+                {String(formationOperationIds.length + index + 1).padStart(2, "0")}
+              </span>
+            </div>
+          );
+        }) : null}
         {pluginOperations.map((operation) => {
           const baseGeometry = canvas.operations[operation.id] ?? operation.geometry ?? ensurePluginGeometry(operation);
           const operationMaximized = panelMaximized === operation.id;

--- a/runtime/fleet-console/core/client/src/canvas/coordinates.ts
+++ b/runtime/fleet-console/core/client/src/canvas/coordinates.ts
@@ -55,6 +55,17 @@ export interface ModeGeometryRect {
   readonly height: number;
 }
 
+/** 본문 geometry에 창 캡션(top:-32px)을 더한 시각 프레임.
+ *  Tactical 빈칸 가이드가 점유 패널과 같은 상자를 그리게 한다. */
+export function operationWindowFrameFor(body: CanvasRect): CanvasRect {
+  return {
+    x: body.x,
+    y: body.y - OPERATION_WINDOW_CAPTION_HEIGHT,
+    width: body.width,
+    height: body.height + OPERATION_WINDOW_CAPTION_HEIGHT,
+  };
+}
+
 export function modeSlotGeometryFor(
   rect: ModeGeometryRect,
   slotIndex: number,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2989,6 +2989,7 @@
   position: absolute;
   z-index: 0;
   pointer-events: none;
+  /* 크기는 JS가 본문 슬롯에 캡션 높이를 더해 점유 창과 맞춘다. */
   border: 1px dashed color-mix(in oklch, var(--brass) 34%, transparent);
   border-radius: var(--radius-md);
 }

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
 import { CanvasMinimap } from "../core/client/src/canvas/canvas-minimap.js";
-import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, consumePendingFitAllOperations, fitAllOperations, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, minimizeOperation, requestFitAllOperations, resetCanvasViewportSize, setCanvasViewportSize, setMaximizedOperationId, setState, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, consumePendingFitAllOperations, fitAllOperations, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, minimizeOperation, OPERATION_WINDOW_CAPTION_HEIGHT, requestFitAllOperations, resetCanvasViewportSize, setCanvasViewportSize, setMaximizedOperationId, setState, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
 
 vi.mock("../core/client/src/plugin-registry.js", () => ({
@@ -228,6 +228,13 @@ describe("CanvasMinimap collapse behavior", () => {
       expect(document.querySelector(".canvas-mode-hud")).toBeNull();
       expect([...document.querySelectorAll(".canvas-operation-formation-slot")].map((element) => element.textContent)).toEqual(["01", "02", "03"]);
       expect(document.querySelector(".canvas-formation-guide-index")?.textContent).toBe("04");
+      const occupied = document.querySelector<HTMLElement>('[data-operation-id="formation-3"]');
+      const guide = document.querySelector<HTMLElement>(".canvas-formation-guide");
+      expect(occupied).not.toBeNull();
+      expect(guide).not.toBeNull();
+      expect(Number.parseFloat(guide!.style.height)).toBe(Number.parseFloat(occupied!.style.height) + OPERATION_WINDOW_CAPTION_HEIGHT);
+      expect(Number.parseFloat(guide!.style.top)).toBe(Number.parseFloat(occupied!.style.top) - OPERATION_WINDOW_CAPTION_HEIGHT);
+      expect(Number.parseFloat(guide!.style.width)).toBe(Number.parseFloat(occupied!.style.width));
       expect(document.querySelector(".canvas-formation-curtain")).not.toBeNull();
 
       act(() => vi.advanceTimersByTime(1_950));

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1916,6 +1916,8 @@ describe("Instrument core design contract", () => {
     expect(source("canvas/canvas.tsx")).toContain("TITLEBAR_OUTSET_PX * effectiveZoom");
     expect(source("canvas/coordinates.ts")).toContain("y: 18 + OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/coordinates.ts")).toContain("canvasSize.height - 36 - OPERATION_WINDOW_CAPTION_HEIGHT");
+    expect(source("canvas/coordinates.ts")).toContain("export function operationWindowFrameFor");
+    expect(source("canvas/canvas.tsx")).toContain("operationWindowFrameFor(geometry)");
     expect(source("canvas/operation-frame.tsx")).not.toContain("canvas-operation-drag-edge");
     expect(source("canvas/operation-frame.tsx")).not.toContain('className="canvas-operation-cli"');
     expect(components).toContain(".canvas-operation-beacon-button {");


### PR DESCRIPTION
## Summary
- Tactical Grid 빈칸 점선 상자가 창 캡션을 빼고 본문 geometry만 그려, 점유 패널보다 낮고 짧게 보였습니다.
- 빈칸 가이드를 캡션(32px) + 본문 프레임으로 그려 같은 칸의 점유 창과 위치·크기를 맞춥니다.

## Test Plan
- [x] `pnpm exec vitest run tests/canvas-minimap-formation.test.ts tests/canvas-store.test.ts tests/instrument-design-contract.test.ts` (138 passed)
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` in `runtime/fleet-console`
- [ ] Codex review