### PR TITLE
feat(fleet-console): clear panel activation outside the Map

### DIFF
--- a/.changelog.d/panel-blur-outside-map.md
+++ b/.changelog.d/panel-blur-outside-map.md
@@ -1,0 +1,8 @@
+---
+branch: panel-blur-outside-map
+---
+
+### fleet-console
+#### Added
+- Clicking Console chrome outside the Map, including the left sidebar and right rail, now clears the active panel.
+  ko: Map이 아닌 콘솔 크롬(좌측 사이드바, 우측 레일 등)을 누르면 활성 패널이 풀립니다.

--- a/.changelog.d/panel-blur-outside-map.md
+++ b/.changelog.d/panel-blur-outside-map.md
@@ -4,5 +4,5 @@ branch: panel-blur-outside-map
 
 ### fleet-console
 #### Added
-- Clicking Console chrome outside the Map, including the left sidebar and right rail, now clears the active panel.
-  ko: Map이 아닌 콘솔 크롬(좌측 사이드바, 우측 레일 등)을 누르면 활성 패널이 풀립니다.
+- Clicking Console chrome outside the Map, including the left sidebar and right rail, now clears the active panel. Clicks on the Map itself, including empty sea, keep it.
+  ko: Map이 아닌 콘솔 크롬(좌측 사이드바, 우측 레일 등)을 누르면 활성 패널이 풀립니다. 빈 바다를 포함한 Map 클릭은 활성 상태를 유지합니다.

--- a/runtime/fleet-console/core/client/src/active-operation-surface.ts
+++ b/runtime/fleet-console/core/client/src/active-operation-surface.ts
@@ -1,0 +1,31 @@
+import { isBlockingDialogOpen } from "./focus-guards.js";
+import { setActiveOperation } from "./store.js";
+
+// Map 위 패널·미니맵·빈 바다만 활성 표면이다. 좌·우 사이드바는 data-canvas-blocker라서
+// 제스처만 막고, 활성화는 유지하지 않는다.
+// 칩은 그 Operation을 고르는 진입점이고, 커맨드 밴드·패널 포털 메뉴는 활성 Operation을
+// 전제로 하므로 별도 표식으로 유지한다.
+const KEEP_ACTIVE_SELECTOR = [
+  ".operations-canvas",
+  "[data-canvas-operation]",
+  "[data-side-bar-chip-id]",
+  "[data-keep-operation-active]",
+].join(", ");
+
+export function isMapActivationSurface(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(".operations-canvas, [data-canvas-operation]") !== null;
+}
+
+export function shouldReleaseActiveOperation(target: EventTarget | null, documentFor: Document = document): boolean {
+  if (isBlockingDialogOpen(documentFor)) return false;
+  if (!(target instanceof Element)) return false;
+  return target.closest(KEEP_ACTIVE_SELECTOR) === null;
+}
+
+export function clearActiveOperation(): void {
+  if (typeof document !== "undefined") {
+    const active = document.activeElement;
+    if (active instanceof HTMLElement) active.blur();
+  }
+  setActiveOperation(null);
+}

--- a/runtime/fleet-console/core/client/src/active-operation-surface.ts
+++ b/runtime/fleet-console/core/client/src/active-operation-surface.ts
@@ -22,10 +22,13 @@ export function shouldReleaseActiveOperation(target: EventTarget | null, documen
   return target.closest(KEEP_ACTIVE_SELECTOR) === null;
 }
 
+export function blurActiveElement(): void {
+  if (typeof document === "undefined") return;
+  const active = document.activeElement;
+  if (active instanceof HTMLElement) active.blur();
+}
+
 export function clearActiveOperation(): void {
-  if (typeof document !== "undefined") {
-    const active = document.activeElement;
-    if (active instanceof HTMLElement) active.blur();
-  }
+  blurActiveElement();
   setActiveOperation(null);
 }

