### PR TITLE
fix(fleet-console): keep Quaker speech surfaces opaque off Instrument

### DIFF
--- a/.changelog.d/fix-quaker-bubble-theme-opacity.md
+++ b/.changelog.d/fix-quaker-bubble-theme-opacity.md
@@ -1,0 +1,8 @@
+---
+branch: fix/quaker-bubble-theme-opacity
+---
+
+### fleet-console
+#### Fixed
+- Keep the Quaker aides' speech bubbles and full-answer card opaque in the Carbon, Maritime, and Whites themes, so the Map and panels behind them no longer show through the words.
+  ko: Carbon·Maritime·Whites 테마에서 퀘이커 부관의 말풍선과 전문 보기 카드를 불투명하게 유지해, 글 뒤로 맵과 패널이 비쳐 보이지 않습니다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -36,6 +36,7 @@ const PRODUCT_SOURCE_SKIP_DIR_NAMES = new Set([
 ]);
 const JSX_FACTORY_NAMES = new Set(["createElement", "jsx", "jsxs"]);
 const SKILLS_CSS_PATH = new URL("../../fleet-plugins/skills/client/skills.css", import.meta.url);
+const SCUTTLEBUTT_CSS_PATH = new URL("../../fleet-plugins/scuttlebutt/client/styles.css", import.meta.url);
 const TERMINAL_AGENT_PATH = new URL("../../fleet-plugins/terminal/client/agent/index.tsx", import.meta.url);
 const TERMINAL_ANALYSIS_CSS_PATH = new URL("../../fleet-plugins/terminal/client/agent/analysis.css", import.meta.url);
 const TERMINAL_AGENT_CLI_CSS_PATH = new URL("../../fleet-plugins/terminal/client/agent/agent-cli.css", import.meta.url);
@@ -1075,6 +1076,7 @@ describe("Instrument core design contract", () => {
     const layout = source("styles/layout.css");
     const skillsCss = externalSource(SKILLS_CSS_PATH);
     const terminalAnalysisCss = externalSource(TERMINAL_ANALYSIS_CSS_PATH);
+    const scuttlebuttCss = externalSource(SCUTTLEBUTT_CSS_PATH);
     // Doctrine: scrim-backed popup cards, floating menus, and anchored guidance cards
     // composite their glass layers over an opaque var(--ink-deep) final layer —
     // maritime/carbon/whites glass tokens carry 60~82% alpha, so without the underlay they
@@ -1111,6 +1113,19 @@ describe("Instrument core design contract", () => {
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__artifact-menu \{[^}]*var\(--ink-deep\);/);
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__export-menu \{[^}]*var\(--ink-deep\);/);
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__slash \{[^}]*var\(--ink-deep\);/);
+    // Quaker aides float over the Map — the same glass token that is opaque on Instrument
+    // is 78~82% alpha on every other theme, so the speech surfaces need the underlay too.
+    for (const selector of [
+      ".scuttlebutt-bird-tag",
+      ".scuttlebutt-bird-say",
+      ".scuttlebutt-arrival-bubble",
+      ".scuttlebutt-answer-bubble",
+      ".scuttlebutt-departure-bubble",
+      ".scuttlebutt-chat-card",
+    ]) {
+      const scoped = selector.replace(/\./g, "\\.");
+      expect(scuttlebuttCss).toMatch(new RegExp(`${scoped} \\{[\\s\\S]*?\\),\\s*var\\(--ink-deep\\);`));
+    }
   });
 
   it("pins the Command Band and closed-chrome contracts", () => {

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -32,7 +32,10 @@
   left: 50%;
   top: calc(100% - 8px);
   transform: translateX(-50%);
-  background: var(--surface-glass-strong);
+  /* 팝업 판독성 계약: glass 층 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
+  background:
+    linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
+    var(--ink-deep);
   border: 1px solid var(--hairline);
   border-radius: var(--radius-pill);
   color: var(--text-secondary);
@@ -56,7 +59,10 @@
   left: 50%;
   bottom: 96%;
   transform: translate(-50%, -4px);
-  background: var(--surface-glass-strong);
+  /* 팝업 판독성 계약: glass 층 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
+  background:
+    linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
+    var(--ink-deep);
   border: 1px solid color-mix(in oklch, var(--brass) 45%, var(--hairline));
   border-radius: var(--radius-md);
   color: var(--text-primary);
@@ -378,7 +384,13 @@
   overflow: hidden;
   border: 1px solid color-mix(in oklch, var(--positive) 50%, var(--hairline));
   border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--positive) 12%, var(--surface-glass-strong));
+  /* 팝업 판독성 계약: positive wash와 glass 층 아래 불투명 --ink-deep 언더레이를 둔다. */
+  background:
+    linear-gradient(
+      color-mix(in oklch, var(--positive) 12%, var(--surface-glass-strong)),
+      color-mix(in oklch, var(--positive) 12%, var(--surface-glass-strong))
+    ),
+    var(--ink-deep);
   box-shadow: var(--shadow-floating);
   color: var(--text-primary);
   font-size: 12px;
@@ -454,7 +466,10 @@
   overflow: hidden;
   border: 1px solid color-mix(in oklch, var(--brass) 45%, var(--hairline));
   border-radius: var(--radius-md);
-  background: var(--surface-glass-strong);
+  /* 팝업 판독성 계약: glass 층 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
+  background:
+    linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
+    var(--ink-deep);
   box-shadow: var(--shadow-floating);
   color: var(--text-primary);
   font-size: 12px;
@@ -629,7 +644,13 @@
      alpha 조절로 hue 80~90(amber)을 유지한다(awaiting 비콘의 color-mix(aurora, transparent)와 동형). */
   border: 1px solid color-mix(in oklch, var(--warn) 55%, transparent);
   border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--warn) 12%, var(--surface-glass-strong));
