### PR TITLE
feat(fleet-console): hide Analyst and Chat chips on War Room cards

### DIFF
--- a/.changelog.d/warroom-hide-card-chrome.md
+++ b/.changelog.d/warroom-hide-card-chrome.md
@@ -4,5 +4,5 @@ branch: warroom-hide-card-chrome
 
 ### fleet-console
 #### Changed
-- Hide the Analyst and Chat view chips on a War Room card. They return on the staged panel, where they can be used.
-  ko: War Room 카드에서는 분석가와 채팅 뷰 칩을 숨깁니다. 무대에 오른 패널에서는 기존처럼 다시 보입니다.
+- Hide the Analyst and Chat view chips on a War Room card, and let a chat-mode card use the space those chips leave. They return on the staged panel, where they can be used.
+  ko: War Room 카드에서는 분석가와 채팅 뷰 칩을 숨기고, 채팅 모드 카드는 그 자리를 본문에 돌려줍니다. 무대에 오른 패널에서는 기존처럼 다시 보입니다.

--- a/.changelog.d/warroom-hide-card-chrome.md
+++ b/.changelog.d/warroom-hide-card-chrome.md
@@ -1,0 +1,8 @@
+---
+branch: warroom-hide-card-chrome
+---
+
+### fleet-console
+#### Changed
+- Hide the Analyst and Chat view chips on a War Room card. They return on the staged panel, where they can be used.
+  ko: War Room 카드에서는 분석가와 채팅 뷰 칩을 숨깁니다. 무대에 오른 패널에서는 기존처럼 다시 보입니다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2432,6 +2432,10 @@ describe("War Room deck panel grammar", () => {
     expect(hide).not.toContain("is-quicklook");
     // 회신 버튼은 칩 줄이 아니다 — 별도 규칙으로 숨기면 이 계약이 깨져야 한다.
     expect(terminalChatCss).not.toContain(".canvas-operation.is-deck-tile .agent-chat-reply");
+    // 칩을 숨긴 카드에서는 그 자리를 피하던 상단 여백만 거둔다. 하단은 회신 버튼이 쓴다.
+    const logOnTile = terminalChatCss.match(/\.canvas-operation\.is-deck-tile \.agent-chat-log \{[^}]*\}/)?.[0] ?? "";
+    expect(logOnTile).toContain("padding-top: var(--space-3);");
+    expect(logOnTile).not.toContain("45px");
   });
 
   it("gives the promotion surface the body and leaves the caption its own controls", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2417,6 +2417,23 @@ describe("War Room deck panel grammar", () => {
     expect(frame).not.toMatch(/canvas-operation-titlebar"[^>]*inert/);
   });
 
+  it("hides Analyst and Chat-view chips on a deck tile and keeps them on the stage", () => {
+    // 카드 본문은 inert이고 승격 면이 클릭을 가로채므로 칩은 눌러도 동작하지 않는다.
+    // 무대에 오른 패널은 is-deck-tile이 아니므로 칩이 기존처럼 보인다.
+    const terminalChatCss = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_CSS_PATH), "utf8");
+    expect(terminalChatCss).toContain(".canvas-operation.is-deck-tile .agent-view-chip-row");
+    expect(terminalChatCss).toContain(".canvas-operation.is-deck-tile .agent-chat-mode-chip");
+    expect(terminalChatCss).toContain(".canvas-operation.is-deck-tile .agent-chat-dormant-open");
+    const hide = terminalChatCss.match(/\.canvas-operation\.is-deck-tile \.agent-view-chip-row,\s*\n\.canvas-operation\.is-deck-tile \.agent-chat-mode-chip,\s*\n\.canvas-operation\.is-deck-tile \.agent-chat-dormant-open \{[^}]*\}/)?.[0] ?? "";
+    expect(hide).toContain("display: none;");
+    // 선택(무대) 축은 카드 클래스의 부재다 — is-active나 is-quicklook에 묶이면 카드이면서
+    // 선택된 칸, 또는 확대된 칸에서 다시 그려진다.
+    expect(hide).not.toContain("is-active");
+    expect(hide).not.toContain("is-quicklook");
+    // 회신 버튼은 칩 줄이 아니다 — 별도 규칙으로 숨기면 이 계약이 깨져야 한다.
+    expect(terminalChatCss).not.toContain(".canvas-operation.is-deck-tile .agent-chat-reply");
+  });
+
   it("gives the promotion surface the body and leaves the caption its own controls", () => {
     // 덱에서 패널의 본문은 읽는 것이지 조작하는 것이 아니다 — 본문 위를 덮는 면이 클릭 한 번을
     // 승격으로 받고, 캡션은 그 위에 남아 창 컨트롤이 자기 클릭을 지킨다.

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -565,6 +565,11 @@
   display: none;
 }
 
+/* 칩이 없으면 로그가 그 자리를 되찾는다. 하단 45px는 회신 버튼 몫이라 건드리지 않는다. */
+.canvas-operation.is-deck-tile .agent-chat-log {
+  padding-top: var(--space-3);
+}
+
 /* Analyst 진입 칩의 진행 표식 — 상태 신호는 aurora 도트만 진다. */
 .agent-analyst-chip-live {
   width: 6px;

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -555,6 +555,16 @@
   position: static;
 }
 
+/* War Room 카드의 본문은 읽는 자리다 — 승격 면이 클릭을 가로채고 본문은 inert라
+   Analyst·채팅 뷰 칩은 눌러도 동작하지 않는다. 무대에 오른 패널은 is-deck-tile이
+   아니므로 칩이 기존처럼 보인다. 휴면 카드의 채팅 진입 고스트도 같은 줄이 아니라
+   본문 안에 있으므로 함께 숨긴다. */
+.canvas-operation.is-deck-tile .agent-view-chip-row,
+.canvas-operation.is-deck-tile .agent-chat-mode-chip,
+.canvas-operation.is-deck-tile .agent-chat-dormant-open {
+  display: none;
+}
+
 /* Analyst 진입 칩의 진행 표식 — 상태 신호는 aurora 도트만 진다. */
 .agent-analyst-chip-live {
   width: 6px;


### PR DESCRIPTION
## Summary
- War Room 카드에서는 분석가·채팅 뷰 칩을 숨깁니다. 카드 본문은 inert이고 승격 면이 클릭을 가로채므로 그 자리의 칩은 눌러도 동작하지 않습니다.
- 카드를 눌러 무대에 올린 패널에서는 칩이 기존처럼 다시 보입니다. 회신 버튼은 그대로입니다.
- 숨김은 플러그인 CSS가 호스트의 `.is-deck-tile` 조상을 보는 한 규칙이며, `OperationRenderContext`에는 `deckTile`을 넣지 않았습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts -t "War Room deck panel grammar"`
- [x] 격리 콘솔에서 War Room 카드에 분석가/채팅 뷰가 없고, 무대에 올리면 다시 보이는지 사용자 확인
- [ ] Codex 리뷰 통과