--- a/runtime/fleet-console/core/client/src/canvas/accent-popover.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/accent-popover.tsx
@@ -104,7 +104,7 @@ export function AccentPopover({ anchor, accentKey, onSelect, onClose }: AccentPo
   };
 
   return createPortal(
-    <div className="accent-popover-overlay" role="presentation" onPointerDown={onClose}>
+    <div className="accent-popover-overlay" data-keep-operation-active role="presentation" onPointerDown={onClose}>
       {style ? (
         <div className="accent-popover-card" role="menu" aria-label={t("canvas.accent.menuAria")} style={style} onPointerDown={(event) => event.stopPropagation()}>
           <AccentToneList accentKey={accentKey} includeNone onSelect={choose} />

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -8,7 +8,7 @@ import type { CompanionPanelDescriptor, ConsoleTheme, FleetClientPlugin, Operati
 import { fetchOperations } from "../api.js";
 import { availableCompanionPanels } from "../companion-shortcut.js";
 import { isBlockingDialogOpen } from "../focus-guards.js";
-import { clearActiveOperation } from "../active-operation-surface.js";
+import { blurActiveElement } from "../active-operation-surface.js";
 import { flattenGroupedOrder, focusCycleOperationIds, hydrateOperations, requestOperationKeyboardFocus, requestOperationLaunchMenu, setActiveOperation } from "../store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
@@ -247,7 +247,8 @@ export function OperationsCanvas({
     },
     consumePointerDown: contextMenu !== null,
     onConsumePointerDown: () => { setContextMenu(null); },
-    onClick: clearActiveOperation,
+    // 빈 바다 클릭은 Map 안이다 — 터미널 키보드는 거두되 패널 활성화는 유지한다.
+    onClick: blurActiveElement,
   });
 
   // 우클릭 가드는 다음 우클릭에서만 돈다. 마지막 Theater를 잊는 동안 이미 열린 상자는

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -8,6 +8,7 @@ import type { CompanionPanelDescriptor, ConsoleTheme, FleetClientPlugin, Operati
 import { fetchOperations } from "../api.js";
 import { availableCompanionPanels } from "../companion-shortcut.js";
 import { isBlockingDialogOpen } from "../focus-guards.js";
+import { clearActiveOperation } from "../active-operation-surface.js";
 import { flattenGroupedOrder, focusCycleOperationIds, hydrateOperations, requestOperationKeyboardFocus, requestOperationLaunchMenu, setActiveOperation } from "../store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
@@ -246,7 +247,7 @@ export function OperationsCanvas({
     },
     consumePointerDown: contextMenu !== null,
     onConsumePointerDown: () => { setContextMenu(null); },
-    onClick: clearTerminalFocus,
+    onClick: clearActiveOperation,
   });
 
   // 우클릭 가드는 다음 우클릭에서만 돈다. 마지막 Theater를 잊는 동안 이미 열린 상자는
@@ -1134,14 +1135,6 @@ function viewportBoundsFor(element: HTMLElement | null): { readonly width: numbe
   if (!element) return undefined;
   const rect = element.getBoundingClientRect();
   return { width: rect.width, height: rect.height };
-}
-
-function clearTerminalFocus(): void {
-  if (typeof document !== "undefined") {
-    const active = document.activeElement;
-    if (active instanceof HTMLElement) active.blur();
-  }
-  setActiveOperation(null);
 }
 
 function rectToGeometry(rect: CanvasRect): OperationGeometry {

--- a/runtime/fleet-console/core/client/src/canvas/group-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/group-context-menu.tsx
@@ -70,7 +70,7 @@ export function GroupContextMenu(props: GroupContextMenuProps) {
   }, [onClose]);
 
   return createPortal(
-    <div className="group-context-menu-overlay" role="presentation" onPointerDown={onClose}>
+    <div className="group-context-menu-overlay" data-keep-operation-active role="presentation" onPointerDown={onClose}>
       {style ? (
         <div
           className="group-context-menu-card"

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -601,7 +601,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
         </div> : null}
       </div> : null}
       {centerBreadcrumbVisible ? <div className="command-band-center">
-        {operationsViewVisible && activeTheater ? <div ref={switcherRef} className="command-band-switcher" onBlur={handleSwitcherFocusOut}>
+        {operationsViewVisible && activeTheater ? <div ref={switcherRef} className="command-band-switcher" data-keep-operation-active onBlur={handleSwitcherFocusOut}>
           <div className="command-band-theater-cluster" aria-label={t("chrome.commandBand.activeTheater", { label: activeTheater.label })}>
             <button
               ref={theaterTriggerRef}

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -5,6 +5,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
 import { createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, patchOperation, patchTheaterOrder, renameOperation, updateGroup, ApiError, type DeferredDeletionReceipt } from "../api.js";
+import { clearActiveOperation, shouldReleaseActiveOperation } from "../active-operation-surface.js";
 import { isBlockingDialogOpen } from "../focus-guards.js";
 import { closeOperationCompletely } from "../operation-close.js";
 import { resumeOperationInPlace } from "../operation-resume.js";
@@ -252,6 +253,20 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
   }, [companionOperationId, formationView, maximizedOperationId, registry.operationKinds, viewMode.effective]);
+
+  // Map이 아닌 곳(좌·우 사이드바, 레일, 커맨드 밴드 크롬 등)을 누르면 패널 활성화를 푼다.
+  // 칩·브레드크럼·Map 표면은 가드가 유지하고, 칩 클릭의 onFocus가 그 Operation을 다시 켠다.
+  useEffect(() => {
+    if (viewMode.effective === "mobile") return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.button !== 0) return;
+      if (stateRef.current.activeOperationId === null) return;
+      if (!shouldReleaseActiveOperation(event.target)) return;
+      clearActiveOperation();
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [viewMode.effective]);
 
   useEffect(() => {
     const resumeBootProtection = resumeBootProtectionRef.current?.theaterId === state.activeTheaterId

--- a/runtime/fleet-console/tests/active-operation-surface.test.ts
+++ b/runtime/fleet-console/tests/active-operation-surface.test.ts
@@ -74,3 +74,12 @@ describe("operations page wires Map-outside release", () => {
     expect(source).toContain("document.addEventListener(\"pointerdown\", onPointerDown, true)");
   });
 });
+
+describe("empty Map click keeps activation", () => {
+  const source = readFileSync(resolve(process.cwd(), "core/client/src/canvas/canvas.tsx"), "utf8");
+
+  it("blurs the terminal without clearing the active Operation", () => {
+    expect(source).toContain("onClick: blurActiveElement");
+    expect(source).not.toContain("onClick: clearActiveOperation");
+  });
+});

--- a/runtime/fleet-console/tests/active-operation-surface.test.ts
+++ b/runtime/fleet-console/tests/active-operation-surface.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { isMapActivationSurface, shouldReleaseActiveOperation } from "../core/client/src/active-operation-surface.js";
+
+function el(html: string): HTMLElement {
+  const host = document.createElement("div");
+  host.innerHTML = html.trim();
+  const child = host.firstElementChild;
+  if (!(child instanceof HTMLElement)) throw new Error("expected an element");
+  return child;
+}
+
+describe("shouldReleaseActiveOperation", () => {
+  it("releases when the click is on the left sidebar chrome", () => {
+    const sidebar = el(`<aside class="operations-side-bar"><div class="side-bar-theater-name">Harbor</div></aside>`);
+    document.body.append(sidebar);
+    expect(shouldReleaseActiveOperation(sidebar.querySelector(".side-bar-theater-name"))).toBe(true);
+    sidebar.remove();
+  });
+
+  it("releases when the click is on the right rail chrome", () => {
+    const rail = el(`<div class="right-rail"><button type="button">Alerts</button></div>`);
+    document.body.append(rail);
+    expect(shouldReleaseActiveOperation(rail.querySelector("button"))).toBe(true);
+    rail.remove();
+  });
+
+  it("keeps activation on a sidebar chip that selects an Operation", () => {
+    const chip = el(`<li data-side-bar-chip-id="op-1" class="side-bar-chip">Session</li>`);
+    const sidebar = el(`<aside class="operations-side-bar"></aside>`);
+    sidebar.append(chip);
+    document.body.append(sidebar);
+    expect(shouldReleaseActiveOperation(chip)).toBe(false);
+    sidebar.remove();
+  });
+
+  it("keeps activation on the Map and on a panel frame", () => {
+    const canvas = el(`<main class="operations-canvas"><article class="canvas-operation" data-canvas-operation><div class="canvas-operation-titlebar">Panel</div></article></main>`);
+    document.body.append(canvas);
+    expect(isMapActivationSurface(canvas)).toBe(true);
+    expect(shouldReleaseActiveOperation(canvas.querySelector(".canvas-operation-titlebar"))).toBe(false);
+    expect(shouldReleaseActiveOperation(canvas)).toBe(false);
+    canvas.remove();
+  });
+
+  it("keeps activation on a Map-owned portal menu", () => {
+    const menu = el(`<div class="accent-popover-overlay" data-keep-operation-active><button type="button">Accent</button></div>`);
+    document.body.append(menu);
+    expect(shouldReleaseActiveOperation(menu.querySelector("button"))).toBe(false);
+    menu.remove();
+  });
+
+  it("does not release while a blocking dialog is open", () => {
+    const dialog = el(`<div role="dialog" aria-modal="true">Confirm</div>`);
+    const sidebar = el(`<aside class="operations-side-bar"><div class="side-bar-theater-name">Harbor</div></aside>`);
+    document.body.append(dialog, sidebar);
+    expect(shouldReleaseActiveOperation(sidebar.querySelector(".side-bar-theater-name"))).toBe(false);
+    dialog.remove();
+    sidebar.remove();
+  });
+});
+
+describe("operations page wires Map-outside release", () => {
+  const source = readFileSync(resolve(process.cwd(), "core/client/src/pages/operations.tsx"), "utf8");
+
+  it("clears the active Operation from a capture pointerdown outside the Map", () => {
+    expect(source).toContain("shouldReleaseActiveOperation(event.target)");
+    expect(source).toContain("clearActiveOperation()");
+    expect(source).toContain("document.addEventListener(\"pointerdown\", onPointerDown, true)");
+  });
+});


### PR DESCRIPTION
## Summary
- Map이 아닌 콘솔 크롬(좌측 사이드바, 우측 레일, 커맨드 밴드 검색/토글 등)을 누르면 활성 패널이 풀립니다.
- 사이드바 칩, Map 위 패널/빈 바다/미니맵, 브레드크럼, 패널이 연 메뉴는 활성 Operation을 유지합니다.
- 가드는 `active-operation-surface`에 두고, Operations 페이지의 capture `pointerdown`에서 해제합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/active-operation-surface.test.ts`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] 패널을 활성화한 뒤 좌측 사이드바 빈 곳/Theater 행을 눌러 활성화가 풀리는지 확인
- [ ] 우측 레일 아이콘/패널 본문을 눌러 활성화가 풀리는지 확인
- [ ] 사이드바 칩을 누르면 해당 Operation이 다시 활성화되는지 확인
- [ ] Map 위 패널·빈 바다·미니맵 클릭은 활성화를 유지하는지 확인
- [ ] 커맨드 밴드 브레드크럼에서 이름 변경/전환이 깨지지 않는지 확인