### PR TITLE
fix(fleet-console): keep an unfocused accented caption on the panel fill

### DIFF
--- a/.changelog.d/panel-group-caption-label.md
+++ b/.changelog.d/panel-group-caption-label.md
@@ -8,5 +8,5 @@ branch: panel-group-caption-label
   ko: Operation의 그룹을 패널 캡션에 색 도트와 그룹 이름으로 표시해, 사이드바를 열지 않아도 소속이 읽힙니다.
 
 #### Removed
-- Drop the accent stripe down a panel's left edge; identity now speaks only through the caption's nameplate mark and wash.
-  ko: 패널 왼쪽 가장자리의 accent 띠를 걷어내고, 정체성은 캡션의 명판 마크와 워시로만 말합니다.
+- Drop the accent stripe down a panel's left edge; identity now speaks only through the caption's nameplate mark, so an unfocused caption stays on the same surface as the panel.
+  ko: 패널 왼쪽 가장자리의 accent 띠를 걷어내고, 정체성은 캡션의 명판 마크로만 말해 포커스가 없는 캡션이 패널과 한 면으로 남습니다.

--- a/runtime/fleet-console/AGENTS.md
+++ b/runtime/fleet-console/AGENTS.md
@@ -42,7 +42,7 @@
 
 ## Design invariants
 
-- Every color speaks on exactly one channel: signal tokens (`aurora`/`warn`/`coral`/`positive`) carry state only, `brass` carries location/focus/hover only, and user or agent identity uses the `--id-*` tones painted exclusively through the spine+mark+wash grammar — borders stay state-owned and identity never repaints signal surfaces.
+- Every color speaks on exactly one channel: signal tokens (`aurora`/`warn`/`coral`/`positive`) carry state only, `brass` carries location/focus/hover only, and user or agent identity uses the `--id-*` tones painted exclusively as marks (caption nameplate, rail-chip spine, minimap dot) — borders stay state-owned and identity never repaints signal surfaces or the unfocused caption fill.
 - Core and built-in plugin CSS consume colors only as theme tokens via `var()`/`color-mix`; chromatic raw literals live solely in `theme.css` token definitions so all three themes retune together. Near-achromatic shadow, scrim, and sheen literals that carry depth rather than hue are the sanctioned exception.
 - `tests/instrument-design-contract.test.ts` pins the design grammar: a legitimate grammar change updates the contract together with the change, and intentional exceptions are recorded as doctrine comments beside the exempted CSS rule.
 

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -98,7 +98,7 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
       restoreIdentityFocusRef.current = true;
     },
   });
-  // 사용자 accent(정체성)는 명판 마크와 명판 워시만 소유한다.
+  // 사용자 accent(정체성)는 명판 마크만 소유한다. 캡션 채움은 액센트가 없을 때와 같다.
   // 패널 보더/글로우/비콘은 상태 채널(brass 포커스·aurora 대기·coral 위험) 전용이다.
   const accentColor = accentKey ? resolveAccentColor(accentKey) : null;
   // 그룹 소속은 개인 accent와 다른 축이므로 자기 마크(도트)와 중립 티어 이름으로 따로 선다 —

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4660,8 +4660,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
   --caption-rail: var(--positive);
 }
 
