### PR TITLE
fix(fleet-console): stop inertial scroll typing NaN

### DIFF
--- a/.changelog.d/fix-mobile-scroll-nan.md
+++ b/.changelog.d/fix-mobile-scroll-nan.md
@@ -1,0 +1,8 @@
+---
+branch: fix-mobile-scroll-nan
+---
+
+### fleet-console
+#### Fixed
+- Keep inertial phone scrolling from typing malformed mouse coordinates into terminal prompts.
+  ko: 휴대폰 관성 스크롤이 잘못된 마우스 좌표를 터미널 프롬프트에 입력하지 않도록 했습니다.

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -16,6 +16,7 @@ import { createTerminalOsc52Clipboard } from "./terminal-osc52-clipboard.js";
 import { TERMINAL_OPTIONS } from "./terminal-options.js";
 import { dispatchSyntheticTerminalWheel } from "./terminal-synthetic-wheel.js";
 import { createTerminalTouchGestures, MIN_FONT_SCALE } from "./terminal-touch-gestures.js";
+import { createXtermGestureOriginGuard } from "./terminal-xterm-gesture-origin.js";
 import { FailureNotice } from "@fleet-console/sdk/components/failure-notice";
 import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
 
@@ -318,6 +319,11 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
       terminal.loadAddon(fitAddon);
       terminal.open(container);
       syncTerminalViewportBackground(container, terminalTheme);
