### PR TITLE
fix(fleet-console): keep Station captions out of neighboring panels

### DIFF
--- a/.changelog.d/station-caption-gap.md
+++ b/.changelog.d/station-caption-gap.md
@@ -6,3 +6,5 @@ branch: station-caption-gap
 #### Fixed
 - Station Keeping now keeps window captions out of neighboring panels, not just the panel bodies.
   ko: Station Keeping이 본문뿐 아니라 창 캡션까지 이웃 패널과 겹치지 않게 간격을 유지합니다.
+- Station Keeping now settles a panel when a drag is interrupted without pointerup, so captions do not stay overlapped.
+  ko: 드래그가 pointerup 없이 끊겨도 Station Keeping이 정착해 캡션이 겹친 채 멈추지 않습니다.

--- a/.changelog.d/station-caption-gap.md
+++ b/.changelog.d/station-caption-gap.md
@@ -1,0 +1,8 @@
+---
+branch: station-caption-gap
+---
+
+### fleet-console
+#### Fixed
+- Station Keeping now keeps window captions out of neighboring panels, not just the panel bodies.
+  ko: Station Keeping이 본문뿐 아니라 창 캡션까지 이웃 패널과 겹치지 않게 간격을 유지합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -85,6 +85,7 @@ const ZOOM_TWEEN_ZOOM_EPSILON = 0.001;
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, operations: {}, operationOrder: [], operationAccent: {}, minimized: [], collapsedGroups: [], stationKeeping: false };
 // Station Keeping이 유지하는 패널 사이 최소 간격(월드 단위). 줌과 무관하게 월드 좌표로만 계산한다.
+// 충돌 상자는 본문이 아니라 창 캡션(top:-32px)을 더한 시각 프레임이다.
 export const STATION_KEEPING_GAP = 16;
 
 const listeners = new Set<Listener>();
