### PR TITLE
feat(fleet-console): pin provider bands and open the effort gate in Quick Launch decks

### DIFF
--- a/.changelog.d/quick-launch-deck-refit.md
+++ b/.changelog.d/quick-launch-deck-refit.md
@@ -12,5 +12,5 @@ branch: quick-launch-deck-refit
   ko: 추론 강도 사다리가 쓸 수 있는 폭 전체로 벌어져, 나란히 놓고 비교하지 않아도 이웃한 단이 한눈에 갈립니다.
 
 #### Added
-- Quick Launch `/effort` ends with a gate row that reveals MAX and ULTRACODE, and omits that row for models whose ladder stops earlier, so the list tells a hidden tier apart from an unavailable one.
-  ko: Quick Launch `/effort` 맨 아래에 MAX·ULTRACODE를 여는 문 행이 서고, 사다리가 그보다 낮은 모델에서는 그 행이 서지 않습니다 — 숨은 단과 없는 단이 목록에서 갈립니다.
+- Quick Launch `/effort` ends with a gate row that names and reveals the gated tiers the chosen model actually offers, and omits that row for a model that gates none, so the list tells a hidden tier apart from an unavailable one.
+  ko: Quick Launch `/effort` 맨 아래에 고른 모델이 실제로 내놓는 게이트 단만 이름 붙여 여는 문 행이 서고, 게이트 단이 없는 모델에서는 그 행이 서지 않습니다 — 숨은 단과 없는 단이 목록에서 갈립니다.

