### PR TITLE
fix(fleet-console): drop War Room hover magnification when the deck density changes

### DIFF
--- a/.changelog.d/warroom-cell-width.md
+++ b/.changelog.d/warroom-cell-width.md
@@ -1,0 +1,8 @@
+---
+branch: warroom-cell-width
+---
+
+### fleet-console
+#### Fixed
+- Drop a War Room panel's hover magnification the moment the deck density changes, so adjusting density no longer leaves one panel enlarged across its neighbours.
+  ko: War Room에서 덱 밀도를 바꾸면 호버 확대를 즉시 걷어, 밀도를 조절하는 동안 패널 하나가 확대된 채 옆 패널들을 덮는 일이 없습니다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -267,6 +267,21 @@ export interface TriageDeckZoomControl {
   readonly attachWheelListener: (element: HTMLElement) => () => void;
 }
 
+// 밀도 신호 — 줌 컨트롤러가 판의 칸 크기를 실제로 바꾼 프레임에만 울린다. store의 라이브 배율은
+// 표시용으로 소수 첫째 자리까지만 실리므로(매 프레임 emit이 캔버스를 통째로 리렌더하는 것을 막는
+// 장치다) 트랙패드의 작은 델타를 놓치고, 칸 크기를 정하는 CSS 변수는 줌 컨트롤러가 캔버스에 쓴다 —
+// 덱이 그 요소를 알아내 관찰하는 것은 배치에 기대는 결합이라, 값을 쓰는 쪽이 직접 알린다.
+const deckDensityListeners = new Set<() => void>();
+
+function subscribeDeckDensity(listener: () => void): () => void {
+  deckDensityListeners.add(listener);
+  return () => { deckDensityListeners.delete(listener); };
+}
+
+function emitDeckDensityChange(): void {
+  for (const listener of [...deckDensityListeners]) listener();
+}
+
 const TRIAGE_DECK_ZOOM_TWEEN_FACTOR = 0.18;
 const TRIAGE_DECK_ZOOM_TWEEN_EPSILON = 0.002;
 const TRIAGE_DECK_ZOOM_WHEEL_SPEED = 0.0022;
