### PR TITLE
perf(fleet-console): keep File Explorer opens off the listing tail

### DIFF
--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -144,6 +144,25 @@ export function isCurrentContextRequest(requestContextKey: string, currentContex
   return requestContextKey === currentContextKey;
 }
 
+export type FolderExpandFetch = "none" | "foreground" | "background";
+
+export interface FolderExpandPlan {
+  readonly nextExpanded: boolean;
+  readonly fetch: FolderExpandFetch;
+}
+
+/** 접힘→펼침은 캐시가 있으면 즉시 그리고, 진행 중 요청은 합류한다. */
+export function planFolderExpand(
+  isCurrentlyExpanded: boolean,
+  hasCachedResult: boolean,
+  isInFlight: boolean,
+): FolderExpandPlan {
+  if (isCurrentlyExpanded) return { nextExpanded: false, fetch: "none" };
+  if (isInFlight) return { nextExpanded: true, fetch: "none" };
+  if (hasCachedResult) return { nextExpanded: true, fetch: "background" };
+  return { nextExpanded: true, fetch: "foreground" };
+}
+
 // 탭 복귀 시 git 배지를 다시 읽을지 판정한다 — 외부 터미널의 add/commit 같은
 // git 메타데이터 전용 변경은 fs.watch가 감지하지 못하므로 focus 복귀가 갱신 기회다.
 export function shouldRefreshGitStatusOnVisibility(visibilityState: string): boolean {
@@ -367,6 +386,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
   contextKeyRef.current = contextKey;
   const childResultsRef = useRef<Map<string, FolderListResult>>(childResults);
   childResultsRef.current = childResults;
+  const inFlightFoldersRef = useRef(new Map<string, Promise<void>>());
   const filterRequestRef = useRef(0);
   const isFiltering = Boolean(filterText);
 
@@ -399,6 +419,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
     setCurrentPath("");
     setExpandedDirs(new Set());
     setChildResults(new Map());
+    inFlightFoldersRef.current.clear();
     setFilterText("");
     setFilterCollapsedDirs(new Set());
     setScrollTop(0);
@@ -607,28 +628,44 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
 
   const handleDirClick = useCallback((entry: FolderEntry) => {
     const relPath = entry.relativePath;
-    // 현재 펼침 상태를 읽어 펼치는 동작인지 판단
-    const isExpanding = !expandedDirs.has(relPath);
+    const plan = planFolderExpand(
+      expandedDirsRef.current.has(relPath),
+      childResultsRef.current.has(relPath),
+      inFlightFoldersRef.current.has(relPath),
+    );
     setExpandedDirs((prev) => {
       const next = new Set(prev);
-      if (next.has(relPath)) { next.delete(relPath); return next; }
-      next.add(relPath);
+      if (plan.nextExpanded) next.add(relPath);
+      else next.delete(relPath);
+      expandedDirsRef.current = next;
       return next;
     });
-    // 폴더를 펼 때마다 항상 서버에서 재조회 (영구 캐시 제거)
-    if (isExpanding) {
-      const requestContextKey = contextKey;
-      setLoadingDirs((prev) => new Set(prev).add(relPath));
-      files.listFolder(relPath).then((r) => {
-        if (!isCurrentContextRequest(requestContextKey, contextKeyRef.current)) return;
-        setChildResults((prev) => new Map(prev).set(relPath, r));
-        setLoadingDirs((prev) => { const s = new Set(prev); s.delete(relPath); return s; });
-      }).catch(() => {
-        if (!isCurrentContextRequest(requestContextKey, contextKeyRef.current)) return;
-        setLoadingDirs((prev) => { const s = new Set(prev); s.delete(relPath); return s; });
+    if (plan.fetch === "none") return;
+    const requestContextKey = contextKey;
+    const showSpinner = plan.fetch === "foreground";
+    if (showSpinner) setLoadingDirs((prev) => new Set(prev).add(relPath));
+    const request = files.listFolder(relPath).then((r) => {
+      if (!isCurrentContextRequest(requestContextKey, contextKeyRef.current)) return;
+      setChildResults((prev) => new Map(prev).set(relPath, r));
+    }).catch(() => {
+      if (!isCurrentContextRequest(requestContextKey, contextKeyRef.current)) return;
+      // 캐시가 없는 첫 펼침 실패는 빈 폴더로 남기지 않고 접는다.
+      if (childResultsRef.current.has(relPath)) return;
+      setExpandedDirs((prev) => {
+        if (!prev.has(relPath)) return prev;
+        const next = new Set(prev);
+        next.delete(relPath);
+        expandedDirsRef.current = next;
+        return next;
       });
-    }
-  }, [contextKey, files, expandedDirs]);
+    }).finally(() => {
+      inFlightFoldersRef.current.delete(relPath);
+      if (!showSpinner) return;
+      if (!isCurrentContextRequest(requestContextKey, contextKeyRef.current)) return;
+      setLoadingDirs((prev) => { const s = new Set(prev); s.delete(relPath); return s; });
+    });
+    inFlightFoldersRef.current.set(relPath, request);
+  }, [contextKey, files]);
 
   const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
     setScrollTop((e.currentTarget as HTMLDivElement).scrollTop);

--- a/runtime/fleet-plugins/file-explorer/server/tree-services.ts
+++ b/runtime/fleet-plugins/file-explorer/server/tree-services.ts
@@ -28,6 +28,8 @@ export class FolderBrowserError extends Error {
 }
 
 const DIRECTORY_ENTRY_CAP = 500;
+/** 심링크 분류 동시성 — 직렬 realpath/stat가 큰 폴더 펼침을 막지 않게 한다. */
+const CLASSIFY_CONCURRENCY = 16;
 
 /** 버전 관리 날것 디렉터리 — 목록·필터·검색에서 항상 제외하고, 제외 사실은 hiddenVcsInternals로 알린다. */
 export const VCS_INTERNAL_NAMES: ReadonlySet<string> = new Set([".git", ".svn", ".hg"]);
@@ -102,29 +104,103 @@ async function collectContentsEntries(
 ): Promise<boolean> {
   const directory = await openDirectory(targetPath, opendir);
   try {
+    const pending: fs.Dirent[] = [];
+    let truncated = false;
+
+    const accept = (entry: FolderEntry | VcsInternalMarker | null): boolean => {
+      if (entry === null) return false;
+      if ("vcsInternal" in entry) {
+        hiddenVcs.push(entry.vcsInternal);
+        return false;
+      }
+      if (entries.length >= DIRECTORY_ENTRY_CAP) return true;
+      entries.push(entry);
+      return false;
+    };
+
+    const flushPending = async (): Promise<boolean> => {
+      while (pending.length > 0) {
+        if (entries.length >= DIRECTORY_ENTRY_CAP) {
+          pending.length = 0;
+          return true;
+        }
+        const remaining = DIRECTORY_ENTRY_CAP - entries.length;
+        const batch = pending.splice(0, Math.min(CLASSIFY_CONCURRENCY, remaining));
+        const classified = await Promise.all(
+          batch.map((item) => toContentsEntry(targetPath, theaterPath, item, stat)),
+        );
+        let overflowed = false;
+        for (const entry of classified) {
+          if (overflowed) {
+            if (entry && "vcsInternal" in entry) hiddenVcs.push(entry.vcsInternal);
+            continue;
+          }
+          if (accept(entry)) overflowed = true;
+        }
+        if (overflowed) {
+          pending.length = 0;
+          return true;
+        }
+      }
+      return false;
+    };
+
+    // 상한 이후에는 이름만 보고 VCS 날것을 기록한다. 심링크 실해석은 하지 않고,
+    // 표시에서 빠진 일반 항목을 하나라도 보면 즉시 멈춘다.
+    const finishCheapTail = async (first: fs.Dirent | null): Promise<boolean> => {
+      pending.length = 0;
+      let current = first;
+      let omitted = false;
+      while (current !== null) {
+        if (VCS_INTERNAL_NAMES.has(current.name)) hiddenVcs.push(current.name);
+        else {
+          omitted = true;
+          break;
+        }
+        current = await directory.read();
+      }
+      return omitted;
+    };
+
     let dirent = await directory.read();
     while (dirent !== null) {
-      // 분류(이름 + 심링크 실해석)가 cap 판정보다 먼저다 — 상한은 "표시 가능한" 항목만 센다.
       if (VCS_INTERNAL_NAMES.has(dirent.name)) {
         hiddenVcs.push(dirent.name);
         dirent = await directory.read();
         continue;
       }
-      const entry = await toContentsEntry(targetPath, theaterPath, dirent, stat);
-      if (entry === null) {
-        dirent = await directory.read();
-        continue;
+      if (entries.length >= DIRECTORY_ENTRY_CAP) {
+        truncated = await finishCheapTail(dirent);
+        dirent = null;
+        break;
       }
-      if ("vcsInternal" in entry) {
-        hiddenVcs.push(entry.vcsInternal);
-        dirent = await directory.read();
-        continue;
+      if (dirent.isDirectory() || dirent.isFile()) {
+        if (pending.length > 0 && await flushPending()) {
+          truncated = true;
+          await finishCheapTail(dirent);
+          dirent = null;
+          break;
+        }
+        const rel = path.relative(theaterPath, path.join(targetPath, dirent.name));
+        if (accept({ name: dirent.name, relativePath: rel, kind: dirent.isDirectory() ? "dir" : "file" })) {
+          truncated = true;
+          await finishCheapTail(await directory.read());
+          dirent = null;
+          break;
+        }
+      } else {
+        pending.push(dirent);
+        if (pending.length >= CLASSIFY_CONCURRENCY && await flushPending()) {
+          truncated = true;
+          await finishCheapTail(await directory.read());
+          dirent = null;
+          break;
+        }
       }
-      if (entries.length >= DIRECTORY_ENTRY_CAP) return true;
-      entries.push(entry);
       dirent = await directory.read();
     }
-    return false;
+    if (!truncated && await flushPending()) truncated = true;
+    return truncated;
   } catch (error) {
     throw mapFolderBrowserFsError(error);
   } finally {
@@ -579,7 +655,8 @@ export async function handleFilesList(
 
   try {
     const result = await listTheaterContents(theaterPath, relPath);
-    await watcherRegistry.trackDirectory(rawTheaterId, theaterPath, relPath);
+    // 감시 등록은 응답을 막지 않는다. Linux 첫 펼침의 중복 realpath/stat를 목록 지연에서 뺀다.
+    void watcherRegistry.trackDirectory(rawTheaterId, theaterPath, relPath).catch(() => {});
     ctx.host.http.writeJson(res, 200, result);
   } catch (error) {
     if (error instanceof FolderBrowserError) {

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -309,6 +309,9 @@ export function createWatcherRegistry(
     try {
       startWatcher(theaterId, entry, relativePath, target.path, target.identity);
       entry.pendingDirectories.delete(relativePath);
+      // 목록 응답은 등록을 기다리지 않으므로, 스냅샷과 watcher 사이 공백을
+      // 등록 직후 한 번 더 알려 클라이언트가 다시 읽게 한다.
+      scheduleChange(entry, relativePath);
     } catch {
       for (const notify of entry.stateSubscribers) notify("degraded");
     }

--- a/runtime/fleet-plugins/file-explorer/tests/theater-contents.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/theater-contents.test.ts
@@ -174,11 +174,13 @@ describe("listTheaterContents VCS edge cases", () => {
     }
   });
 
-  it("500개 항목 뒤의 .git 별칭 심링크도 cap 판정 전에 실해석으로 분류한다", async () => {
+  it("표시 상한 이후의 심링크 꼬리는 실해석하지 않고 truncated로 알린다", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-contents-aliascap-"));
     fs.mkdirSync(path.join(dir, ".git"));
     fs.symlinkSync(path.join(dir, ".git"), path.join(dir, "metadata"), "dir");
-    // 순서 통제: 표시 가능 파일 500개를 먼저, 별칭 심링크를 마지막에 낸다.
+    const realpath = vi.spyOn(fs.promises, "realpath");
+    const stat = vi.spyOn(fs.promises, "stat");
+    // 순서 통제: 표시 가능 파일 500개를 먼저, 별칭 심링크와 깨진 심링크 꼬리를 뒤에 낸다.
     const dirents = [
       ...Array.from({ length: 500 }, (_, i) => ({
         name: `file-${String(i).padStart(3, "0")}.txt`,
@@ -192,6 +194,12 @@ describe("listTheaterContents VCS edge cases", () => {
         isFile: () => false,
         isSymbolicLink: () => true,
       },
+      ...Array.from({ length: 32 }, (_, i) => ({
+        name: `alias-${String(i).padStart(2, "0")}`,
+        isDirectory: () => false,
+        isFile: () => false,
+        isSymbolicLink: () => true,
+      })),
     ];
     const fakeOpendir = async () => ({
       read: async () => dirents.shift() ?? null,
@@ -199,12 +207,97 @@ describe("listTheaterContents VCS edge cases", () => {
     });
 
     try {
-      const result = await listTheaterContents(dir, "", { opendir: fakeOpendir as unknown as typeof fs.promises.opendir });
+      const result = await listTheaterContents(dir, "", {
+        opendir: fakeOpendir as unknown as typeof fs.promises.opendir,
+      });
 
       expect(result.entries).toHaveLength(500);
-      expect(result).not.toHaveProperty("truncated");
-      expect(result.hiddenVcsInternals).toEqual([".git"]);
+      expect(result).toMatchObject({ truncated: true, cap: 500 });
+      expect(result).not.toHaveProperty("hiddenVcsInternals");
+      // 루트/대상 containment용 realpath 2회만 — 상한 이후 심링크는 분류하지 않는다.
+      expect(realpath).toHaveBeenCalledTimes(2);
+      expect(stat).toHaveBeenCalledTimes(1);
     } finally {
+      realpath.mockRestore();
+      stat.mockRestore();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("심링크 배치가 상한을 넘기면 디렉터리 끝에서도 truncated이다", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-contents-batchcap-"));
+    fs.writeFileSync(path.join(dir, "target.txt"), "");
+    for (let index = 0; index < 16; index++) {
+      fs.symlinkSync(path.join(dir, "target.txt"), path.join(dir, `link-${String(index).padStart(2, "0")}`));
+    }
+    const dirents = [
+      ...Array.from({ length: 485 }, (_, i) => ({
+        name: `file-${String(i).padStart(3, "0")}.txt`,
+        isDirectory: () => false,
+        isFile: () => true,
+        isSymbolicLink: () => false,
+      })),
+      ...Array.from({ length: 16 }, (_, i) => ({
+        name: `link-${String(i).padStart(2, "0")}`,
+        isDirectory: () => false,
+        isFile: () => false,
+        isSymbolicLink: () => true,
+      })),
+    ];
+    const fakeOpendir = async () => ({
+      read: async () => dirents.shift() ?? null,
+      close: async () => undefined,
+    });
+
+    try {
+      const result = await listTheaterContents(dir, "", {
+        opendir: fakeOpendir as unknown as typeof fs.promises.opendir,
+      });
+
+      expect(result.entries).toHaveLength(500);
+      expect(result).toMatchObject({ truncated: true, cap: 500 });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("상한을 넘는 심링크 배치는 남은 칸만 실해석한다", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-contents-remain-"));
+    fs.writeFileSync(path.join(dir, "target.txt"), "");
+    for (let index = 0; index < 16; index++) {
+      fs.symlinkSync(path.join(dir, "target.txt"), path.join(dir, `link-${String(index).padStart(2, "0")}`));
+    }
+    const realpath = vi.spyOn(fs.promises, "realpath");
+    const dirents = [
+      ...Array.from({ length: 499 }, (_, i) => ({
+        name: `file-${String(i).padStart(3, "0")}.txt`,
+        isDirectory: () => false,
+        isFile: () => true,
+        isSymbolicLink: () => false,
+      })),
+      ...Array.from({ length: 16 }, (_, i) => ({
+        name: `link-${String(i).padStart(2, "0")}`,
+        isDirectory: () => false,
+        isFile: () => false,
+        isSymbolicLink: () => true,
+      })),
+    ];
+    const fakeOpendir = async () => ({
+      read: async () => dirents.shift() ?? null,
+      close: async () => undefined,
+    });
+
+    try {
+      const result = await listTheaterContents(dir, "", {
+        opendir: fakeOpendir as unknown as typeof fs.promises.opendir,
+      });
+
+      expect(result.entries).toHaveLength(500);
+      expect(result).toMatchObject({ truncated: true, cap: 500 });
+      // containment 2회 + 상한을 채우는 심링크 1회만.
+      expect(realpath).toHaveBeenCalledTimes(3);
+    } finally {
+      realpath.mockRestore();
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/runtime/fleet-plugins/file-explorer/tests/tree-context-state.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/tree-context-state.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { FolderListResult } from "../server/types.js";
 
-import { buildFlatRows, FILTER_DIRECTORY_CAP, isCurrentContextRequest, isEntryRow, loadFilterDescendants, type PluginFilesClient } from "../client/tree.js";
+import { buildFlatRows, FILTER_DIRECTORY_CAP, isCurrentContextRequest, isEntryRow, loadFilterDescendants, planFolderExpand, type PluginFilesClient } from "../client/tree.js";
 
 const ROOT_ENTRIES = [{ name: "src", relativePath: "src", kind: "dir" }] as const;
 const SRC_RESULT: FolderListResult = {
@@ -103,6 +103,19 @@ describe("FileTree context request guard", () => {
 
     expect(source).toContain("const isFiltering = Boolean(filterText);");
     expect(source).toContain("}, [contextKey, files, isFiltering, result, showHidden]);");
+  });
+
+  it("re-expands from cache and joins an in-flight list instead of starting another", () => {
+    expect(planFolderExpand(true, true, false)).toEqual({ nextExpanded: false, fetch: "none" });
+    expect(planFolderExpand(false, false, false)).toEqual({ nextExpanded: true, fetch: "foreground" });
+    expect(planFolderExpand(false, true, false)).toEqual({ nextExpanded: true, fetch: "background" });
+    expect(planFolderExpand(false, true, true)).toEqual({ nextExpanded: true, fetch: "none" });
+    expect(planFolderExpand(false, false, true)).toEqual({ nextExpanded: true, fetch: "none" });
+    const source = fs.readFileSync(new URL("../client/tree.tsx", import.meta.url), "utf8");
+    expect(source).toContain("planFolderExpand(");
+    expect(source).toContain("inFlightFoldersRef");
+    expect(source).toContain("if (childResultsRef.current.has(relPath)) return;");
+    expect(source).toMatch(/setExpandedDirs\(\(prev\) => \{\s*if \(!prev\.has\(relPath\)\) return prev;/);
   });
 
   it("stops traversing when a server result repeats a visited relative path", async () => {

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -330,7 +330,15 @@ describe("createWatcherRegistry", () => {
     try {
       const unsub = registry.subscribe("t1", tempRoot, onChange, () => {});
       await registry.trackDirectory("t1", tempRoot, "src");
+      vi.advanceTimersByTime(100);
+      // 첫 등록은 스냅샷–감시 공백을 메우려고 한 번 알린다.
+      expect(onChange).toHaveBeenCalledOnce();
+      expect(onChange).toHaveBeenCalledWith("src");
+      onChange.mockClear();
+
       await registry.trackDirectory("t1", tempRoot, "src");
+      vi.advanceTimersByTime(100);
+      expect(onChange).not.toHaveBeenCalled();
 
       expect(mockFactory).toHaveBeenCalledTimes(2);
       expect(mockFactory).toHaveBeenLastCalledWith(


### PR DESCRIPTION
## Summary
- PR #730이 500개 상한 뒤의 심링크 꼬리까지 `realpath`/`stat`로 분류해 폴더 펼침이 느려졌습니다. 표시 상한에 도달하면 값싼 VCS 이름만 더 읽고 즉시 멈춥니다.
- 접었다가 다시 열 때는 캐시된 자식을 바로 그리고, 진행 중 목록 요청은 합류합니다.
- 목록 응답은 Linux watcher 등록을 기다리지 않습니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/file-explorer test`
- [x] `pnpm --filter @fleet-plugins/file-explorer typecheck`
- [ ] 큰 폴더(심링크/`node_modules` 포함)를 펼쳤을 때 파일이 바로 보이는지 확인
- [ ] 같은 폴더를 접었다 다시 열면 캐시가 즉시 그려지는지 확인