--- a/.changelog.d/quick-launch-deck-refit.md
+++ b/.changelog.d/quick-launch-deck-refit.md
@@ -1,0 +1,16 @@
+---
+branch: quick-launch-deck-refit
+---
+
+### fleet-console
+#### Changed
+- Quick Launch `/model` pins each provider band to the top of the list while you scroll and indents model names under it, so a supplier is named once instead of on every row.
+  ko: Quick Launch `/model`에서 공급자 밴드가 스크롤 중에도 목록 위에 붙어 있고 모델 이름이 그 아래로 들여써져, 공급자를 행마다 되풀이하지 않고 한 번만 말합니다.
+- Quick Launch `/effort` paints each rung in the same tone ladder the effort track uses, with MAX and ULTRACODE carrying their own molten-copper and aurora treatments.
+  ko: Quick Launch `/effort`의 각 단이 강도 트랙과 같은 톤 사다리로 칠해지고, MAX와 ULTRACODE는 각자의 용융 구리·오로라 표현을 가집니다.
+- The reasoning-effort ladder spreads across its full available range, so neighbouring rungs read apart at a glance instead of only under direct comparison.
+  ko: 추론 강도 사다리가 쓸 수 있는 폭 전체로 벌어져, 나란히 놓고 비교하지 않아도 이웃한 단이 한눈에 갈립니다.
+
+#### Added
+- Quick Launch `/effort` ends with a gate row that reveals MAX and ULTRACODE, and omits that row for models whose ladder stops earlier, so the list tells a hidden tier apart from an unavailable one.
+  ko: Quick Launch `/effort` 맨 아래에 MAX·ULTRACODE를 여는 문 행이 서고, 사다리가 그보다 낮은 모델에서는 그 행이 서지 않습니다 — 숨은 단과 없는 단이 목록에서 갈립니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -5,7 +5,7 @@ import { FEATURE_TOUR_BOUNDARY_ATTRIBUTE, FEATURE_TOUR_LAYER_SELECTOR } from "..
 import { getGlobalSettingsStoreState, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { useT } from "../i18n/index.js";
 import { resolveLaunchKindAnnotation } from "../launch-kind-annotations.js";
-import { EffortGaugeGlyph, EffortTrack, effortLadderPosition } from "../components/effort-track.js";
+import { EffortGaugeGlyph, EffortTrack, effortLadderPosition, gatedEffortNames } from "../components/effort-track.js";
 import { appendSeenFeatureTour, EFFORT_CONFIRM_TIP_SEEN_KEY } from "../components/feature-tour.js";
 import { launchEtcGlyph, launchProviderFromGroupId, launchProviderGlyph } from "../components/launch-provider-glyphs.js";
 
@@ -800,8 +800,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
-              apexToggleLabel={t("launchVariants.effort.apexToggle")}
-              apexCollapseLabel={t("launchVariants.effort.apexCollapse")}
+              apexToggleLabel={t("launchVariants.effort.apexToggle", { tiers: gatedEffortNames(effortTargetRow) })}
+              apexCollapseLabel={t("launchVariants.effort.apexCollapse", { tiers: gatedEffortNames(effortTargetRow) })}
             />
             {showEffortConfirmTip ? (
               <p className="operation-launch-effort-confirm-tip" role="status">

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -390,6 +390,20 @@ export function effortLadderPosition(row: OperationLaunchVariantRow, effort: str
   return { rung: effort === null ? 0 : rungs.indexOf(effort) + 1, total: rungs.length };
 }
 
+/**
+ * 게이트가 실제로 열 수 있는 단들의 이름. 문구가 열리지 않는 단을 약속하지 않게 한다 —
+ * max만 내놓는 모델(Codex Luna 계열·Cursor Opus 5 계열·Kimi K3 등)에서 "MAX·ULTRACODE"라고
+ * 말하면 열었을 때 한 단만 서고, 나머지 하나는 어디 갔는지 물을 자리가 없다.
+ * 축에만 오른 단은 세지 않는다 — chips에 실린 것만 실제로 고를 수 있다.
+ */
+export function gatedEffortNames(row: OperationLaunchVariantRow | null): string {
+  const gated = new Set(row?.gatedEfforts ?? []);
+  return (row?.chips ?? [])
+    .filter((chip) => gated.has(chip.id))
+    .map((chip) => chip.label)
+    .join("·");
+}
+
 /** 기억해 둔 강도가 이 모델 사다리에 없으면 비운 상태로 떨어진다. */
 export function resolveRowEffort(row: OperationLaunchVariantRow | null, effort: string | null): string | null {
   if (!row || effort === null) return null;

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -391,16 +391,22 @@ export function effortLadderPosition(row: OperationLaunchVariantRow, effort: str
 }
 
 /**
- * 게이트가 실제로 열 수 있는 단들의 이름. 문구가 열리지 않는 단을 약속하지 않게 한다 —
- * max만 내놓는 모델(Codex Luna 계열·Cursor Opus 5 계열·Kimi K3 등)에서 "MAX·ULTRACODE"라고
- * 말하면 열었을 때 한 단만 서고, 나머지 하나는 어디 갔는지 물을 자리가 없다.
- * 축에만 오른 단은 세지 않는다 — chips에 실린 것만 실제로 고를 수 있다.
+ * 게이트가 여는 단들의 이름. 문구가 열리지 않는 단을 약속하지 않게 한다 — max만 내놓는
+ * 모델(Codex Luna 계열·Cursor Opus 5 계열·Kimi K3 등)에서 "MAX·ULTRACODE"라고 말하면 열었을 때
+ * 한 단만 서고, 나머지 하나는 어디 갔는지 물을 자리가 없다.
+ *
+ * 기준은 트랙이 문을 세우는 기준과 같은 **사다리**다. chips만 세면, 축에만 오른 게이트 단을
+ * 실은 카탈로그 행(SDK가 그 형태를 보존한다)에서 토글은 서는데 이름이 빈 문자열이 되어
+ * "Show " 같은 빈 aria-label이 남는다. 이름 없는 단은 트랙이 스톱 라벨에 쓰는 것과 같은
+ * 폴백(id 대문자)으로 채운다.
  */
 export function gatedEffortNames(row: OperationLaunchVariantRow | null): string {
-  const gated = new Set(row?.gatedEfforts ?? []);
-  return (row?.chips ?? [])
-    .filter((chip) => gated.has(chip.id))
-    .map((chip) => chip.label)
+  if (!row) return "";
+  const gated = new Set(row.gatedEfforts ?? []);
+  const byId = new Map((row.chips ?? []).map((chip) => [chip.id, chip.label]));
+  return ladderRungs(row)
+    .filter((id) => gated.has(id))
+    .map((id) => byId.get(id) ?? id.toUpperCase())
     .join("·");
 }
 

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -17,7 +17,7 @@ import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { isTriageActive } from "../canvas/triage-store.js";
 import { clearQuickLaunchRejection, closeQuickLaunch, consumeQuickLaunchDraft, consumeQuickLaunchMentionSeed, getState, isQuickLaunchDocked, preserveQuickLaunchDraft, requestQuickLaunch, setActiveTheater, setQuickLaunchDockSuppressed, setQuickLaunchPinned } from "../store.js";
 import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph, type LaunchProviderGlyphId } from "./launch-provider-glyphs.js";
-import { EffortTrack, resolveRowEffort } from "./effort-track.js";
+import { EffortTrack, gatedEffortNames, resolveRowEffort } from "./effort-track.js";
 
 // 카드 폭은 팔레트(920px)보다 좁다 — 팔레트는 결과 목록을 담고, 여기는 한 문단을 담는다.
 const CARD_WIDTH_FALLBACK = 760;
@@ -755,9 +755,10 @@ export function QuickLaunch() {
     // 트랙이 그 자리에 남아 있는 것과 같다. 게이트 단을 하나도 내놓지 않는 모델에서는 서지 않아,
     // "이 모델엔 없다"가 "접혀 있다"와 처음으로 갈린다.
     if (deck.showGateRow) {
+      const tiers = gatedEffortNames(selectedRow);
       rows.push({
         id: "effort-gate",
-        label: t(deck.gateOpen ? "launchVariants.effort.apexCollapse" : "launchVariants.effort.apexToggle"),
+        label: t(deck.gateOpen ? "launchVariants.effort.apexCollapse" : "launchVariants.effort.apexToggle", { tiers }),
         lead: <span className="quick-launch-command-gate-glyph" aria-hidden="true">{deck.gateOpen ? "‹" : "✦"}</span>,
         gate: true,
         pick: () => {
@@ -1407,9 +1408,10 @@ export function QuickLaunch() {
                       className={`quick-launch-mention-row quick-launch-command-row${active ? " is-active" : ""}${row.gate ? " is-gate" : ""}`}
                       role="option"
                       aria-selected={active}
-                      // 문 행은 값을 고르는 자리가 아니라 목록을 여닫는 자리다 — 스크린리더에도
-                      // 그 상태로 말한다(트랙 ✦ 토글의 aria-expanded와 같은 계약).
-                      aria-expanded={row.gate ? commandGateOpen : undefined}
+                      // 문 행에 aria-expanded를 달지 않는다 — option role이 지원하는 상태가 아니라
+                      // 무시되거나 무효로 읽힌다. 여는지 접는지는 라벨 자체가 말한다("… 펼치기" ↔
+                      // "… 접기"). 이 행을 listbox 밖으로 빼면 유효한 토글 role을 쓸 수 있지만,
+                      // aria-activedescendant 순회에서 빠져 키보드 문법이 값 행과 갈라진다.
                       tabIndex={-1}
                       data-effort-level={row.effortLevel}
                       data-apex={row.apex ? true : undefined}
@@ -1603,8 +1605,8 @@ export function QuickLaunch() {
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
-              apexToggleLabel={t("launchVariants.effort.apexToggle")}
-              apexCollapseLabel={t("launchVariants.effort.apexCollapse")}
+              apexToggleLabel={t("launchVariants.effort.apexToggle", { tiers: gatedEffortNames(selectedRow) })}
+              apexCollapseLabel={t("launchVariants.effort.apexCollapse", { tiers: gatedEffortNames(selectedRow) })}
               className="quick-launch-effort-track"
             />
           ) : null}

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -758,10 +758,14 @@ export function QuickLaunch() {
     // 트랙이 그 자리에 남아 있는 것과 같다. 게이트 단을 하나도 내놓지 않는 모델에서는 서지 않아,
     // "이 모델엔 없다"가 "접혀 있다"와 처음으로 갈린다.
     if (deck.showGateRow) {
-      const tiers = gatedEffortNames(selectedRow);
+      // 이름은 이 덱이 실제로 열 단에서만 나온다(deck.gatedNames). 트랙의 사다리 기준을 빌려 오면
+      // 축에만 오른 단까지 이름에 실려, 열었을 때 없는 단을 약속하게 된다.
       rows.push({
         id: "effort-gate",
-        label: t(deck.gateOpen ? "launchVariants.effort.apexCollapse" : "launchVariants.effort.apexToggle", { tiers }),
+        label: t(
+          deck.gateOpen ? "launchVariants.effort.apexCollapse" : "launchVariants.effort.apexToggle",
+          { tiers: deck.gatedNames },
+        ),
         lead: <span className="quick-launch-command-gate-glyph" aria-hidden="true">{deck.gateOpen ? "‹" : "✦"}</span>,
         gate: true,
         pick: () => {

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -616,10 +616,13 @@ export function QuickLaunch() {
   // 게이트는 이 덱을 보는 동안만 열려 있다. `/effort` 값 레벨을 떠나면(명령 목록으로 돌아가든,
   // 다른 커맨드로 가든, 덱을 닫든) 접힌 상태로 복귀한다 — 트랙이 apex 아닌 단으로 내려오면
   // 스스로 접히는 것과 같은 계약이고, 다음 방문이 열린 채로 시작하는 놀라움을 없앤다.
+  // 컴포저가 닫히는 것도 떠나는 것이다: 컴포넌트는 언마운트되지 않고 렌더만 접으므로(`if (!open)
+  // return null`), 문면이 `/effort `인 채 보존된 초안으로 돌아오면 commandInput이 그대로라
+  // open을 조건에 넣지 않으면 게이트가 펼쳐진 채 되살아난다.
   useEffect(() => {
-    if (commandInput?.kind === "values" && commandInput.command === "effort") return;
+    if (open && commandInput?.kind === "values" && commandInput.command === "effort") return;
     setCommandGateOpen(false);
-  }, [commandInput]);
+  }, [commandInput, open]);
 
   // '/' 커맨드 덱의 목록. 문면이 레벨을 소유하므로(commandInput.kind) 여기는 그 레벨의 행만
   // 계산한다. 값 레벨은 기존 픽커·트랙과 같은 원천(theaters·카탈로그 groups·chips)과 같은

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -736,13 +736,9 @@ export function QuickLaunch() {
       return rows.length === 0 ? [] : [{ key: "views", band: null, rows }];
     }
     // 게이트된 apex 단은 트랙의 ✦ 계약을 미러링한다 — 덱에서는 맨 아래 문 행이 그 토글이다.
-    const deck = buildQuickLaunchEffortDeck(
-      selectedRow,
-      effort,
-      t("launchVariants.effort.auto"),
-      commandInput.query,
-      commandGateOpen,
-    );
+    const effortQuery = commandInput.query;
+    const autoLabel = t("launchVariants.effort.auto");
+    const deck = buildQuickLaunchEffortDeck(selectedRow, effort, autoLabel, effortQuery, commandGateOpen);
     const rows = deck.options.map<QuickLaunchCommandRow>((chip) => ({
       id: `effort-${chip.id ?? "auto"}`,
       label: chip.label,
@@ -758,13 +754,23 @@ export function QuickLaunch() {
     // 문 행은 값이 아니라 문이다. 골라도 덱은 열려 있고 문면도 그대로 — 트랙의 ✦을 눌렀을 때
     // 트랙이 그 자리에 남아 있는 것과 같다. 게이트 단을 하나도 내놓지 않는 모델에서는 서지 않아,
     // "이 모델엔 없다"가 "접혀 있다"와 처음으로 갈린다.
-    if (deck.hasGate && !deck.gateHeldByValue) {
+    if (deck.showGateRow) {
       rows.push({
         id: "effort-gate",
         label: t(deck.gateOpen ? "launchVariants.effort.apexCollapse" : "launchVariants.effort.apexToggle"),
         lead: <span className="quick-launch-command-gate-glyph" aria-hidden="true">{deck.gateOpen ? "‹" : "✦"}</span>,
         gate: true,
-        pick: () => setCommandGateOpen(!deck.gateOpen),
+        pick: () => {
+          const nextOpen = !deck.gateOpen;
+          // 문 행은 늘 목록의 마지막이다. 게이트를 열면 단 둘이 그 앞에 끼어드는데 활성 인덱스를
+          // 그대로 두면 같은 자리가 MAX를 가리켜, 접으려고 누른 두 번째 Enter가 MAX를 확정하고
+          // 저장까지 한다 — 게이트가 막으려던 바로 그 실수다. 다음 목록에서 문 행이 설 자리로
+          // 옮겨 둔다(값 행 뒤가 언제나 그 자리다).
+          setCommandActiveIndex(
+            buildQuickLaunchEffortDeck(selectedRow, effort, autoLabel, effortQuery, nextOpen).options.length,
+          );
+          setCommandGateOpen(nextOpen);
+        },
       });
     }
     return rows.length === 0 ? [] : [{ key: "efforts", band: null, rows }];

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -9,7 +9,7 @@ import { useT } from "../i18n/index.js";
 import type { OperationSearchEntry } from "../operation-search.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { readQuickLaunchSelection, writeQuickLaunchMentionFocused, writeQuickLaunchModelEffort, writeQuickLaunchSelection, writeQuickLaunchStartView, writeQuickLaunchTheater, type QuickLaunchStartView } from "../quick-launch-preferences.js";
-import { buildQuickLaunchEffortOptions, buildQuickLaunchMentionGroups, findVariantLaunchKind, isMentionSelectable, isQuickLaunchAttachmentCandidate, isUltracodeDisarmCaret, nextUltracodeIgnored, QUICK_LAUNCH_ATTACHMENT_MAX_BYTES, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_MAX_ATTACHMENTS, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchAttachmentErrorMessageKey, quickLaunchErrorMessageKey, quickLaunchMentionErrorMessageKey, readCommandInput, readMentionToken, readUltracodeTokens, resolveFocusedMention, resolveMentionEntry, resolveSelection, shouldApplyFocusedMention, stripMentionToken, type QuickLaunchCommandInput, type QuickLaunchMentionToken, type UltracodeToken } from "../quick-launch.js";
+import { buildQuickLaunchEffortDeck, buildQuickLaunchMentionGroups, findVariantLaunchKind, isMentionSelectable, isQuickLaunchAttachmentCandidate, isUltracodeDisarmCaret, nextUltracodeIgnored, QUICK_LAUNCH_ATTACHMENT_MAX_BYTES, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_MAX_ATTACHMENTS, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchAttachmentErrorMessageKey, quickLaunchErrorMessageKey, quickLaunchMentionErrorMessageKey, readCommandInput, readMentionToken, readUltracodeTokens, resolveFocusedMention, resolveMentionEntry, resolveSelection, shouldApplyFocusedMention, stripMentionToken, type QuickLaunchCommandInput, type QuickLaunchMentionToken, type UltracodeToken } from "../quick-launch.js";
 import { FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
 import { formatShortcutCombo, QUICK_LAUNCH_TOGGLE_COMBOS } from "../shortcuts-catalog.js";
 import type { QuickLaunchDraftAttachment } from "../types.js";
@@ -58,6 +58,12 @@ interface QuickLaunchCommandRow {
   readonly value?: string;
   /** 1레벨 명령 행의 타이핑 별칭(`/theater`) — 오른쪽 끝에서 문법을 가르친다. */
   readonly token?: string;
+  /** 강도 행의 단계 톤 좌표. CSS가 이 속성 하나로 색을 읽는다(트랙과 같은 계약). */
+  readonly effortLevel?: string;
+  /** 게이트 뒤 티어인가 — MAX의 이글거림을 트랙과 같은 조건으로 가른다. */
+  readonly apex?: boolean;
+  /** 값이 아니라 게이트를 여닫는 행. 선택해도 덱이 닫히지 않는다. */
+  readonly gate?: boolean;
   readonly pick: () => void;
 }
 
@@ -146,6 +152,9 @@ export function QuickLaunch() {
   // 결과와 키보드 활성 행만 산다. '@' 덱과는 한 번에 하나만 선다(updatePrompt가 강제).
   const [commandInput, setCommandInput] = useState<QuickLaunchCommandInput | null>(null);
   const [commandActiveIndex, setCommandActiveIndex] = useState(0);
+  // `/effort` 게이트의 열림. 트랙의 ✦ 토글과 같은 자리를 덱에서는 문 행이 맡는다. 덱을 떠나면
+  // 접힌 상태로 돌아간다 — 게이트는 "이번에 열었다"이지 기억되는 설정이 아니다(트랙도 그렇다).
+  const [commandGateOpen, setCommandGateOpen] = useState(false);
   // 이미지 첨부: 붙여넣기·드롭 즉시 업로드가 시작되고, 칩은 업로드가 끝나야 발사 가능해진다.
   const [attachments, setAttachments] = useState<readonly ComposerAttachment[]>([]);
   const [attachmentErrorKey, setAttachmentErrorKey] = useState<string | null>(null);
@@ -604,6 +613,14 @@ export function QuickLaunch() {
     }
   }, []);
 
+  // 게이트는 이 덱을 보는 동안만 열려 있다. `/effort` 값 레벨을 떠나면(명령 목록으로 돌아가든,
+  // 다른 커맨드로 가든, 덱을 닫든) 접힌 상태로 복귀한다 — 트랙이 apex 아닌 단으로 내려오면
+  // 스스로 접히는 것과 같은 계약이고, 다음 방문이 열린 채로 시작하는 놀라움을 없앤다.
+  useEffect(() => {
+    if (commandInput?.kind === "values" && commandInput.command === "effort") return;
+    setCommandGateOpen(false);
+  }, [commandInput]);
+
   // '/' 커맨드 덱의 목록. 문면이 레벨을 소유하므로(commandInput.kind) 여기는 그 레벨의 행만
   // 계산한다. 값 레벨은 기존 픽커·트랙과 같은 원천(theaters·카탈로그 groups·chips)과 같은
   // 저장 계층(고르면 즉시 기억)을 쓴다 — 커맨드는 지름길이지 두 번째 진실이 아니다.
@@ -672,17 +689,12 @@ export function QuickLaunch() {
               .filter((row) => row.label.toLowerCase().includes(query))
               .map<QuickLaunchCommandRow>((row) => {
                 const rowModel = row.launch.model ?? null;
-                // 밴드가 프로바이더를 말하지 못하는 그룹에서도 행은 자기 공급자 마크를 단다 —
-                // 필터로 밴드가 성기어질수록 행 스스로 출처를 말해야 한다.
-                const rowProvider = provider ?? launchProviderFromModelId(rowModel ?? row.id);
+                // 행은 공급자 마크를 달지 않는다. 섹션은 행이 남을 때만 렌더되므로(아래 filter)
+                // 밴드 없는 행은 존재할 수 없고, 밴드가 스크롤을 따라 붙어 있어(CSS sticky)
+                // 좁힌 목록에서도 출처가 사라지지 않는다 — 행 마크는 순전한 중복이었다.
                 return {
                   id: `model-${row.id}`,
                   label: row.label,
-                  lead: rowProvider === null ? null : (
-                    <span className={`quick-launch-kind-icon is-${rowProvider}`} aria-hidden="true">
-                      {launchProviderGlyph(rowProvider)}
-                    </span>
-                  ),
                   starred: row.starred === true,
                   checked: rowModel === model,
                   pick: () => {
@@ -723,20 +735,40 @@ export function QuickLaunch() {
         }));
       return rows.length === 0 ? [] : [{ key: "views", band: null, rows }];
     }
-    // 게이트된 apex 단은 트랙의 ✦ 펼침 계약을 미러링해 명시적 타이핑으로만 드러난다(헬퍼 주석 참조).
-    const rows = buildQuickLaunchEffortOptions(selectedRow, effort, t("launchVariants.effort.auto"), commandInput.query)
-      .map<QuickLaunchCommandRow>((chip) => ({
-        id: `effort-${chip.id ?? "auto"}`,
-        label: chip.label,
-        checked: chip.checked,
-        pick: () => {
-          setEffort(chip.id);
-          writeQuickLaunchModelEffort(model, chip.id);
-          finishCommand();
-        },
-      }));
+    // 게이트된 apex 단은 트랙의 ✦ 계약을 미러링한다 — 덱에서는 맨 아래 문 행이 그 토글이다.
+    const deck = buildQuickLaunchEffortDeck(
+      selectedRow,
+      effort,
+      t("launchVariants.effort.auto"),
+      commandInput.query,
+      commandGateOpen,
+    );
+    const rows = deck.options.map<QuickLaunchCommandRow>((chip) => ({
+      id: `effort-${chip.id ?? "auto"}`,
+      label: chip.label,
+      checked: chip.checked,
+      effortLevel: chip.id ?? "auto",
+      apex: chip.apex,
+      pick: () => {
+        setEffort(chip.id);
+        writeQuickLaunchModelEffort(model, chip.id);
+        finishCommand();
+      },
+    }));
+    // 문 행은 값이 아니라 문이다. 골라도 덱은 열려 있고 문면도 그대로 — 트랙의 ✦을 눌렀을 때
+    // 트랙이 그 자리에 남아 있는 것과 같다. 게이트 단을 하나도 내놓지 않는 모델에서는 서지 않아,
+    // "이 모델엔 없다"가 "접혀 있다"와 처음으로 갈린다.
+    if (deck.hasGate && !deck.gateHeldByValue) {
+      rows.push({
+        id: "effort-gate",
+        label: t(deck.gateOpen ? "launchVariants.effort.apexCollapse" : "launchVariants.effort.apexToggle"),
+        lead: <span className="quick-launch-command-gate-glyph" aria-hidden="true">{deck.gateOpen ? "‹" : "✦"}</span>,
+        gate: true,
+        pick: () => setCommandGateOpen(!deck.gateOpen),
+      });
+    }
     return rows.length === 0 ? [] : [{ key: "efforts", band: null, rows }];
-  }, [activeTheater, applyCommandPrompt, chatStart, chatStartAvailable, commandInput, dockSuppressed, effort, expandAndFocus, finishCommand, groups, model, pinned, selectedRow, t, theaterId, theaters]);
+  }, [activeTheater, applyCommandPrompt, chatStart, chatStartAvailable, commandGateOpen, commandInput, dockSuppressed, effort, expandAndFocus, finishCommand, groups, model, pinned, selectedRow, t, theaterId, theaters]);
 
   const commandRowsFlat = useMemo(() => commandSections.flatMap((section) => section.rows), [commandSections]);
   const commandDeckOpen = commandInput !== null;
@@ -1346,7 +1378,9 @@ export function QuickLaunch() {
             {commandRowsFlat.length === 0 ? (
               <p className="quick-launch-mention-empty">{t("chrome.quickLaunch.commandNoMatch")}</p>
             ) : commandSections.map((section) => (
-              <div key={section.key}>
+              // 밴드가 선 섹션의 행은 밴드 라벨 자리까지 들여쓴다(CSS). 행이 밴드보다 바깥에서
+              // 시작하면 항목이 자기 머리글보다 앞에 서서 소속이 역전돼 읽힌다.
+              <div key={section.key} className={section.band ? "quick-launch-command-group is-banded" : "quick-launch-command-group"}>
                 {section.band ? (
                   <p className={`quick-launch-pop-band${section.band.provider ? ` is-${section.band.provider}` : ""}`}>
                     {section.band.provider ? (
@@ -1364,10 +1398,15 @@ export function QuickLaunch() {
                       key={row.id}
                       id={`quick-launch-command-${row.id}`}
                       type="button"
-                      className={`quick-launch-mention-row quick-launch-command-row${active ? " is-active" : ""}`}
+                      className={`quick-launch-mention-row quick-launch-command-row${active ? " is-active" : ""}${row.gate ? " is-gate" : ""}`}
                       role="option"
                       aria-selected={active}
+                      // 문 행은 값을 고르는 자리가 아니라 목록을 여닫는 자리다 — 스크린리더에도
+                      // 그 상태로 말한다(트랙 ✦ 토글의 aria-expanded와 같은 계약).
+                      aria-expanded={row.gate ? commandGateOpen : undefined}
                       tabIndex={-1}
+                      data-effort-level={row.effortLevel}
+                      data-apex={row.apex ? true : undefined}
                       // 클릭이 textarea 포커스를 뺏지 않아야 선택 직후 바로 타이핑이 이어진다.
                       onMouseDown={(event) => event.preventDefault()}
                       onClick={row.pick}

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -79,8 +79,8 @@ export const commonEn = {
   "launchVariants.effort.track": "Reasoning effort",
   "launchVariants.effort.auto": "AUTO",
   "launchVariants.effort.autoValue": "Automatic — the model's own default",
-  "launchVariants.effort.apexToggle": "Show Max and Ultracode",
-  "launchVariants.effort.apexCollapse": "Hide Max and Ultracode",
+  "launchVariants.effort.apexToggle": "Show {tiers}",
+  "launchVariants.effort.apexCollapse": "Hide {tiers}",
   "launchVariants.effort.confirmTip": "Press the knob again to launch.",
 } as const;
 
@@ -164,7 +164,7 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchVariants.effort.track": "추론 강도",
   "launchVariants.effort.auto": "자동",
   "launchVariants.effort.autoValue": "자동 — 모델 자체 기본값",
-  "launchVariants.effort.apexToggle": "MAX·ULTRACODE 펼치기",
-  "launchVariants.effort.apexCollapse": "MAX·ULTRACODE 접기",
+  "launchVariants.effort.apexToggle": "{tiers} 펼치기",
+  "launchVariants.effort.apexCollapse": "{tiers} 접기",
   "launchVariants.effort.confirmTip": "노브를 다시 누르면 실행됩니다.",
 };

--- a/runtime/fleet-console/core/client/src/quick-launch.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch.ts
@@ -233,25 +233,53 @@ export interface QuickLaunchEffortOption {
   readonly id: string | null;
   readonly label: string;
   readonly checked: boolean;
+  /**
+   * 게이트 뒤 티어인가. 색 채널을 가르는 데 쓴다 — 트랙과 같은 계약으로, 게이트 없는 모델의
+   * 최고 단(max)은 같은 단 이름이라도 이글거리지 않고 정적 글로우에 머문다.
+   */
+  readonly apex: boolean;
+}
+
+export interface QuickLaunchEffortDeck {
+  readonly options: readonly QuickLaunchEffortOption[];
+  /** 이 모델이 게이트 뒤 티어를 내놓는가 — 문 행을 세울지 가른다. */
+  readonly hasGate: boolean;
+  /** 게이트가 열려 있는가. 열려 있으면 문 행은 접힘 행이 된다. */
+  readonly gateOpen: boolean;
+  /**
+   * 지금 고른 값 자체가 게이트 단이라 게이트가 닫힐 수 없는 상태. 이때 문 행은 서지 않는다 —
+   * 접어도 접히지 않는 컨트롤이 되고, 트랙처럼 "접으면 일상 단으로 내려" 해결하면 접힘 클릭이
+   * 실행 강도를 조용히 바꾸는 부작용이 된다(트랙은 손잡이가 눈앞에서 움직여 그 대가를 보여준다).
+   */
+  readonly gateHeldByValue: boolean;
 }
 
 /**
  * `/effort` 값 목록. EffortTrack의 apex 게이트를 미러링한다 — 게이트된 단(MAX·ULTRACODE)은
- * 기본 목록에 서지 않고, 그 단의 이름을 앞에서부터 명시적으로 타이핑했을 때만 나타난다(트랙의
- * ✦ 펼침에 상응하는 명시 동작). 현재 값이 이미 게이트된 단이면 트랙이 게이트를 열어 두는 것과
- * 같이 전부 보인다. includes가 아니라 startsWith로 가르는 이유: "l" 같은 우연한 부분 일치가
- * 고비용 단을 조용히 드러내면 게이트가 없는 것과 같다.
+ * 기본 목록에 서지 않고, 덱 맨 아래 문 행(트랙의 ✦ 토글에 상응)을 열거나 그 단의 이름을
+ * 앞에서부터 명시적으로 타이핑했을 때만 나타난다. 현재 값이 이미 게이트된 단이면 트랙이
+ * 게이트를 열어 두는 것과 같이 전부 보인다. 타이핑 경로를 includes가 아니라 startsWith로
+ * 가르는 이유: "l" 같은 우연한 부분 일치가 고비용 단을 조용히 드러내면 게이트가 없는 것과 같다.
+ *
+ * 문 행은 트랙의 ✦이 없는 모델에서 서지 않는다 — 그래야 "이 모델엔 그 단이 없다"와
+ * "있는데 접혀 있다"가 처음으로 갈린다. 두 상태가 같은 5행으로 보이던 것이 이 덱의 결함이었다.
  */
-export function buildQuickLaunchEffortOptions(
+export function buildQuickLaunchEffortDeck(
   row: OperationLaunchVariantRow | null,
   effort: string | null,
   autoLabel: string,
   query: string,
-): readonly QuickLaunchEffortOption[] {
+  opened: boolean,
+): QuickLaunchEffortDeck {
   const trimmed = query.trim().toLowerCase();
   const gated = new Set(row?.gatedEfforts ?? []);
-  const gateOpen = effort !== null && gated.has(effort);
-  return [
+  // 모델이 축에만 올리고 실제로 내놓지 않은 게이트 단은 문을 열어도 고를 것이 없다 —
+  // chips에 실린 것만 게이트가 있다고 센다(트랙의 ✦ 출현 조건과 같다).
+  const offeredGated = (row?.chips ?? []).filter((chip) => gated.has(chip.id));
+  const hasGate = offeredGated.length > 0;
+  const gateHeldByValue = hasGate && effort !== null && gated.has(effort);
+  const gateOpen = hasGate && (opened || gateHeldByValue);
+  const options = [
     { id: null as string | null, label: autoLabel },
     ...(row?.chips ?? []).map((chip) => ({ id: chip.id as string | null, label: chip.label })),
   ]
@@ -263,7 +291,13 @@ export function buildQuickLaunchEffortOptions(
       if (gateOpen) return true;
       return trimmed.length > 0 && (label.startsWith(trimmed) || id.startsWith(trimmed));
     })
-    .map((chip) => ({ id: chip.id, label: chip.label, checked: chip.id === effort }));
+    .map((chip) => ({
+      id: chip.id,
+      label: chip.label,
+      checked: chip.id === effort,
+      apex: chip.id !== null && gated.has(chip.id),
+    }));
+  return { options, hasGate, gateOpen, gateHeldByValue };
 }
 
 /**

--- a/runtime/fleet-console/core/client/src/quick-launch.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch.ts
@@ -252,6 +252,13 @@ export interface QuickLaunchEffortDeck {
    * 실행 강도를 조용히 바꾸는 부작용이 된다(트랙은 손잡이가 눈앞에서 움직여 그 대가를 보여준다).
    */
   readonly gateHeldByValue: boolean;
+  /**
+   * 문 행을 세울지. 질의를 치는 동안에는 서지 않는다 — 문 행이 남으면 매치 0인 질의에서도 덱이
+   * 비지 않아, "일치 없으면 Enter는 문장을 그대로 보낸다"는 커맨드 덱 공통 계약이 이 레벨에서만
+   * 깨진다(`/effort zebra`가 제출 대신 게이트를 여닫는다). 질의 중에는 접두 타이핑 게이트가
+   * 이미 같은 문을 맡고 있고, 좁힌 목록 위의 "펼치기"는 필터와도 모순된다.
+   */
+  readonly showGateRow: boolean;
 }
 
 /**
@@ -297,7 +304,13 @@ export function buildQuickLaunchEffortDeck(
       checked: chip.id === effort,
       apex: chip.id !== null && gated.has(chip.id),
     }));
-  return { options, hasGate, gateOpen, gateHeldByValue };
+  return {
+    options,
+    hasGate,
+    gateOpen,
+    gateHeldByValue,
+    showGateRow: hasGate && !gateHeldByValue && trimmed.length === 0,
+  };
 }
 
 /**

--- a/runtime/fleet-console/core/client/src/quick-launch.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch.ts
@@ -259,6 +259,13 @@ export interface QuickLaunchEffortDeck {
    * 이미 같은 문을 맡고 있고, 좁힌 목록 위의 "펼치기"는 필터와도 모순된다.
    */
   readonly showGateRow: boolean;
+  /**
+   * 문 행이 말할 단들의 이름. 문 행을 세우는 판정(`hasGate`)과 **같은 원천**에서 나온다 —
+   * 이 덱은 chips에 실린 단만 행으로 내므로, 축에만 오른 단까지 세는 트랙의 사다리 기준을
+   * 빌려 오면 열리지 않는 단을 이름에 싣는다. 두 표면은 여는 것이 서로 다르고, 그래서 이름도
+   * 각자 자기가 열 것에서 뽑는다(트랙 쪽은 `gatedEffortNames`).
+   */
+  readonly gatedNames: string;
 }
 
 /**
@@ -310,6 +317,7 @@ export function buildQuickLaunchEffortDeck(
     gateOpen,
     gateHeldByValue,
     showGateRow: hasGate && !gateHeldByValue && trimmed.length === 0,
+    gatedNames: offeredGated.map((chip) => chip.label).join("·"),
   };
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8029,13 +8029,19 @@ body[data-side-bar-animating="true"] .canvas-operation {
    채도가 0에 가까워도 hue를 하나 들고 있어(다크 3종은 245~250) oklch로 섞으면 중간 단이 그 hue와
    brass(78) 사이 호를 따라간다 — instrument의 medium이 초록(174), carbon의 high가 붉은색(0)으로
    서서, 상태 채널인 positive·coral을 강도 라벨이 흉내 내게 된다. oklab은 직선으로 섞어 hue를
-   brass 쪽에 두고 채도만 떨어뜨린다. */
+   brass 쪽에 두고 채도만 떨어뜨린다.
+
+   간격은 램프가 쓸 수 있는 구간 전체를 쓴다. 예전 20/42/64/84는 양 끝을 안쪽으로 접어 두어
+   가용 폭의 3분의 2만 썼고, 한 번에 한 값만 보이는 트랙에서는 단이 바뀌어도 색이 바뀌지 않는
+   것처럼 읽혔다(instrument 실측 L 0.672→0.774). 최고 일상 단을 brass 그 자체에 두고 최저 단만
+   하한에서 살짝 띄우면 같은 채널 안에서 폭이 L 0.656→0.800으로 넓어진다. 더 벌릴 곳은 없다 —
+   위로는 warn(hue 90)과 crest(48)가, 아래로는 판독 하한이 구간을 닫는다. */
 [data-effort-level] { --effort-tone: var(--text-secondary); }
 [data-effort-level="auto"] { --effort-tone: var(--text-tertiary); }
-[data-effort-level="low"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 20%, var(--text-tertiary)); }
-[data-effort-level="medium"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 42%, var(--text-tertiary)); }
-[data-effort-level="high"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 64%, var(--text-tertiary)); }
-[data-effort-level="xhigh"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 84%, var(--text-tertiary)); }
+[data-effort-level="low"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 10%, var(--text-tertiary)); }
+[data-effort-level="medium"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 40%, var(--text-tertiary)); }
+[data-effort-level="high"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 70%, var(--text-tertiary)); }
+[data-effort-level="xhigh"] { --effort-tone: var(--brass-ink); }
 [data-effort-level="max"] { --effort-tone: var(--crest-ink); }
 [data-effort-level="ultra"] { --effort-tone: var(--apex-ink); }
 
@@ -12744,6 +12750,138 @@ body[data-codex-reading="true"] .operations-side-bar {
 
 .quick-launch-command-row.is-active .quick-launch-command-token {
   color: var(--brass);
+}
+
+/* 프로바이더 밴드는 이 덱에서만 스크롤을 따라 붙는다. 덱은 340px에서 스크롤을 시작하는데
+   6모델 선별이면 내용이 480px에 이르러, 붙지 않으면 밴드가 시야 밖으로 나간 채 모델 이름만
+   남는다 — 그 공백을 행마다 반복된 공급자 마크가 메우고 있었다. 밴드를 고정하면 마크는
+   순수한 중복이 되어 걷어낼 수 있다. 배경은 덱의 것을 다시 칠한다(투명이면 행이 밑으로 비친다). */
+.quick-launch-command-deck .quick-launch-pop-band {
+  position: sticky;
+  /* 덱 패딩(--space-1)만큼 위로 물려 스크롤 상단에 빈틈이 생기지 않게 한다. */
+  top: calc(var(--space-1) * -1);
+  z-index: 1;
+  background:
+    linear-gradient(
+      color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar)),
+      color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar))
+    ),
+    var(--ink-deep);
+}
+
+/* 밴드가 선 섹션의 행은 밴드 라벨 자리(패딩 + 글리프 16px + 간격 6px)에 맞춰 들어간다.
+   행이 밴드보다 바깥에서 시작하면 항목이 자기 머리글 앞에 서서 소속이 역전돼 읽힌다. */
+.quick-launch-command-group.is-banded .quick-launch-command-row {
+  padding-left: calc(var(--space-2) + 22px);
+}
+
+/* `/effort` 게이트의 문. 트랙 우측 ✦ 토글과 같은 어휘를 목록 문법으로 옮긴 것이라, 값 행과
+   달리 apex 채널로 말하고 고딕이 아닌 계기 글꼴을 쓴다 — 값이 아니라는 표시. */
+.quick-launch-command-row.is-gate .quick-launch-mention-name {
+  color: var(--apex-ink);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.quick-launch-command-gate-glyph {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 18px;
+  height: 18px;
+  color: var(--apex-ink);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.quick-launch-command-row.is-gate.is-active .quick-launch-mention-name,
+.quick-launch-command-row.is-gate.is-active .quick-launch-command-gate-glyph {
+  color: var(--brass);
+}
+
+/* 강도 행은 트랙과 같은 톤 사다리를 입는다 — 같은 축을 한 표면은 색으로, 다른 표면은 흑백으로
+   말하던 어긋남을 없앤다. 활성 행만 brass로 덮는다: brass는 위치 채널이라, 값 톤이 그 자리를
+   침범하면 "지금 보고 있는 행"과 "높은 단"이 서로를 흉내 낸다. */
+.quick-launch-command-row[data-effort-level]:not(.is-active) .quick-launch-mention-name {
+  color: var(--effort-tone);
+}
+
+/* 자동은 사다리 위의 한 단이 아니라 사다리를 쓰지 않는 상태다 — 트랙의 파선 어휘를 그대로 쓴다. */
+.quick-launch-command-row[data-effort-level="auto"] .quick-launch-mention-name {
+  text-decoration: underline dashed;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-color: color-mix(in oklch, var(--text-tertiary) 55%, transparent);
+}
+
+.quick-launch-command-row[data-effort-level="max"] .quick-launch-mention-name,
+.quick-launch-command-row[data-effort-level="ultra"] .quick-launch-mention-name {
+  font-weight: var(--weight-medium);
+}
+
+/* 게이트 뒤 MAX·ULTRACODE는 트랙의 모션을 그대로 쓴다. 조건도 같다 — data-apex 없는 max
+   (게이트 없는 모델의 최고 단)는 정적 crest 글로우에 머문다. 덱은 트랙과 달리 여러 행이
+   동시에 보이므로, 일렁이는 것은 이 두 단으로 끝난다. */
+.quick-launch-command-row[data-effort-level="max"]:not(.is-active) .quick-launch-mention-name {
+  text-shadow: 0 0 12px var(--crest-glow);
+}
+
+.quick-launch-command-row[data-apex="true"][data-effort-level="max"]:not(.is-active) .quick-launch-mention-name {
+  background-image: linear-gradient(
+    100deg,
+    var(--crest-ink) 0%,
+    color-mix(in oklch, var(--crest) 45%, white) 14%,
+    var(--crest-ink) 30%,
+    color-mix(in oklch, var(--crest) 60%, var(--brass)) 52%,
+    color-mix(in oklch, var(--crest) 40%, white) 72%,
+    var(--crest-ink) 100%
+  );
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: none;
+  animation:
+    effort-max-ember-wave 2.1s linear infinite,
+    effort-max-ember-flicker 1.7s linear infinite;
+}
+
+.quick-launch-command-row[data-effort-level="ultra"]:not(.is-active) .quick-launch-mention-name {
+  background-image: linear-gradient(
+    105deg,
+    var(--apex-ink) 0%,
+    color-mix(in oklch, var(--apex) 55%, white) 16%,
+    var(--apex-ink) 32%,
+    color-mix(in oklch, var(--apex) 65%, var(--brass)) 48%,
+    var(--apex-ink) 64%,
+    color-mix(in oklch, var(--apex) 55%, white) 80%,
+    var(--apex-ink) 100%
+  );
+  background-size: 240% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: effort-ultracode-wave 2.6s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quick-launch-command-row[data-apex="true"][data-effort-level="max"]:not(.is-active) .quick-launch-mention-name {
+    animation: none;
+    background-image: none;
+    -webkit-background-clip: unset;
+    background-clip: unset;
+    color: var(--crest-ink);
+    text-shadow: 0 0 12px var(--crest-glow);
+  }
+
+  .quick-launch-command-row[data-effort-level="ultra"]:not(.is-active) .quick-launch-mention-name {
+    animation: none;
+    background-image: none;
+    -webkit-background-clip: unset;
+    background-clip: unset;
+    color: var(--apex-ink);
+  }
 }
 
 /* 멘션 확정 시 런치 3종은 접히고(가로 접힘 + 페이드) 행선지 태그가 나타난다. 접힌 컨트롤은

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OperationLaunchVariantRow } from "@fleet-console/sdk/operations";
 
-import { EffortTrack, effortLadderPosition, resolveRowEffort } from "../core/client/src/components/effort-track.js";
+import { EffortTrack, effortLadderPosition, gatedEffortNames, resolveRowEffort } from "../core/client/src/components/effort-track.js";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -462,5 +462,26 @@ describe("resolveRowEffort", () => {
     expect(resolveRowEffort(row(), "medium")).toBeNull();
     expect(resolveRowEffort(row({ chips: [] }), "high")).toBeNull();
     expect(resolveRowEffort(null, "high")).toBeNull();
+  });
+});
+
+describe("gatedEffortNames", () => {
+  it("names only the gated tiers the model actually offers", () => {
+    // K3-1M은 max만 내놓는다 — 게이트 문구가 "MAX·ULTRACODE"라고 말하면 열었을 때 한 단만 서고,
+    // 나머지 하나는 어디 갔는지 물을 자리가 없다.
+    expect(gatedEffortNames(row({ gatedEfforts: ["max", "ultra"] }))).toBe("MAX");
+    expect(gatedEffortNames(row({
+      gatedEfforts: ["max", "ultra"],
+      chips: ["low", "max", "ultra"].map((id) => ({
+        id,
+        label: id === "ultra" ? "ULTRACODE" : id.toUpperCase(),
+        launch: { model: "kimi--k3", effort: id },
+      })),
+    }))).toBe("MAX·ULTRACODE");
+  });
+
+  it("names nothing when the row gates no rung", () => {
+    expect(gatedEffortNames(row())).toBe("");
+    expect(gatedEffortNames(null)).toBe("");
   });
 });

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -484,4 +484,12 @@ describe("gatedEffortNames", () => {
     expect(gatedEffortNames(row())).toBe("");
     expect(gatedEffortNames(null)).toBe("");
   });
+
+  it("falls back to the rung id for an axis-only gated tier so the toggle never announces an empty name", () => {
+    // 트랙은 사다리에서 문을 세우므로, chips에 없는 게이트 단만 실린 행에서도 토글이 뜬다.
+    // chips만 세면 그 토글의 이름이 빈 문자열이 되어 "Show " 같은 라벨이 남는다.
+    // 이 픽스처의 축은 low/medium/high/xhigh/max이고 chips는 low/high/max다 — xhigh가 축에만 있다.
+    expect(gatedEffortNames(row({ gatedEfforts: ["xhigh"] }))).toBe("XHIGH");
+    expect(gatedEffortNames(row({ gatedEfforts: ["xhigh", "max"] }))).toBe("XHIGH·MAX");
+  });
 });

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2197,6 +2197,121 @@ describe("Effort track interaction grammar", () => {
     expect(components).toMatch(/data-effort-level="ultra"\] \.effort-track-fill::before,[\s\S]{0,120}::after \{[^}]*content: "✦"/);
   });
 
+  it("pins the effort tone ramp between the reading floor and brass, with no signal channel borrowed", () => {
+    const components = source("styles/components.css");
+    // 끝 앵커는 줄머리로 잡는다 — `.effort-track-shell {`는 앞선 `.operation-launch-effort-menu
+    // .effort-track-shell {`에도 부분 문자열로 걸려, 그대로 쓰면 램프 앞을 가리켜 빈 슬라이스가 된다.
+    const ramp = components.slice(
+      components.indexOf('[data-effort-level] { --effort-tone:'),
+      components.indexOf("\n.effort-track-shell {"),
+    );
+    expect(ramp).not.toBe("");
+
+    // 램프는 판독 하한(--text-tertiary)에서 출발해 --brass-ink에서 끝난다. 양 끝을 안쪽으로
+    // 접어 두면 구간이 좁아져, 한 번에 한 값만 보이는 트랙에서 단이 바뀌어도 색이 그대로인
+    // 것처럼 읽힌다 — 최고 일상 단은 brass 그 자체이고, 최저 단만 하한에서 살짝 띄운다.
+    expect(ramp).toContain('[data-effort-level="auto"] { --effort-tone: var(--text-tertiary); }');
+    expect(ramp).toContain('[data-effort-level="xhigh"] { --effort-tone: var(--brass-ink); }');
+    expect(ramp).toMatch(/\[data-effort-level="low"\] \{ --effort-tone: color-mix\(in oklab, var\(--brass-ink\) 10%/);
+
+    // 보간은 oklab이다. oklch로 섞으면 중간 단이 tertiary의 hue와 brass 사이 호를 따라가
+    // positive·coral 같은 상태 채널을 강도 라벨이 흉내 낸다.
+    for (const rung of ["low", "medium", "high"]) {
+      expect(ramp, rung).toContain(`[data-effort-level="${rung}"] { --effort-tone: color-mix(in oklab, var(--brass-ink)`);
+    }
+
+    // 일상 단은 brass 한 채널 안에서만 논다 — 게이트 뒤 두 단만 자기 채널로 갈라진다.
+    for (const signal of ["--aurora", "--warn", "--coral", "--positive"]) {
+      expect(ramp, signal).not.toContain(signal);
+    }
+    expect(ramp).toContain('[data-effort-level="max"] { --effort-tone: var(--crest-ink); }');
+    expect(ramp).toContain('[data-effort-level="ultra"] { --effort-tone: var(--apex-ink); }');
+  });
+
+  it("pins the Quick Launch effort row grammar — value tone yields to the location channel", () => {
+    const components = source("styles/components.css");
+    const composer = source("components/quick-launch.tsx");
+
+    // 덱 행은 트랙과 같은 좌표(data-effort-level)로 색을 읽는다 — 라벨 문자열은 번역·모델마다
+    // 달라 색의 기준이 될 수 없다.
+    expect(composer).toContain("data-effort-level={row.effortLevel}");
+    expect(composer).toContain("data-apex={row.apex ? true : undefined}");
+
+    // 값 톤은 활성 행에 올라가지 않는다. brass는 위치·초점 채널이라, 값 톤이 그 자리를 침범하면
+    // "지금 보고 있는 행"과 "높은 단"이 서로를 흉내 낸다.
+    expect(components).toMatch(
+      /\.quick-launch-command-row\[data-effort-level\]:not\(\.is-active\) \.quick-launch-mention-name \{\s*color: var\(--effort-tone\);/,
+    );
+    expect(components).toMatch(/\.quick-launch-mention-row\.is-active \.quick-launch-mention-name \{\s*color: var\(--brass\);/);
+
+    // 자동은 사다리 위의 한 단이 아니라 사다리를 쓰지 않는 상태다 — 트랙의 파선 어휘를 공유한다.
+    expect(components).toMatch(
+      /\.quick-launch-command-row\[data-effort-level="auto"\] \.quick-launch-mention-name \{[^}]*text-decoration: underline dashed;/,
+    );
+
+    // 문 행은 apex 채널로만 말한다(트랙의 ✦ 토글과 같은 어휘). 신호 토큰도 위치 채널도 빌리지 않는다.
+    const gateRule = components.match(/\.quick-launch-command-row\.is-gate \.quick-launch-mention-name \{[^}]*\}/)?.[0] ?? "";
+    const gateGlyph = components.match(/\.quick-launch-command-gate-glyph \{[^}]*\}/)?.[0] ?? "";
+    expect(gateRule).toContain("var(--apex-ink)");
+    expect(gateGlyph).toContain("var(--apex-ink)");
+    for (const signal of ["--aurora", "--warn", "--coral", "--positive", "--brass)"]) {
+      expect(gateRule, signal).not.toContain(signal);
+      expect(gateGlyph, signal).not.toContain(signal);
+    }
+  });
+
+  it("holds the deck's apex motion to the track's condition and reduced-motion cutoff", () => {
+    const components = source("styles/components.css");
+
+    // 덱은 트랙과 같은 키프레임을 쓴다 — 같은 능력이면 같은 어휘다. MAX의 이글거림은 트랙과
+    // 똑같이 data-apex(게이트 뒤 티어)에만 붙어, 게이트 없는 모델의 max는 정적 글로우에 머문다.
+    expect(components).toMatch(
+      /\.quick-launch-command-row\[data-apex="true"\]\[data-effort-level="max"\]:not\(\.is-active\) \.quick-launch-mention-name \{[\s\S]*?animation:\s*\n?\s*effort-max-ember-wave 2\.1s linear infinite,\s*\n?\s*effort-max-ember-flicker 1\.7s linear infinite;/,
+    );
+    expect(components).toMatch(
+      /\.quick-launch-command-row\[data-effort-level="ultra"\]:not\(\.is-active\) \.quick-launch-mention-name \{[\s\S]*?animation: effort-ultracode-wave 2\.6s linear infinite;/,
+    );
+
+    // 덱은 트랙과 달리 여러 행이 동시에 보인다 — 모션은 게이트 뒤 두 단으로 끝나고, 일상 5단은
+    // 정적 톤만 가진다. 여섯 줄이 동시에 일렁이면 목록이 아니라 배경이 된다.
+    for (const rung of ["low", "medium", "high", "xhigh", "auto"]) {
+      expect(components, rung).not.toMatch(
+        new RegExp(`\\.quick-launch-command-row\\[data-effort-level="${rung}"\\][^{]*\\{[^}]*animation:`),
+      );
+    }
+
+    // 감속 모션에서는 트랙과 같은 자리로 돌아간다 — MAX는 정적 crest 글로우, ULTRACODE는 apex ink.
+    const reduced = components.slice(components.indexOf(".quick-launch-command-row[data-effort-level]"));
+    expect(reduced).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.quick-launch-command-row\[data-apex="true"\]\[data-effort-level="max"\]:not\(\.is-active\) \.quick-launch-mention-name \{\s*animation: none;[\s\S]*?color: var\(--crest-ink\);/,
+    );
+    expect(reduced).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.quick-launch-command-row\[data-effort-level="ultra"\]:not\(\.is-active\) \.quick-launch-mention-name \{\s*animation: none;[\s\S]*?color: var\(--apex-ink\);/,
+    );
+  });
+
+  it("pins the provider band as the sole supplier mark in the command deck", () => {
+    const components = source("styles/components.css");
+    const composer = source("components/quick-launch.tsx");
+
+    // 밴드가 스크롤을 따라 붙기 때문에 행 마크를 걷어낼 수 있다. 두 규칙은 한 쌍이다 —
+    // sticky를 잃으면 스크롤한 목록에서 모델 이름만 남고 공급자를 잃는다.
+    const bandRule = components.match(/\.quick-launch-command-deck \.quick-launch-pop-band \{[^}]*\}/)?.[0] ?? "";
+    expect(bandRule).toContain("position: sticky");
+    expect(bandRule).toContain("var(--ink-deep)");
+    expect(composer).not.toMatch(/id: `model-\$\{row\.id\}`,[\s\S]{0,200}?quick-launch-kind-icon/);
+
+    // 행은 밴드 라벨 자리(패딩 + 글리프 16px + 간격 6px)에서 시작한다 — 항목이 자기 머리글보다
+    // 바깥에서 시작하면 소속이 역전돼 읽힌다.
+    expect(components).toMatch(
+      /\.quick-launch-command-group\.is-banded \.quick-launch-command-row \{\s*padding-left: calc\(var\(--space-2\) \+ 22px\);/,
+    );
+
+    // '@' 멘션 덱의 행 마크는 남는다 — 그쪽 밴드는 Theater 이름이라 공급자를 말하지 않고,
+    // 행 글리프가 유일한 출처 표식이다. 모델 덱과 같은 이유로 지우면 그쪽이 회귀한다.
+    expect(composer).toContain("launchProviderGlyph(entry.launchProvider)");
+  });
+
   it("pins the shared effort track's pointer preview motion", () => {
     const components = source("styles/components.css");
     const quickLaunch = source("components/quick-launch.tsx");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2249,6 +2249,23 @@ describe("Effort track interaction grammar", () => {
       /\.quick-launch-command-row\[data-effort-level="auto"\] \.quick-launch-mention-name \{[^}]*text-decoration: underline dashed;/,
     );
 
+    // 문구는 실제로 열리는 단에서 유도한다 — max만 내놓는 모델(Codex Luna 계열·Kimi K3 등)에서
+    // 고정 문구는 열리지 않는 단을 약속한다. 세 표면(덱 문 행·바 트랙·캔버스 트랙)이 같은 유도를
+    // 쓰므로 문구가 갈라지지 않는다.
+    const common = source("i18n/messages/common.ts");
+    const canvasMenu = source("canvas/canvas-context-menu.tsx");
+    expect(common).toContain('"launchVariants.effort.apexToggle": "Show {tiers}"');
+    expect(common).toContain('"launchVariants.effort.apexCollapse": "Hide {tiers}"');
+    for (const surface of [composer, canvasMenu]) {
+      expect(surface).toMatch(/apexToggleLabel=\{t\("launchVariants\.effort\.apexToggle", \{ tiers: gatedEffortNames\(/u);
+      expect(surface).toMatch(/apexCollapseLabel=\{t\("launchVariants\.effort\.apexCollapse", \{ tiers: gatedEffortNames\(/u);
+    }
+    expect(composer).toMatch(/const tiers = gatedEffortNames\(selectedRow\);/u);
+
+    // 문 행은 listbox 안에 산다. option role이 지원하지 않는 aria-expanded를 달면 무시되거나
+    // 무효로 읽히므로, 여는지 접는지는 라벨 자체가 말한다("… 펼치기" ↔ "… 접기").
+    expect(composer).not.toContain("aria-expanded={row.gate");
+
     // 문 행은 apex 채널로만 말한다(트랙의 ✦ 토글과 같은 어휘). 신호 토큰도 위치 채널도 빌리지 않는다.
     const gateRule = components.match(/\.quick-launch-command-row\.is-gate \.quick-launch-mention-name \{[^}]*\}/)?.[0] ?? "";
     const gateGlyph = components.match(/\.quick-launch-command-gate-glyph \{[^}]*\}/)?.[0] ?? "";

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2260,7 +2260,13 @@ describe("Effort track interaction grammar", () => {
       expect(surface).toMatch(/apexToggleLabel=\{t\("launchVariants\.effort\.apexToggle", \{ tiers: gatedEffortNames\(/u);
       expect(surface).toMatch(/apexCollapseLabel=\{t\("launchVariants\.effort\.apexCollapse", \{ tiers: gatedEffortNames\(/u);
     }
-    expect(composer).toMatch(/const tiers = gatedEffortNames\(selectedRow\);/u);
+
+    // 두 표면은 여는 것이 다르므로 이름의 원천도 다르다. 트랙은 사다리에서 문을 세우니 사다리
+    // 기준(gatedEffortNames)을, 덱은 chips에 실린 단만 행으로 내니 자기 판정과 같은 원천
+    // (deck.gatedNames)을 쓴다. 한쪽 기준을 다른 쪽에 빌려 주면 열리지 않는 단이 이름에 실린다.
+    expect(composer).toMatch(/\{ tiers: deck\.gatedNames \}/u);
+    expect(composer).not.toMatch(/const tiers = gatedEffortNames\(selectedRow\);/u);
+    expect(source("quick-launch.ts")).toMatch(/gatedNames: offeredGated\.map\(\(chip\) => chip\.label\)\.join\("·"\),/u);
 
     // 문 행은 listbox 안에 산다. option role이 지원하지 않는 aria-expanded를 달면 무시되거나
     // 무효로 읽히므로, 여는지 접는지는 라벨 자체가 말한다("… 펼치기" ↔ "… 접기").

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -173,6 +173,22 @@ describe("Quick Launch effort surface", () => {
     expect(quickLaunch).toMatch(/&& !submitting && !deckHasRows/u);
   });
 
+  it("keeps the keyboard on the gate row after it toggles", () => {
+    // 게이트를 열면 MAX·ULTRACODE가 문 행 **앞에** 끼어든다. 활성 인덱스를 그대로 두면 같은
+    // 자리가 MAX를 가리켜, 접으려고 누른 두 번째 Enter가 MAX를 확정하고 저장까지 한다 —
+    // 게이트가 막으려던 실수를 게이트 자신이 만든다. 다음 목록의 값 행 개수가 문 행의 자리다.
+    expect(quickLaunch).toMatch(
+      /const nextOpen = !deck\.gateOpen;[\s\S]{0,400}?setCommandActiveIndex\([\s\S]{0,200}?buildQuickLaunchEffortDeck\(selectedRow, effort, autoLabel, effortQuery, nextOpen\)\.options\.length,?[\s\S]{0,40}?\);[\s\S]{0,80}?setCommandGateOpen\(nextOpen\);/u,
+    );
+  });
+
+  it("stands the gate row only when the deck owns the whole list", () => {
+    // 문 행이 질의 중에도 남으면 매치 0인 `/effort zebra`에서 덱이 비지 않아, 커맨드 덱 공통
+    // 계약("일치 없으면 Enter는 문장을 그대로 보낸다")이 이 레벨에서만 깨진다.
+    expect(quickLaunch).toMatch(/if \(deck\.showGateRow\) \{/u);
+    expect(quickLaunch).not.toMatch(/if \(deck\.hasGate && !deck\.gateHeldByValue\) \{/u);
+  });
+
   it("gives the track a fixed berth instead of letting it compete with the spacer", () => {
     // 셸은 max-content, 트랙 폭은 캔버스 추론강도와 같은 116px 비례 규칙을 쓴다.
     const rule = ruleFor(".quick-launch-effort-track");

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -182,6 +182,15 @@ describe("Quick Launch effort surface", () => {
     );
   });
 
+  it("folds the effort gate back when the composer closes, not only when the level changes", () => {
+    // 컴포저는 언마운트되지 않고 렌더만 접는다(`if (!open) return null`). 문면이 `/effort `인 채
+    // 보존된 초안으로 돌아오면 commandInput이 그대로라, open을 조건에 넣지 않으면 게이트가
+    // 펼쳐진 채 되살아난다 — "이번 방문에만 열린다"는 계약이 그 경로에서만 깨진다.
+    expect(quickLaunch).toMatch(
+      /if \(open && commandInput\?\.kind === "values" && commandInput\.command === "effort"\) return;\s*\n\s*setCommandGateOpen\(false\);\s*\n\s*\}, \[commandInput, open\]\);/u,
+    );
+  });
+
   it("stands the gate row only when the deck owns the whole list", () => {
     // 문 행이 질의 중에도 남으면 매치 0인 `/effort zebra`에서 덱이 비지 않아, 커맨드 덱 공통
     // 계약("일치 없으면 Enter는 문장을 그대로 보낸다")이 이 레벨에서만 깨진다.

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -694,6 +694,26 @@ describe("buildQuickLaunchEffortDeck", () => {
     expect(buildQuickLaunchEffortDeck(axisOnly, null, "AUTO", "", false).hasGate).toBe(false);
   });
 
+  it("names the gate from what this deck opens, never from the track's ladder", () => {
+    // 이 덱은 chips에 실린 단만 행으로 낸다. 축에만 오른 게이트 단까지 이름에 실으면
+    // "XHIGH·MAX 펼치기"라 해 놓고 열었을 때 MAX만 서는, 문구가 거짓이 되는 상태가 된다.
+    expect(buildQuickLaunchEffortDeck(row, null, "AUTO", "", false).gatedNames).toBe("MAX·ULTRACODE");
+    const axisOnlyRung = {
+      ...plainRow,
+      effortAxis: ["low", "medium", "high", "xhigh", "max"],
+      gatedEfforts: ["xhigh", "max"],
+      chips: [
+        { id: "low", label: "LOW", launch: { model: "cursor--grok-4.6-fast", effort: "low" } },
+        { id: "max", label: "MAX", launch: { model: "cursor--grok-4.6-fast", effort: "max" } },
+      ],
+    } as const;
+    const deck = buildQuickLaunchEffortDeck(axisOnlyRung, null, "AUTO", "", true);
+    expect(deck.gatedNames).toBe("MAX");
+    expect(ids(deck)).toEqual([null, "low", "max"]);
+    // 게이트가 없는 행은 이름도 비어 있다 — 문 행 자체가 서지 않으므로 쓰이지 않는다.
+    expect(buildQuickLaunchEffortDeck(plainRow, null, "AUTO", "", false).gatedNames).toBe("");
+  });
+
   it("marks the checked option and survives a missing row", () => {
     const deck = buildQuickLaunchEffortDeck(row, "high", "AUTO", "", false);
     expect(deck.options.find((option) => option.id === "high")?.checked).toBe(true);
@@ -703,6 +723,7 @@ describe("buildQuickLaunchEffortDeck", () => {
       gateOpen: false,
       gateHeldByValue: false,
       showGateRow: false,
+      gatedNames: "",
     });
   });
 });

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { OperationCatalogPlugin, OperationLaunchVariantGroup } from "@fleet-console/sdk/operations";
 
 import { readQuickLaunchSelection, writeQuickLaunchMentionFocused, writeQuickLaunchModelEffort, writeQuickLaunchPinned, writeQuickLaunchSelection } from "../core/client/src/quick-launch-preferences.js";
-import { buildQuickLaunchEffortOptions, buildQuickLaunchMentionGroups, findVariantLaunchKind, isMentionSelectable, isQuickLaunchAttachmentCandidate, isUltracodeDisarmCaret, nextUltracodeIgnored, QUICK_LAUNCH_ATTACHMENT_MAX_BYTES, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_MAX_ATTACHMENTS, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchAttachmentErrorMessageKey, quickLaunchErrorMessageKey, quickLaunchMentionErrorMessageKey, readCommandInput, readMentionToken, readUltracodeTokens, resolveFocusedMention, resolveMentionEntry, resolveSelection, shouldApplyFocusedMention, stripMentionToken } from "../core/client/src/quick-launch.js";
+import { buildQuickLaunchEffortDeck, buildQuickLaunchMentionGroups, findVariantLaunchKind, isMentionSelectable, isQuickLaunchAttachmentCandidate, isUltracodeDisarmCaret, nextUltracodeIgnored, QUICK_LAUNCH_ATTACHMENT_MAX_BYTES, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_MAX_ATTACHMENTS, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchAttachmentErrorMessageKey, quickLaunchErrorMessageKey, quickLaunchMentionErrorMessageKey, readCommandInput, readMentionToken, readUltracodeTokens, resolveFocusedMention, resolveMentionEntry, resolveSelection, shouldApplyFocusedMention, stripMentionToken } from "../core/client/src/quick-launch.js";
 import { clearQuickLaunchRejection, consumeQuickLaunchDraft, getState, isQuickLaunchDocked, openQuickLaunch, preserveQuickLaunchDraft, removeTheater, reopenQuickLaunchWithDraft, setQuickLaunchDockSuppressed, setQuickLaunchPinned, setState, toggleQuickLaunch } from "../core/client/src/store.js";
 import type { OperationNode, TheaterInfo } from "../core/client/src/types.js";
 
@@ -605,7 +605,7 @@ describe("readCommandInput", () => {
   });
 });
 
-describe("buildQuickLaunchEffortOptions", () => {
+describe("buildQuickLaunchEffortDeck", () => {
   const row = {
     id: "fable",
     label: "Fable",
@@ -620,27 +620,74 @@ describe("buildQuickLaunchEffortOptions", () => {
     ],
   } as const;
 
+  /** 게이트 단을 하나도 내놓지 않는 모델 — 트랙에 ✦이 서지 않는 그 상태. */
+  const plainRow = {
+    id: "grok",
+    label: "Grok",
+    launch: { model: "cursor--grok-4.6-fast" },
+    effortAxis: ["low", "medium", "high", "xhigh"],
+    chips: [
+      { id: "low", label: "LOW", launch: { model: "cursor--grok-4.6-fast", effort: "low" } },
+      { id: "xhigh", label: "XHIGH", launch: { model: "cursor--grok-4.6-fast", effort: "xhigh" } },
+    ],
+  } as const;
+
+  const ids = (deck: ReturnType<typeof buildQuickLaunchEffortDeck>) => deck.options.map((option) => option.id);
+
   it("hides gated apex tiers from the default list — the track's gate is mirrored", () => {
-    expect(buildQuickLaunchEffortOptions(row, null, "AUTO", "").map((option) => option.id))
-      .toEqual([null, "low", "high"]);
+    expect(ids(buildQuickLaunchEffortDeck(row, null, "AUTO", "", false))).toEqual([null, "low", "high"]);
   });
 
   it("reveals a gated tier only when its name is typed from the start", () => {
-    expect(buildQuickLaunchEffortOptions(row, null, "AUTO", "ma").map((option) => option.id)).toEqual(["max"]);
-    expect(buildQuickLaunchEffortOptions(row, null, "AUTO", "ultra").map((option) => option.id)).toEqual(["ultracode"]);
+    expect(ids(buildQuickLaunchEffortDeck(row, null, "AUTO", "ma", false))).toEqual(["max"]);
+    expect(ids(buildQuickLaunchEffortDeck(row, null, "AUTO", "ultra", false))).toEqual(["ultracode"]);
     // 우연한 부분 일치("l" ⊂ ULTRACODE)는 게이트를 열지 않는다.
-    expect(buildQuickLaunchEffortOptions(row, null, "AUTO", "l").map((option) => option.id)).toEqual(["low"]);
+    expect(ids(buildQuickLaunchEffortDeck(row, null, "AUTO", "l", false))).toEqual(["low"]);
   });
 
   it("keeps the gate open while the current effort is a gated tier", () => {
-    expect(buildQuickLaunchEffortOptions(row, "max", "AUTO", "").map((option) => option.id))
-      .toEqual([null, "low", "high", "max", "ultracode"]);
-    expect(buildQuickLaunchEffortOptions(row, "max", "AUTO", "").find((option) => option.id === "max")?.checked).toBe(true);
+    const deck = buildQuickLaunchEffortDeck(row, "max", "AUTO", "", false);
+    expect(ids(deck)).toEqual([null, "low", "high", "max", "ultracode"]);
+    expect(deck.options.find((option) => option.id === "max")?.checked).toBe(true);
+    // 고른 값이 게이트를 붙들고 있으면 문 행은 서지 않는다 — 접어도 접히지 않을 컨트롤이다.
+    expect(deck.gateHeldByValue).toBe(true);
+  });
+
+  it("opens every gated tier when the gate row is opened", () => {
+    const deck = buildQuickLaunchEffortDeck(row, null, "AUTO", "", true);
+    expect(ids(deck)).toEqual([null, "low", "high", "max", "ultracode"]);
+    expect(deck.gateOpen).toBe(true);
+    expect(deck.gateHeldByValue).toBe(false);
+  });
+
+  it("marks gated tiers as apex so the deck can split MAX's ember from a plain max", () => {
+    const deck = buildQuickLaunchEffortDeck(row, null, "AUTO", "", true);
+    expect(deck.options.filter((option) => option.apex).map((option) => option.id)).toEqual(["max", "ultracode"]);
+  });
+
+  it("reports no gate when the model offers no gated tier — 'absent' must not look like 'collapsed'", () => {
+    const deck = buildQuickLaunchEffortDeck(plainRow, null, "AUTO", "", false);
+    expect(deck.hasGate).toBe(false);
+    expect(deck.gateOpen).toBe(false);
+    expect(ids(deck)).toEqual([null, "low", "xhigh"]);
+    // 열어 달라고 해도 열 문이 없다.
+    expect(buildQuickLaunchEffortDeck(plainRow, null, "AUTO", "", true).hasGate).toBe(false);
+  });
+
+  it("counts only offered gated tiers — an axis-only rung raises no door", () => {
+    const axisOnly = { ...plainRow, gatedEfforts: ["max", "ultracode"] } as const;
+    expect(buildQuickLaunchEffortDeck(axisOnly, null, "AUTO", "", false).hasGate).toBe(false);
   });
 
   it("marks the checked option and survives a missing row", () => {
-    expect(buildQuickLaunchEffortOptions(row, "high", "AUTO", "").find((option) => option.id === "high")?.checked).toBe(true);
-    expect(buildQuickLaunchEffortOptions(null, null, "AUTO", "")).toEqual([{ id: null, label: "AUTO", checked: true }]);
+    const deck = buildQuickLaunchEffortDeck(row, "high", "AUTO", "", false);
+    expect(deck.options.find((option) => option.id === "high")?.checked).toBe(true);
+    expect(buildQuickLaunchEffortDeck(null, null, "AUTO", "", false)).toEqual({
+      options: [{ id: null, label: "AUTO", checked: true, apex: false }],
+      hasGate: false,
+      gateOpen: false,
+      gateHeldByValue: false,
+    });
   });
 });
 

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -660,6 +660,21 @@ describe("buildQuickLaunchEffortDeck", () => {
     expect(deck.gateHeldByValue).toBe(false);
   });
 
+  it("drops the gate row while a query is typed — an unmatched query must stay submittable prose", () => {
+    // 문 행이 남으면 매치 0인 질의에서도 덱이 비지 않아, Enter가 제출 대신 게이트를 여닫는다.
+    expect(buildQuickLaunchEffortDeck(row, null, "AUTO", "", false).showGateRow).toBe(true);
+    expect(buildQuickLaunchEffortDeck(row, null, "AUTO", "zebra", false).showGateRow).toBe(false);
+    expect(ids(buildQuickLaunchEffortDeck(row, null, "AUTO", "zebra", false))).toEqual([]);
+    // 공백만 친 질의는 아직 질의가 아니다.
+    expect(buildQuickLaunchEffortDeck(row, null, "AUTO", "  ", false).showGateRow).toBe(true);
+    // 게이트가 열려 있어도 질의 중에는 서지 않는다 — 좁힌 목록 위의 "펼치기"는 필터와 모순된다.
+    expect(buildQuickLaunchEffortDeck(row, null, "AUTO", "ma", true).showGateRow).toBe(false);
+  });
+
+  it("hides the gate row while the selected value holds the gate open", () => {
+    expect(buildQuickLaunchEffortDeck(row, "max", "AUTO", "", false).showGateRow).toBe(false);
+  });
+
   it("marks gated tiers as apex so the deck can split MAX's ember from a plain max", () => {
     const deck = buildQuickLaunchEffortDeck(row, null, "AUTO", "", true);
     expect(deck.options.filter((option) => option.apex).map((option) => option.id)).toEqual(["max", "ultracode"]);
@@ -687,6 +702,7 @@ describe("buildQuickLaunchEffortDeck", () => {
       hasGate: false,
       gateOpen: false,
       gateHeldByValue: false,
+      showGateRow: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

- `/model` 덱의 행 프로바이더 글리프를 제거하고, 대신 프로바이더 밴드를 `position: sticky`로 목록 위에 고정한다. 행 마크가 중복이 아니었던 유일한 이유는 밴드가 스크롤에 밀려 사라져서였다 — 덱은 340px에서 스크롤을 시작하고 6모델 선별이면 약 480px가 필요해, 스크롤한 상태에서는 모델 이름만 남고 공급자를 잃는다. 모델 이름은 밴드 라벨 자리(패딩 + 글리프 16px + 간격 6px)에 맞춰 들여써, 항목이 자기 머리글보다 바깥에서 시작하던 역계층을 없앤다.
- `/effort` 덱은 MAX·ULTRACODE를 접두 타이핑 뒤에만 드러냈고 그 존재를 알리는 표식이 하나도 없었다. 그래서 두 단을 내놓는 모델과 사다리가 XHIGH에서 끝나는 모델의 목록이 픽셀 단위로 같았다. 트랙의 ✦ 게이트를 목록 문법으로 옮긴 문 행을 맨 아래에 세우고, 게이트 단을 하나도 내놓지 않는 모델에서는 그 행을 세우지 않는다.
- 강도 행에 `data-effort-level`을 붙여 덱이 트랙과 같은 톤 사다리로 말하게 한다. 사다리 자체도 쓸 수 있는 구간 전체로 벌린다 — 기존 20/42/64/84는 양 끝을 안쪽으로 접어 채널의 3분의 2만 썼고, 한 번에 한 값만 보이는 트랙에서는 단이 바뀌어도 색이 그대로인 것처럼 읽혔다(instrument 실측 L 0.672→0.774 → 0.656→0.800).

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run` — 2149 passed / 24 skipped / 0 failed
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK (19 entries)
- [x] 격리 콘솔 헤드리스 실측: `/model` 덱 행 글리프 0개·밴드 글리프 5개 유지, 스크롤 40/80/120px에서 밴드가 상단 고정(top=1px), 밴드 라벨 x=35 = 행 라벨 x=35
- [x] 격리 콘솔 헤드리스 실측: Opus에서 문 행 노출 → 클릭·Enter 모두 그 자리에서 MAX·ULTRACODE 펼침(문면 `/effort ` 유지), MAX는 `effort-max-ember-wave, effort-max-ember-flicker`·ULTRACODE는 `effort-ultracode-wave`
- [x] 격리 콘솔 헤드리스 실측: Cursor Grok-4.6-Fast(상한 XHIGH)에서 문 행 미출력 — 트랙에 ✦이 서지 않는 것과 같은 조건
- [x] 격리 콘솔 헤드리스 실측: 덱을 떠났다 돌아오면 게이트가 접힌 상태로 복귀
- [x] 4테마(instrument·maritime·carbon·whites) 톤 사다리 실측 — 라이트에서도 판독 하한 아래로 흐려지지 않고 채도만 상승
- [x] 페이지 에러 0