@@ -293,9 +308,14 @@ export function useTriageDeckZoomControl(): {
     zoomRef.current = zoom;
     const owner = ownerRef.current;
     if (owner) {
-      owner.style.setProperty("--triage-card-min", `${Math.round(TRIAGE_DECK_CARD_BASE_MIN_PX * zoom)}px`);
+      const cardMin = `${Math.round(TRIAGE_DECK_CARD_BASE_MIN_PX * zoom)}px`;
+      // 칸 크기가 실제로 달라진 프레임에만 밀도 신호를 울린다. 최초 부착(이전 값이 비어 있는
+      // 상태)은 전환이 아니라 초기화이므로 울리지 않는다.
+      const previousCardMin = owner.style.getPropertyValue("--triage-card-min");
+      owner.style.setProperty("--triage-card-min", cardMin);
       owner.style.setProperty("--triage-row-min", `${Math.max(84, Math.round(150 * zoom))}px`);
       owner.style.setProperty("--triage-row-max", `${Math.max(84, Math.round(210 * zoom))}px`);
+      if (previousCardMin !== "" && previousCardMin !== cardMin) emitDeckDensityChange();
     }
     // 지도 판정은 프레임 정확도로 반영한다 — tween이 임계를 가로지르는 중간에도
     // 카드↔지도 전환이 정확한 프레임에 일어나야 한다.
@@ -779,16 +799,25 @@ export function TriageWatchDeck({
   // 덱 위에서만 발화하므로 조작 내내 포인터는 어떤 칸 위에 있다: 이 충돌은 예외가 아니라 밀도
   // 조작의 기본값이다. 확대를 걷고, 포인터가 실제로 움직이기 전까지는 다시 무장하지 않는다 —
   // 재배치되며 커서 밑으로 들어온 칸은 사용자가 겨눈 칸이 아니라 판이 흘려보낸 칸이다.
-  const deckZoomLive = useSyncExternalStore(subscribeTriage, getTriageDeckZoomLive, () => TRIAGE_DECK_ZOOM_DEFAULT);
   const zoomSuppressRef = useRef(false);
+  const releaseForDensityChange = () => {
+    zoomSuppressRef.current = true;
+    dismissQuicklook();
+  };
+  // 칸 크기가 실제로 달라진 모든 전환을 이 구독이 받는다 — 표시값이 움직이지 않는 작은 델타까지.
+  const releaseRef = useRef(releaseForDensityChange);
+  releaseRef.current = releaseForDensityChange;
+  useEffect(() => subscribeDeckDensity(() => { releaseRef.current(); }), []);
+  // 표시값 경로도 함께 둔다 — 줌 컨트롤러가 아직 어떤 요소도 소유하지 않은 구간(덱 마운트 전
+  // 프리셋 순환)에서는 CSS 변수 쓰기가 일어나지 않아 위 신호가 울리지 않는다.
+  const deckZoomLive = useSyncExternalStore(subscribeTriage, getTriageDeckZoomLive, () => TRIAGE_DECK_ZOOM_DEFAULT);
   const previousZoomRef = useRef(deckZoomLive);
   useEffect(() => {
     // 마운트는 밀도 전환이 아니다 — 여기서 억제를 걸면 덱에 처음 들어와 칸에 커서를 얹는 평범한
     // 진입까지 확대가 열리지 않는다. 실제로 값이 움직인 전환에만 반응한다.
     if (previousZoomRef.current === deckZoomLive) return;
     previousZoomRef.current = deckZoomLive;
-    zoomSuppressRef.current = true;
-    dismissQuicklook();
+    releaseForDensityChange();
   }, [deckZoomLive]);
 
   // 열린 지도 확대창의 좌표는 발동 시점 스냅샷이다 — 판이 리사이즈되면(사이드바 토글·창 변경)

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -774,6 +774,23 @@ export function TriageWatchDeck({
     dismissQuicklook();
   }, [visible, stagedOperationId, mapMode]);
 
+  // 밀도 전환은 한 칸을 들여다보는 조작이 아니라 판 전체를 다시 짜는 조작이다 — 그동안 한 칸만
+  // 확대된 채로 두면 그 칸이 이웃을 덮어, 사용자가 방금 바꾼 밀도를 읽을 수 없다. 그리고 덱 줌은
+  // 덱 위에서만 발화하므로 조작 내내 포인터는 어떤 칸 위에 있다: 이 충돌은 예외가 아니라 밀도
+  // 조작의 기본값이다. 확대를 걷고, 포인터가 실제로 움직이기 전까지는 다시 무장하지 않는다 —
+  // 재배치되며 커서 밑으로 들어온 칸은 사용자가 겨눈 칸이 아니라 판이 흘려보낸 칸이다.
+  const deckZoomLive = useSyncExternalStore(subscribeTriage, getTriageDeckZoomLive, () => TRIAGE_DECK_ZOOM_DEFAULT);
+  const zoomSuppressRef = useRef(false);
+  const previousZoomRef = useRef(deckZoomLive);
+  useEffect(() => {
+    // 마운트는 밀도 전환이 아니다 — 여기서 억제를 걸면 덱에 처음 들어와 칸에 커서를 얹는 평범한
+    // 진입까지 확대가 열리지 않는다. 실제로 값이 움직인 전환에만 반응한다.
+    if (previousZoomRef.current === deckZoomLive) return;
+    previousZoomRef.current = deckZoomLive;
+    zoomSuppressRef.current = true;
+    dismissQuicklook();
+  }, [deckZoomLive]);
+
   // 열린 지도 확대창의 좌표는 발동 시점 스냅샷이다 — 판이 리사이즈되면(사이드바 토글·창 변경)
   // 점은 %로 재배치되는데 확대창만 옛 px에 남으므로, 재계산 대신 해제해 유령 창을 만들지 않는다.
   useEffect(() => {
@@ -847,6 +864,9 @@ export function TriageWatchDeck({
       if (!cell || cellOf(event.relatedTarget) === cell) return;
       const operationId = cell.dataset.triageDeckCard;
       if (!operationId || deckPointerRef.current.arriving === operationId) return;
+      // 밀도를 막 바꾼 직후의 진입은 포인터가 아니라 판이 움직여 생긴 것이다 — 겨눔은 다음
+      // pointermove가 증명한다.
+      if (zoomSuppressRef.current) return;
       deckPointerRef.current.arm(operationId, cell, true);
     };
     // 확대를 붙들 자격 — 포인터가 그 칸 안에 있거나, 키보드 포커스가 그 칸을 잡고 있어야 한다.
@@ -873,8 +893,18 @@ export function TriageWatchDeck({
     // out은 도착지(relatedTarget)가, move는 현재 지점(target)이 자격을 답한다.
     const onPointerOut = (event: PointerEvent) => { releaseUnless(event.relatedTarget); };
     // 덱을 떠나지 않은 채 칸만 포인터 밑에서 빠져나간 경우는 out이 오지 않는다 — 다음 이동에서
-    // 현재 지점을 다시 물어 확대의 주인을 확인한다.
-    const onPointerMove = (event: PointerEvent) => { releaseUnless(event.target); };
+    // 현재 지점을 다시 물어 확대의 주인을 확인한다. 밀도 전환으로 무장을 막아 둔 동안에는, 이
+    // 이동이 곧 "사용자가 이 칸을 겨눴다"는 증명이므로 여기서 무장을 되살린다(같은 칸에 머무르면
+    // pointerover는 다시 오지 않아 확대가 영영 열리지 않는다).
+    const onPointerMove = (event: PointerEvent) => {
+      releaseUnless(event.target);
+      if (!zoomSuppressRef.current || event.pointerType === "touch") return;
+      zoomSuppressRef.current = false;
+      const cell = cellOf(event.target);
+      const operationId = cell?.dataset.triageDeckCard;
+      if (!cell || !operationId || deckPointerRef.current.arriving === operationId) return;
+      deckPointerRef.current.arm(operationId, cell, true);
+    };
     const onContextMenu = (event: MouseEvent) => {
       const cell = cellOf(event.target);
       const operationId = cell?.dataset.triageDeckCard;

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -308,14 +308,24 @@ export function useTriageDeckZoomControl(): {
     zoomRef.current = zoom;
     const owner = ownerRef.current;
     if (owner) {
-      const cardMin = `${Math.round(TRIAGE_DECK_CARD_BASE_MIN_PX * zoom)}px`;
-      // 칸 크기가 실제로 달라진 프레임에만 밀도 신호를 울린다. 최초 부착(이전 값이 비어 있는
-      // 상태)은 전환이 아니라 초기화이므로 울리지 않는다.
-      const previousCardMin = owner.style.getPropertyValue("--triage-card-min");
-      owner.style.setProperty("--triage-card-min", cardMin);
-      owner.style.setProperty("--triage-row-min", `${Math.max(84, Math.round(150 * zoom))}px`);
-      owner.style.setProperty("--triage-row-max", `${Math.max(84, Math.round(210 * zoom))}px`);
-      if (previousCardMin !== "" && previousCardMin !== cardMin) emitDeckDensityChange();
+      // 칸 크기를 정하는 값 중 하나라도 실제로 달라진 프레임에만 밀도 신호를 울린다. 폭만 비교하면
+      // 같은 폭 구간 안에서 행 높이만 넘어가는 델타(예: 1.0020 → 1.0030은 폭을 261px로 둔 채 행
+      // 상한을 210px → 211px로 옮긴다)를 놓쳐, 칸이 바뀌는데 확대가 살아남는다. 최초 부착(이전 값이
+      // 비어 있는 상태)은 전환이 아니라 초기화이므로 울리지 않는다.
+      const sizing: readonly (readonly [string, string])[] = [
+        ["--triage-card-min", `${Math.round(TRIAGE_DECK_CARD_BASE_MIN_PX * zoom)}px`],
+        ["--triage-row-min", `${Math.max(84, Math.round(150 * zoom))}px`],
+        ["--triage-row-max", `${Math.max(84, Math.round(210 * zoom))}px`],
+      ];
+      let initialised = true;
+      let resized = false;
+      for (const [name, value] of sizing) {
+        const previous = owner.style.getPropertyValue(name);
+        if (previous === "") initialised = false;
+        else if (previous !== value) resized = true;
+        owner.style.setProperty(name, value);
+      }
+      if (initialised && resized) emitDeckDensityChange();
     }
     // 지도 판정은 프레임 정확도로 반영한다 — tween이 임계를 가로지르는 중간에도
     // 카드↔지도 전환이 정확한 프레임에 일어나야 한다.

--- a/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
+++ b/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
@@ -21,7 +21,7 @@ vi.mock("../core/client/src/plugin-registry.js", () => ({
 
 import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
 import { loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
-import { getTriageDeckZoomLive, resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoomLive } from "../core/client/src/canvas/triage-store.js";
+import { getTriageDeckZoomLive, resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoom, setTriageDeckZoomLive } from "../core/client/src/canvas/triage-store.js";
 import { TRIAGE_DECK_QUICKLOOK_DWELL_MS } from "../core/client/src/canvas/triage-watch-deck.js";
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
 
@@ -238,6 +238,30 @@ describe("War Room deck Quick-Look release", () => {
     act(() => cell.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: 9, deltaMode: 0 })));
     expect(getTriageDeckZoomLive(), "the displayed zoom must not move, or this case is not the one under test")
       .toBe(displayedBefore);
+    expect(expanded()).toEqual([]);
+  });
+
+  // 폭 구간 안에서 행 높이만 넘어가는 델타 — 1.0020 → 1.0030은 폭을 261px로 둔 채 행 상한을
+  // 210px → 211px로 옮긴다. 폭만 비교하면 이 전환이 신호를 만들지 못해 칸이 바뀌는데 확대가 남는다.
+  it("releases the expansion when only the row size crosses a boundary", () => {
+    act(() => setTriageDeckZoom(1.002));
+    const grid = enterDeck();
+    const owner = container!.querySelector<HTMLElement>(".operations-canvas")!;
+    const read = () => ["--triage-card-min", "--triage-row-min", "--triage-row-max"]
+      .map((name) => owner.style.getPropertyValue(name));
+    const before = read();
+    // 초기 배율을 세우는 tween이 이미 한 번 판을 다시 짰으므로, 무장은 포인터 이동이 증명한다.
+    const cell = cellFor(OPERATION.id);
+    act(() => cell.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
+    expect(expanded()).toEqual([OPERATION.id]);
+
+    const displayedBefore = getTriageDeckZoomLive();
+    act(() => grid.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: -0.4534, deltaMode: 0 })));
+    const after = read();
+    expect(after[0], "the card width must stay put, or this case is not the one under test").toBe(before[0]);
+    expect(after[2], "the row cap must be the value that moved").not.toBe(before[2]);
+    expect(getTriageDeckZoomLive()).toBe(displayedBefore);
     expect(expanded()).toEqual([]);
   });
 

--- a/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
+++ b/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
@@ -21,7 +21,7 @@ vi.mock("../core/client/src/plugin-registry.js", () => ({
 
 import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
 import { loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
-import { resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive } from "../core/client/src/canvas/triage-store.js";
+import { resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoomLive } from "../core/client/src/canvas/triage-store.js";
 import { TRIAGE_DECK_QUICKLOOK_DWELL_MS } from "../core/client/src/canvas/triage-watch-deck.js";
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
 
@@ -209,6 +209,42 @@ describe("War Room deck Quick-Look release", () => {
       act(() => grid.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
       expect(expanded()).toEqual([OPERATION.id]);
     });
+  });
+
+  // 덱 줌은 덱 위에서만 발화하므로, 밀도를 바꾸는 내내 포인터는 어떤 칸 위에 있다. 확대를 그대로
+  // 두면 그 칸이 1.95배로 이웃을 덮은 채 밀도가 바뀌어, 사용자가 방금 조절한 판을 읽을 수 없다.
+  it("releases the expansion when the deck density changes", () => {
+    enterDeck();
+    hover(cellFor(OPERATION.id));
+    expect(expanded()).toEqual([OPERATION.id]);
+
+    act(() => setTriageDeckZoomLive(0.6));
+    expect(expanded()).toEqual([]);
+  });
+
+  it("does not re-arm on the entry the density change itself produced", () => {
+    enterDeck();
+    const cell = cellFor(OPERATION.id);
+    act(() => setTriageDeckZoomLive(0.6));
+
+    // 재배치되며 커서 밑으로 들어온 칸은 사용자가 겨눈 칸이 아니다 — 브라우저는 포인터가 멈춰
+    // 있어도 그 진입을 boundary 이벤트로 보고하므로, 그것만으로 확대를 열면 밀도를 바꿀 때마다
+    // 아무 칸이나 커진다.
+    act(() => cell.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse" })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
+    expect(expanded()).toEqual([]);
+  });
+
+  it("re-arms once the pointer actually moves after a density change", () => {
+    enterDeck();
+    const cell = cellFor(OPERATION.id);
+    act(() => setTriageDeckZoomLive(0.6));
+
+    // 이동이 곧 겨눔의 증명이다. 같은 칸에 머무르면 pointerover는 다시 오지 않으므로, 되살리는
+    // 책임은 이동 쪽에 있어야 확대가 영영 닫히는 일이 없다.
+    act(() => cell.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
+    expect(expanded()).toEqual([OPERATION.id]);
   });
 
   it("cancels an armed dwell that never became an expansion", () => {

--- a/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
+++ b/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
@@ -21,7 +21,7 @@ vi.mock("../core/client/src/plugin-registry.js", () => ({
 
 import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
 import { loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
-import { resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoomLive } from "../core/client/src/canvas/triage-store.js";
+import { getTriageDeckZoomLive, resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoomLive } from "../core/client/src/canvas/triage-store.js";
 import { TRIAGE_DECK_QUICKLOOK_DWELL_MS } from "../core/client/src/canvas/triage-watch-deck.js";
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
 
@@ -99,6 +99,7 @@ describe("War Room deck Quick-Look release", () => {
 
   const expanded = () => [...container!.querySelectorAll(".canvas-triage-deck-cell.is-quicklook")]
     .map((cell) => (cell as HTMLElement).dataset.triageDeckCard);
+
 
   beforeEach(() => { vi.useFakeTimers(); });
   afterEach(() => { vi.useRealTimers(); });
@@ -219,6 +220,24 @@ describe("War Room deck Quick-Look release", () => {
     expect(expanded()).toEqual([OPERATION.id]);
 
     act(() => setTriageDeckZoomLive(0.6));
+    expect(expanded()).toEqual([]);
+  });
+
+  // 라이브 배율은 표시용으로 소수 첫째 자리까지만 실린다 — 트랙패드의 작은 델타는 그 값을 그대로
+  // 둔 채 칸 크기만 바꾸므로, 표시값을 신호로 삼으면 바로 그 구간에서 확대가 살아남는다. 제품이
+  // 실제로 칸 크기를 정할 때 쓰는 경로(덱에 실리는 CSS 변수)로 잰다.
+  it("releases the expansion on a density change too small to move the displayed zoom", () => {
+    enterDeck();
+    const cell = cellFor(OPERATION.id);
+    hover(cell);
+    expect(expanded()).toEqual([OPERATION.id]);
+
+    // 제품과 같은 경로로 민다: 덱 위의 휠이 곧 밀도 조작이다. deltaY 9는 1.00 → 0.98로, 칸 크기는
+    // 260px → 255px로 바뀌지만 표시 배율은 "1.0" 그대로다.
+    const displayedBefore = getTriageDeckZoomLive();
+    act(() => cell.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: 9, deltaMode: 0 })));
+    expect(getTriageDeckZoomLive(), "the displayed zoom must not move, or this case is not the one under test")
+      .toBe(displayedBefore);
     expect(expanded()).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- **재현**: 격리 콘솔 · shell 10개 · War Room에서 휠로 밀도 1.0×→0.6× 조절. 첫 칸이 `is-quicklook`(scale 1.95)을 유지한 채 **298 → 581.1px**로 커져 옆 칸(x=615)을 **273.1px** 침범했고, 밀도를 0.6×로 낮춘 뒤에도 **166 → 323.7px**로 **147.7px** 침범이 이어졌습니다. 스크린샷으로도 큰 패널 하나가 격자 두 칸을 덮는 모습이 확인됩니다.
- **원인**: 덱 줌은 덱 위에서만 발화하므로 밀도 조작 내내 포인터는 어떤 칸 위에 있습니다. 그 칸의 호버 확대가 조작 내내 유지되어, 사용자가 방금 바꾼 밀도를 읽을 수 없게 이웃을 덮습니다. 겹침은 예외 상황이 아니라 밀도 조작의 기본값이었습니다.
- **수정**: 라이브 덱 줌이 움직이면 확대를 걷고, **포인터가 실제로 움직이기 전까지** 재무장을 막습니다(재배치되며 커서 밑으로 들어온 칸은 사용자가 겨눈 칸이 아닙니다). 그 첫 이동이 겨눔의 증명이므로 거기서 무장을 되살립니다 — 같은 칸에 머무르면 `pointerover`가 다시 오지 않아 확대가 영영 닫히기 때문입니다. 마운트는 밀도 전환이 아니므로 평범한 첫 호버 확대는 그대로 동작합니다.

## Test Plan
- [x] `vitest run tests/triage-deck-quicklook-release.test.tsx` — 10 passed(신규 3건 포함). 밀도 해제를 되돌리면 3건 실패
- [x] `vitest run` (fleet-console 전체) — 2163 passed / 24 skipped
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [x] 격리 콘솔 헤드리스 실측(수정 후): 밀도 1.0×→0.6× 전환에서 10칸 전부 균등, **겹침 0**, 확대 셀 0 — 스크린샷 확인
- [x] 기능 회귀 없음: 포인터가 실제로 이동해 칸에 닿으면 확대 복귀(166 → 323.7), 덱을 떠나면 해제(→ 166)