### PR TITLE
fix(fleet-console): keep a War Room panel's content inside its own tile

### DIFF
--- a/.changelog.d/warroom-deck-tile-overflow.md
+++ b/.changelog.d/warroom-deck-tile-overflow.md
@@ -1,0 +1,8 @@
+---
+branch: warroom-deck-tile-overflow
+---
+
+### fleet-console
+#### Fixed
+- Keep a War Room panel's caption and body inside the tile it stands in, so lowering the deck density - or narrowing the deck until it adds a column - no longer paints one panel's text across its neighbours.
+  ko: War Room 패널의 캡션과 본문이 자기 칸 안에 머무릅니다. 덱 밀도를 낮추거나 덱이 좁아져 열이 늘어날 때 한 패널의 글자가 옆 패널 위에 겹쳐 그려지지 않습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4275,6 +4275,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   min-height: 0;
   width: auto;
   height: auto;
+  /* 열 트랙을 적지 않으면 암시적 `auto` 열의 최소값이 본문의 min-content가 되고, 그 값(xterm은
+     실측 288px)이 칸보다 크면 패널 상자는 칸에 맞은 채 자식만 밖으로 그려진다 — 패널은
+     overflow:visible이라 캡션·본문이 옆 칸 위를 덮는다. 밀도를 낮출수록 칸이 좁아져
+     War Room의 최소 카드 폭(140px)에서 항상 재현된다. 칸이 곧 패널이자 PTY 크기라는 계약은
+     행처럼 열에도 최소값 0을 명시해야 성립한다. */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   border-top-width: 1px;
   border-top-style: solid;

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -928,6 +928,20 @@ describe("triage store", () => {
     }
   });
 
+  it("keeps the deck tile's own track from growing past the slot it stands in", () => {
+    // 칸이 곧 패널이자 PTY 크기라는 계약은 두 축 모두에 최소값 0을 적어야 성립한다. 열 트랙을
+    // 비워 두면 암시적 `auto` 열의 최소값이 본문의 min-content가 되고(xterm은 실측 288px),
+    // 패널은 overflow:visible이라 그만큼이 옆 칸 위에 그려진다 — 밀도를 낮출수록 항상 재현된다.
+    const css = readFileSync("core/client/src/styles/components.css", "utf8");
+    const rule = /\.canvas-operation\.is-deck-tile\s*\{([^}]*)\}/.exec(css)?.[1];
+    expect(rule, "is-deck-tile rule is gone").toBeDefined();
+    for (const axis of ["columns", "rows"]) {
+      const track = new RegExp(`grid-template-${axis}:([^;]*);`).exec(rule!)?.[1];
+      expect(track, `is-deck-tile declares no grid-template-${axis}`).toBeDefined();
+      expect(track, `is-deck-tile ${axis} track can outgrow its slot`).toContain("minmax(0,");
+    }
+  });
+
   it("routes deck-slot, map-dot, and owned empty-region context menus without guessing bare space", () => {
     const container = document.createElement("div");
     document.body.append(container);


### PR DESCRIPTION
## Summary
- War Room 덱 칸에 선 패널(`.canvas-operation.is-deck-tile`)은 행 트랙만 선언해 암시적 `auto` 열의 최소값이 본문의 min-content(xterm 실측 288px)가 됐습니다. 패널 상자는 `min-width: 0`이라 칸에 맞지만 열 트랙이 칸보다 커지고, 패널은 `overflow: visible`이라 캡션과 본문이 옆 칸 위에 그대로 그려졌습니다.
- 열에도 `minmax(0, 1fr)`을 명시해 "칸이 곧 패널이자 PTY 크기"라는 계약을 두 축 모두에서 성립시킵니다.
- 두 축 최소값 계약을 덱 CSS 계약 테스트에 고정했습니다.

## Test Plan
- [x] 격리 콘솔 실측(패널 9개, 1440x900, DPR 1) — 카드 폭 208/182/157/142px에서 자식이 칸 밖으로 나간 최대치 **60/114/149/175px → 1px**
- [x] 밀도 2.0x~카드 최소폭 전 구간(열 2→7) 및 뷰포트 1440/1180/1024/900/1600/1920(열 7→5→4→3→8→10)에서 최대 1px
- [x] 회귀 없음 — 무대 승격 패널 정상, Quick-Look 확대 동작(347→677px) 유지
- [x] `pnpm vitest run` — 2209 passed / 24 skipped
- [x] `tsc --noEmit` — clean
- [x] `pnpm --filter @dotobokuri/fleet-console build` — clean
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 22 entries OK