### PR TITLE
feat(fleet-console): name a panel's group in its caption

### DIFF
--- a/.changelog.d/panel-group-caption-label.md
+++ b/.changelog.d/panel-group-caption-label.md
@@ -1,0 +1,12 @@
+---
+branch: panel-group-caption-label
+---
+
+### fleet-console
+#### Added
+- Show an Operation's group on its panel caption as a coloured dot and the group name, so membership reads without opening the sidebar.
+  ko: Operation의 그룹을 패널 캡션에 색 도트와 그룹 이름으로 표시해, 사이드바를 열지 않아도 소속이 읽힙니다.
+
+#### Removed
+- Drop the accent stripe down a panel's left edge; identity now speaks only through the caption's nameplate mark and wash.
+  ko: 패널 왼쪽 가장자리의 accent 띠를 걷어내고, 정체성은 캡션의 명판 마크와 워시로만 말합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -10,7 +10,7 @@ import { fetchOperations } from "../api.js";
 import { availableCompanionPanels } from "../companion-shortcut.js";
 import { isBlockingDialogOpen } from "../focus-guards.js";
 import { blurActiveElement } from "../active-operation-surface.js";
-import { flattenGroupedOrder, focusCycleOperationIds, hydrateOperations, requestOperationKeyboardFocus, requestOperationLaunchMenu, setActiveOperation } from "../store.js";
+import { flattenGroupedOrder, focusCycleOperationIds, hydrateOperations, requestOperationKeyboardFocus, requestOperationLaunchMenu, resolveOperationGroup, setActiveOperation } from "../store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
@@ -729,8 +729,8 @@ export function OperationsCanvas({
     }, 1_500);
     return () => clearTimeout(timer);
   }, [companionOperationId, currentPanelCompanion]);
