### PR TITLE
feat(fleet-console): answer an up-to-date sync on the Sync button

### DIFF
--- a/.changelog.d/repo-sync-icon-feedback.md
+++ b/.changelog.d/repo-sync-icon-feedback.md
@@ -1,0 +1,8 @@
+---
+branch: repo-sync-icon-feedback
+---
+
+### fleet-console
+#### Changed
+- A repository sync that finds nothing new now answers on the Sync button itself: the refresh icon settles into a check and returns, with a short hint beside it, instead of opening a notice that shifts the panel.
+  ko: 가져올 것이 없는 저장소 동기화는 패널을 밀어내는 알림 대신 동기화 버튼에서 답합니다 — 새로고침 아이콘이 체크로 바뀐 뒤 되돌아오고, 짧은 안내가 곁에 뜹니다.

--- a/runtime/fleet-plugins/repository/client/i18n/index.ts
+++ b/runtime/fleet-plugins/repository/client/i18n/index.ts
@@ -139,7 +139,7 @@ export const repositoryEn = {
   "repository.sync.failedNoRemote": "Sync failed — no remote is configured.",
   "repository.sync.failedGit": "Sync failed — git error.",
   "repository.sync.summary": "Synced — {newRefs} new · {updatedRefs} updated · {pruned} pruned",
-  "repository.sync.summaryClean": "Synced — already up to date",
+  "repository.sync.upToDate": "Already up to date",
   "repository.sync.dismiss": "Dismiss",
   "repository.sync.lastFailed": "Last sync failed",
 
@@ -269,7 +269,7 @@ export const repositoryKo: Record<keyof typeof repositoryEn, string> = {
   "repository.sync.failedNoRemote": "동기화 실패 — 설정된 remote가 없습니다.",
   "repository.sync.failedGit": "동기화 실패 — git 오류.",
   "repository.sync.summary": "동기화 완료 — 신규 {newRefs} · 갱신 {updatedRefs} · 정리 {pruned}",
-  "repository.sync.summaryClean": "동기화 완료 — 이미 최신 상태",
+  "repository.sync.upToDate": "이미 최신 상태",
   "repository.sync.dismiss": "닫기",
   "repository.sync.lastFailed": "마지막 동기화 실패",
 

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -40,6 +40,10 @@ const SCAN_DEPTH_MAX = 8;
 const SCAN_DEPTH_DEFAULT = 3;
 const LIST_PANE_DEFAULT_WIDTH = 248;
 const LIST_PANE_MIN_WIDTH = 220;
+// ✓ 체류는 클릭했다는 사실이 눈에 남을 만큼만, 말풍선은 짧은 한 마디를 읽을 만큼만.
+// 원격 왕복이 수백 ms라 요청 자체는 거의 보이지 않으므로, 결과 쪽 체류가 피드백을 진다.
+const SYNC_SETTLED_MS = 1400;
+const SYNC_HINT_MS = 2200;
 
 function readViewMode(): ViewMode {
   try {
@@ -180,11 +184,19 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const [inspectRequest, setInspectRequest] = useState<{ fullHash: string; seq: number } | null>(null);
   type SyncNotice =
     | { kind: "error"; code: "auth_failed" | "network" | "timeout" | "no_remote" | "git_failed" }
-    | { kind: "success"; newRefs: number; updatedRefs: number; pruned: number }
-    | { kind: "successClean" };
+    | { kind: "success"; newRefs: number; updatedRefs: number; pruned: number };
   const [syncNotice, setSyncNotice] = useState<SyncNotice | null>(null);
   const [syncFailed, setSyncFailed] = useState(false);
   const syncNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // "이미 최신 상태"는 가져온 것이 없는 결과라 배너로 표면화하면 흐름 안의 블록이 패널 본문을
+  // 밀어낸다(등장·소멸 각 1회). 정보량 없는 결과는 버튼 자리에서만 답한다 — 아이콘이 잠깐 ✓로
+  // 바뀌고(settled), 말풍선이 짧게 안내한 뒤(hinting) 스스로 물러나며, 문면은 다음 동기화까지
+  // hover로 다시 열 수 있다(hintAvailable). 갱신·실패는 계속 배너를 쓴다.
+  const [syncSettled, setSyncSettled] = useState(false);
+  const [syncHinting, setSyncHinting] = useState(false);
+  const [syncHintAvailable, setSyncHintAvailable] = useState(false);
+  const syncSettledTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const syncHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [syncing, setSyncing] = useState(false);
   const syncRequestIdRef = useRef(0);
   const autoSyncTheaterRef = useRef<string | null>(null);
@@ -272,8 +284,19 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       clearTimeout(syncNoticeTimerRef.current);
       syncNoticeTimerRef.current = null;
     }
+    if (syncSettledTimerRef.current !== null) {
+      clearTimeout(syncSettledTimerRef.current);
+      syncSettledTimerRef.current = null;
+    }
+    if (syncHintTimerRef.current !== null) {
+      clearTimeout(syncHintTimerRef.current);
+      syncHintTimerRef.current = null;
+    }
     setSyncNotice(null);
     setSyncFailed(false);
+    setSyncSettled(false);
+    setSyncHinting(false);
+    setSyncHintAvailable(false);
     setChangedFiles({ kind: "loading" });
     setCompareRequest(null);
     setInspectRequest(null);
@@ -388,13 +411,45 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       setSyncNotice(null);
     }, 6000);
   }, []);
