### PR TITLE
fix(fleet-console): arm War Room magnification from pointer movement, not entry

### DIFF
--- a/.changelog.d/warroom-lowzoom.md
+++ b/.changelog.d/warroom-lowzoom.md
@@ -1,0 +1,8 @@
+---
+branch: warroom-lowzoom
+---
+
+### fleet-console
+#### Fixed
+- Open a War Room panel's hover magnification only when the pointer moves onto it, so a tile that slides under a still cursor - on entering the deck, changing density, or resizing the sidebar - no longer enlarges itself across its neighbours.
+  ko: War Room의 호버 확대를 포인터가 그 패널로 옮겨 왔을 때만 엽니다. 덱 진입·밀도 변경·사이드바 리사이즈로 멈춰 있는 커서 밑에 칸이 들어와도 그 칸이 혼자 커져 옆 패널들을 덮지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -809,14 +809,9 @@ export function TriageWatchDeck({
   // 덱 위에서만 발화하므로 조작 내내 포인터는 어떤 칸 위에 있다: 이 충돌은 예외가 아니라 밀도
   // 조작의 기본값이다. 확대를 걷고, 포인터가 실제로 움직이기 전까지는 다시 무장하지 않는다 —
   // 재배치되며 커서 밑으로 들어온 칸은 사용자가 겨눈 칸이 아니라 판이 흘려보낸 칸이다.
-  const zoomSuppressRef = useRef(false);
-  const releaseForDensityChange = () => {
-    zoomSuppressRef.current = true;
-    dismissQuicklook();
-  };
   // 칸 크기가 실제로 달라진 모든 전환을 이 구독이 받는다 — 표시값이 움직이지 않는 작은 델타까지.
-  const releaseRef = useRef(releaseForDensityChange);
-  releaseRef.current = releaseForDensityChange;
+  const releaseRef = useRef(dismissQuicklook);
+  releaseRef.current = dismissQuicklook;
   useEffect(() => subscribeDeckDensity(() => { releaseRef.current(); }), []);
   // 표시값 경로도 함께 둔다 — 줌 컨트롤러가 아직 어떤 요소도 소유하지 않은 구간(덱 마운트 전
   // 프리셋 순환)에서는 CSS 변수 쓰기가 일어나지 않아 위 신호가 울리지 않는다.
@@ -827,7 +822,7 @@ export function TriageWatchDeck({
     // 진입까지 확대가 열리지 않는다. 실제로 값이 움직인 전환에만 반응한다.
     if (previousZoomRef.current === deckZoomLive) return;
     previousZoomRef.current = deckZoomLive;
-    releaseForDensityChange();
+    dismissQuicklook();
   }, [deckZoomLive]);
 
   // 열린 지도 확대창의 좌표는 발동 시점 스냅샷이다 — 판이 리사이즈되면(사이드바 토글·창 변경)
@@ -896,18 +891,6 @@ export function TriageWatchDeck({
     if (!grid || !visible) return;
     const cellOf = (node: EventTarget | null): HTMLElement | null =>
       node instanceof Element ? node.closest<HTMLElement>("[data-triage-deck-card]") : null;
-    const onPointerOver = (event: PointerEvent) => {
-      if (event.pointerType === "touch") return;
-      const cell = cellOf(event.target);
-      // 같은 칸 안의 이동(본문 → 캡션 → 컨트롤)은 진입이 아니다.
-      if (!cell || cellOf(event.relatedTarget) === cell) return;
-      const operationId = cell.dataset.triageDeckCard;
-      if (!operationId || deckPointerRef.current.arriving === operationId) return;
-      // 밀도를 막 바꾼 직후의 진입은 포인터가 아니라 판이 움직여 생긴 것이다 — 겨눔은 다음
-      // pointermove가 증명한다.
-      if (zoomSuppressRef.current) return;
-      deckPointerRef.current.arm(operationId, cell, true);
-    };
     // 확대를 붙들 자격 — 포인터가 그 칸 안에 있거나, 키보드 포커스가 그 칸을 잡고 있어야 한다.
     // 포커스 예외가 없으면 키보드로 연 확대가 무관한 포인터 이동 한 번에 걷힌다.
     const holds = (node: EventTarget | null, operationId: string): boolean =>
@@ -931,16 +914,18 @@ export function TriageWatchDeck({
     };
     // out은 도착지(relatedTarget)가, move는 현재 지점(target)이 자격을 답한다.
     const onPointerOut = (event: PointerEvent) => { releaseUnless(event.relatedTarget); };
-    // 덱을 떠나지 않은 채 칸만 포인터 밑에서 빠져나간 경우는 out이 오지 않는다 — 다음 이동에서
-    // 현재 지점을 다시 물어 확대의 주인을 확인한다. 밀도 전환으로 무장을 막아 둔 동안에는, 이
-    // 이동이 곧 "사용자가 이 칸을 겨눴다"는 증명이므로 여기서 무장을 되살린다(같은 칸에 머무르면
-    // pointerover는 다시 오지 않아 확대가 영영 열리지 않는다).
+    // 확대를 여는 근거는 "포인터가 그 칸으로 옮겨 왔다"는 사실이고, 그것을 증명하는 것은 이동뿐이다.
+    // pointerover는 증명하지 못한다 — 커서가 멈춰 있어도 칸이 그 밑으로 들어오면(덱 진입, 밀도
+    // 전환, 열 수 변화, 사이드바 리사이즈) 브라우저는 똑같이 진입으로 보고한다. 그렇게 열린 확대는
+    // 사용자가 겨눈 적 없는 칸을 1.95배로 키워 이웃을 덮은 채 남고, 커서가 그 위에 있으니 해제 신호도
+    // 오지 않는다. 그래서 무장은 pointermove가 지고, pointerover는 아무것도 열지 않는다.
     const onPointerMove = (event: PointerEvent) => {
-      releaseUnless(event.target);
-      if (!zoomSuppressRef.current || event.pointerType === "touch") return;
-      zoomSuppressRef.current = false;
+      if (event.pointerType === "touch") return;
       const cell = cellOf(event.target);
-      const operationId = cell?.dataset.triageDeckCard;
+      const operationId = cell?.dataset.triageDeckCard ?? null;
+      // 같은 칸 안의 이동(본문 → 캡션 → 창 컨트롤)은 무장을 새로 걸 일도, 걷을 일도 아니다.
+      if (armedQuicklookRef.current !== null && armedQuicklookRef.current === operationId) return;
+      releaseUnless(event.target);
       if (!cell || !operationId || deckPointerRef.current.arriving === operationId) return;
       deckPointerRef.current.arm(operationId, cell, true);
     };
@@ -950,12 +935,10 @@ export function TriageWatchDeck({
       if (!cell || !operationId) return;
       deckPointerRef.current.openMenu(operationId, event, cell);
     };
-    grid.addEventListener("pointerover", onPointerOver);
     grid.addEventListener("pointerout", onPointerOut);
     grid.addEventListener("pointermove", onPointerMove, { passive: true });
     grid.addEventListener("contextmenu", onContextMenu);
     return () => {
-      grid.removeEventListener("pointerover", onPointerOver);
       grid.removeEventListener("pointerout", onPointerOut);
       grid.removeEventListener("pointermove", onPointerMove);
       grid.removeEventListener("contextmenu", onContextMenu);

--- a/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
+++ b/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
@@ -302,14 +302,28 @@ describe("War Room deck Quick-Look release", () => {
 
   it("cancels an armed dwell that never became an expansion", () => {
     const grid = enterDeck();
-    // 드웰 중(아직 확대 전)에 포인터가 칸을 떠나면 확대는 열리지 않아야 한다. 확대 상태만 보고
-    // 판정하면 이 구간이 비어 있어, 떠난 뒤에 확대가 뒤늦게 열린다.
-    act(() => cellFor(OPERATION.id).dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse" })));
-    act(() => grid.dispatchEvent(new PointerEvent("pointerout", {
+    const cell = cellFor(OPERATION.id);
+    const leave = () => act(() => grid.dispatchEvent(new PointerEvent("pointerout", {
       bubbles: true,
       pointerType: "mouse",
       relatedTarget: document.body,
     })));
+
+    // 먼저 이 시퀀스가 실제로 드웰을 무장한다는 것을 대조로 보인다 — 무장되지 않는 시퀀스로 취소를
+    // 재면, 취소가 망가져도 이 케이스는 초록으로 남는다.
+    act(() => cell.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
+    expect(expanded(), "the setup must actually arm, or the cancellation below proves nothing")
+      .toEqual([OPERATION.id]);
+    leave();
+    expect(expanded()).toEqual([]);
+
+    // 같은 무장을 다시 걸고, 이번엔 드웰이 끝나기 전에 떠난다. 확대는 뒤늦게라도 열리면 안 된다 —
+    // 확대 상태만 보고 해제를 판정하면 이 구간이 비어 있어 떠난 뒤에 열린다.
+    act(() => cell.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS - 50); });
+    expect(expanded()).toEqual([]);
+    leave();
     act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
     expect(expanded()).toEqual([]);
   });

--- a/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
+++ b/runtime/fleet-console/tests/triage-deck-quicklook-release.test.tsx
@@ -92,8 +92,10 @@ describe("War Room deck Quick-Look release", () => {
   const cellFor = (operationId: string) =>
     container!.querySelector<HTMLElement>(`[data-triage-deck-card="${operationId}"]`)!;
 
+  // 확대를 여는 것은 이동이다 — pointerover는 커서가 멈춰 있어도 칸이 그 밑으로 들어오면 오므로
+  // 겨눔을 증명하지 못한다. 제품이 무장에 쓰는 신호 그대로 민다.
   const hover = (cell: HTMLElement) => {
-    act(() => cell.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse" })));
+    act(() => cell.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
     act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
   };
 
@@ -155,9 +157,11 @@ describe("War Room deck Quick-Look release", () => {
     hover(from);
     expect(expanded()).toEqual([OPERATION.id]);
 
-    // 브라우저는 out(도착지=새 칸) → over(새 칸) 순으로 보낸다. 두 칸이 동시에 확대되면 안 된다.
+    // 브라우저는 칸을 건너는 이동에서 out(도착지=새 칸) → over(새 칸) → move를 함께 보낸다.
+    // 두 칸이 동시에 확대되면 안 된다.
     act(() => from.dispatchEvent(new PointerEvent("pointerout", { bubbles: true, pointerType: "mouse", relatedTarget: to })));
     act(() => to.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse", relatedTarget: from })));
+    act(() => to.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse" })));
     act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
     expect(expanded()).toEqual([OPERATION_B.id]);
   });
@@ -265,14 +269,20 @@ describe("War Room deck Quick-Look release", () => {
     expect(expanded()).toEqual([]);
   });
 
-  it("does not re-arm on the entry the density change itself produced", () => {
+  // 이번 결함의 핵심 계약 — 커서가 멈춰 있는데 칸이 그 밑으로 들어온 경우(덱 진입, 밀도 전환,
+  // 열 수 변화, 사이드바 리사이즈)에도 브라우저는 진입을 보고한다. 그것으로 확대를 열면 사용자가
+  // 겨눈 적 없는 칸이 1.95배로 이웃을 덮고, 커서가 그 위에 있으니 해제 신호도 오지 않는다.
+  it("never arms from an entry alone, whatever produced it", () => {
     enterDeck();
     const cell = cellFor(OPERATION.id);
-    act(() => setTriageDeckZoomLive(0.6));
 
-    // 재배치되며 커서 밑으로 들어온 칸은 사용자가 겨눈 칸이 아니다 — 브라우저는 포인터가 멈춰
-    // 있어도 그 진입을 boundary 이벤트로 보고하므로, 그것만으로 확대를 열면 밀도를 바꿀 때마다
-    // 아무 칸이나 커진다.
+    // 덱에 막 들어온 직후: 칸이 커서 밑에 나타난 것이지 커서가 칸으로 간 것이 아니다.
+    act(() => cell.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse" })));
+    act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
+    expect(expanded()).toEqual([]);
+
+    // 밀도가 판을 다시 짜며 칸이 커서 밑으로 옮겨 온 경우도 같다.
+    act(() => setTriageDeckZoomLive(0.6));
     act(() => cell.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, pointerType: "mouse" })));
     act(() => { vi.advanceTimersByTime(TRIAGE_DECK_QUICKLOOK_DWELL_MS + 1); });
     expect(expanded()).toEqual([]);


### PR DESCRIPTION
## Summary
- **재현 (최신 canary, #744 포함)**: shell 10개로 War Room에 **들어가기만** 해도 첫 칸이 `is-quicklook`으로 **298 → 581.1px**가 되어 이웃 **3칸과 겹칩니다**. 포인터는 움직인 적 없고 `activeElement`는 BODY입니다. 밀도 1.1× / 1.0× 및 그 하위 전부에서 나타납니다.
- **원인**: 칸은 커서가 멈춰 있어도 그 밑으로 들어올 수 있습니다 — 덱 진입, 밀도 변경, 열 수 변화, 사이드바 드래그. 브라우저는 그 도착도 똑같이 `pointerover`로 보고하므로, 진입을 무장 근거로 삼으면 **사용자가 겨눈 적 없는 칸**이 1.95배로 이웃을 덮습니다. 게다가 그 뒤 커서가 그 칸 위에 있으니 해제 신호도 오지 않아 그대로 굳습니다.
- **수정**: 무장의 근거를 **포인터 이동**으로 단일화합니다. `pointerover`는 아무것도 열지 않습니다. #744에서 밀도 전이에만 걸었던 억제 플래그는 같은 규칙을 한 원인에만 적용한 것이라 제거했습니다 — 이동만이 무장을 여는 규칙이 모든 원인을 한 번에 덮으므로, 밀도 전환은 이제 **걷기만** 하면 됩니다.

## Test Plan
- [x] `vitest run tests/triage-deck-quicklook-release.test.tsx` — 12 passed. "진입만으로는 무엇이 만든 진입이든 무장하지 않는다"를 계약으로 고정
- [x] `vitest run` (fleet-console 전체) — 2208 passed / 24 skipped
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [x] 격리 콘솔 헤드리스 실측(수정 후): War Room 진입 시 10칸 4열 균등, **겹침 0** — 스크린샷 확인
- [x] 밀도 1.1× / 1.0× / 0.9× / 0.7× / 0.5× 전 구간(열 수 4→5→6→8 전이 포함) **겹침 0, 확대 셀 0**
- [x] 기능 회귀 없음: 포인터가 실제로 이동하면 확대(144 → 280.8px), 진입만으로는 확대 없음(두 칸 다 144px), 이탈 시 해제