### PR TITLE
feat(quota): show Claude, Codex, and xAI extra-usage plan badges

### DIFF
--- a/.changelog.d/quota-plan-badges.md
+++ b/.changelog.d/quota-plan-badges.md
@@ -1,0 +1,8 @@
+---
+branch: quota-plan-badges
+---
+
+### fleet-console
+#### Changed
+- Quota cards now show Claude Max 5x/20x, Codex Pro 5x/20x, and xAI SuperGrok plan names.
+  ko: 쿼터 카드가 Claude Max 5x/20x, Codex Pro 5x/20x, xAI SuperGrok 플랜 이름을 보여 줍니다.

--- a/packages/core-ai-gateway/src/anthropic/credentials.ts
+++ b/packages/core-ai-gateway/src/anthropic/credentials.ts
@@ -7,6 +7,8 @@ export interface ClaudeCredentials {
   readonly accessToken: string;
   readonly expiresAt?: number;
   readonly subscriptionType?: string;
+  /** Login-snapshot extra-usage multiplier, e.g. `default_claude_max_20x`. */
+  readonly rateLimitTier?: string;
   readonly method: CredentialMethod;
 }
 
@@ -26,10 +28,12 @@ function parseClaudeCredentialJson(raw: string, method: CredentialMethod): Claud
     const oauth = credentialRecord(parsed.claudeAiOauth);
     const accessToken = optionalString(oauth?.accessToken ?? parsed.accessToken);
     if (!accessToken) return null;
+    const rateLimitTier = optionalString(oauth?.rateLimitTier ?? parsed.rateLimitTier);
     return {
       accessToken,
       expiresAt: optionalEpoch(oauth?.expiresAt ?? parsed.expiresAt),
       subscriptionType: optionalString(oauth?.subscriptionType ?? parsed.subscriptionType),
+      ...(rateLimitTier === undefined ? {} : { rateLimitTier }),
       method,
     };
   } catch {

--- a/packages/core-ai-gateway/src/anthropic/quota.ts
+++ b/packages/core-ai-gateway/src/anthropic/quota.ts
@@ -26,6 +26,21 @@ import { resolveClaudeCredentials } from "./credentials.js";
 // `durationBasis: "catalog"` — visibly an assumption that can go stale.
 export const CLAUDE_SESSION_MS = 5 * HOUR_MS;
 
+/**
+ * OpenUsage reads `subscriptionType` plus a `\d+x` suffix from `rateLimitTier`.
+ * Only Max carries that extra-usage multiplier; Pro/Team/Free stay the product name.
+ */
+export function formatClaudePlan(
+  subscriptionType: unknown,
+  rateLimitTier?: unknown,
+): string | undefined {
+  const base = titleCase(subscriptionType);
+  if (!base) return undefined;
+  if (base.toLowerCase() !== "max" || typeof rateLimitTier !== "string") return base;
+  const match = /\d+x/i.exec(rateLimitTier.trim());
+  return match ? titleCase(`${base} ${match[0].toLowerCase()}`) : base;
+}
+
 function firstClaudePercent(row: Record<string, unknown>): number | undefined {
   for (const key of ["percent", "used_percentage", "utilization"] as const) {
     const value = row[key];
@@ -121,7 +136,7 @@ export async function fetchClaudeUsage(deps: ProviderDeps = {}): Promise<Provide
     return {
       status: "ok",
       method: credentials.method,
-      plan: titleCase(credentials.subscriptionType),
+      plan: formatClaudePlan(credentials.subscriptionType, credentials.rateLimitTier),
       windows: parsed.windows,
       fetchedAt: (deps.now ?? Date.now)(),
     };

--- a/packages/core-ai-gateway/src/codex/quota.ts
+++ b/packages/core-ai-gateway/src/codex/quota.ts
@@ -35,6 +35,22 @@ function codexWindow(source: unknown, fallbackId: "session" | "weekly"): QuotaWi
   };
 }
 
+/**
+ * Codex `plan_type` is a product slug. OpenUsage maps the two Pro extra-usage
+ * SKUs to the public 5x/20x labels; every other slug stays a title-cased name.
+ */
+export function formatCodexPlan(value: unknown): string | undefined {
+  if (typeof value !== "string") return titleCase(value);
+  switch (value.trim().toLowerCase()) {
+    case "prolite":
+      return "Pro 5x";
+    case "pro":
+      return "Pro 20x";
+    default:
+      return titleCase(value);
+  }
+}
+
 export function parseCodexUsage(payload: unknown): { readonly windows: readonly QuotaWindow[]; readonly plan?: string } {
   const root = object(payload) ?? {};
   const rateLimit = object(root.rate_limit) ?? {};
@@ -43,7 +59,7 @@ export function parseCodexUsage(payload: unknown): { readonly windows: readonly 
       codexWindow(rateLimit.primary_window, "session"),
       codexWindow(rateLimit.secondary_window, "weekly"),
     ].filter((row): row is QuotaWindow => row !== null),
-    plan: titleCase(root.plan_type),
+    plan: formatCodexPlan(root.plan_type),
   };
 }
 

