### PR TITLE
fix(fleet-console): stop phone pans typing NaN into Claude prompts

### DIFF
--- a/.changelog.d/fix-mobile-scroll-nan.md
+++ b/.changelog.d/fix-mobile-scroll-nan.md
@@ -1,0 +1,8 @@
+---
+branch: fix-mobile-scroll-nan
+---
+
+### fleet-console
+#### Fixed
+- Scrolling a full-screen agent on a phone no longer types `NaN` into the CLI prompt.
+  ko: 휴대폰에서 전체 화면 에이전트를 스크롤해도 CLI 입력창에 `NaN`이 입력되지 않습니다.

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -14,6 +14,7 @@ import { describeTerminalFailure } from "./terminal-failure.js";
 import { createTerminalCopyOnSelect } from "./terminal-copy-on-select.js";
 import { createTerminalOsc52Clipboard } from "./terminal-osc52-clipboard.js";
 import { TERMINAL_OPTIONS } from "./terminal-options.js";
+import { dispatchSyntheticTerminalWheel } from "./terminal-synthetic-wheel.js";
 import { createTerminalTouchGestures, MIN_FONT_SCALE } from "./terminal-touch-gestures.js";
 import { FailureNotice } from "@fleet-console/sdk/components/failure-notice";
 import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
@@ -371,10 +372,12 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
       );
       const touchGestures = createTerminalTouchGestures(container, {
         // The wheel is the input xterm already routes correctly for whatever is running, so a pan
-        // arrives as one rather than as a buffer scroll this surface chose on its own.
-        scrollByPixels: (deltaY) => {
+        // arrives as one rather than as a buffer scroll this surface chose on its own. The finger's
+        // client point must travel with it: a coordinate-less WheelEvent encodes as `NaN` under
+        // mouse tracking and Claude Code types that literal into the prompt.
+        scrollByPixels: (deltaY, origin) => {
           const target = container.querySelector(".xterm-screen") ?? container.querySelector(".xterm") ?? container;
-          target.dispatchEvent(new WheelEvent("wheel", { deltaY, deltaMode: 0, bubbles: true, cancelable: true }));
+          dispatchSyntheticTerminalWheel(target, deltaY, origin);
         },
       }, {
         onFontScale: setTouchFontScale,

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-synthetic-wheel.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-synthetic-wheel.ts
@@ -1,0 +1,63 @@
+/**
+ * Touch pans are turned into wheel events so xterm can decide what scrolling means
+ * for whatever is running — its own scrollback, alt-buffer cursor keys, or a mouse
+ * report a full-screen program asked for.
+ *
+ * A wheel with no client coordinates is not a real pointer. In a desktop browser the
+ * constructor fills those with 0, but Android WebView leaves them unset, so xterm's
+ * SGR encoder interpolates `NaN` into the report (`CSI < cb ; NaN ; NaN M`). Claude
+ * Code then types that literal into its prompt. Refuse to dispatch until both axes
+ * are finite numbers.
+ */
+
+export interface TerminalWheelOrigin {
+  readonly clientX: number;
+  readonly clientY: number;
+}
+
+export interface TerminalWheelFallbackRect {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export function isFiniteWheelOrigin(origin: TerminalWheelOrigin | null | undefined): origin is TerminalWheelOrigin {
+  return origin !== null
+    && origin !== undefined
+    && Number.isFinite(origin.clientX)
+    && Number.isFinite(origin.clientY);
+}
+
+export function resolveSyntheticWheelOrigin(
+  origin: TerminalWheelOrigin | undefined,
+  fallbackRect: TerminalWheelFallbackRect | null,
+): TerminalWheelOrigin | null {
+  if (isFiniteWheelOrigin(origin)) return { clientX: origin.clientX, clientY: origin.clientY };
+  if (fallbackRect === null) return null;
+  const resolved = {
+    clientX: fallbackRect.left + fallbackRect.width / 2,
+    clientY: fallbackRect.top + fallbackRect.height / 2,
+  };
+  return isFiniteWheelOrigin(resolved) ? resolved : null;
+}
+
+export function dispatchSyntheticTerminalWheel(
+  target: EventTarget & { getBoundingClientRect?: () => DOMRect },
+  deltaY: number,
+  origin?: TerminalWheelOrigin,
+): boolean {
+  if (!Number.isFinite(deltaY) || deltaY === 0) return false;
+  const rect = typeof target.getBoundingClientRect === "function" ? target.getBoundingClientRect() : null;
+  const resolved = resolveSyntheticWheelOrigin(origin, rect);
+  if (resolved === null) return false;
+  target.dispatchEvent(new WheelEvent("wheel", {
+    deltaY,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+    clientX: resolved.clientX,
+    clientY: resolved.clientY,
+  }));
+  return true;
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-touch-gestures.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-touch-gestures.ts
@@ -17,8 +17,12 @@ export interface TerminalTouchGestureHost {
    * output. The terminal already decides what scrolling means for what is running: its own
    * scrollback, the keys a full-screen program expects, or the wheel report a program that asked
    * for mouse tracking reads. Deciding that here would answer differently than the wheel does.
+   *
+   * `origin` is the finger that produced this step. A wheel report encodes a cell, so the
+   * surface must know where the finger is — inventing a coordinate-less wheel is how `NaN`
+   * used to reach the session.
    */
-  scrollByPixels(deltaY: number): void;
+  scrollByPixels(deltaY: number, origin?: { readonly clientX: number; readonly clientY: number }): void;
 }
 
 export interface TerminalTouchGestureOptions {
@@ -97,11 +101,12 @@ export function createTerminalTouchGestures(
       return;
     }
     event.preventDefault();
-    const travelled = event.touches[0]!.clientY - panAnchorY;
-    panAnchorY = event.touches[0]!.clientY;
+    const finger = event.touches[0]!;
+    const travelled = finger.clientY - panAnchorY;
+    panAnchorY = finger.clientY;
     if (travelled === 0) return;
     // Dragging down reveals older output, the direction a scrollbar would move under the finger.
-    terminal.scrollByPixels(-travelled);
+    terminal.scrollByPixels(-travelled, { clientX: finger.clientX, clientY: finger.clientY });
   };
 
   const onTouchEnd = (event: TouchEvent) => {

--- a/runtime/fleet-plugins/terminal/tests/terminal-synthetic-wheel.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-synthetic-wheel.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import {
+  dispatchSyntheticTerminalWheel,
+  resolveSyntheticWheelOrigin,
+} from "../client/shared/terminal-synthetic-wheel.js";
+
+describe("synthetic terminal wheel", () => {
+  it("prefers the finger origin when both axes are finite", () => {
+    expect(resolveSyntheticWheelOrigin(
+      { clientX: 12, clientY: 40 },
+      { left: 0, top: 0, width: 100, height: 80 },
+    )).toEqual({ clientX: 12, clientY: 40 });
+  });
+
+  it("falls back to the target centre when the origin is missing or not finite", () => {
+    expect(resolveSyntheticWheelOrigin(
+      { clientX: Number.NaN, clientY: 10 },
+      { left: 10, top: 20, width: 40, height: 30 },
+    )).toEqual({ clientX: 30, clientY: 35 });
+    expect(resolveSyntheticWheelOrigin(
+      undefined,
+      { left: 0, top: 0, width: 20, height: 10 },
+    )).toEqual({ clientX: 10, clientY: 5 });
+  });
+
+  it("refuses to invent a coordinate when neither origin nor rect is usable", () => {
+    expect(resolveSyntheticWheelOrigin({ clientX: Number.NaN, clientY: Number.NaN }, null)).toBeNull();
+    expect(resolveSyntheticWheelOrigin(undefined, null)).toBeNull();
+    expect(resolveSyntheticWheelOrigin(
+      undefined,
+      { left: Number.NaN, top: 0, width: 10, height: 10 },
+    )).toBeNull();
+  });
+
+  it("dispatches a wheel whose client point is finite, never the default-empty constructor", () => {
+    const target = document.createElement("div");
+    document.body.append(target);
+    Object.defineProperty(target, "getBoundingClientRect", {
+      value: () => ({ left: 8, top: 16, width: 40, height: 20, right: 48, bottom: 36, x: 8, y: 16, toJSON() { return {}; } }),
+    });
+    const seen: WheelEvent[] = [];
+    target.addEventListener("wheel", (event) => { seen.push(event); });
+
+    expect(dispatchSyntheticTerminalWheel(target, 24, { clientX: 11, clientY: 19 })).toBe(true);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.deltaY).toBe(24);
+    expect(seen[0]!.deltaMode).toBe(0);
+    expect(Number.isFinite(seen[0]!.clientX)).toBe(true);
+    expect(Number.isFinite(seen[0]!.clientY)).toBe(true);
+    expect(seen[0]!.clientX).toBe(11);
+    expect(seen[0]!.clientY).toBe(19);
+    expect(String(seen[0]!.clientX)).not.toBe("NaN");
+    expect(String(seen[0]!.clientY)).not.toBe("NaN");
+  });
+
+  it("dispatches the rect centre when the origin is missing or one axis is not finite", () => {
+    const target = document.createElement("div");
+    document.body.append(target);
+    Object.defineProperty(target, "getBoundingClientRect", {
+      value: () => ({ left: 10, top: 20, width: 40, height: 30, right: 50, bottom: 50, x: 10, y: 20, toJSON() { return {}; } }),
+    });
+    const seen: WheelEvent[] = [];
+    target.addEventListener("wheel", (event) => { seen.push(event); });
+
+    expect(dispatchSyntheticTerminalWheel(target, 16)).toBe(true);
+    expect(dispatchSyntheticTerminalWheel(target, 16, { clientX: Number.NaN, clientY: 10 })).toBe(true);
+    expect(dispatchSyntheticTerminalWheel(target, 16, { clientX: Number.POSITIVE_INFINITY, clientY: 10 })).toBe(true);
+    expect(seen).toHaveLength(3);
+    for (const event of seen) {
+      expect(event.clientX).toBe(30);
+      expect(event.clientY).toBe(35);
+      expect(String(event.clientX)).not.toBe("NaN");
+      expect(String(event.clientY)).not.toBe("NaN");
+    }
+  });
+
+  it("does not dispatch a zero, non-finite, or unlocated wheel", () => {
+    const target = document.createElement("div");
+    const seen: Event[] = [];
+    target.addEventListener("wheel", (event) => { seen.push(event); });
+    Object.defineProperty(target, "getBoundingClientRect", {
+      value: () => ({ left: Number.NaN, top: Number.NaN, width: Number.NaN, height: Number.NaN }),
+    });
+
+    expect(dispatchSyntheticTerminalWheel(target, 0, { clientX: 1, clientY: 1 })).toBe(false);
+    expect(dispatchSyntheticTerminalWheel(target, Number.NaN, { clientX: 1, clientY: 1 })).toBe(false);
+    expect(dispatchSyntheticTerminalWheel(target, 10)).toBe(false);
+    expect(seen).toHaveLength(0);
+  });
+});

--- a/runtime/fleet-plugins/terminal/tests/terminal-touch-gestures.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-touch-gestures.test.ts
@@ -44,7 +44,7 @@ describe("terminal touch gestures", () => {
     container.dispatchEvent(touchEvent("touchmove", [{ x: 10, y: 120 }]));
     container.dispatchEvent(touchEvent("touchmove", [{ x: 10, y: 150 }]));
     // Dragging down reaches older output, the direction a wheel scrolls back.
-    expect(scrollByPixels).toHaveBeenCalledWith(-30);
+    expect(scrollByPixels).toHaveBeenCalledWith(-30, { clientX: 10, clientY: 150 });
     gestures.dispose();
   });
 
@@ -53,7 +53,7 @@ describe("terminal touch gestures", () => {
     container.dispatchEvent(touchEvent("touchstart", [{ x: 10, y: 200 }]));
     container.dispatchEvent(touchEvent("touchmove", [{ x: 10, y: 180 }]));
     container.dispatchEvent(touchEvent("touchmove", [{ x: 10, y: 160 }]));
-    expect(scrollByPixels).toHaveBeenCalledWith(20);
+    expect(scrollByPixels).toHaveBeenCalledWith(20, { clientX: 10, clientY: 160 });
     gestures.dispose();
   });
 


### PR DESCRIPTION
## Summary
- 휴대폰에서 전체 화면 Claude 에이전트를 스크롤하면 CLI 입력창에 `NaN`이 대량 입력되던 문제를 고칩니다.
- 터치 팬이 좌표 없는 `WheelEvent`로 바뀌고, Android WebView가 `clientX`/`clientY`를 비워 두면 xterm SGR 마우스 리포트가 `NaN`을 PTY에 넣었습니다.
- 합성 휠은 유한한 손가락 좌표(없으면 target 중심)를 함께 보내고, 좌표를 만들 수 없으면 dispatch하지 않습니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` (712 passed)
- [x] Isolated Console (`FLEET_DATA_DIR` / `FLEET_CONSOLE_DATA_DIR` + `CLAUDE_CODE_*` 제거)에서 Claude Gateway 세션 기동
- [ ] 실제 Android 기기에서 Claude operation을 스크롤해 프롬프트에 `NaN`이 들어가지 않는지 확인 (에뮬레이터 LAN 조인은 slirp 한계로 완료하지 못함)