-/* Map에서 사용자 accent(정체성)는 명판 마크·명판 워시만 소유한다 — 좌측 스파인은 폐기됐다.
-   패널 본문은 어떤 정체성 색도 지지 않고, 정체성은 전부 캡션 위에서 말한다.
+/* Map에서 사용자 accent(정체성)는 명판 마크만 소유한다 — 좌측 스파인과 캡션 워시는 폐기됐다.
+   패널 본문과 언포커스 캡션은 어떤 정체성 색도 지지 않고, 정체성은 캡션 위 마크에서 말한다.
+   캡션 채움은 액센트가 없을 때와 같다: 언포커스는 --surface-panel, 포커스는 brass 워시.
    패널 보더/글로우/비콘은 상태 채널(brass 포커스·aurora 대기·coral 위험) 전용으로 남는다.
    사이드바 칩의 3px accent 스파인은 레일 소속이라 그대로 남는다. */
 .canvas-operation-id-mark {
@@ -4670,12 +4671,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 14px;
   border-radius: 2px;
   background: var(--user-accent);
-}
-
-.canvas-operation[style*="--user-accent"] .canvas-operation-titlebar {
-  background: color-mix(in oklch, var(--user-accent) 10%, var(--surface-panel));
-  /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
-  background-clip: padding-box;
 }
 
 /* 그룹 소속 = 도트(정체성 mark 문법) + 중립 티어 이름. 색은 도트 하나만 지고, 이름은 캡션의
@@ -5970,13 +5965,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .canvas-operation.is-active > .canvas-operation-titlebar {
   background: color-mix(in oklab, var(--brass) 10%, var(--surface-panel));
   /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
-  background-clip: padding-box;
-}
-
-/* 정체성(--user-accent)은 캡션 채움을 계속 소유한다 — 포커스 워시는 그 위에 얹혀 두 채널이
-   같은 표면을 다투지 않는다. 이 결합 규칙이 없으면 accent가 있는 패널만 포커스를 잃는다. */
-.canvas-operation[style*="--user-accent"].is-active > .canvas-operation-titlebar {
-  background: color-mix(in oklab, var(--brass) 10%, color-mix(in oklch, var(--user-accent) 10%, var(--surface-panel)));
   background-clip: padding-box;
 }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -576,12 +576,11 @@ describe("Instrument core design contract", () => {
     expect(violations).toEqual([]);
   });
 