--- a/packages/core-ai-gateway/src/xai/quota.ts
+++ b/packages/core-ai-gateway/src/xai/quota.ts
@@ -6,11 +6,13 @@ import {
   object,
   percent,
   safeTimestamp,
+  titleCase,
   type ProviderDeps,
 } from "../quota/windows.js";
 import { resolveXaiCliAuth, type XaiCliCredentials } from "./credentials.js";
 
 export const XAI_CLI_CREDITS_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+export const XAI_CLI_SETTINGS_URL = "https://cli-chat-proxy.grok.com/v1/settings";
 const WEEKLY_PERIOD = "USAGE_PERIOD_TYPE_WEEKLY";
 
 export type ParsedXaiCredits =
@@ -55,6 +57,11 @@ export function parseXaiCredits(payload: unknown): ParsedXaiCredits | null {
       },
     },
   };
+}
+
+/** OpenUsage reads the display string Grok already localizes for the CLI. */
+export function parseXaiPlan(payload: unknown): string | undefined {
+  return titleCase(object(payload)?.subscription_tier_display);
 }
 
 function creditsHeaders(credentials: XaiCliCredentials): Record<string, string> {
@@ -104,8 +111,16 @@ export async function fetchXaiUsage(deps: ProviderDeps = {}): Promise<ProviderRe
     }
     const parsed = parseXaiCredits(payload);
     if (!parsed) throw new Error("Grok returned an unsupported quota response");
+    let plan: string | undefined;
+    try {
+      plan = parseXaiPlan(await getJson(fetchImpl, XAI_CLI_SETTINGS_URL, creditsHeaders(credentials)));
+    } catch {
+      // Plan metadata is display-only; its failure must not sink the usage snapshot.
+      plan = undefined;
+    }
     return {
       status: "ok",
+      ...(plan ? { plan } : {}),
       windows: parsed.status === "weekly" ? [parsed.window] : [],
       fetchedAt: now(),
     };