+  const showSyncSettled = useCallback(() => {
+    if (syncSettledTimerRef.current !== null) clearTimeout(syncSettledTimerRef.current);
+    if (syncHintTimerRef.current !== null) clearTimeout(syncHintTimerRef.current);
+    setSyncSettled(true);
+    setSyncHinting(true);
+    setSyncHintAvailable(true);
+    syncSettledTimerRef.current = setTimeout(() => {
+      syncSettledTimerRef.current = null;
+      setSyncSettled(false);
+    }, SYNC_SETTLED_MS);
+    syncHintTimerRef.current = setTimeout(() => {
+      syncHintTimerRef.current = null;
+      setSyncHinting(false);
+    }, SYNC_HINT_MS);
+  }, []);
+  const clearSyncSettled = useCallback(() => {
+    if (syncSettledTimerRef.current !== null) {
+      clearTimeout(syncSettledTimerRef.current);
+      syncSettledTimerRef.current = null;
+    }
+    if (syncHintTimerRef.current !== null) {
+      clearTimeout(syncHintTimerRef.current);
+      syncHintTimerRef.current = null;
+    }
+    setSyncSettled(false);
+    setSyncHinting(false);
+    setSyncHintAvailable(false);
+  }, []);
   useEffect(() => () => {
     if (syncNoticeTimerRef.current !== null) clearTimeout(syncNoticeTimerRef.current);
+    if (syncSettledTimerRef.current !== null) clearTimeout(syncSettledTimerRef.current);
+    if (syncHintTimerRef.current !== null) clearTimeout(syncHintTimerRef.current);
   }, []);
   const syncRepository = useCallback(async (mode?: "auto") => {
     if (!ctx.theaterId) return;
     const isManual = mode !== "auto";
     const requestId = ++syncRequestIdRef.current;
+    // 새 시도는 지난 결과의 표면을 먼저 걷는다 — ✓가 남은 채 다음 요청이 돌면 어느 시도의 결과인지 읽을 수 없다.
+    if (isManual) clearSyncSettled();
     setSyncing(true);
     let response: Response;
     try {
@@ -430,12 +485,11 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       const newRefs = "newRefs" in payload ? payload.newRefs : 0;
       const updatedRefs = "updatedRefs" in payload ? payload.updatedRefs : 0;
       const pruned = "pruned" in payload ? payload.pruned : 0;
-      showSyncNotice(newRefs === 0 && updatedRefs === 0 && pruned === 0
-        ? { kind: "successClean" }
-        : { kind: "success", newRefs, updatedRefs, pruned });
+      if (newRefs === 0 && updatedRefs === 0 && pruned === 0) showSyncSettled();
+      else showSyncNotice({ kind: "success", newRefs, updatedRefs, pruned });
     }
     refreshRepositoryData();
-  }, [ctx.theaterId, refreshRepositoryData, repoRel, showSyncNotice]);
+  }, [clearSyncSettled, ctx.theaterId, refreshRepositoryData, repoRel, showSyncNotice, showSyncSettled]);
   useEffect(() => {
     if (!ctx.theaterId) return;
     const contextKey = `${ctx.theaterId}:${repoRel}`;
@@ -574,15 +628,14 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
         : syncNotice.code === "timeout" ? "repository.sync.failedTimeout"
         : syncNotice.code === "no_remote" ? "repository.sync.failedNoRemote"
         : "repository.sync.failedGit")
-      : syncNotice.kind === "successClean"
-        ? t("repository.sync.summaryClean")
-        : t("repository.sync.summary", { newRefs: syncNotice.newRefs, updatedRefs: syncNotice.updatedRefs, pruned: syncNotice.pruned });
+      : t("repository.sync.summary", { newRefs: syncNotice.newRefs, updatedRefs: syncNotice.updatedRefs, pruned: syncNotice.pruned });
   // Changes만 hidden으로 상시 마운트해 섹션 전환에도 내부 상태를 보존한다.
   const workspaceMainVisible = source === "changes";
   const workspaceMain = <div className="repository-source-fill" hidden={source !== "changes"}>{changesView}</div>;
   return (
     <div className="repository-unified is-workspace">
-      <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? t("repository.panel.title")}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}<button type="button" className={`repository-sync-button${syncing ? " is-syncing" : ""}`} title={t("repository.sync.title")} aria-label={t("repository.sync.title")} disabled={syncing} onClick={() => { void syncRepository(); }}><span className="repository-sync-icon" aria-hidden="true">↻</span>{t("repository.sync.button")}{syncFailed && <span className="repository-sync-dot" title={t("repository.sync.lastFailed")} aria-hidden="true" />}</button></div>
+      <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? t("repository.panel.title")}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}<button type="button" className={`repository-sync-button${syncing ? " is-syncing" : ""}`} title={t("repository.sync.title")} aria-label={t("repository.sync.title")} disabled={syncing} onClick={() => { void syncRepository(); }}><span className={`repository-sync-icon${syncSettled ? " is-settled" : ""}`} aria-hidden="true"><span className="repository-sync-glyph repository-sync-glyph-idle">↻</span><span className="repository-sync-glyph repository-sync-glyph-settled">✓</span></span>{t("repository.sync.button")}{syncFailed && <span className="repository-sync-dot" title={t("repository.sync.lastFailed")} aria-hidden="true" />}{syncHintAvailable && <span className={`repository-sync-hint${syncHinting ? " is-open" : ""}`} aria-hidden="true">{t("repository.sync.upToDate")}</span>}</button></div>
+      <span className="repository-sr-only" role="status">{syncHinting ? t("repository.sync.upToDate") : ""}</span>
       {syncNotice && syncNoticeMessage ? <div className={`repository-sync-toast is-${syncNotice.kind === "error" ? "error" : "success"}`} role="status"><span>{syncNoticeMessage}</span><button type="button" aria-label={t("repository.sync.dismiss")} onClick={() => setSyncNotice(null)}>✕</button></div> : null}
       <div ref={layoutRef} className={`repository-ws-layout${isTreeDragging ? " is-dragging" : ""}`} style={{ "--ws-tree-width": `${treeWidth}px` } as React.CSSProperties}>
         <WorkspaceTree theaterId={ctx.theaterId ?? ""} t={t} repos={repos} reposError={reposError} reposTruncated={reposTruncated} scanDepth={scanDepth} worktrees={worktrees} worktreesError={worktreesError} refs={refs} refsError={refsError} changedFiles={changedFiles} selectedRel={repoRel} source={source} refFilter={refFilter} onRepository={handleSelectRepository} onScanDepth={setScanDepth} onRetryRepos={() => setReposRetry((value) => value + 1)} onRetryWorktrees={() => setWorktreesRetry((value) => value + 1)} onRetryRefs={() => setRefsRetry((value) => value + 1)} onSource={setSource} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} onCompare={openCompare} onStashInspect={openStashInspect} />

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -426,15 +426,18 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       setSyncHinting(false);
     }, SYNC_HINT_MS);
   }, []);
