### PR TITLE
fix(fleet-console): release War Room hover magnification when the pointer leaves

### DIFF
--- a/.changelog.d/warroom-deck-gap.md
+++ b/.changelog.d/warroom-deck-gap.md
@@ -1,0 +1,8 @@
+---
+branch: warroom-deck-gap
+---
+
+### fleet-console
+#### Fixed
+- Release a War Room panel's hover magnification as soon as the pointer leaves it, so a magnified panel no longer stays enlarged over its neighbour and close the gap between deck tiles.
+  ko: War Room에서 포인터가 패널을 벗어나면 확대를 즉시 걷어, 확대된 패널이 옆 패널을 덮은 채 남아 덱 칸 사이 간격을 가리는 일이 없습니다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -853,8 +853,14 @@ export function TriageWatchDeck({
     // 포커스 예외가 없으면 키보드로 연 확대가 무관한 포인터 이동 한 번에 걷힌다.
     const holds = (node: EventTarget | null, operationId: string): boolean =>
       cellOf(node)?.dataset.triageDeckCard === operationId;
-    const keyboardHolds = (operationId: string): boolean =>
-      holds(grid.ownerDocument.activeElement, operationId);
+    // 포커스가 확대를 붙들 수 있는 것은 키보드로 옮겨온 포커스뿐이다 — 무장 경로(onFocus)와 같은
+    // :focus-visible 술어를 쓴다. 포인터가 남긴 포커스까지 인정하면, 확대된 칸의 캡션 컨트롤을
+    // 누른 뒤(닫기 첫 클릭은 확인만 무장하고 칸이 그대로 남는다) 포인터를 치워도 해제가 막혀
+    // 이 변경이 없애려는 고착이 그대로 되살아난다.
+    const keyboardHolds = (operationId: string): boolean => {
+      const active = grid.ownerDocument.activeElement;
+      return active instanceof Element && active.matches(":focus-visible") && holds(active, operationId);
+    };
     // 이탈 판정은 "떠나는 칸"이 아니라 "붙들고 있는 칸"을 기준으로 한다. 칸에서 발화한 out만
     // 보면, 칸이 재정렬·재마운트로 포인터 밑을 빠져나간 뒤의 이탈은 영영 오지 않아 확대가
     // 주인 없이 남는다 — 포인터를 치워도 풀리지 않고 이웃 칸을 덮은 채 굳는 경로다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -538,6 +538,11 @@ export function TriageWatchDeck({
   const mapDragRef = useRef<TriageMapDragState | null>(null);
   const [draggingMarkerId, setDraggingMarkerId] = useState<string | null>(null);
   const quicklookTimerRef = useRef<number | null>(null);
+  // 확대를 붙들고 있는 Operation — 드웰 무장 시점부터 기록한다. 확대가 존재할 근거는 "포인터(또는
+  // 키보드 포커스)가 그 칸 위에 있다"는 사실이므로, 해제 판정은 그 사실을 직접 물어야 한다.
+  // 상태(quicklook)는 드웰이 끝나야 채워지므로 무장 구간을 덮지 못하고, ref는 렌더를 기다리지
+  // 않아 같은 프레임의 포인터 이벤트에서도 최신이다.
+  const armedQuicklookRef = useRef<string | null>(null);
   // rect 기록 effect는 quicklook을 deps로 갖지 않으므로(스크롤/리사이즈마다 재구독 방지),
   // 스테일 클로저 없이 현재 값을 읽도록 ref 미러를 둔다.
   const quicklookRef = useRef<typeof quicklook>(null);
@@ -703,11 +708,13 @@ export function TriageWatchDeck({
 
   const dismissQuicklook = () => {
     clearQuicklookTimer();
+    armedQuicklookRef.current = null;
     setQuicklook(null);
     setMapQuicklook(null);
   };
 
   const armQuicklook = (operationId: string, card: HTMLElement, dwell: boolean) => {
+    armedQuicklookRef.current = operationId;
     const fire = () => {
       quicklookTimerRef.current = null;
       const grid = gridRef.current;
@@ -842,11 +849,26 @@ export function TriageWatchDeck({
       if (!operationId || deckPointerRef.current.arriving === operationId) return;
       deckPointerRef.current.arm(operationId, cell, true);
     };
-    const onPointerOut = (event: PointerEvent) => {
-      const cell = cellOf(event.target);
-      if (!cell || cellOf(event.relatedTarget) === cell) return;
+    // 확대를 붙들 자격 — 포인터가 그 칸 안에 있거나, 키보드 포커스가 그 칸을 잡고 있어야 한다.
+    // 포커스 예외가 없으면 키보드로 연 확대가 무관한 포인터 이동 한 번에 걷힌다.
+    const holds = (node: EventTarget | null, operationId: string): boolean =>
+      cellOf(node)?.dataset.triageDeckCard === operationId;
+    const keyboardHolds = (operationId: string): boolean =>
+      holds(grid.ownerDocument.activeElement, operationId);
+    // 이탈 판정은 "떠나는 칸"이 아니라 "붙들고 있는 칸"을 기준으로 한다. 칸에서 발화한 out만
+    // 보면, 칸이 재정렬·재마운트로 포인터 밑을 빠져나간 뒤의 이탈은 영영 오지 않아 확대가
+    // 주인 없이 남는다 — 포인터를 치워도 풀리지 않고 이웃 칸을 덮은 채 굳는 경로다.
+    const releaseUnless = (node: EventTarget | null) => {
+      const armed = armedQuicklookRef.current;
+      if (armed === null) return;
+      if (holds(node, armed) || keyboardHolds(armed)) return;
       deckPointerRef.current.dismiss();
     };
+    // out은 도착지(relatedTarget)가, move는 현재 지점(target)이 자격을 답한다.
+    const onPointerOut = (event: PointerEvent) => { releaseUnless(event.relatedTarget); };
+    // 덱을 떠나지 않은 채 칸만 포인터 밑에서 빠져나간 경우는 out이 오지 않는다 — 다음 이동에서
+    // 현재 지점을 다시 물어 확대의 주인을 확인한다.
+    const onPointerMove = (event: PointerEvent) => { releaseUnless(event.target); };
     const onContextMenu = (event: MouseEvent) => {
       const cell = cellOf(event.target);
       const operationId = cell?.dataset.triageDeckCard;
@@ -855,10 +877,12 @@ export function TriageWatchDeck({
     };
     grid.addEventListener("pointerover", onPointerOver);
     grid.addEventListener("pointerout", onPointerOut);
+    grid.addEventListener("pointermove", onPointerMove, { passive: true });
     grid.addEventListener("contextmenu", onContextMenu);
     return () => {
       grid.removeEventListener("pointerover", onPointerOver);
       grid.removeEventListener("pointerout", onPointerOut);
+      grid.removeEventListener("pointermove", onPointerMove);
       grid.removeEventListener("contextmenu", onContextMenu);
     };
   }, [visible]);

--- a/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
+++ b/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
@@ -161,6 +161,56 @@ describe("War Room deck Quick-Look release", () => {
     expect(expanded()).toEqual([OPERATION_B.id]);
   });
 
+  // 확대된 칸의 캡션 컨트롤을 포인터로 누르면 그 컨트롤이 activeElement로 남는다 — 닫기 첫 클릭은
+  // 확인만 무장하고 칸이 그대로 살아 있으므로 실제로 일어나는 상태다. 포커스가 확대를 붙들 자격은
+  // 키보드로 옮겨온 포커스(:focus-visible)뿐이라, 그 두 경우가 갈리는지를 함께 잰다.
+  // jsdom의 `:focus-visible`은 포커스가 있으면 무조건 참이라 포커스의 유래를 구분하지 못한다 —
+  // 제품이 읽는 바로 그 술어만 이 테스트가 통제해, 두 방향을 모두 실제 계약으로 검증한다.
+  const withFocusVisible = (visible: boolean, run: () => void) => {
+    const original = Element.prototype.matches;
+    Element.prototype.matches = function matchesWithFocusVisible(this: Element, selector: string): boolean {
+      if (selector === ":focus-visible") return visible && this.ownerDocument.activeElement === this;
+      return original.call(this, selector);
+    };
+    try { run(); } finally { Element.prototype.matches = original; }
+  };
+
+  it("does not let pointer-borne focus hold the expansion", () => {
+    const grid = enterDeck();
+    const cell = cellFor(OPERATION.id);
+    hover(cell);
+    expect(expanded()).toEqual([OPERATION.id]);
+
+    withFocusVisible(false, () => {
+      act(() => cell.querySelector<HTMLElement>(".canvas-triage-deck-pick")!.focus());
+      expect(cell.contains(document.activeElement)).toBe(true);
+      act(() => grid.dispatchEvent(new PointerEvent("pointerout", {
+        bubbles: true,
+        pointerType: "mouse",
+        relatedTarget: document.body,
+      })));
+    });
+    expect(expanded()).toEqual([]);
+  });
+
+  it("lets keyboard focus hold the expansion after the pointer leaves", () => {
+    const grid = enterDeck();
+    const cell = cellFor(OPERATION.id);
+
+    withFocusVisible(true, () => {
+      // 키보드 사용자는 포인터 없이 확대를 연다 — 포인터 이벤트가 그 확대를 걷어내면 안 된다.
+      act(() => cell.querySelector<HTMLElement>(".canvas-triage-deck-pick")!.focus());
+      expect(expanded()).toEqual([OPERATION.id]);
+      act(() => grid.dispatchEvent(new PointerEvent("pointerout", {
+        bubbles: true,
+        pointerType: "mouse",
+        relatedTarget: document.body,
+      })));
+      act(() => grid.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
+      expect(expanded()).toEqual([OPERATION.id]);
+    });
+  });
+
   it("cancels an armed dwell that never became an expansion", () => {
     const grid = enterDeck();
     // 드웰 중(아직 확대 전)에 포인터가 칸을 떠나면 확대는 열리지 않아야 한다. 확대 상태만 보고

--- a/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
+++ b/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../core/client/src/plugin-registry.js", () => ({
+  usePluginRegistry: () => ({
+    plugins: [],
+    operationKinds: [{
+      pluginId: "test-plugin",
+      type: "shell",
+      title: "Test",
+      render: () => null,
+    }],
+    settingsSections: [],
+    notificationKinds: [],
+    railPanels: [],
+  }),
+}));
+
+import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
+import { loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
+import { resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive } from "../core/client/src/canvas/triage-store.js";
+import { TRIAGE_DECK_QUICKLOOK_DWELL_MS } from "../core/client/src/canvas/triage-watch-deck.js";
+import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
+
+const THEATER = "theater-a";
+const OPERATION: OperationNode = {
+  id: "operation-a",
+  theaterId: THEATER,
+  type: "shell",
+  pluginId: "test-plugin",
+  title: "Operation A",
+  payload: {},
+  geometry: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 },
+  ts: { createdAt: 0, updatedAt: 0 },
+};
+const OPERATION_B: OperationNode = { ...OPERATION, id: "operation-b", title: "Operation B" };
+const CATALOG = [{ id: "test-plugin", title: "Test", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }];
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  loadForTheater(THEATER);
+  setCanvasState({ viewport: { x: 0, y: 0, zoom: 1 }, operations: { [OPERATION.id]: OPERATION.geometry! } });
+  setTriageActive(true);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  resetTriageDeckZoomForTests();
+  setTriageActive(false);
+  resetTriageTheater(THEATER);
+  loadForTheater(null);
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+// Quick-Look은 칸을 최대 1.95배로 키워 이웃 칸 위로 넘긴다 — 그 확대가 주인 없이 남으면 덱은
+// "패널 하나만 밀도보다 크고 옆 칸을 덮은" 상태로 굳는다. 확대의 존재 근거는 포인터(또는 키보드
+// 포커스)가 그 칸을 붙들고 있다는 사실이므로, 그 사실이 깨지는 모든 경로가 확대를 걷어야 한다.
+describe("War Room deck Quick-Look release", () => {
+  const enterDeck = () => {
+    act(() => root!.render(createElement(OperationsCanvas, {
+      state: STATE,
+      catalog: CATALOG,
+      canLaunch: true,
+      renderKindIcon: () => null,
+      onLaunchKind: () => {},
+      onLaunchAtGeometry: () => {},
+      onClose: () => {},
+      onFocus: () => {},
+      onRename: () => {},
+      onSetAccent: () => {},
+    })));
+    // 진입 커튼이 걷혀야 덱이 선다.
+    act(() => { vi.advanceTimersByTime(2_000); });
+    const grid = container!.querySelector<HTMLElement>(".canvas-triage-deck-grid");
+    expect(grid, "deck grid must be mounted once the curtain lifts").not.toBeNull();
+    return grid!;
+  };
+
+  const cellFor = (operationId: string) =>
+    container!.querySelector<HTMLElement>(`[data-triage-deck-card="${operationId}"]`)!;
+
+  const hover = (cell: HTMLElement) => {
+    act(() => cell.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse" })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
+  };
+
+  const expanded = () => [...container!.querySelectorAll(".canvas-triage-deck-cell.is-quicklook")]
+    .map((cell) => (cell as HTMLElement).dataset.triageDeckCard);
+
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("releases the expanded cell when the pointer leaves the deck from outside any cell", () => {
+    const grid = enterDeck();
+    hover(cellFor(OPERATION.id));
+    expect(expanded()).toEqual([OPERATION.id]);
+
+    // 칸이 재정렬·재마운트로 포인터 밑을 빠져나간 뒤의 이탈은 칸에서 발화하지 않는다. 종전 판정은
+    // "칸에서 시작한 out"만 해제로 받아, 이 경로에서 확대가 영영 주인 없이 남았다.
+    act(() => grid.dispatchEvent(new PointerEvent("pointerout", {
+      bubbles: true,
+      pointerType: "mouse",
+      relatedTarget: document.body,
+    })));
+    expect(expanded()).toEqual([]);
+  });
+
+  it("releases the expanded cell on the next pointer move over a cell-free part of the deck", () => {
+    const grid = enterDeck();
+    hover(cellFor(OPERATION.id));
+    expect(expanded()).toEqual([OPERATION.id]);
+
+    // 포인터를 치우면 풀려야 한다 — 덱 안이지만 칸이 아닌 자리(밴드 여백)로의 이동이 그 최소 신호다.
+    act(() => grid.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
+    expect(expanded()).toEqual([]);
+  });
+
+  it("keeps the expansion while the pointer moves within the same cell", () => {
+    enterDeck();
+    const cell = cellFor(OPERATION.id);
+    hover(cell);
+    expect(expanded()).toEqual([OPERATION.id]);
+
+    // 칸 안의 이동(본문 → 캡션 → 창 컨트롤)은 이탈이 아니다 — 여기서 걷히면 커서 밑에서 컨트롤이
+    // 사라진다. 패널은 캔버스가 portal한 것이라 이 이동은 네이티브 버블로만 관측된다.
+    const inside = cell.querySelector<HTMLElement>(".canvas-triage-deck-pick") ?? cell;
+    act(() => inside.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
+    expect(expanded()).toEqual([OPERATION.id]);
+    act(() => inside.dispatchEvent(new PointerEvent("pointerout", {
+      bubbles: true,
+      pointerType: "mouse",
+      relatedTarget: cell,
+    })));
+    expect(expanded()).toEqual([OPERATION.id]);
+  });
+
+  it("hands the expansion to the cell the pointer moved onto", () => {
+    enterDeck();
+    const from = cellFor(OPERATION.id);
+    const to = cellFor(OPERATION_B.id);
+    hover(from);
+    expect(expanded()).toEqual([OPERATION.id]);
+
+    // 브라우저는 out(도착지=새 칸) → over(새 칸) 순으로 보낸다. 두 칸이 동시에 확대되면 안 된다.
+    act(() => from.dispatchEvent(new PointerEvent("pointerout", { bubbles: true, pointerType: "mouse", relatedTarget: to })));
+    act(() => to.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse", relatedTarget: from })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
+    expect(expanded()).toEqual([OPERATION_B.id]);
+  });
+
+  it("cancels an armed dwell that never became an expansion", () => {
+    const grid = enterDeck();
+    // 드웰 중(아직 확대 전)에 포인터가 칸을 떠나면 확대는 열리지 않아야 한다. 확대 상태만 보고
+    // 판정하면 이 구간이 비어 있어, 떠난 뒤에 확대가 뒤늦게 열린다.
+    act(() => cellFor(OPERATION.id).dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse" })));
+    act(() => grid.dispatchEvent(new PointerEvent("pointerout", {
+      bubbles: true,
+      pointerType: "mouse",
+      relatedTarget: document.body,
+    })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
+    expect(expanded()).toEqual([]);
+  });
+});
+
+const STATE: ConsoleState = {
+  connection: "connecting",
+  connectionLostAt: null,
+  channel: "unknown",
+  activeTheme: "maritime",
+  version: "test",
+  updateAvailable: false,
+  latestVersion: null,
+  portMode: "dynamic",
+  requestedPort: null,
+  effectivePort: 0,
+  portHonored: true,
+  theaters: [{ id: THEATER, label: "Alpha" }],
+  operations: [OPERATION, OPERATION_B],
+  operationsHydrated: true,
+  groups: [],
+  activeTheaterId: THEATER,
+  activeOperationId: OPERATION.id,
+  activeOperationAcknowledged: true,
+  operationRuntime: {
+    [OPERATION.id]: { lifecycle: "live", activity: "idle" },
+    [OPERATION_B.id]: { lifecycle: "live", activity: "idle" },
+  },
+  addingTheater: false,
+  theaterError: null,
+  operationsViewActive: true,
+  operationSearchOpen: false,
+  operationSearchSeed: null,
+  quickLaunchOpen: false,
+  quickLaunchPinned: false,
+  quickLaunchFocusToggle: 0,
+  quickLaunchExpandRequest: 0,
+  quickLaunchDockSuppressed: false,
+  quickLaunchDraft: null,
+  quickLaunchError: null,
+  pendingQuickLaunch: null,
+  whatsNewOpen: false,
+  releaseNotes: [],
+  releaseNotesLoading: false,
+  releaseNotesError: null,
+  releaseNotesSourceRef: null,
+  releaseNotesFetchedAt: null,
+  releaseNotesStale: false,
+  automaticWhatsNewVersion: null,
+  selectedReleaseNoteKey: null,
+  onboardingOpen: false,
+  bootstrapped: true,
+  pendingOperationFocus: null,
+  keyboardFocusRequest: null,
+  pendingSideBarAddTheater: false,
+  pendingSideBarTheaterLaunch: null,
+  launchMenuRequest: null,
+  keyboardShortcutsOpen: false,
+  operationNotifications: {},
+  notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
+  codexReader: null,
+  codexReaderExpanded: false,
+};


### PR DESCRIPTION
## Summary
- War Room 덱의 Quick-Look 확대가 **칸에서 발화한 `pointerout`** 으로만 해제되어, 칸이 정지한 포인터 밑을 빠져나간 뒤(재정렬·재마운트·리플로우)에는 그 이벤트가 영영 오지 않아 확대가 주인 없이 남았습니다. 그 결과 패널 하나만 덱 밀도보다 크게 그려져 이웃 칸을 덮고 10px 칸 간격을 가렸고, 포인터를 치워도 풀리지 않았습니다(칸이 아닌 자리에서 나가는 경로도 같은 early return에 걸림).
- 해제 판정을 "떠나는 칸"이 아니라 **"확대를 붙들고 있는 칸"** 기준으로 바꾸고, 드웰 무장 시점부터 그 주인을 기록해 확대 이전 구간까지 덮습니다. `pointermove`로도 주인을 재확인해, `pointerout` 없이 칸이 포인터를 떠난 경우 다음 이동에서 걷습니다.
- 같은 칸 안의 이동(본문 → 캡션 → 창 컨트롤)과 키보드 포커스가 그 칸을 잡고 있는 동안에는 확대를 유지합니다.

## Test Plan
- [x] `vitest run tests/triage-deck-quicklook-release.test.tsx` — 신규 회귀 5건 통과. 수정을 되돌리면 3건 실패(결함을 실제로 잡는지 확인)
- [x] `vitest run` (fleet-console 전체) — 2158 passed / 24 skipped
- [x] `tsc --noEmit -p tsconfig.json` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] 격리 콘솔 헤드리스 실측(줌 2.0×, 2열): 확대 시 첫 칸 `521 → 543.9px`로 이웃(x=838)을 12.9px 침범 → 칸 밖 `pointerout` 및 `pointermove` 각각에서 `521px` 복원, 칸 간격 `10px` 확인