+  /* 팝업 판독성 계약: warn wash와 glass 층 아래 불투명 --ink-deep 언더레이를 둔다. */
+  background:
+    linear-gradient(
+      color-mix(in oklch, var(--warn) 12%, var(--surface-glass-strong)),
+      color-mix(in oklch, var(--warn) 12%, var(--surface-glass-strong))
+    ),
+    var(--ink-deep);
   box-shadow: var(--shadow-floating);
   color: var(--text-primary);
   font-size: 12px;
@@ -727,7 +748,10 @@
   overflow: hidden;
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-lg);
-  background: var(--surface-glass-strong);
+  /* 팝업 판독성 계약: glass 층 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
+  background:
+    linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
+    var(--ink-deep);
   box-shadow: var(--shadow-floating);
   animation: scuttlebutt-card-in var(--duration-base) var(--ease-spring);
 }

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-design-tokens.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-design-tokens.test.ts
@@ -13,20 +13,37 @@ describe("Scuttlebutt design tokens", () => {
   });
 
   it("keeps departure announcements on the warn channel token tiers", () => {
-    const bubble = styles.match(/\.scuttlebutt-departure-bubble \{[^}]*\}/)?.[0] ?? "";
+    const bubble = styles.match(/\.scuttlebutt-departure-bubble \{[\s\S]*?\n\}/)?.[0] ?? "";
     const label = styles.match(/\.scuttlebutt-departure-label \{[^}]*\}/)?.[0] ?? "";
     const focus = styles.match(/\.scuttlebutt-departure-open:focus-visible[^{]*\{[^}]*\}/)?.[0] ?? "";
     // 테두리는 alpha 조절로 amber hue를 지킨다 — hairline 믹스는 hue 보간이 그린에 착륙한다(실측).
     expect(bubble).toContain(
       "border: 1px solid color-mix(in oklch, var(--warn) 55%, transparent);",
     );
+    // 팝업 판독성 계약: warn wash는 그대로 두고, 반투명 glass 아래 불투명 언더레이를 깐다.
     expect(bubble).toContain(
-      "background: color-mix(in oklch, var(--warn) 12%, var(--surface-glass-strong));",
+      "color-mix(in oklch, var(--warn) 12%, var(--surface-glass-strong))",
     );
+    expect(bubble).toMatch(/\),\s*var\(--ink-deep\);/);
     expect(label).toContain("color: var(--warn-ink);");
     expect(label).not.toContain("72%");
     expect(focus).toContain("outline: 2px solid var(--warn);");
     // 닫기 액션도 같은 신호 채널의 포커스 규칙을 공유한다.
     expect(focus).toContain(".scuttlebutt-departure-dismiss:focus-visible");
+  });
+
+  it("keeps floating speech surfaces opaque under translucent glass themes", () => {
+    for (const selector of [
+      ".scuttlebutt-bird-tag",
+      ".scuttlebutt-bird-say",
+      ".scuttlebutt-arrival-bubble",
+      ".scuttlebutt-answer-bubble",
+      ".scuttlebutt-departure-bubble",
+      ".scuttlebutt-chat-card",
+    ]) {
+      const escaped = selector.replace(/\./g, "\\.");
+      const block = styles.match(new RegExp(`${escaped} \\{[\\s\\S]*?\\n\\}`))?.[0] ?? "";
+      expect(block, selector).toMatch(/\),\s*var\(--ink-deep\);/);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Maritime, Carbon, Whites 테마에서 `--surface-glass-strong`이 78–82% 알파라 퀘이커 부관의 말풍선과 전문 보기 카드 뒤로 맵이 비칩니다.
- 기존 팝업 판독성 계약과 같이 glass 층 아래 불투명 `--ink-deep` 언더레이를 깔아 Instrument 외 테마에서도 글이 읽히게 합니다.
- 답변·도착·출발 말풍선, 전문 보기 카드, 지저귐 말풍선과 이름 태그에 같은 처리를 적용하고 계약 테스트로 고정합니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/scuttlebutt test`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts -t "pins the popup opacity underlay contract"`
- [ ] Console에서 Carbon / Maritime / Whites로 전환한 뒤 퀘이커 답변 말풍선과 전문 보기 카드 뒤로 맵이 비치지 않는지 확인