-  const clearSyncSettled = useCallback(() => {
-    if (syncSettledTimerRef.current !== null) {
-      clearTimeout(syncSettledTimerRef.current);
-      syncSettledTimerRef.current = null;
+  // 한 시도의 답은 배너·✓·말풍선 세 표면에 나뉘어 앉는다. 새 시도를 시작할 때 셋을 함께 걷지 않으면
+  // 앞 시도의 배너가 자기 6초를 사는 동안 뒤 시도의 ✓가 겹쳐, 실패 배너와 "이미 최신 상태"가 동시에 뜬다.
+  // 수동 동기화에는 throttle이 없어 두 번 누르는 것으로 재현된다. 지속 실패 점은 시도별 알림이 아니라
+  // "마지막 결과" 표식이라 여기서 걷지 않고 성공 시에만 해제한다.
+  const clearSyncSurfacing = useCallback(() => {
+    for (const timer of [syncNoticeTimerRef, syncSettledTimerRef, syncHintTimerRef]) {
+      if (timer.current !== null) {
+        clearTimeout(timer.current);
+        timer.current = null;
+      }
     }
-    if (syncHintTimerRef.current !== null) {
-      clearTimeout(syncHintTimerRef.current);
-      syncHintTimerRef.current = null;
-    }
+    setSyncNotice(null);
     setSyncSettled(false);
     setSyncHinting(false);
     setSyncHintAvailable(false);
@@ -448,8 +451,8 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     if (!ctx.theaterId) return;
     const isManual = mode !== "auto";
     const requestId = ++syncRequestIdRef.current;
-    // 새 시도는 지난 결과의 표면을 먼저 걷는다 — ✓가 남은 채 다음 요청이 돌면 어느 시도의 결과인지 읽을 수 없다.
-    if (isManual) clearSyncSettled();
+    // 새 시도는 지난 결과의 표면을 먼저 걷는다 — 앞 결과가 남은 채 다음 요청이 돌면 어느 시도의 결과인지 읽을 수 없다.
+    if (isManual) clearSyncSurfacing();
     setSyncing(true);
     let response: Response;
     try {
@@ -489,7 +492,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       else showSyncNotice({ kind: "success", newRefs, updatedRefs, pruned });
     }
     refreshRepositoryData();
-  }, [clearSyncSettled, ctx.theaterId, refreshRepositoryData, repoRel, showSyncNotice, showSyncSettled]);
+  }, [clearSyncSurfacing, ctx.theaterId, refreshRepositoryData, repoRel, showSyncNotice, showSyncSettled]);
   useEffect(() => {
     if (!ctx.theaterId) return;
     const contextKey = `${ctx.theaterId}:${repoRel}`;

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1123,10 +1123,21 @@
 .repository-sync-button { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; padding: 4px 7px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--text-tertiary); cursor: pointer; flex: none; font: inherit; font-size: 12px; }
 .repository-sync-button:hover:not(:disabled) { border-color: var(--surface-rim); background: color-mix(in oklch, var(--ink-fog) 9%, transparent); color: var(--text-primary); }
 .repository-sync-button:disabled { cursor: default; opacity: .7; }
-.repository-identity .repository-sync-icon { display: inline-block; min-width: auto; overflow: visible; color: inherit; flex: none; font: inherit; font-size: 13px; line-height: 1; }
+/* 아이콘은 ↻와 ✓를 같은 자리에 겹쳐 두는 13px 슬롯이다 — 글리프를 교체하면 버튼 폭이 흔들려
+   옆의 라벨이 밀린다. 회전은 계속 슬롯 자체에 걸어 두 글리프가 같은 축을 돈다. */
+.repository-identity .repository-sync-icon { position: relative; display: inline-block; width: 13px; height: 13px; min-width: auto; overflow: visible; color: inherit; flex: none; font: inherit; font-size: 13px; line-height: 1; }
+.repository-identity .repository-sync-glyph { position: absolute; inset: 0; display: grid; min-width: auto; overflow: visible; place-items: center; color: inherit; font: inherit; font-size: 13px; line-height: 1; opacity: 0; transform: scale(.72); transition: opacity 150ms ease, transform 190ms cubic-bezier(.2, 1.5, .4, 1); }
+/* ✓는 "가져올 것이 없었다"는 상태이므로 positive 신호 채널을 쓴다 — brass(위치·포커스)를 쓰면 채널이 섞인다. */
+.repository-identity .repository-sync-glyph-settled { color: var(--positive-ink); }
+.repository-sync-icon:not(.is-settled) .repository-sync-glyph-idle,
+.repository-sync-icon.is-settled .repository-sync-glyph-settled { opacity: 1; transform: none; }
 .repository-sync-button.is-syncing .repository-sync-icon { animation: repository-sync-spin 800ms linear infinite; }
 @keyframes repository-sync-spin { to { transform: rotate(360deg); } }
-@media (prefers-reduced-motion: reduce) { .repository-sync-button.is-syncing .repository-sync-icon { animation: none; } }
+@media (prefers-reduced-motion: reduce) {
+  .repository-sync-button.is-syncing .repository-sync-icon { animation: none; }
+  /* 상태 전이 자체는 남기고 전이 연출만 걷는다 — ✓가 아예 뜨지 않으면 결과를 잃는다. */
+  .repository-identity .repository-sync-glyph { transition-duration: 1ms; }
+}
 /* 숨김-마운트 래퍼가 높이 문맥을 끊으면 history-root의 height:100%가 내용 높이로 풀려 내부 스크롤이 죽는다 */
 .repository-source-fill { height: 100%; min-width: 0; min-height: 0; }
 .repository-discovery { display: flex; align-items: center; gap: 8px; flex: none; padding: 6px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
@@ -1657,6 +1668,52 @@
   margin-left: auto;
 }
 .repository-sync-button { position: relative; }
+/* 말풍선은 버튼 아래로만 열린다 — 레일 패널 body가 overflow:hidden이라 위쪽은 잘리고,
+   버튼 오른쪽 끝이 패널 오른쪽 끝에 붙어 있어 right:0 정렬이 아니면 밖으로 나간다.
+   너비를 max-content로 잡지 않으면 좁은 버튼이 containing block이라 한 마디가 두 줄로 접힌다. */
+.repository-sync-hint {
+  position: absolute;
+  z-index: 3;
+  top: calc(100% + 6px);
+  right: 0;
+  width: max-content;
+  max-width: 220px;
+  min-width: auto;
+  overflow: visible;
+  padding: 4px 7px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-xs);
+  background: var(--ink-veil);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 11.5px;
+  line-height: 1.4;
+  white-space: normal;
+  text-align: left;
+  opacity: 0;
+  transform: translateY(-3px);
+  transition: opacity 160ms ease, transform 160ms ease;
+  pointer-events: none;
+}
+.repository-sync-hint::before {
+  content: "";
+  position: absolute;
+  top: -4px;
+  right: 11px;
+  width: 7px;
+  height: 7px;
+  transform: rotate(45deg);
+  border-top: 1px solid var(--hairline-strong);
+  border-left: 1px solid var(--hairline-strong);
+  background: var(--ink-veil);
+}
+/* 자동 노출이 물러난 뒤에도 다음 동기화까지 hover·포커스로 같은 한 마디를 다시 열 수 있다. */
+.repository-sync-hint.is-open,
+.repository-sync-button:hover .repository-sync-hint,
+.repository-sync-button:focus-visible .repository-sync-hint { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  .repository-sync-hint { transition-duration: 1ms; }
+}
 .repository-sync-dot {
   position: absolute;
   top: -3px;

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1670,8 +1670,11 @@
 .repository-sync-button { position: relative; }
 /* 말풍선은 버튼 아래로만 열린다 — 레일 패널 body가 overflow:hidden이라 위쪽은 잘리고,
    버튼 오른쪽 끝이 패널 오른쪽 끝에 붙어 있어 right:0 정렬이 아니면 밖으로 나간다.
-   너비를 max-content로 잡지 않으면 좁은 버튼이 containing block이라 한 마디가 두 줄로 접힌다. */
-.repository-sync-hint {
+   너비를 max-content로 잡지 않으면 좁은 버튼이 containing block이라 한 마디가 두 줄로 접힌다.
+   `.repository-identity`로 스코프하는 것이 필수다 — `.repository-identity span`(0,1,1)이 브랜치용
+   brass·mono·ellipsis를 모든 자손 span에 걸어 두므로, 클래스 하나(0,1,0)로는 상태 문면이 위치
+   채널(brass)로 칠해지고 10px mono로 접힌다. */
+.repository-identity .repository-sync-hint {
   position: absolute;
   z-index: 3;
   top: calc(100% + 6px);
@@ -1712,7 +1715,8 @@
 .repository-sync-button:hover .repository-sync-hint,
 .repository-sync-button:focus-visible .repository-sync-hint { opacity: 1; transform: none; }
 @media (prefers-reduced-motion: reduce) {
-  .repository-sync-hint { transition-duration: 1ms; }
+  /* 기본 규칙과 같은 스코프여야 한다 — 클래스 하나로는 위 (0,2,0) 규칙의 transition을 못 이긴다. */
+  .repository-identity .repository-sync-hint { transition-duration: 1ms; }
 }
 .repository-sync-dot {
   position: absolute;

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -61,6 +61,34 @@ function blockOf(selector: string): string {
   return blocksOf(selector)[0]!;
 }
 
+// prefers-reduced-motion 블록들의 본문만 모은다 — 파일 뒤쪽에 같은 선언이 있으면 통과해 버리는
+// slice(indexOf(...)) 방식은 "미디어 블록 안에 있음"을 증명하지 못한다.
+function reducedMotionBodies(): string {
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const bodies: string[] = [];
+  const prelude = "@media (prefers-reduced-motion: reduce)";
+  let from = 0;
+  for (;;) {
+    const start = stripped.indexOf(prelude, from);
+    if (start === -1) break;
+    const open = stripped.indexOf("{", start);
+    if (open === -1) break;
+    let depth = 0;
+    let index = open;
+    for (; index < stripped.length; index += 1) {
+      if (stripped[index] === "{") depth += 1;
+      else if (stripped[index] === "}") {
+        depth -= 1;
+        if (depth === 0) break;
+      }
+    }
+    bodies.push(stripped.slice(open + 1, index));
+    from = index + 1;
+  }
+  if (bodies.length === 0) throw new Error("Missing prefers-reduced-motion block");
+  return bodies.join("\n");
+}
+
 describe("Repository design grammar", () => {
   it("reserves brass for location while selections use neutral ink", () => {
     expect(blockOf(".repository-ref-row.is-current")).toContain("var(--text-primary)");
@@ -112,6 +140,31 @@ describe("Repository design grammar", () => {
   it("keeps the sync button spin animation reducible and omits the status strip", () => {
     expect(css).not.toContain(".repository-sync-status");
     expect(blocksOf(".repository-sync-button.is-syncing .repository-sync-icon").some((body) => body.includes("animation: none"))).toBe(true);
+  });
+
+  // 2026-08-15 재가 — "이미 최신 상태"는 배너를 쓰지 않는다. 아이콘 슬롯과 말풍선이 그 결과를 진다.
+  it("keeps the up-to-date result on the icon slot and hint, with motion reducible but state intact", () => {
+    // 글리프 교체가 아니라 겹친 슬롯이어야 버튼 폭이 흔들리지 않는다.
+    const iconSlot = blockOf(".repository-identity .repository-sync-icon");
+    expect(iconSlot).toContain("position: relative");
+    expect(iconSlot).toContain("width: 13px");
+    const glyph = blockOf(".repository-identity .repository-sync-glyph");
+    expect(glyph).toContain("position: absolute");
+    expect(glyph).toContain("opacity: 0");
+    // 말풍선은 아래로만, 오른쪽 정렬로, 접히지 않는 너비로 열린다.
+    const hint = blockOf(".repository-sync-hint");
+    expect(hint).toContain("top: calc(100% + 6px)");
+    expect(hint).toContain("right: 0");
+    expect(hint).toContain("width: max-content");
+    expect(hint).toContain("pointer-events: none");
+    // 자동 노출이 끝난 뒤에도 hover·포커스로 다시 열려야 한다.
+    expect(css).toContain(".repository-sync-button:hover .repository-sync-hint");
+    expect(css).toContain(".repository-sync-button:focus-visible .repository-sync-hint");
+    // 동작 줄이기에서는 전이 연출만 걷고 상태는 남긴다 — opacity/transform 규칙을 지우면 안 된다.
+    const reduced = reducedMotionBodies();
+    expect(reduced).toContain(".repository-identity .repository-sync-glyph { transition-duration: 1ms; }");
+    expect(reduced).toContain(".repository-sync-hint { transition-duration: 1ms; }");
+    expect(glyph).toContain("transition:");
   });
 
   // 2026-08-05 재가 — in-history compare 앵커와 수동 Sync 표면화의 신호 채널 문법.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -152,18 +152,24 @@ describe("Repository design grammar", () => {
     expect(glyph).toContain("position: absolute");
     expect(glyph).toContain("opacity: 0");
     // 말풍선은 아래로만, 오른쪽 정렬로, 접히지 않는 너비로 열린다.
-    const hint = blockOf(".repository-sync-hint");
+    // `.repository-identity span`(0,1,1)이 자손 span 전부에 brass·mono·ellipsis를 걸어 두므로
+    // 상태 문면 규칙은 반드시 같은 스코프로 선언해야 한다 — 클래스 하나면 위치 채널로 칠해진다.
+    const hint = blockOf(".repository-identity .repository-sync-hint");
     expect(hint).toContain("top: calc(100% + 6px)");
     expect(hint).toContain("right: 0");
     expect(hint).toContain("width: max-content");
     expect(hint).toContain("pointer-events: none");
+    expect(hint).toContain("color: var(--text-primary)");
+    expect(hint).toContain("overflow: visible");
+    expect(hint).toContain("font-family: inherit");
+    expect(hint).toContain("white-space: normal");
     // 자동 노출이 끝난 뒤에도 hover·포커스로 다시 열려야 한다.
     expect(css).toContain(".repository-sync-button:hover .repository-sync-hint");
     expect(css).toContain(".repository-sync-button:focus-visible .repository-sync-hint");
     // 동작 줄이기에서는 전이 연출만 걷고 상태는 남긴다 — opacity/transform 규칙을 지우면 안 된다.
     const reduced = reducedMotionBodies();
     expect(reduced).toContain(".repository-identity .repository-sync-glyph { transition-duration: 1ms; }");
-    expect(reduced).toContain(".repository-sync-hint { transition-duration: 1ms; }");
+    expect(reduced).toContain(".repository-identity .repository-sync-hint { transition-duration: 1ms; }");
     expect(glyph).toContain("transition:");
   });
 

--- a/runtime/fleet-plugins/repository/tests/sync-client.test.ts
+++ b/runtime/fleet-plugins/repository/tests/sync-client.test.ts
@@ -16,6 +16,36 @@ describe("Repository sync client contracts", () => {
     expect(railPanelSource).toContain("git_failed");
   });
 
+  // 2026-08-15 재가 — 가져온 것이 없는 결과는 배너를 쓰지 않는다. 아이콘 ✓ 체류와 말풍선이 그 결과를 지고,
+  // 갱신·실패만 배너로 남는다. 세 카운트가 0인 분기가 showSyncNotice로 되돌아가면 본문 이동이 부활한다.
+  it("answers an up-to-date manual sync on the button instead of the banner", () => {
+    expect(railPanelSource).toContain("if (newRefs === 0 && updatedRefs === 0 && pruned === 0) showSyncSettled();");
+    expect(railPanelSource).toContain("else showSyncNotice({ kind: \"success\", newRefs, updatedRefs, pruned });");
+    expect(railPanelSource).not.toContain("successClean");
+    expect(railPanelSource).not.toContain("repository.sync.summaryClean");
+  });
+
+  it("clears the previous settled result before the next manual attempt", () => {
+    expect(railPanelSource).toContain("if (isManual) clearSyncSettled();");
+  });
+
+  it("keeps the up-to-date result announced and re-openable", () => {
+    expect(railPanelSource).toContain("className=\"repository-sr-only\" role=\"status\"");
+    expect(railPanelSource).toContain("repository.sync.upToDate");
+    expect(railPanelSource).toContain("syncHintAvailable");
+  });
+
+  it("clears every sync surfacing timer on unmount and on repository transition", () => {
+    for (const timer of ["syncNoticeTimerRef", "syncSettledTimerRef", "syncHintTimerRef"]) {
+      const unmountStart = railPanelSource.indexOf("useEffect(() => () => {");
+      const unmountEnd = railPanelSource.indexOf("}, []);", unmountStart);
+      expect(railPanelSource.slice(unmountStart, unmountEnd), timer).toContain(timer);
+      const transitionStart = railPanelSource.indexOf("const transitionRepository");
+      const transitionEnd = railPanelSource.indexOf("setChangedFiles({ kind: \"loading\" })", transitionStart);
+      expect(railPanelSource.slice(transitionStart, transitionEnd), timer).toContain(timer);
+    }
+  });
+
   it("keeps throttle skips as a silent early return", () => {
     expect(railPanelSource).toContain('if ("skipped" in payload) return');
   });

--- a/runtime/fleet-plugins/repository/tests/sync-client.test.ts
+++ b/runtime/fleet-plugins/repository/tests/sync-client.test.ts
@@ -25,8 +25,19 @@ describe("Repository sync client contracts", () => {
     expect(railPanelSource).not.toContain("repository.sync.summaryClean");
   });
 
-  it("clears the previous settled result before the next manual attempt", () => {
-    expect(railPanelSource).toContain("if (isManual) clearSyncSettled();");
+  // 한 시도의 답은 배너·✓·말풍선 세 표면에 나뉘어 앉는다. 새 시도가 셋을 함께 걷지 않으면 앞 시도의
+  // 배너가 자기 6초를 사는 동안 뒤 시도의 ✓가 겹쳐 실패 배너와 "이미 최신 상태"가 동시에 뜬다.
+  it("clears every per-attempt surface before the next manual attempt", () => {
+    expect(railPanelSource).toContain("if (isManual) clearSyncSurfacing();");
+    const start = railPanelSource.indexOf("const clearSyncSurfacing");
+    const end = railPanelSource.indexOf("}, []);", start);
+    const body = railPanelSource.slice(start, end);
+    expect(body).toContain("syncNoticeTimerRef");
+    expect(body).toContain("setSyncNotice(null)");
+    expect(body).toContain("setSyncSettled(false)");
+    expect(body).toContain("setSyncHintAvailable(false)");
+    // 지속 실패 점은 시도별 알림이 아니라 "마지막 결과" 표식이므로 여기서 해제하지 않는다.
+    expect(body).not.toContain("setSyncFailed");
   });
 
   it("keeps the up-to-date result announced and re-openable", () => {


### PR DESCRIPTION
## Summary

- Repository 레일 패널의 수동 동기화가 **가져올 것이 없었을 때** 인-플로우 배너를 띄우지 않는다. 아이콘 슬롯이 ↻ → ✓(`--positive`)로 1.4초 머문 뒤 되돌아오고, 버튼 아래·우측에 `이미 최신 상태` 말풍선이 2.2초 떴다가 물러난다. 다음 동기화까지는 hover/포커스로 같은 한 마디를 다시 열 수 있다.
- 기존 배너는 **흐름 안의 블록**이라 등장·소멸에 각각 패널 본문을 41px 밀어냈다(실측). 정보량이 가장 적은 결과가 가장 큰 반응을 받고 있었다. 이 케이스의 본문 이동은 41px → **0px**이 된다.
- **갱신·실패는 의도적으로 그대로 둔다.** `신규 N · 갱신 N · 정리 N` 배너, 실패 배너, 우상단 지속 coral 점 모두 현행 유지다. 이 PR은 "최신 상태" 결과 하나만 옮긴다.
- 배너가 지고 있던 `role="status"` 통보는 `repository-sr-only` 라이브 영역으로 이관해 스크린리더에서 결과가 사라지지 않게 했다.

## Type of Change

- [x] feat — new feature or carrier capability

## Test Plan

- [x] `pnpm vitest run` (`@fleet-plugins/repository`) — 38 files / 390 tests pass
- [x] `pnpm typecheck` (`@fleet-plugins/repository`) — pass
- [x] `pnpm vitest run tests/instrument-design-contract.test.ts` (`@dotobokuri/fleet-console`) — 61 tests pass (플러그인 CSS를 스캔하므로 함께 실행)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — pass
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK
- [x] 격리 Console 실브라우저 검증 (`FLEET_CONSOLE_DATA_DIR`, 서브된 번들 해시 = 빌드 산출물 일치)
  - 최신 상태 동기화: 본문 기준 요소 top 불변 = **0px 이동**, ✓ 103ms 등장 → 1517ms 복귀, 말풍선 103ms → 2326ms 페이드
  - 말풍선 재열람: hover 시 80×24, 우측 끝 1223 (패널 우측 1236 안쪽)
  - 갱신 있음: `동기화 완료 — 신규 1 · 갱신 1 · 정리 0` 배너 + 41px 이동 — **현행 그대로**
  - 실패(`no_remote`): 오류 배너 + 지속 점, ✓·말풍선 미출현
  - 저장소 전환: ✓·말풍선 즉시 해제
  - CDP `Emulation.setEmulatedMedia` 로 `prefers-reduced-motion: reduce` 강제 — 회전 없음, 전이 1ms, **✓·말풍선 상태는 유지**
  - Instrument / Whites 두 테마 computed style 실측 — 말풍선 `--text-primary` on `--ink-veil`, ✓ `--positive-ink`
  - 페이지 오류·미처리 거부 0건

## Changelog

- `.repository-sync-toast` 의 `successClean` 분기 제거 — 세 카운트가 모두 0이면 배너 대신 아이콘·말풍선으로 답한다.
- 아이콘은 글리프를 교체하지 않고 13px 슬롯에 ↻/✓를 겹쳐 둔다 — 교체하면 버튼 폭이 흔들려 라벨이 밀린다.
- `repository.sync.summaryClean` (긴 문장) → `repository.sync.upToDate` (짧은 한 마디), en/ko 동시.
- 타이머 3종(notice / settled / hint) 모두 언마운트·저장소 전환에서 정리한다.
- 계약 테스트 갱신: 아이콘 슬롯·말풍선 문법·`prefers-reduced-motion` 상태 유지, clean 분기가 배너로 되돌아가는 것 차단, 타이머 정리.

## Notes for Reviewers

- **채널 함정 주의.** `.repository-identity span`(특이도 0,1,1)이 브랜치 칩용 `--brass-ink`·mono 10px·`overflow:hidden`·ellipsis 를 모든 자손 span에 걸고 있다. 말풍선을 클래스 하나(0,1,0)로 선언하면 조용히 그 캐스케이드에 먹혀 **상태 문면이 위치 채널(brass)로 칠해지고** 10px mono로 접히며 캐럿이 클립된다. 테스트·빌드·타입체크는 전부 green이었고 라이브 computed style 측정에서만 드러났다. 그래서 기본 규칙과 `prefers-reduced-motion` 오버라이드를 **둘 다** `.repository-identity` 로 스코프했고, 회복된 선언들을 디자인 계약에 핀으로 박았다(두 번째 커밋).
- 갱신·실패 케이스의 배너 유지는 **의도된 범위 제한**이다. 그쪽까지 조용하게 만드는 안(델타 칩, 사유 말풍선)은 검토했고 이번 범위에서 명시적으로 제외했다.