@@ -535,7 +536,7 @@ export function restoreOperation(sessionId: string): void {
   let restored: OperationGeometry = { ...geometry, zIndex };
   // Station Keeping 중에는 복원도 정착을 거친다 — 자리를 비운 사이 다른 패널이 그 자리를 쓸 수 있다.
   if (state.stationKeeping) {
-    const spot = resolveClearPosition(restored, visibleObstacles(sessionId));
+    const spot = resolveStationKeepingPosition(restored, visibleObstacles(sessionId));
     restored = { ...restored, x: spot.x, y: spot.y };
   }
   setState({
@@ -593,7 +594,7 @@ export function ensureDefaultGeometry(sessionId: string): OperationGeometry {
     zIndex: claimTopZIndex(),
   };
   if (state.stationKeeping) {
-    const spot = resolveClearPosition(geometry, visibleObstacles(sessionId));
+    const spot = resolveStationKeepingPosition(geometry, visibleObstacles(sessionId));
     geometry = { ...geometry, x: spot.x, y: spot.y };
   }
   setState({ operations: { ...state.operations, [sessionId]: geometry } });
@@ -602,12 +603,24 @@ export function ensureDefaultGeometry(sessionId: string): OperationGeometry {
 
 // ── Station Keeping ──────────────────────────────────────────────────────────
 // Cruise의 상시 비겹침 규율. 모든 계산은 월드 좌표이고 캔버스는 무한 평면이므로 해는 항상 존재한다.
+// 충돌 상자는 본문 geometry가 아니라 창 캡션(top:-32px)을 더한 시각 프레임이다. 저장 좌표는 본문 그대로다.
 
 interface StationKeepingRect {
   readonly x: number;
   readonly y: number;
   readonly width: number;
   readonly height: number;
+}
+
+// Formation 가이드와 같은 시각 프레임 — 캡션은 본문 위(top:-32px)에 붙으므로 본문 AABB만
+// 보면 아래 패널 캡션이 위 패널 본문·캡션을 침범해도 규율이 침묵한다.
+function stationKeepingFrameFor(body: StationKeepingRect): StationKeepingRect {
+  return {
+    x: body.x,
+    y: body.y - OPERATION_WINDOW_CAPTION_HEIGHT,
+    width: body.width,
+    height: body.height + OPERATION_WINDOW_CAPTION_HEIGHT,
+  };
 }
 
 // gap 이상 떨어져 있으면 clear — 정확히 gap만큼 떨어진 접촉은 규율을 만족한다.
@@ -649,6 +662,20 @@ export function resolveClearPosition(
   return best ?? { x: target.x, y: target.y };
 }
 
+// 본문 좌표를 받아 시각 프레임으로 정착한 뒤 본문 좌표로 되돌린다.
+function resolveStationKeepingPosition(
+  body: StationKeepingRect,
+  obstacleBodies: readonly StationKeepingRect[],
+  gap = STATION_KEEPING_GAP,
+): { readonly x: number; readonly y: number } {
+  const spot = resolveClearPosition(
+    stationKeepingFrameFor(body),
+    obstacleBodies.map(stationKeepingFrameFor),
+    gap,
+  );
+  return { x: spot.x, y: spot.y + OPERATION_WINDOW_CAPTION_HEIGHT };
+}
+
 // 규율의 장애물은 "보이는 Cruise 패널"뿐이다 — 최소화·모드 투영·접힘은 자리를 차지하지 않는다.
 function visibleObstacles(excludeId: string | null): readonly StationKeepingRect[] {
   return Object.entries(state.operations)
@@ -670,7 +697,7 @@ function spreadVisibleOperations(
   const next = { ...operations };
   let changed = false;
   for (const [sessionId, geometry] of sorted) {
-    const spot = resolveClearPosition(geometry, placed);
+    const spot = resolveStationKeepingPosition(geometry, placed);
     if (spot.x !== geometry.x || spot.y !== geometry.y) {
       next[sessionId] = { ...geometry, x: spot.x, y: spot.y };
       changed = true;
@@ -711,7 +738,7 @@ export function settleOperationGeometry(sessionId: string): void {
   if (!state.stationKeeping) return;
   const geometry = state.operations[sessionId];
   if (!geometry || state.minimized.includes(sessionId)) return;
-  const spot = resolveClearPosition(geometry, visibleObstacles(sessionId));
+  const spot = resolveStationKeepingPosition(geometry, visibleObstacles(sessionId));
   if (spot.x === geometry.x && spot.y === geometry.y) return;
   setState({ operations: { ...state.operations, [sessionId]: { ...geometry, x: spot.x, y: spot.y } } });
 }
@@ -725,7 +752,7 @@ export function resolveLaunchGeometry(theaterId: string, geometry: OperationGeom
   const obstacles = Object.entries(snapshot.operations)
     .filter(([sessionId]) => !minimizedSet.has(sessionId))
     .map(([, existing]) => existing);
-  const spot = resolveClearPosition(geometry, obstacles);
+  const spot = resolveStationKeepingPosition(geometry, obstacles);
   if (spot.x === geometry.x && spot.y === geometry.y) return geometry;
   return { ...geometry, x: spot.x, y: spot.y };
 }

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -190,20 +190,29 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
     }, CLOSE_ARM_DURATION_MS);
   };
 
-  // 드래그/리사이즈 도중 캡처 대상(드래그 에지·리사이즈 핸들)이 언마운트되는 상태 전환에서는
-  // pointerup/pointercancel이 도달하지 않아 is-dragging이 잔존하고 공통 모션 transition이 영구 차단된다.
-  useEffect(() => {
-    if (!maximized && !interactionDisabled && !minimized) return;
+  // 캡처가 포인터업 없이 끊기면(언마운트·lostpointercapture) 라이브 좌표를 커밋한다.
+  // 버리면 Station Keeping이 정착하지 못해 캡션이 이웃 위에 겹친 채 멈춘다.
+  const finishPointerManipulation = (shouldCommit: boolean) => {
+    const drag = dragRef.current;
+    const resize = resizeRef.current;
+    if (!drag && !resize) return;
     dragRef.current = null;
     resizeRef.current = null;
     setDragging(false);
+    if (!shouldCommit) return;
+    if (drag?.capturing) onGeometryCommit(drag.latest);
+    else if (resize) onGeometryCommit(resize.latest);
+  };
+
+  // 드래그/리사이즈 도중 캡처 대상이 언마운트되면 pointerup이 오지 않는다.
+  // is-dragging을 걷고, 움직인 좌표는 정착 경로로 넘긴다.
+  useEffect(() => {
+    if (!maximized && !interactionDisabled && !minimized) return;
+    finishPointerManipulation(true);
   }, [maximized, interactionDisabled, minimized]);
 
   const abortPointerManipulation = () => {
-    if (!dragRef.current && !resizeRef.current) return;
-    dragRef.current = null;
-    resizeRef.current = null;
-    setDragging(false);
+    finishPointerManipulation(true);
   };
 
   const beginDrag = (event: ReactPointerEvent<HTMLDivElement>) => {

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -675,6 +675,15 @@ describe("canvas store", () => {
 describe("station keeping", () => {
   const rect = (x: number, y: number, width = 100, height = 100): OperationGeometry => ({ x, y, width, height, zIndex: 0 });
 
+  function windowFrame(body: OperationGeometry): { x: number; y: number; width: number; height: number } {
+    return {
+      x: body.x,
+      y: body.y - OPERATION_WINDOW_CAPTION_HEIGHT,
+      width: body.width,
+      height: body.height + OPERATION_WINDOW_CAPTION_HEIGHT,
+    };
+  }
+
   function expectAllVisibleClear(): void {
     const snapshot = getSnapshot();
     const visible = Object.entries(snapshot.operations)
@@ -682,11 +691,11 @@ describe("station keeping", () => {
       .map(([, geometry]) => geometry);
     for (let i = 0; i < visible.length; i += 1) {
       for (let j = i + 1; j < visible.length; j += 1) {
-        const a = visible[i]!;
-        const b = visible[j]!;
+        const a = windowFrame(visible[i]!);
+        const b = windowFrame(visible[j]!);
         const clear = a.x + a.width + STATION_KEEPING_GAP <= b.x || b.x + b.width + STATION_KEEPING_GAP <= a.x
           || a.y + a.height + STATION_KEEPING_GAP <= b.y || b.y + b.height + STATION_KEEPING_GAP <= a.y;
-        expect(clear, `panels ${i} and ${j} overlap: ${JSON.stringify([a, b])}`).toBe(true);
+        expect(clear, `panels ${i} and ${j} overlap: ${JSON.stringify([visible[i], visible[j]])}`).toBe(true);
       }
     }
   }
@@ -700,6 +709,21 @@ describe("station keeping", () => {
     const spot = resolveClearPosition(rect(0, 0), [rect(0, 0)]);
     const distance = Math.sqrt((spot.x - 0) ** 2 + (spot.y - 0) ** 2);
     expect(distance).toBeCloseTo(100 + STATION_KEEPING_GAP, 10);
+  });
+
+  it("spreads a vertical stack whose bodies are clear but whose caption sits on the panel above", () => {
+    // 본문은 정확히 gap만큼 떨어졌고, 아래 패널 캡션(top:-32px)만 위 본문을 침범한다.
+    setOperationGeometry("op-a", rect(0, 0, 640, 400));
+    setOperationGeometry("op-b", rect(0, 400 + STATION_KEEPING_GAP, 640, 400));
+
+    setStationKeeping(true);
+
+    expectAllVisibleClear();
+    const upper = getSnapshot().operations["op-a"]!;
+    const lower = getSnapshot().operations["op-b"]!;
+    expect(lower.y).toBeGreaterThanOrEqual(
+      upper.y + upper.height + STATION_KEEPING_GAP + OPERATION_WINDOW_CAPTION_HEIGHT,
+    );
   });
 
   it("enabling spreads overlapping panels and leaves them clear", () => {
@@ -753,6 +777,22 @@ describe("station keeping", () => {
     expect({ x: settled.x, y: settled.y }).toEqual({ x: anchor.x, y: anchor.y });
   });
 
+  it("settleOperationGeometry clears a caption that sits on the panel above", () => {
+    setOperationGeometry("op-a", rect(0, 0, 640, 400));
+    setOperationGeometry("op-b", rect(800, 0, 640, 400));
+    setStationKeeping(true);
+    const anchor = getSnapshot().operations["op-a"]!;
+
+    setOperationGeometry("op-b", { ...getSnapshot().operations["op-b"]!, x: 0, y: 400 + STATION_KEEPING_GAP });
+    settleOperationGeometry("op-b");
+
+    expectAllVisibleClear();
+    expect(getSnapshot().operations["op-a"]).toMatchObject({ x: anchor.x, y: anchor.y });
+    expect(getSnapshot().operations["op-b"]!.y).toBeGreaterThanOrEqual(
+      anchor.y + anchor.height + STATION_KEEPING_GAP + OPERATION_WINDOW_CAPTION_HEIGHT,
+    );
+  });
+
   it("settleOperationGeometry is a no-op while disabled", () => {
     setOperationGeometry("op-a", rect(0, 0));
     setOperationGeometry("op-b", rect(10, 10));
@@ -783,6 +823,21 @@ describe("station keeping", () => {
     expectAllVisibleClear();
   });
 
+  it("restoreOperation settles when only the restored caption overlaps the occupant", () => {
+    setOperationGeometry("op-a", rect(0, 400 + STATION_KEEPING_GAP, 640, 400));
+    setStationKeeping(true);
+    minimizeOperation("op-a");
+    setOperationGeometry("op-b", rect(0, 0, 640, 400));
+
+    restoreOperation("op-a");
+
+    expectAllVisibleClear();
+    const occupant = getSnapshot().operations["op-b"]!;
+    expect(getSnapshot().operations["op-a"]!.y).toBeGreaterThanOrEqual(
+      occupant.y + occupant.height + STATION_KEEPING_GAP + OPERATION_WINDOW_CAPTION_HEIGHT,
+    );
+  });
+
   it("resolveLaunchGeometry settles launch coordinates while enabled and passes them through while disabled", () => {
     setOperationGeometry("op-a", rect(0, 0));
     const launch = rect(10, 10);
@@ -791,9 +846,32 @@ describe("station keeping", () => {
 
     setStationKeeping(true);
     const settled = resolveLaunchGeometry("theater-a", launch);
-    const clear = settled.x >= 100 + STATION_KEEPING_GAP || settled.y >= 100 + STATION_KEEPING_GAP
-      || settled.x + settled.width + STATION_KEEPING_GAP <= 0 || settled.y + settled.height + STATION_KEEPING_GAP <= 0;
+    const launchFrame = windowFrame(settled);
+    const obstacleFrame = windowFrame(rect(0, 0));
+    const clear = launchFrame.x >= obstacleFrame.x + obstacleFrame.width + STATION_KEEPING_GAP
+      || launchFrame.y >= obstacleFrame.y + obstacleFrame.height + STATION_KEEPING_GAP
+      || launchFrame.x + launchFrame.width + STATION_KEEPING_GAP <= obstacleFrame.x
+      || launchFrame.y + launchFrame.height + STATION_KEEPING_GAP <= obstacleFrame.y;
     expect(clear).toBe(true);
+  });
+
+  it("resolveLaunchGeometry treats a caption-only stack as occupied", () => {
+    setOperationGeometry("op-a", rect(0, 0, 640, 400));
+    setStationKeeping(true);
+    const launch = rect(0, 400 + STATION_KEEPING_GAP, 640, 400);
+
+    const settled = resolveLaunchGeometry("theater-a", launch);
+
+    const occupant = getSnapshot().operations["op-a"]!;
+    expect(settled.y).toBeGreaterThanOrEqual(
+      occupant.y + occupant.height + STATION_KEEPING_GAP + OPERATION_WINDOW_CAPTION_HEIGHT,
+    );
+    const settledFrame = windowFrame(settled);
+    const occupantFrame = windowFrame(occupant);
+    expect(
+      settledFrame.y >= occupantFrame.y + occupantFrame.height + STATION_KEEPING_GAP
+        || occupantFrame.y >= settledFrame.y + settledFrame.height + STATION_KEEPING_GAP,
+    ).toBe(true);
   });
 
   it("persists the flag per theater and round-trips through storage", () => {
@@ -830,6 +908,27 @@ describe("station keeping", () => {
 
     expect(getStationKeeping()).toBe(true);
     expectAllVisibleClear();
+  });
+
+  it("loadForTheater restores the invariant when only captions overlap stored bodies", () => {
+    window.localStorage.setItem("fleet-console.canvas.theater-caption-drift", JSON.stringify({
+      viewport: { x: 0, y: 0, zoom: 1 },
+      operations: {
+        "op-a": rect(0, 0, 640, 400),
+        "op-b": rect(0, 400 + STATION_KEEPING_GAP, 640, 400),
+      },
+      stationKeeping: true,
+    }));
+
+    loadForTheater("theater-caption-drift");
+
+    expect(getStationKeeping()).toBe(true);
+    expectAllVisibleClear();
+    const upper = getSnapshot().operations["op-a"]!;
+    const lower = getSnapshot().operations["op-b"]!;
+    expect(lower.y).toBeGreaterThanOrEqual(
+      upper.y + upper.height + STATION_KEEPING_GAP + OPERATION_WINDOW_CAPTION_HEIGHT,
+    );
   });
 });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1939,6 +1939,9 @@ describe("Instrument core design contract", () => {
     // Tactical grid/rows 행 보폭은 같은 32px를 본문 피치에 넣어 아래 행 캡션이 위 칸을 침범하지 않는다.
     expect(source("canvas/canvas-store.ts")).toContain("export const OPERATION_WINDOW_CAPTION_HEIGHT = 32");
     expect(source("canvas/canvas-store.ts")).toContain("const rowStride = gap + OPERATION_WINDOW_CAPTION_HEIGHT");
+    // Station Keeping도 같은 32px를 충돌 상자에 넣는다 — 본문 AABB만 보면 아래 캡션이 위를 침범한다.
+    expect(source("canvas/canvas-store.ts")).toContain("function stationKeepingFrameFor");
+    expect(source("canvas/canvas-store.ts")).toContain("function resolveStationKeepingPosition");
     expect(source("canvas/canvas.tsx")).toContain("const TITLEBAR_OUTSET_PX = OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/canvas.tsx")).toContain("y: TITLEBAR_OUTSET_PX");
     expect(source("canvas/canvas.tsx")).toContain("TITLEBAR_OUTSET_PX * effectiveZoom");

--- a/runtime/fleet-console/tests/operation-frame-identity.test.ts
+++ b/runtime/fleet-console/tests/operation-frame-identity.test.ts
@@ -128,6 +128,35 @@ describe("OperationFrame identity rename", () => {
     expect(identityInput()).toBeNull();
   });
 
+  it("commits a captured drag when pointer capture is lost without pointerup", () => {
+    const onGeometryCommit = vi.fn();
+    renderFrame(vi.fn(), true, false, onGeometryCommit);
+    const titlebar = document.querySelector(".canvas-operation-titlebar") as HTMLElement;
+    titlebar.setPointerCapture = vi.fn();
+
+    act(() => {
+      titlebar.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true, pointerId: 11, clientX: 20, clientY: 20, button: 0 }));
+      titlebar.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, cancelable: true, pointerId: 11, clientX: 20, clientY: 40, button: 0 }));
+      titlebar.dispatchEvent(new PointerEvent("lostpointercapture", { bubbles: true, cancelable: true, pointerId: 11 }));
+    });
+
+    expect(onGeometryCommit).toHaveBeenCalledTimes(1);
+    expect(onGeometryCommit.mock.calls[0]?.[0]).toMatchObject({ x: 0, y: 20, width: 320, height: 200 });
+  });
+
+  it("does not commit a title press that never crossed the drag threshold", () => {
+    const onGeometryCommit = vi.fn();
+    renderFrame(vi.fn(), true, false, onGeometryCommit);
+    const titlebar = document.querySelector(".canvas-operation-titlebar") as HTMLElement;
+
+    act(() => {
+      titlebar.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true, pointerId: 12, clientX: 20, clientY: 20, button: 0 }));
+      titlebar.dispatchEvent(new PointerEvent("lostpointercapture", { bubbles: true, cancelable: true, pointerId: 12 }));
+    });
+
+    expect(onGeometryCommit).not.toHaveBeenCalled();
+  });
+
   it("marks the frame with is-top-edge when the canvas would clip the attached caption", () => {
     renderFrame(vi.fn(), false, true);
     expect(document.querySelector(".canvas-operation")!.className).toContain("is-top-edge");
@@ -213,7 +242,12 @@ function renderInactiveFrame(onRename: (title: string) => void): HTMLButtonEleme
   return identityTrigger();
 }
 
-function renderFrame(onRename: (title: string) => void, active: boolean, topEdge = false): void {
+function renderFrame(
+  onRename: (title: string) => void,
+  active: boolean,
+  topEdge = false,
+  onGeometryCommit: (geometry: { x: number; y: number; width: number; height: number; zIndex: number }) => void = () => {},
+): void {
   act(() => root!.render(createElement(OperationFrame, {
     topEdge,
     operation: {
@@ -244,7 +278,7 @@ function renderFrame(onRename: (title: string) => void, active: boolean, topEdge
     onRename,
     onSetAccent: () => {},
     onGeometryChange: () => {},
-    onGeometryCommit: () => {},
+    onGeometryCommit,
     children: createElement("div"),
   })));
 }


### PR DESCRIPTION
## Summary
- Cruise Station Keeping이 본문 AABB만 보고 창 캡션(`top:-32px`)을 충돌에서 빼 이웃 패널 위로 겹쳤습니다. 정착은 시각 프레임을 쓰고 저장 좌표는 본문으로 둡니다.
- 드래그가 `pointerup` 없이 끊기면(`lostpointercapture`·언마운트) 정착이 빠져 캡션이 겹친 채 멈췄습니다. 끊긴 드래그·리사이즈도 같은 정착 경로를 탑니다.

## Test Plan
- [x] `pnpm exec vitest run tests/canvas-store.test.ts tests/instrument-design-contract.test.ts tests/operation-frame-identity.test.ts` (워크트리 `runtime/fleet-console`)
- [x] `pnpm typecheck` (`@dotobokuri/fleet-console`)
- [x] 격리 Console `:62408` — Station off에서 세로 스택 캡션 겹침, Station on에서 Lower 캡션이 Upper 본문 아래로 16px 이상 이격