--- a/packages/core-ai-gateway/tests/anthropic/credentials.test.ts
+++ b/packages/core-ai-gateway/tests/anthropic/credentials.test.ts
@@ -25,7 +25,12 @@ function deps(overrides: Partial<CredentialResolverDeps> = {}): CredentialResolv
 describe("credential resolvers", () => {
   it("uses the macOS keychain first and passes an argv array without a shell", async () => {
     const execFile = vi.fn(async () => JSON.stringify({
-      claudeAiOauth: { accessToken: "secret", expiresAt: 9_000, subscriptionType: "max" },
+      claudeAiOauth: {
+        accessToken: "secret",
+        expiresAt: 9_000,
+        subscriptionType: "max",
+        rateLimitTier: "default_claude_max_20x",
+      },
     }));
     const readBounded = vi.fn(async () => "");
     const result = await resolveClaudeCredentials(deps({ platform: "darwin", execFile, readBounded }));
@@ -35,7 +40,13 @@ describe("credential resolvers", () => {
       { timeout: 5_000 },
     );
     expect(readBounded).not.toHaveBeenCalled();
-    expect(result).toEqual({ accessToken: "secret", expiresAt: 9_000, subscriptionType: "max", method: "keychain" });
+    expect(result).toEqual({
+      accessToken: "secret",
+      expiresAt: 9_000,
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+      method: "keychain",
+    });
   });
 
   it("falls back to CLAUDE_CONFIG_DIR on macOS when keychain lookup fails", async () => {

--- a/packages/core-ai-gateway/tests/anthropic/quota.test.ts
+++ b/packages/core-ai-gateway/tests/anthropic/quota.test.ts
@@ -1,15 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { CredentialResolverDeps } from "../../src/transport/credentials.js";
-import { fetchClaudeUsage, parseClaudeUsage } from "../../src/anthropic/quota.js";
+import { fetchClaudeUsage, formatClaudePlan, parseClaudeUsage } from "../../src/anthropic/quota.js";
 import { parseCodexUsage, parseResetCredits } from "../../src/codex/quota.js";
 
-function claudeCredentials(subscriptionType = "max"): CredentialResolverDeps {
+function claudeCredentials(subscriptionType = "max", rateLimitTier?: string): CredentialResolverDeps {
   return {
     platform: "linux",
     homedir: () => "/users/operator",
     env: {},
-    readBounded: async () => JSON.stringify({ claudeAiOauth: { accessToken: "secret", subscriptionType } }),
+    readBounded: async () => JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "secret",
+        subscriptionType,
+        ...(rateLimitTier === undefined ? {} : { rateLimitTier }),
+      },
+    }),
     execFile: async () => "",
   };
 }
@@ -147,8 +153,24 @@ function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
       .toEqual({ available: 150_000, nextExpiresAt: 2_000_000_000_000 });
   });
 
+  it("appends a Max extra-usage multiplier from the login snapshot", async () => {
+    expect(formatClaudePlan("max", "default_claude_max_5x")).toBe("Max 5x");
+    expect(formatClaudePlan("max", "claude_max_subscription_20x")).toBe("Max 20x");
+    expect(formatClaudePlan("pro", "default_claude_max_20x")).toBe("Pro");
+    expect(formatClaudePlan("max")).toBe("Max");
+
+    const max20 = await fetchClaudeUsage({
+      credentials: claudeCredentials("max", "default_claude_max_20x"),
+      fetch: (async () => jsonResponse({})) as typeof fetch,
+      now: () => 1,
+    });
+    expect(max20.status === "ok" ? max20.plan : undefined).toBe("Max 20x");
+  });
+
   it("shape-validates plans and model labels without an enumerated allowlist", async () => {
-    expect(parseCodexUsage({ plan_type: "pro" }).plan).toBe("Pro");
+    expect(parseCodexUsage({ plan_type: "pro" }).plan).toBe("Pro 20x");
+    expect(parseCodexUsage({ plan_type: "prolite" }).plan).toBe("Pro 5x");
+    expect(parseCodexUsage({ plan_type: "plus" }).plan).toBe("Plus");
     expect(parseClaudeUsage({
       limits: [{
         kind: "weekly_scoped",
@@ -196,7 +218,7 @@ function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
       }).windows[0]?.label, value).toBe("Model");
     }
 
-    for (const value of ["max", "pro", "Sonnet 4.5", "Fable", "Max 20x"]) {
+    for (const value of ["max", "plus", "Sonnet 4.5", "Fable", "Max 20x"]) {
       expect(parseCodexUsage({ plan_type: value }).plan, value)
         .toBe(`${value[0]?.toUpperCase() ?? ""}${value.slice(1)}`);
       expect(parseClaudeUsage({

--- a/packages/core-ai-gateway/tests/codex/quota.test.ts
+++ b/packages/core-ai-gateway/tests/codex/quota.test.ts
@@ -34,7 +34,7 @@ describe("Codex response parsing", () => {
         secondary_window: { used_percent: -3, limit_window_seconds: 10_080 * 60, reset_at: 2_000_000_000_000 },
       },
     })).toEqual({
-      plan: "Pro",
+      plan: "Pro 20x",
       windows: [
         {
           id: "session",

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -5,9 +5,11 @@ import {
   XAI_CLI_CREDITS_URL,
   XAI_CLI_REFRESH_URL,
   XAI_CLI_RESPONSES_URL,
+  XAI_CLI_SETTINGS_URL,
   XaiResponsesAdapter,
   fetchXaiUsage,
   parseXaiCredits,
+  parseXaiPlan,
   resolveXaiCliAuth,
   resolveXaiCliCredentials,
   xaiCliAuthFilePath,
@@ -155,6 +157,13 @@ const WEEKLY_PERIOD = {
 
 function creditsResponse(config: Record<string, unknown>, status = 200): Response {
   return new Response(JSON.stringify({ config }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function settingsResponse(plan: string, status = 200): Response {
+  return new Response(JSON.stringify({ subscription_tier_display: plan }), {
     status,
     headers: { "content-type": "application/json" },
   });
@@ -321,6 +330,14 @@ describe("Grok quota", () => {
     expect(XAI_CLI_CREDITS_URL).toContain("billing?format=credits");
   });
 
+  it("reads the Grok settings display string as the plan badge", () => {
+    expect(parseXaiPlan({ subscription_tier_display: "SuperGrok" })).toBe("SuperGrok");
+    expect(parseXaiPlan({ subscription_tier_display: "SuperGrok Plus" })).toBe("SuperGrok Plus");
+    expect(parseXaiPlan({ subscription_tier_display: "SuperGrok Heavy" })).toBe("SuperGrok Heavy");
+    expect(parseXaiPlan({ subscription_tier_display: "Bearer abc123" })).toBeUndefined();
+    expect(XAI_CLI_SETTINGS_URL).toContain("/v1/settings");
+  });
+
   it("treats an omitted creditUsagePercent as a genuine 0%", () => {
     // proto3 JSON drops zeros. OpenUsage documents the same shape: absent means 0, not drift.
     expect(parseXaiCredits({ config: { currentPeriod: WEEKLY_PERIOD } })).toMatchObject({
@@ -337,10 +354,13 @@ describe("Grok quota", () => {
   });
 
   it("reads weekly credits with Grok CLI subscription headers", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async () => creditsResponse({
-      creditUsagePercent: 42.4,
-      currentPeriod: WEEKLY_PERIOD,
-    }));
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      if (String(url) === XAI_CLI_SETTINGS_URL) return settingsResponse("SuperGrok Heavy");
+      return creditsResponse({
+        creditUsagePercent: 42.4,
+        currentPeriod: WEEKLY_PERIOD,
+      });
+    });
     const result = await fetchXaiUsage({
       credentials: deps(JSON.stringify({
         "https://auth.x.ai::profile": {
@@ -360,7 +380,12 @@ describe("Grok quota", () => {
     expect(headers.get("authorization")).toBe("Bearer access-token");
     expect(headers.get("x-xai-token-auth")).toBe("xai-grok-cli");
     expect(headers.get("x-userid")).toBe("user-1");
-    expect(result).toMatchObject({ status: "ok", windows: [{ id: "weekly", usedPercent: 42 }] });
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(XAI_CLI_SETTINGS_URL);
+    expect(result).toMatchObject({
+      status: "ok",
+      plan: "SuperGrok Heavy",
+      windows: [{ id: "weekly", usedPercent: 42 }],
+    });
   });
 
   it("returns an empty weekly window when proto-JSON omitted the 0% field", async () => {
@@ -388,27 +413,50 @@ describe("Grok quota", () => {
         user_id: "user-1",
       },
     };
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      throw new Error("unexpected fetch");
-    });
-    fetchMock
-      .mockImplementationOnce(async () => new Response("unauthorized", { status: 401 }))
-      .mockImplementationOnce(async (url) => {
-        expect(String(url)).toBe(XAI_CLI_REFRESH_URL);
-        return refreshResponse("fresh-token");
-      })
-      .mockImplementationOnce(async (url, init) => {
-        expect(String(url)).toBe(XAI_CLI_CREDITS_URL);
+    let creditsCalls = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (url, init) => {
+      const href = String(url);
+      if (href === XAI_CLI_CREDITS_URL) {
+        creditsCalls += 1;
+        if (creditsCalls === 1) return new Response("unauthorized", { status: 401 });
         expect(new Headers(init?.headers).get("authorization")).toBe("Bearer fresh-token");
         return creditsResponse({ creditUsagePercent: 7, currentPeriod: WEEKLY_PERIOD });
-      });
+      }
+      if (href === XAI_CLI_REFRESH_URL) return refreshResponse("fresh-token");
+      if (href === XAI_CLI_SETTINGS_URL) return settingsResponse("SuperGrok Plus");
+      throw new Error(`unexpected fetch ${href}`);
+    });
     const result = await fetchXaiUsage({
       credentials: deps(JSON.stringify(auth)),
       fetch: fetchMock,
       now: () => Date.parse("2026-08-14T00:00:00Z"),
     });
-    expect(result).toMatchObject({ status: "ok", windows: [{ usedPercent: 7 }] });
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({
+      status: "ok",
+      plan: "SuperGrok Plus",
+      windows: [{ usedPercent: 7 }],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps the usage snapshot when the settings plan call fails", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      if (String(url) === XAI_CLI_SETTINGS_URL) return new Response("not found", { status: 404 });
+      return creditsResponse({ creditUsagePercent: 11, currentPeriod: WEEKLY_PERIOD });
+    });
+    const result = await fetchXaiUsage({
+      credentials: deps(JSON.stringify({
+        "https://auth.x.ai::profile": {
+          key: "access-token",
+          oidc_issuer: "https://auth.x.ai",
+          expires_at: "2026-08-15T00:00:00Z",
+        },
+      })),
+      fetch: fetchMock,
+      now: () => Date.parse("2026-08-14T00:00:00Z"),
+    });
+    expect(result).toMatchObject({ status: "ok", windows: [{ usedPercent: 11 }] });
+    expect(result.status === "ok" ? result.plan : "missing").toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Claude 쿼터 배지가 로그인 스냅샷의 `rateLimitTier`에서 Max 5x/20x를 읽고, Pro/Team 등 하위 구독은 상품명만 유지합니다.
- Codex `plan_type`의 `prolite`/`pro`를 Pro 5x/20x로 표시하고, Plus 등 나머지는 기존 title-case를 유지합니다.
- xAI는 OpenUsage와 같은 `/v1/settings`의 `subscription_tier_display`로 SuperGrok / SuperGrok Plus / SuperGrok Heavy를 붙이며, settings 실패는 주간 사용률 조회를 깨지 않습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`