-  it("keeps user identity on the mark+wash grammar and off the state border channel", () => {
+  it("keeps user identity on the mark grammar and off the caption fill and state border channel", () => {
     const frame = source("canvas/operation-frame.tsx");
     const chip = source("sidebar/operations-side-bar-chip.tsx");
     const components = source("styles/components.css");
     const markBlock = components.match(/\.canvas-operation-id-mark \{[^}]*\}/)?.[0] ?? "";
-    const washBlock = components.match(/\.canvas-operation\[style\*="--user-accent"\] \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
     const chipAccentBlock = components.match(/\.side-bar-chip\[style\*="--user-accent"\]::before \{[^}]*\}/)?.[0] ?? "";
     const minimapDotBlock = components.match(/\.canvas-minimap-operation\[style\*="--user-accent"\]::after \{[^}]*\}/)?.[0] ?? "";
     const accentSources = [frame, chip, components].join("\n");
@@ -589,18 +588,19 @@ describe("Instrument core design contract", () => {
     expect(frame).toContain('{ "--user-accent": accentColor }');
     expect(frame).toContain('className="canvas-operation-id-mark"');
     expect(chip).toContain('{ "--user-accent": accentValue }');
-    // Map의 좌측 스파인은 폐기됐다 — 패널 본문은 어떤 정체성 색도 지지 않고, 정체성은 전부
-    // 캡션 위(명판 마크·명판 워시)에서 말한다. 선택자·렌더·클래스 어느 쪽으로도 되살아나면
-    // 캡션이 유일한 정체성 면이라는 계약이 조용히 깨진다.
+    // Map의 좌측 스파인과 캡션 워시는 폐기됐다 — 패널 본문과 언포커스 캡션은 어떤 정체성
+    // 색도 지지 않고, 정체성은 캡션 위 마크에서 말한다. 선택자·렌더·클래스 어느 쪽으로도
+    // 되살아나면 캡션이 패널과 한 면이라는 계약이 조용히 깨진다.
     expect(components).not.toContain(".canvas-operation-spine");
     expect(frame).not.toContain("canvas-operation-spine");
+    expect(components).not.toContain('.canvas-operation[style*="--user-accent"] .canvas-operation-titlebar {');
+    expect(components).not.toContain('.canvas-operation[style*="--user-accent"].is-active > .canvas-operation-titlebar {');
+    expect(components).not.toContain("color-mix(in oklch, var(--user-accent) 10%, var(--surface-panel))");
     // 정체성은 보더 채널을 소유하지 않는다 — 보더는 상태(brass/aurora/coral) 전용.
     expect(components).not.toContain("border-color: var(--user-accent)");
     expect(markBlock).toContain("width: 8px;");
     expect(markBlock).toContain("height: 14px;");
     expect(markBlock).toContain("background: var(--user-accent);");
-    expect(washBlock).toContain("color-mix(in oklch, var(--user-accent) 10%, var(--surface-panel))");
-    expect(washBlock).toContain("background-clip: padding-box");
     expect(chipAccentBlock).toContain("width: 3px;");
     expect(chipAccentBlock).toContain("top: 7px;");
     expect(chipAccentBlock).toContain("bottom: 7px;");
@@ -608,10 +608,9 @@ describe("Instrument core design contract", () => {
     expect(chipAccentBlock).toContain("pointer-events: none;");
     expect(chipAccentBlock).not.toMatch(/animation/);
     expect(minimapDotBlock).toContain("background: var(--user-accent);");
-    // 5개 소비처: 미니맵 도트 · 명판 마크 · 명판 워시 · 사이드바 칩 스파인 · 포커스 결합 워시.
-    // 마지막은 정체성 워시 위에 포커스 워시를 겹치는 결합 규칙이라 새 채널이 아니다 —
-    // Map에서 accent는 mark+wash에만 머물고, 3px 스파인은 레일(사이드바 칩)에만 남는다.
-    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(5);
+    // 3개 소비처: 미니맵 도트 · 명판 마크 · 사이드바 칩 스파인.
+    // Map에서 accent는 마크에만 머물고, 3px 스파인은 레일(사이드바 칩)에만 남는다.
+    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(3);
     expect(accentSources).not.toMatch(/--op-accent|--chip-accent/);
   });
 
@@ -1912,11 +1911,11 @@ describe("Instrument core design contract", () => {
     expect(components).not.toMatch(/\.canvas-operation\.is-unseen > \.canvas-operation-titlebar::after \{\n\s*animation: caption-rail-arrive/);
     expect(operationFrame).toContain('arrivalFlash ? "is-unseen-arriving" : ""');
     expect(operationFrame).toContain("previousUnseenRef");
-    // 정체성 워시와 포커스 워시는 같은 표면을 다투지 않는다 — 결합 규칙이 둘을 겹쳐 칠한다.
-    // 둘 다 캡션만 진다. 창 면 변수로 올리면 채팅 본문까지 따라간다.
-    expect(components).toContain('.canvas-operation[style*="--user-accent"] .canvas-operation-titlebar {');
-    expect(components).toContain('.canvas-operation[style*="--user-accent"].is-active > .canvas-operation-titlebar {');
-    expect(components).toContain("color-mix(in oklab, var(--brass) 10%, color-mix(in oklch, var(--user-accent) 10%, var(--surface-panel)))");
+    // 정체성은 캡션 채움을 소유하지 않는다 — 언포커스는 --surface-panel, 포커스는 brass
+    // 워시 하나만. 창 면 변수로 올리면 채팅 본문까지 따라간다.
+    expect(components).not.toContain('.canvas-operation[style*="--user-accent"] .canvas-operation-titlebar {');
+    expect(components).not.toContain('.canvas-operation[style*="--user-accent"].is-active > .canvas-operation-titlebar {');
+    expect(components).not.toContain("color-mix(in oklab, var(--brass) 10%, color-mix(in oklch, var(--user-accent) 10%, var(--surface-panel)))");
     expect(components).not.toContain('.canvas-operation[style*="--user-accent"]:not(.is-active) .canvas-operation-titlebar {');
     // oklch 믹스는 hue를 극좌표 호로 보간한다 — brass(78)+ink-rim(245) 62%는 hue 141(초록)에
     // 착지해 위치 채널이 신호 채널 positive(160) 옆에 앉았다. 캡션 워시는 oklab으로 섞는다.


### PR DESCRIPTION
## Summary
- 액센트가 있는 패널의 언포커스 캡션이 정체성 워시를 입어 본문과 다른 면으로 갈라지던 문제를 고칩니다.
- 캡션 채움은 액센트가 없을 때와 같습니다. 언포커스는 `--surface-panel`, 포커스는 brass 워시. 정체성은 명판 마크·레일 칩 스파인·미니맵 도트에만 남습니다.
- 아직 미릴리스인 캡션 정체성 노트를 워시를 뺀 계약에 맞게 고칩니다.

Changelog-Amend: panel-group-caption-label.md

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/operation-frame-identity.test.ts tests/active-operation-surface.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] 액센트가 있는 패널과 없는 패널을 나란히 두고, 언포커스 캡션이 본문과 한 면인지 확인
- [ ] 포커스 시 둘 다 같은 brass 워시를 입는지 확인
- [ ] 명판 마크·레일 칩 스파인·미니맵 도트는 액센트 색을 유지하는지 확인