-  // 캡션 그룹 라벨의 조회는 Theater로 거르지 않는다 — 선별 무대는 활성 Theater 밖 Operation도
-  // 올리고, group id는 전역 유일하므로 필터가 라벨을 조용히 비우기만 한다.
+  // 캡션 그룹 라벨의 조회는 활성 Theater로 좁히지 않는다 — 선별 무대는 활성 Theater 밖 Operation도
+  // 올린다. 소속 판정은 resolveOperationGroup이 Operation 자신의 Theater 기준으로 내린다.
   const groupById = new Map(state.groups.map((group) => [group.id, group]));
   const formationOperationIds = flattenGroupedOrder(
     theaterOperations,
@@ -863,7 +863,7 @@ export function OperationsCanvas({
           const operationMaximized = panelMaximized === operation.id;
           const operationCompanion = panelCompanion === operation.id;
           const operationTriageStage = triageStageId === operation.id;
-          const operationGroup = operation.groupId ? groupById.get(operation.groupId) ?? null : null;
+          const operationGroup = resolveOperationGroup(operation, groupById);
           // 색을 못 푸는 그룹은 라벨 자체를 내지 않는다 — 도트 없는 이름만 남으면 그것이 그룹이라는
           // 사실을 캡션에서 읽을 수 없다.
           const operationGroupColor = operationGroup ? resolveAccentColor(operationGroup.color) : null;

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -729,6 +729,9 @@ export function OperationsCanvas({
     }, 1_500);
     return () => clearTimeout(timer);
   }, [companionOperationId, currentPanelCompanion]);
+  // 캡션 그룹 라벨의 조회는 Theater로 거르지 않는다 — 선별 무대는 활성 Theater 밖 Operation도
+  // 올리고, group id는 전역 유일하므로 필터가 라벨을 조용히 비우기만 한다.
+  const groupById = new Map(state.groups.map((group) => [group.id, group]));
   const formationOperationIds = flattenGroupedOrder(
     theaterOperations,
     state.groups.filter((group) => group.theaterId === state.activeTheaterId),
@@ -860,6 +863,10 @@ export function OperationsCanvas({
           const operationMaximized = panelMaximized === operation.id;
           const operationCompanion = panelCompanion === operation.id;
           const operationTriageStage = triageStageId === operation.id;
+          const operationGroup = operation.groupId ? groupById.get(operation.groupId) ?? null : null;
+          // 색을 못 푸는 그룹은 라벨 자체를 내지 않는다 — 도트 없는 이름만 남으면 그것이 그룹이라는
+          // 사실을 캡션에서 읽을 수 없다.
+          const operationGroupColor = operationGroup ? resolveAccentColor(operationGroup.color) : null;
           // focus layer는 peer를 실제 최소화하지 않고, mount를 보존한 채 렌더만 감춘다.
           const focusLayerHidden = triageActive
             ? !operationTriageStage
@@ -945,6 +952,8 @@ export function OperationsCanvas({
               canvasRef.current?.focus();
             },
             accentKey: canvas.operationAccent[operation.id] ?? operationAccentFromNode(operation),
+            groupName: operationGroup?.name ?? null,
+            groupColor: operationGroupColor,
             onActivate: () => {
               setActiveOperation(operation.id);
               // 선별 중에는 기록하지 않는다 — 무대는 슬롯 geometry이고, 외부 Theater 무대의 기록은
@@ -1275,6 +1284,8 @@ function renderPluginOperation(operation: OperationNode, options: {
   readonly onRenderHiddenFocus: () => void;
   readonly topEdge: boolean;
   readonly accentKey: string | null;
+  readonly groupName: string | null;
+  readonly groupColor: string | null;
   readonly onActivate: () => void;
   readonly onClose: () => void;
   readonly onMinimize: () => void;
@@ -1319,6 +1330,8 @@ function renderPluginOperation(operation: OperationNode, options: {
         focusLayerTarget={options.maximized || options.companion}
         interactionDisabled={options.formation || options.companion || options.focusLayerHidden || options.triageStage}
         accentKey={options.accentKey}
+        groupName={options.groupName}
+        groupColor={options.groupColor}
         onActivate={options.onActivate}
         onClose={options.onClose}
         onMinimize={options.onMinimize}

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -27,6 +27,8 @@ interface OperationFrameProps {
   readonly glanceHud: GlanceHudModel;
   readonly formationSlotIndex?: number;
   readonly accentKey?: string | null;
+  readonly groupName?: string | null;
+  readonly groupColor?: string | null;
   readonly children: ReactNode;
   readonly onActivate: () => void;
   readonly onClose: () => void;
@@ -67,7 +69,7 @@ const DRAG_THRESHOLD_PX = 3;
 // 캡션 상태 레일의 도착 플래시 길이 — CSS의 var(--duration-slow)와 한 값이다.
 const ARRIVAL_FLASH_DURATION_MS = 360;
 
-export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, glanceHud, formationSlotIndex, accentKey = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onSetAccent, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
+export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, glanceHud, formationSlotIndex, accentKey = null, groupName = null, groupColor = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onSetAccent, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
   const t = useT();
   const operationRef = useRef<HTMLElement | null>(null);
   const terminalRef = useRef<HTMLDivElement | null>(null);
@@ -96,9 +98,12 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
       restoreIdentityFocusRef.current = true;
     },
   });
-  // 사용자 accent(정체성)는 좌측 스파인과 명판 마크만 소유한다.
+  // 사용자 accent(정체성)는 명판 마크와 명판 워시만 소유한다.
   // 패널 보더/글로우/비콘은 상태 채널(brass 포커스·aurora 대기·coral 위험) 전용이다.
   const accentColor = accentKey ? resolveAccentColor(accentKey) : null;
+  // 그룹 소속은 개인 accent와 다른 축이므로 자기 마크(도트)와 중립 티어 이름으로 따로 선다 —
+  // 색은 도트만 지고 이름은 캡션의 기존 중립 메타 티어를 그대로 상속한다.
+  const groupLabelVisible = Boolean(groupName && groupColor);
   const className = [
     "canvas-operation",
     unseen ? "is-unseen" : "",
@@ -383,12 +388,14 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
       data-canvas-operation
       data-operation-id={operation.id}
       data-focus-layer-target={focusLayerTarget ? "true" : undefined}
-      aria-label={t("canvas.frame.operationAria", { title: displayTitle })}
+      aria-label={t("canvas.frame.operationAria", {
+        title: displayTitle,
+        groupContext: groupLabelVisible ? t("canvas.frame.inGroup", { name: groupName ?? "" }) : "",
+      })}
       aria-hidden={renderHidden || undefined}
       tabIndex={focusLayerTarget ? -1 : undefined}
       inert={minimized || renderHidden ? true : undefined}
     >
-      {accentColor ? <span className="canvas-operation-spine" aria-hidden="true" /> : null}
       <div
         className="canvas-operation-titlebar"
         onPointerDown={beginDrag}
@@ -398,6 +405,17 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
         onLostPointerCapture={abortPointerManipulation}
         data-canvas-blocker
       >
+        {groupLabelVisible ? (
+          <span
+            className="canvas-operation-group-label"
+            style={{ "--group-mark": groupColor } as CSSProperties}
+            title={t("canvas.frame.groupTitle", { name: groupName ?? "" })}
+            aria-hidden="true"
+          >
+            <span className="canvas-operation-group-dot" />
+            <span className="canvas-operation-group-name">{groupName}</span>
+          </span>
+        ) : null}
         {accentColor ? <span className="canvas-operation-id-mark" aria-hidden="true" /> : null}
         {rename.renaming ? (
           <input

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -42,7 +42,9 @@ export const canvasEn = {
   "canvas.glance.defer": "Defer",
   "canvas.glance.setAside": "Set aside",
 
-  "canvas.frame.operationAria": "Operation {title}",
+  "canvas.frame.operationAria": "Operation {title}{groupContext}",
+  "canvas.frame.inGroup": " in group {name}",
+  "canvas.frame.groupTitle": "Group {name}",
   "canvas.frame.renameAria": "Rename operation {title}",
   "canvas.frame.renameTitle": "{title} — Drag to move. Double-click, Enter, or F2 to rename",
   "canvas.frame.setAccentAria": "Set accent for operation {title}",
@@ -248,7 +250,9 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "canvas.glance.defer": "뒤로 미루기",
   "canvas.glance.setAside": "치워두기",
 
-  "canvas.frame.operationAria": "Operation {title}",
+  "canvas.frame.operationAria": "Operation {title}{groupContext}",
+  "canvas.frame.inGroup": " · {name} 그룹",
+  "canvas.frame.groupTitle": "{name} 그룹",
   "canvas.frame.renameAria": "Operation {title} 이름 바꾸기",
   "canvas.frame.renameTitle": "{title} — 드래그로 이동. 더블클릭, Enter 또는 F2로 이름 변경",
   "canvas.frame.setAccentAria": "Operation {title} 액센트 설정",

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -529,6 +529,22 @@ export function nextOperationId(order: readonly string[], currentId: string | nu
   return order[nextIndex] ?? null;
 }
 
+// 그룹은 Operation과 같은 Theater일 때만 그 Operation에 적용된다.
+// 활성 Theater가 아니라 Operation 자신의 Theater를 기준 삼는 것이 핵심이다 — 선별 무대는 활성
+// Theater 밖 Operation도 올리므로 활성 기준으로 거르면 그 무대의 그룹이 사라진다.
+// 서버 PATCH는 groupId가 문자열인지만 보고 Theater 소속을 검사하지 않으므로(operations-domain.ts),
+// API로 타 Theater 그룹이 붙은 Operation이 존재할 수 있다. 사이드바는 그 조합을 미분류로 읽으므로,
+// 이 검사가 없으면 캡션만 홀로 그룹 이름을 주장해 두 면이 서로를 부정한다.
+export function resolveOperationGroup(
+  operation: OperationNode,
+  groupById: ReadonlyMap<string, OperationGroup>,
+): OperationGroup | null {
+  if (!operation.groupId) return null;
+  const group = groupById.get(operation.groupId);
+  if (!group || group.theaterId !== operation.theaterId) return null;
+  return group;
+}
+
 // GROUP 축 SideBar 표시 순서와 Alt+←/→ 순환 순서가 갈라지지 않도록 Operation 정렬을 이 한 함수로 단일화한다.
 // operationOrder(드래그 재정렬 SSoT)에 있는 항목은 그 순서를 따르고, 없는 항목은 createdAt 순으로 뒤에 붙인다.
 export function sortOperationsByOrder(

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4660,20 +4660,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
   --caption-rail: var(--positive);
 }
 
-/* Map에서 사용자 accent(정체성)는 좌측 스파인·명판 마크·명판 워시만 소유한다.
-   패널 보더/글로우/비콘은 상태 채널(brass 포커스·aurora 대기·coral 위험) 전용으로 남는다. */
-.canvas-operation-spine {
-  position: absolute;
-  top: 10px;
-  bottom: 10px;
-  left: 0;
-  z-index: 5;
-  width: 3px;
-  border-radius: 0 3px 3px 0;
-  background: var(--user-accent);
-  pointer-events: none;
-}
-
+/* Map에서 사용자 accent(정체성)는 명판 마크·명판 워시만 소유한다 — 좌측 스파인은 폐기됐다.
+   패널 본문은 어떤 정체성 색도 지지 않고, 정체성은 전부 캡션 위에서 말한다.
+   패널 보더/글로우/비콘은 상태 채널(brass 포커스·aurora 대기·coral 위험) 전용으로 남는다.
+   사이드바 칩의 3px accent 스파인은 레일 소속이라 그대로 남는다. */
 .canvas-operation-id-mark {
   flex: none;
   width: 8px;
@@ -4686,6 +4676,46 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--user-accent) 10%, var(--surface-panel));
   /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
   background-clip: padding-box;
+}
+
+/* 그룹 소속 = 도트(정체성 mark 문법) + 중립 티어 이름. 색은 도트 하나만 지고, 이름은 캡션의
+   기존 중립 메타(Formation 슬롯 번호)와 같은 티어를 상속한다 — 테두리·채움·그룹색 글자는
+   쓰지 않는다. 32px 캡션 안에서 아랫변 2px 상태 레일과 같은 굵기의 색선이 겹치면 두 채널이
+   한 덩어리로 뭉친다(#699 실측). 포커스는 이름 티어 규칙을 그대로 타고 새 채널을 열지 않는다. */
+.canvas-operation-group-label {
+  /* 라벨은 제목보다 먼저 양보한다 — flex-shrink를 크게 잡아야 최소 폭(320px)에서
+     그룹 이름이 Operation 제목을 밀어내지 않는다. */
+  flex: 0 6 auto;
+  min-width: 0;
+  max-width: min(34%, 15ch);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  transition: color var(--duration-base) var(--ease-spring);
+}
+
+.canvas-operation.is-active > .canvas-operation-titlebar .canvas-operation-group-label {
+  color: var(--text-secondary);
+}
+
+.canvas-operation-group-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--group-mark);
+}
+
+.canvas-operation-group-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* 진행 중 캐리어 스트림을 패널 바깥 아래에 floating으로 띄우는 dock. left/top/width는 패널 geometry를
@@ -6457,6 +6487,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 @media (prefers-reduced-motion: reduce) {
   .canvas-operation-titlebar,
   .canvas-operation-titlebar::after,
+  .canvas-operation-group-label,
   .canvas-operation-window-controls,
   .canvas-operation-icon-button {
     transition-duration: 0.01ms;

--- a/runtime/fleet-console/tests/i18n.test.ts
+++ b/runtime/fleet-console/tests/i18n.test.ts
@@ -37,7 +37,7 @@ const IDENTICAL_LOCALE_VALUE_ALLOWLIST = new Set([
   "Cruise",
   "Tactical",
   "War Room",
-  "Operation {title}",
+  "Operation {title}{groupContext}",
   // Quick Launch 멘션 행선지 태그 — mono 대문자 계기 표기라 두 로케일에서 같은 모양으로 읽는다.
   "Operation · {theater}",
   "Companion {title}",

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -576,11 +576,10 @@ describe("Instrument core design contract", () => {
     expect(violations).toEqual([]);
   });
 
-  it("keeps user identity on the spine+mark grammar and off the state border channel", () => {
+  it("keeps user identity on the mark+wash grammar and off the state border channel", () => {
     const frame = source("canvas/operation-frame.tsx");
     const chip = source("sidebar/operations-side-bar-chip.tsx");
     const components = source("styles/components.css");
-    const spineBlock = components.match(/\.canvas-operation-spine \{[^}]*\}/)?.[0] ?? "";
     const markBlock = components.match(/\.canvas-operation-id-mark \{[^}]*\}/)?.[0] ?? "";
     const washBlock = components.match(/\.canvas-operation\[style\*="--user-accent"\] \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
     const chipAccentBlock = components.match(/\.side-bar-chip\[style\*="--user-accent"\]::before \{[^}]*\}/)?.[0] ?? "";
@@ -588,15 +587,15 @@ describe("Instrument core design contract", () => {
     const accentSources = [frame, chip, components].join("\n");
 
     expect(frame).toContain('{ "--user-accent": accentColor }');
-    expect(frame).toContain('className="canvas-operation-spine"');
     expect(frame).toContain('className="canvas-operation-id-mark"');
     expect(chip).toContain('{ "--user-accent": accentValue }');
+    // Map의 좌측 스파인은 폐기됐다 — 패널 본문은 어떤 정체성 색도 지지 않고, 정체성은 전부
+    // 캡션 위(명판 마크·명판 워시)에서 말한다. 선택자·렌더·클래스 어느 쪽으로도 되살아나면
+    // 캡션이 유일한 정체성 면이라는 계약이 조용히 깨진다.
+    expect(components).not.toContain(".canvas-operation-spine");
+    expect(frame).not.toContain("canvas-operation-spine");
     // 정체성은 보더 채널을 소유하지 않는다 — 보더는 상태(brass/aurora/coral) 전용.
     expect(components).not.toContain("border-color: var(--user-accent)");
-    expect(spineBlock).toContain("width: 3px;");
-    expect(spineBlock).toContain("background: var(--user-accent);");
-    expect(spineBlock).toContain("pointer-events: none;");
-    expect(spineBlock).not.toMatch(/animation|box-shadow/);
     expect(markBlock).toContain("width: 8px;");
     expect(markBlock).toContain("height: 14px;");
     expect(markBlock).toContain("background: var(--user-accent);");
@@ -609,10 +608,45 @@ describe("Instrument core design contract", () => {
     expect(chipAccentBlock).toContain("pointer-events: none;");
     expect(chipAccentBlock).not.toMatch(/animation/);
     expect(minimapDotBlock).toContain("background: var(--user-accent);");
-    // 6번째 소비처는 정체성 워시 위에 포커스 워시를 겹치는 결합 규칙이다 — 새 채널이 아니라
-    // 같은 워시를 포커스 상태에서 다시 적는 자리이므로 accent는 여전히 spine+mark+wash에 머문다.
-    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(6);
+    // 5개 소비처: 미니맵 도트 · 명판 마크 · 명판 워시 · 사이드바 칩 스파인 · 포커스 결합 워시.
+    // 마지막은 정체성 워시 위에 포커스 워시를 겹치는 결합 규칙이라 새 채널이 아니다 —
+    // Map에서 accent는 mark+wash에만 머물고, 3px 스파인은 레일(사이드바 칩)에만 남는다.
+    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(5);
     expect(accentSources).not.toMatch(/--op-accent|--chip-accent/);
+  });
+
+  it("pins the caption group label — dot carries the only group colour, the name rides a neutral tier", () => {
+    const frame = source("canvas/operation-frame.tsx");
+    const components = source("styles/components.css");
+    const labelBlock = components.match(/\.canvas-operation-group-label \{[^}]*\}/)?.[0] ?? "";
+    const dotBlock = components.match(/\.canvas-operation-group-dot \{[^}]*\}/)?.[0] ?? "";
+
+    // 그룹 톤 주입은 --group-mark 하나다. --grp-color는 사이드바 존 표면 전용이라 캡션으로 넘어오지 않는다.
+    expect(frame).toContain('{ "--group-mark": groupColor }');
+    expect(frame).toContain('className="canvas-operation-group-label"');
+    expect(components).not.toMatch(/\.canvas-operation[^{}]*--grp-color/);
+    expect(dotBlock).toContain("background: var(--group-mark);");
+    expect(dotBlock).toContain("width: 7px;");
+    expect(dotBlock).toContain("height: 7px;");
+
+    // 색은 도트 하나만 진다 — 라벨에 테두리·채움·그룹색 글자를 얹으면 32px 캡션 안에서
+    // 아랫변 2px 상태 레일과 같은 굵기의 색선이 겹쳐 두 채널이 한 덩어리로 뭉친다(#699 실측).
+    expect(labelBlock).not.toMatch(/border|background/);
+    expect(labelBlock).toContain("color: var(--text-tertiary);");
+    expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar .canvas-operation-group-label {");
+    expect(components).toMatch(/\.canvas-operation\.is-active > \.canvas-operation-titlebar \.canvas-operation-group-label \{\s*color: var\(--text-secondary\);/);
+
+    // 라벨은 제목보다 먼저 양보한다 — 최소 폭(320px)에서 긴 그룹 이름이 Operation 제목을 밀어내면
+    // 캡션의 1순위 정보가 뒤집힌다.
+    expect(labelBlock).toContain("flex: 0 6 auto;");
+    expect(labelBlock).toContain("max-width: min(34%, 15ch);");
+    expect(labelBlock).toContain("min-width: 0;");
+    expect(components).toMatch(/\.canvas-operation-group-name \{[^}]*text-overflow: ellipsis;/);
+
+    // 정체성 채널에는 애니메이션을 걸지 않는다. 포커스 색 전환만 두고, reduced-motion에서 단락한다.
+    expect(labelBlock).not.toMatch(/animation/);
+    const reducedMotion = components.slice(components.indexOf("@media (prefers-reduced-motion: reduce)"));
+    expect(reducedMotion).toContain(".canvas-operation-group-label,");
   });
 
   it("pins the AI Gateway capability-class badge grammar — ink rank, no signal colour, dashed for unclassed", () => {

--- a/runtime/fleet-console/tests/store-flatten-grouped-order.test.ts
+++ b/runtime/fleet-console/tests/store-flatten-grouped-order.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { flattenGroupedOrder } from "../core/client/src/store.js";
+import { flattenGroupedOrder, resolveOperationGroup } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 function makeOp(id: string, groupId: string | null = null, createdAt = 1): OperationNode {
@@ -113,5 +113,37 @@ describe("flattenGroupedOrder", () => {
     const groups = [makeGroup("g1", 1)];
     const result = flattenGroupedOrder(ops, groups, []);
     expect(result.map((o) => o.id)).toEqual(["op-a", "op-b"]);
+  });
+});
+
+describe("resolveOperationGroup", () => {
+  const groupById = (...groups: OperationGroup[]) => new Map(groups.map((group) => [group.id, group]));
+
+  it("같은 Theater의 그룹을 돌려준다", () => {
+    const group = makeGroup("g1", 1);
+    expect(resolveOperationGroup(makeOp("op-a", "g1"), groupById(group))).toBe(group);
+  });
+
+  it("groupId가 없으면 null이다", () => {
+    expect(resolveOperationGroup(makeOp("op-a", null), groupById(makeGroup("g1", 1)))).toBeNull();
+  });
+
+  it("존재하지 않는 groupId는 null이다", () => {
+    expect(resolveOperationGroup(makeOp("op-a", "missing"), groupById(makeGroup("g1", 1)))).toBeNull();
+  });
+
+  // 선별 무대는 활성 Theater 밖 Operation도 올린다. 판정 기준은 활성 Theater가 아니라
+  // Operation 자신의 Theater이므로, 외부 무대의 그룹은 그대로 살아 있어야 한다.
+  it("외부 Theater Operation도 자기 Theater 그룹이면 돌려준다", () => {
+    const foreignOp = { ...makeOp("op-far", "g-far"), theaterId: "t2" };
+    const foreignGroup = { ...makeGroup("g-far", 1), theaterId: "t2" };
+    expect(resolveOperationGroup(foreignOp, groupById(foreignGroup))).toBe(foreignGroup);
+  });
+
+  // 서버 PATCH는 groupId의 Theater 소속을 검사하지 않아 타 Theater 그룹이 붙을 수 있다.
+  // 사이드바는 그 조합을 미분류로 읽으므로 캡션도 같은 답을 내야 두 면이 서로를 부정하지 않는다.
+  it("Theater가 다른 그룹은 거부한다 — 사이드바의 미분류 판정과 같은 답", () => {
+    const crossTheaterGroup = { ...makeGroup("g-other", 1), theaterId: "t2" };
+    expect(resolveOperationGroup(makeOp("op-a", "g-other"), groupById(crossTheaterGroup))).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- 캔버스 패널 캡션 선두에 **그룹 도트 + 그룹 이름**을 표시합니다. 도트는 `--group-mark`(사이드바가 이미 쓰는 그룹 톤), 이름은 캡션에 이미 있는 중립 메타 티어(Formation 슬롯 번호와 같은 티어)를 씁니다. 색 채널은 도트 하나뿐 — 테두리·채움·그룹색 글자는 쓰지 않습니다. 미분류 Operation은 아무것도 렌더하지 않습니다.
- 패널 좌측의 `.canvas-operation-spine`(3px accent 띠)을 **제거**합니다. 정체성은 이제 캡션의 명판 마크와 워시로만 말하고, 패널 본문은 정체성 색을 지지 않습니다. 사이드바 칩의 3px accent 스파인은 레일 소속이라 그대로 둡니다.
- 라벨은 제목보다 먼저 양보합니다(`flex: 0 6 auto`, `max-width: min(34%, 15ch)`). 접근명에는 그룹 이름이 `Operation {title}{groupContext}` 형태로 실리고, 잘린 이름은 `title` 툴팁으로 복구됩니다.

### 배경

실측 결과 캔버스 패널은 그룹에 대해 **아무 신호도 내지 않았습니다**. 그룹은 사이드바 존 레일에만 있어 사이드바를 접거나 Tactical에서 작업하면 소속을 알 수 없었고, 좌측 띠는 그룹이 아니라 Operation 개인 accent를 날라 오히려 오독을 키웠습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console test` — 175 파일 / 2146 통과, 1 skipped
- [x] `npx tsc --noEmit -p runtime/fleet-console/tsconfig.json` — 오류 없음
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 19 fragment 검증 통과
- [x] 격리 콘솔 헤디드 실측(그룹 2개 · Operation 4개 시드)
  - [x] 그룹 도트가 그룹색으로 해석됨(cerulean `oklch(0.73 0.062 235)` / rose `oklch(0.73 0.06 350)`), 미분류는 무렌더
  - [x] 스파인 DOM 0개 — Cruise/Tactical 전 모드
  - [x] 포커스 티어 전환 `--text-tertiary(0.64)` → `--text-secondary(0.7)`
  - [x] `is-top-edge` 클리핑 캡션에서도 라벨 가시
  - [x] Whites 테마 — 라벨 `oklch(0.45 0.012 95)`(기존 `--text-tertiary`), 도트는 라이트 `--id-*`로 재조율
  - [x] 327px 타일 + 27자 그룹명 — 라벨이 45~71px로 먼저 양보, 제목 유지
  - [x] 브라우저 errors/rejections 0