+      const xtermScreen = container.querySelector<HTMLElement>(".xterm-screen");
+      // xterm's own touch inertia emits gesture changes without a client point. Under mouse tracking
+      // it serializes those missing coordinates as `NaN` and sends them to the PTY. Guard the private
+      // event at the public DOM boundary rather than patching or deep-importing xterm internals.
+      const xtermGestureOriginGuard = xtermScreen ? createXtermGestureOriginGuard(xtermScreen) : null;
       const copyOnSelect = createTerminalCopyOnSelect({
         terminal,
         selectionTarget: container,
@@ -479,6 +485,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         osc52Clipboard.dispose();
         scrollGesture.dispose();
         touchGestures.dispose();
+        xtermGestureOriginGuard?.dispose();
         outputScheduler.dispose();
         statusDetailReporter.dispose();
         scrollFollow.dispose();

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-xterm-gesture-origin.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-xterm-gesture-origin.ts
@@ -1,0 +1,68 @@
+const XTERM_GESTURE_CHANGE_EVENT = "-xterm-gesturechange";
+
+interface XtermGesturePoint {
+  readonly clientX?: number;
+  readonly clientY?: number;
+}
+
+export interface XtermGestureOriginGuard {
+  readonly dispose: () => void;
+}
+
+function hasFiniteClientPoint(event: XtermGesturePoint): event is Required<XtermGesturePoint> {
+  return Number.isFinite(event.clientX) && Number.isFinite(event.clientY);
+}
+
+/**
+ * xterm turns a touch release into inertial `-xterm-gesturechange` events. Unlike the changes emitted
+ * while the finger is down, those internal events carry no client point. Under mouse tracking xterm
+ * still encodes the point as an SGR wheel report, so the missing values become literal `NaN` fields
+ * on the PTY input stream. Repair only that missing internal point before xterm's target listener sees
+ * it; a real touch keeps its own coordinates.
+ */
+export function createXtermGestureOriginGuard(screen: HTMLElement): XtermGestureOriginGuard {
+  let lastFingerPoint: Required<XtermGesturePoint> | null = null;
+
+  const onGestureChange = (rawEvent: Event) => {
+    const event = rawEvent as Event & XtermGesturePoint;
+    if (hasFiniteClientPoint(event)) {
+      lastFingerPoint = { clientX: event.clientX, clientY: event.clientY };
+      return;
+    }
+
+    const rect = screen.getBoundingClientRect();
+    const rectCentre = {
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+    };
+    const fallback = lastFingerPoint ?? (hasFiniteClientPoint(rectCentre) ? rectCentre : null);
+    if (fallback === null) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
+    try {
+      Object.defineProperties(event, {
+        clientX: { configurable: true, value: fallback.clientX },
+        clientY: { configurable: true, value: fallback.clientY },
+      });
+    } catch {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
+    if (!hasFiniteClientPoint(event)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  };
+
+  // xterm registers a target listener during terminal.open(). Capture still runs first at the target,
+  // independent of registration order, without importing its private Gesture implementation.
+  screen.addEventListener(XTERM_GESTURE_CHANGE_EVENT, onGestureChange, true);
+  return {
+    dispose: () => screen.removeEventListener(XTERM_GESTURE_CHANGE_EVENT, onGestureChange, true),
+  };
+}

--- a/runtime/fleet-plugins/terminal/tests/terminal-xterm-gesture-origin.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-xterm-gesture-origin.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+import { createXtermGestureOriginGuard } from "../client/shared/terminal-xterm-gesture-origin.js";
+
+const GESTURE_CHANGE = "-xterm-gesturechange";
+
+function screenWithRect(rect = { left: 10, top: 20, width: 80, height: 40 }): HTMLElement {
+  const screen = document.createElement("div");
+  Object.defineProperty(screen, "getBoundingClientRect", {
+    value: () => ({
+      ...rect,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON() { return {}; },
+    }),
+  });
+  document.body.append(screen);
+  return screen;
+}
+
+function gestureChange(point?: { readonly clientX: number; readonly clientY: number }): Event & {
+  readonly clientX?: number;
+  readonly clientY?: number;
+} {
+  const event = new CustomEvent(GESTURE_CHANGE, { bubbles: false, cancelable: true }) as Event & {
+    readonly clientX?: number;
+    readonly clientY?: number;
+  };
+  if (point) {
+    Object.defineProperties(event, {
+      clientX: { configurable: true, value: point.clientX },
+      clientY: { configurable: true, value: point.clientY },
+    });
+  }
+  return event;
+}
+
+describe("xterm gesture origin guard", () => {
+  it("keeps the real finger point unchanged", () => {
+    const screen = screenWithRect();
+    const guard = createXtermGestureOriginGuard(screen);
+    const seen: Array<{ x?: number; y?: number }> = [];
+    screen.addEventListener(GESTURE_CHANGE, (rawEvent) => {
+      const event = rawEvent as Event & { readonly clientX?: number; readonly clientY?: number };
+      seen.push({ x: event.clientX, y: event.clientY });
+    });
+
+    screen.dispatchEvent(gestureChange({ clientX: 12, clientY: 34 }));
+
+    expect(seen).toEqual([{ x: 12, y: 34 }]);
+    guard.dispose();
+  });
+
+  it("carries the last finger point into xterm inertia events", () => {
+    const screen = screenWithRect();
+    const guard = createXtermGestureOriginGuard(screen);
+    const seen: Array<{ x?: number; y?: number }> = [];
+    screen.addEventListener(GESTURE_CHANGE, (rawEvent) => {
+      const event = rawEvent as Event & { readonly clientX?: number; readonly clientY?: number };
+      seen.push({ x: event.clientX, y: event.clientY });
+    });
+
+    screen.dispatchEvent(gestureChange({ clientX: 12, clientY: 34 }));
+    const event = gestureChange();
+    expect(screen.dispatchEvent(event)).toBe(true);
+
+    expect(seen).toEqual([{ x: 12, y: 34 }, { x: 12, y: 34 }]);
+    expect(Number.isFinite(event.clientX)).toBe(true);
+    expect(Number.isFinite(event.clientY)).toBe(true);
+    expect(String(event.clientX)).not.toBe("NaN");
+    expect(String(event.clientY)).not.toBe("NaN");
+    guard.dispose();
+  });
+
+  it("falls back to the screen centre before any finger point has been observed", () => {
+    const screen = screenWithRect();
+    const guard = createXtermGestureOriginGuard(screen);
+    const seen: Array<{ x?: number; y?: number }> = [];
+    screen.addEventListener(GESTURE_CHANGE, (rawEvent) => {
+      const event = rawEvent as Event & { readonly clientX?: number; readonly clientY?: number };
+      seen.push({ x: event.clientX, y: event.clientY });
+    });
+
+    screen.dispatchEvent(gestureChange());
+
+    expect(seen).toEqual([{ x: 50, y: 40 }]);
+    guard.dispose();
+  });
+
+  it("blocks a coordinate-less inertia event when the screen rect is unusable", () => {
+    const screen = screenWithRect({ left: Number.NaN, top: 20, width: 80, height: 40 });
+    const guard = createXtermGestureOriginGuard(screen);
+    const downstream = vi.fn();
+    screen.addEventListener(GESTURE_CHANGE, downstream);
+
+    const event = gestureChange();
+    expect(screen.dispatchEvent(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(downstream).not.toHaveBeenCalled();
+    guard.dispose();
+  });
+
+  it("stops guarding after disposal", () => {
+    const screen = screenWithRect();
+    const guard = createXtermGestureOriginGuard(screen);
+    guard.dispose();
+    const seen: Array<{ x?: number; y?: number }> = [];
+    screen.addEventListener(GESTURE_CHANGE, (rawEvent) => {
+      const event = rawEvent as Event & { readonly clientX?: number; readonly clientY?: number };
+      seen.push({ x: event.clientX, y: event.clientY });
+    });
+
+    screen.dispatchEvent(gestureChange());
+
+    expect(seen).toEqual([{ x: undefined, y: undefined }]);
+  });
+});


### PR DESCRIPTION
## Summary
- repair coordinate-less xterm touch inertia events at the shared terminal DOM boundary before mouse tracking serializes them
- preserve real touch origins, reuse the last finite finger point for inertia, and block events when no finite fallback exists
- add lifecycle and fallback regression coverage plus a Fleet Console release note

## Test Plan
- [x] reproduce on the `fleet-mobile-test` Android Emulator with a remote `cursor-auto` Claude Operation (`119` sent frames, `45` containing `NaN`)
- [x] repeat the same swipe flow after the fix (`189` sent frames, `0` containing `NaN`)
- [x] `pnpm --filter @fleet-plugins/terminal test` (`78` files, `764` tests)
- [x] `pnpm --filter @fleet-mobile/app test` (`3` files, `23` tests)
- [x] terminal and Fleet Mobile typechecks
- [x] terminal and Fleet Console production builds
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`