### PR TITLE
fix(core-ai-gateway): retry transient Grok failures

### DIFF
--- a/.changelog.d/grok-mid-response-retry.md
+++ b/.changelog.d/grok-mid-response-retry.md
@@ -1,0 +1,13 @@
+---
+branch: grok-mid-response-retry
+---
+
+### fleet-cli
+#### Fixed
+- Retry transient Grok server and socket failures before any caller-visible output instead of ending the model turn with an incomplete-response API error.
+  ko: 호출자에게 출력이 보이기 전 발생한 Grok 서버 및 소켓 일시 오류를 재시도하여 모델 턴이 불완전 응답 API 오류로 끝나지 않게 했습니다.
+
+### fleet-console
+#### Fixed
+- Retry transient Grok server and socket failures before any caller-visible output instead of ending the model turn with an incomplete-response API error.
+  ko: 호출자에게 출력이 보이기 전 발생한 Grok 서버 및 소켓 일시 오류를 재시도하여 모델 턴이 불완전 응답 API 오류로 끝나지 않게 했습니다.

--- a/packages/core-ai-gateway/src/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/xai/responses/adapter.ts
@@ -27,6 +27,7 @@ export const XAI_CLI_CLIENT_VERSION = "1.0.3";
 export const DEFAULT_XAI_RESPONSES_MAX_UPSTREAM_BODY_BYTES = 64 * 1024 * 1024;
 export const DEFAULT_XAI_RESPONSES_UPSTREAM_IDLE_TIMEOUT_MS = 30_000;
 export const DEFAULT_XAI_RESPONSES_FUNCTION_CALL_TIMEOUT_MS = 30_000;
+const XAI_RETRY_DELAY_MS = 200;
 
 /**
  * Grok CLI's Responses wire accepts the canonical OpenAI-shaped request after
@@ -55,6 +56,7 @@ export interface XaiResponsesAdapterOptions {
 export class XaiResponsesAdapter implements AiGatewayAdapter {
   readonly capabilities = {} as const;
   private readonly fetchImpl: FetchLike;
+  private readonly isMarkedFetchFailure: (error: unknown) => boolean;
   private readonly maxBodyBytes: number;
   private readonly idleTimeoutMs: number;
   private readonly functionCallTimeoutMs: number;
@@ -66,7 +68,9 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
     // 오버라이드는 provider 어댑터를 다시 범용화하므로 옵션으로 노출하지 않는다.
     this.url = XAI_CLI_RESPONSES_URL;
     this.extraHeaders = options.headers ?? {};
-    this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+    const fetchTracker = createXaiFetchFailureTracker(options.fetch ?? globalThis.fetch.bind(globalThis));
+    this.fetchImpl = fetchTracker.fetch;
+    this.isMarkedFetchFailure = fetchTracker.isMarkedFailure;
     this.maxBodyBytes = positiveInteger(
       options.maxBodyBytes ?? DEFAULT_XAI_RESPONSES_MAX_UPSTREAM_BODY_BYTES,
       "maxBodyBytes"
@@ -89,53 +93,91 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
       throw new TypeError("apiKey must not be empty");
     }
 
+    // 호출자 signal과 초기/retry fetch 및 stream read를 하나의 per-call controller로 묶는다.
     const controller = new AbortController();
     const unlinkAbort = linkAbortSignal(options.signal, controller);
     const payload = forXaiResponsesBackend(request, xaiWireTools(request));
-    // Exact JSON body sent upstream, including each tool's `parameters` and any `strict` flag.
-    wireLog("xai-responses.wire.request", { url: this.url, payload });
-    let response: Response;
+    let retryAvailable = true;
+    let response: AdapterResponse;
 
     try {
-      response = await this.fetchImpl(this.url, {
-        method: "POST",
-        headers: {
-          accept: "text/event-stream",
-          authorization: `Bearer ${options.apiKey}`,
-          "content-type": "application/json",
-          "x-xai-token-auth": "xai-grok-cli",
-          "x-grok-client-version": XAI_CLI_CLIENT_VERSION,
-          "x-grok-model-override": request.model,
-          ...this.extraHeaders
-        },
-        body: JSON.stringify(payload),
-        signal: controller.signal
-      });
+      response = await this.fetchResponse(request, options.apiKey, payload, controller);
     } catch (error) {
-      unlinkAbort();
-      throw error;
+      if (!isRetryableXaiFetchSocket(error, controller.signal, this.isMarkedFetchFailure)) {
+        unlinkAbort();
+        throw error;
+      }
+      retryAvailable = false;
+      wireLog("xai-responses.retry.discarded", {
+        reason: "socket_termination",
+        phase: "fetch",
+      });
+      try {
+        await abortableXaiDelay(XAI_RETRY_DELAY_MS, controller.signal);
+        response = await this.fetchResponse(request, options.apiKey, payload, controller);
+      } catch (retryError) {
+        unlinkAbort();
+        throw retryError;
+      }
     }
+
+    if (!response.ok) {
+      unlinkAbort();
+      return response;
+    }
+
+    return {
+      ...response,
+      events: retryXaiEvents(response.events, async (signal) => {
+        await abortableXaiDelay(XAI_RETRY_DELAY_MS, signal);
+        const retried = await this.fetchResponse(request, options.apiKey, payload, controller);
+        if (!retried.ok) {
+          throw new UpstreamProtocolError(`xAI retry failed with status ${retried.status}`);
+        }
+        return retried.events;
+      }, controller, unlinkAbort, retryAvailable),
+    };
+  }
+
+  private async fetchResponse(
+    request: CanonicalResponseRequest,
+    apiKey: string,
+    payload: XaiResponsesWireRequest,
+    controller: AbortController,
+  ): Promise<AdapterResponse> {
+    // Exact JSON body sent on each attempt, including every tool's parameters and strict flag.
+    wireLog("xai-responses.wire.request", { url: this.url, payload });
+    const response = await this.fetchImpl(this.url, {
+      method: "POST",
+      headers: {
+        accept: "text/event-stream",
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+        "x-xai-token-auth": "xai-grok-cli",
+        "x-grok-client-version": XAI_CLI_CLIENT_VERSION,
+        "x-grok-model-override": request.model,
+        ...this.extraHeaders
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal
+    });
 
     if (!response.ok) {
       if (process.env.FLEET_AI_GATEWAY_DEBUG === "1") {
         const roles = payload.input.map((item) => ("role" in item ? item.role : item.type));
         console.error(`[ai-gateway] upstream ${response.status} input roles=${JSON.stringify(roles)} keys=${JSON.stringify(Object.keys(payload))}`);
       }
-      try {
-        const body = await readBoundedBody(response.body, {
-          controller,
-          idleTimeoutMs: this.idleTimeoutMs,
-          maxBodyBytes: this.maxBodyBytes
-        });
-        return {
-          ok: false,
-          status: response.status,
-          headers: response.headers,
-          body
-        };
-      } finally {
-        unlinkAbort();
-      }
+      const body = await readBoundedBody(response.body, {
+        controller,
+        idleTimeoutMs: this.idleTimeoutMs,
+        maxBodyBytes: this.maxBodyBytes
+      });
+      return {
+        ok: false,
+        status: response.status,
+        headers: response.headers,
+        body
+      };
     }
 
     return {
@@ -146,7 +188,7 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
         controller,
         idleTimeoutMs: this.idleTimeoutMs,
         maxBodyBytes: this.maxBodyBytes,
-        onClose: unlinkAbort
+        onClose: () => undefined
       }, this.functionCallTimeoutMs)
     };
   }
@@ -209,6 +251,212 @@ function toolNameMatches(declaredName: string, selectedName: string): boolean {
 }
 
 type ReadOptions = UpstreamReadOptions;
+
+function retryXaiEvents(
+  events: AsyncIterable<CanonicalResponseEvent>,
+  retry: (signal: AbortSignal) => Promise<AsyncIterable<CanonicalResponseEvent>>,
+  controller: AbortController,
+  unlinkAbort: () => void,
+  retryAvailable: boolean,
+): AsyncIterable<CanonicalResponseEvent> {
+  return {
+    [Symbol.asyncIterator]() {
+      const source = events[Symbol.asyncIterator]();
+      const iterator = generateXaiRetryEvents(source, retry, controller, unlinkAbort, retryAvailable);
+      return {
+        next: () => iterator.next(),
+        return: async () => {
+          controller.abort();
+          return iterator.return(undefined);
+        },
+        throw: async (error?: unknown) => {
+          controller.abort(error);
+          return iterator.throw(error);
+        },
+      };
+    },
+  };
+}
+
+async function* generateXaiRetryEvents(
+  source: AsyncIterator<CanonicalResponseEvent>,
+  retry: (signal: AbortSignal) => Promise<AsyncIterable<CanonicalResponseEvent>>,
+  controller: AbortController,
+  unlinkAbort: () => void,
+  retryAvailable: boolean,
+): AsyncGenerator<CanonicalResponseEvent> {
+  // Anthropic 변환이 message_start/thinking을 즉시 발화하므로 commit 전 lead만 보류한다.
+  const lead: CanonicalResponseEvent[] = [];
+  let committed = false;
+  let normalCompletion = false;
+  let pendingError: Extract<CanonicalResponseEvent, { type: "error" }> | undefined;
+
+  try {
+    while (true) {
+      let result: IteratorResult<CanonicalResponseEvent>;
+      try {
+        result = await source.next();
+      } catch (error) {
+        if (committed || controller.signal.aborted || !isUndiciSocketTermination(error)) {
+          throw error;
+        }
+        if (!retryAvailable) {
+          yield* lead;
+          throw error;
+        }
+        wireLog("xai-responses.retry.discarded", {
+          reason: "socket_termination",
+          phase: "pre_commit",
+        });
+        await source.return?.();
+        lead.length = 0;
+        yield* await retry(controller.signal);
+        return;
+      }
+
+      if (result.done) {
+        yield* lead;
+        if (pendingError !== undefined) {
+          yield pendingError;
+        }
+        normalCompletion = true;
+        return;
+      }
+
+      const event = result.value;
+      if (retryAvailable && !committed && isRetryableXaiFailure(event)) {
+        if (event.type === "response.failed") {
+          const errorTypes = pendingError === undefined
+            ? [event.response.error.type]
+            : [pendingError.error.type, event.response.error.type];
+          wireLog("xai-responses.retry.discarded", pendingError === undefined
+            ? { reason: "response.failed", errorTypes }
+            : { reason: "error_failed_pair", errorTypes });
+          await source.return?.();
+          lead.length = 0;
+          yield* await retry(controller.signal);
+          return;
+        }
+        pendingError = event;
+        continue;
+      }
+
+      if (pendingError !== undefined) {
+        yield* lead;
+        lead.length = 0;
+        yield pendingError;
+        pendingError = undefined;
+        committed = true;
+      }
+
+      if (commitsXaiOutput(event)) {
+        yield* lead;
+        lead.length = 0;
+        committed = true;
+        yield event;
+      } else {
+        lead.push(event);
+      }
+    }
+  } finally {
+    if (!normalCompletion && !controller.signal.aborted) {
+      controller.abort();
+    }
+    unlinkAbort();
+    await source.return?.();
+  }
+}
+
+function isRetryableXaiFailure(event: CanonicalResponseEvent): event is
+  Extract<CanonicalResponseEvent, { type: "response.failed" | "error" }> {
+  return (event.type === "response.failed" && isRetryableXaiErrorType(event.response.error.type))
+    || (event.type === "error" && isRetryableXaiErrorType(event.error.type));
+}
+
+function isRetryableXaiErrorType(type: string): boolean {
+  return type === "server_error"
+    || type === "server_is_overloaded"
+    || type === "service_unavailable_error";
+}
+
+function commitsXaiOutput(event: CanonicalResponseEvent): boolean {
+  if (event.type === "response.created" || event.type === "response.reasoning_summary_text.delta") {
+    return false;
+  }
+  if (event.type === "response.output_item.added" && event.item.type === "message") {
+    return false;
+  }
+  return true;
+}
+
+function createXaiFetchFailureTracker(fetchImpl: FetchLike): {
+  fetch: FetchLike;
+  isMarkedFailure: (error: unknown) => boolean;
+} {
+  const failures = new WeakSet<object>();
+  return {
+    fetch: async (input, init) => {
+      try {
+        return await fetchImpl(input, init);
+      } catch (error) {
+        if (error !== null && typeof error === "object") {
+          failures.add(error);
+        }
+        throw error;
+      }
+    },
+    isMarkedFailure: (error) => error !== null && typeof error === "object" && failures.has(error),
+  };
+}
+
+function isRetryableXaiFetchSocket(
+  error: unknown,
+  signal: AbortSignal,
+  isMarkedFailure: (error: unknown) => boolean,
+): boolean {
+  return !signal.aborted && isMarkedFailure(error) && isUndiciSocketTermination(error);
+}
+
+function isUndiciSocketTermination(error: unknown): boolean {
+  const seen = new Set<object>();
+  let current: unknown = error;
+  for (let depth = 0; depth <= 4; depth += 1) {
+    if (current === null || typeof current !== "object" || seen.has(current)) {
+      return false;
+    }
+    seen.add(current);
+    if ((current as { code?: unknown }).code === "UND_ERR_SOCKET") {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+async function abortableXaiDelay(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    throw signal.reason;
+  }
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(onResolve, delayMs);
+    const onAbort = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason);
+    };
+    function onResolve(): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
 
 function parseXaiEventStream(
   body: ReadableStream<Uint8Array> | null,
@@ -299,13 +547,9 @@ async function* assembleXaiFunctionCalls(
       yield event;
     }
   } finally {
-    // A normal source completion must retain the existing lifecycle: the caller's
-    // signal is not aborted just because the response ended successfully. On an
-    // error or early consumer return, abort first so any pending upstream read is
-    // released before returning the iterator.
-    if (!completedNormally && !controller.signal.aborted) {
-      controller.abort();
-    }
+    // The outer retry seam owns per-call cancellation. Closing this attempt must release
+    // only its source: a retry closes attempt one before reusing the same controller for
+    // attempt two, while outer return/throw and terminal errors abort the controller.
     const returned = iterator.return?.();
     if (returned !== undefined) {
       await returned.catch(() => undefined);

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -7,6 +7,7 @@ import {
   XAI_CLI_RESPONSES_URL,
   XAI_CLI_SETTINGS_URL,
   XaiResponsesAdapter,
+  encodeAnthropicSse,
   fetchXaiUsage,
   parseXaiCredits,
   parseXaiPlan,
@@ -51,10 +52,35 @@ async function collectXaiEvents(events: AsyncIterable<CanonicalResponseEvent>): 
   return collected;
 }
 
+async function collectEncodedBody(body: AsyncIterable<Uint8Array>): Promise<string> {
+  const decoder = new TextDecoder();
+  let text = "";
+  for await (const chunk of body) {
+    text += decoder.decode(chunk, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+function parseEncodedSse(body: string): Array<{ event: string; data: Record<string, unknown> }> {
+  return body
+    .trim()
+    .split(/\r?\n\r?\n/)
+    .map((frameText) => {
+      const lines = frameText.split(/\r?\n/);
+      const event = lines.find((line) => line.startsWith("event: "))?.slice(7);
+      const data = lines.find((line) => line.startsWith("data: "))?.slice(6);
+      if (event === undefined || data === undefined) {
+        throw new Error(`Invalid SSE frame: ${frameText}`);
+      }
+      return { event, data: JSON.parse(data) as Record<string, unknown> };
+    });
+}
+
 function controlledXaiResponse(): {
   response: Response;
   push: (chunk: string) => void;
   close: () => void;
+  error: (reason: unknown) => void;
   wasCancelled: () => boolean;
 } {
   let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
@@ -75,6 +101,9 @@ function controlledXaiResponse(): {
     },
     close() {
       streamController?.close();
+    },
+    error(reason) {
+      streamController?.error(reason);
     },
     wasCancelled() {
       return cancelled;
@@ -98,12 +127,12 @@ function functionCallDone(id: string, outputIndex = 0, argumentsValue = "{}"): C
   };
 }
 
-function responseCompleted(): CanonicalResponseEvent {
-  return { type: "response.completed", response: xaiSnapshot() };
+function responseCompleted(id = "r1"): CanonicalResponseEvent {
+  return { type: "response.completed", response: xaiSnapshot(id) };
 }
 
-function responseCreated(): CanonicalResponseEvent {
-  return { type: "response.created", response: xaiSnapshot() };
+function responseCreated(id = "r1"): CanonicalResponseEvent {
+  return { type: "response.created", response: xaiSnapshot(id) };
 }
 
 function textDelta(delta: string): CanonicalResponseEvent {
@@ -592,6 +621,366 @@ describe("Grok Responses function-call assembly", () => {
     expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: 0 })).toThrow("functionCallTimeoutMs must be a positive integer");
     expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: -1 })).toThrow("functionCallTimeoutMs must be a positive integer");
     expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: 1.5 })).toThrow("functionCallTimeoutMs must be a positive integer");
+  });
+});
+
+describe("Grok Responses retry", () => {
+  function failed(type = "server_error", id = "r1"): CanonicalResponseEvent {
+    return {
+      type: "response.failed",
+      response: { ...xaiSnapshot(id), error: { type, message: "secret marker" } },
+    };
+  }
+
+  function messageAdded(id = "m1"): CanonicalResponseEvent {
+    return {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id, role: "assistant" },
+    };
+  }
+
+  function reasoning(delta = "thinking"): CanonicalResponseEvent {
+    return {
+      type: "response.reasoning_summary_text.delta",
+      item_id: "reasoning-1",
+      output_index: 0,
+      delta,
+    };
+  }
+
+  function socketTermination(): TypeError {
+    const socket = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    return new TypeError("terminated", { cause: socket });
+  }
+
+  it("retries one fetch UND_ERR_SOCKET", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(socketTermination())
+      .mockResolvedValueOnce(xaiResponse(
+        xaiFrame(responseCreated("r2")),
+        xaiFrame(textDelta("ok")),
+      ));
+
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      responseCreated("r2"),
+      textDelta("ok"),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a stream UND_ERR_SOCKET while lead events are buffered", async () => {
+    const first = controlledXaiResponse();
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(first.response)
+      .mockResolvedValueOnce(xaiResponse(
+        xaiFrame(responseCreated("r2")),
+        xaiFrame(textDelta("ok")),
+      ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    const events = collectXaiEvents(response.events);
+    first.push(xaiFrame(responseCreated("r1")));
+    await flushXaiStream();
+    first.error(socketTermination());
+
+    await expect(events).resolves.toEqual([responseCreated("r2"), textDelta("ok")]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes the failed attempt before retrying a server_error", async () => {
+    const first = controlledXaiResponse();
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(first.response)
+      .mockResolvedValueOnce(xaiResponse(
+        xaiFrame(responseCreated("r2")),
+        xaiFrame(textDelta("terminal")),
+      ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    const events = collectXaiEvents(response.events);
+    first.push(xaiFrame(responseCreated("r1")));
+    first.push(xaiFrame(reasoning()));
+    first.push(xaiFrame(messageAdded()));
+    first.push(xaiFrame(failed()));
+
+    await expect(events).resolves.toEqual([responseCreated("r2"), textDelta("terminal")]);
+    expect(first.wasCancelled()).toBe(true);
+  });
+
+  it("exposes only the retry attempt through the Anthropic encoder", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(xaiResponse(
+        xaiFrame(responseCreated("r1")),
+        xaiFrame(reasoning("discarded reasoning")),
+        xaiFrame(messageAdded()),
+        xaiFrame(failed()),
+      ))
+      .mockResolvedValueOnce(xaiResponse(
+        xaiFrame(responseCreated("r2")),
+        xaiFrame(textDelta("OK")),
+        xaiFrame(textDone("OK")),
+        xaiFrame(responseCompleted("r2")),
+      ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    const frames = parseEncodedSse(await collectEncodedBody(encodeAnthropicSse(response.events)));
+    expect(frames.map((frame) => frame.event)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+    expect(frames[0]?.data).toMatchObject({
+      type: "message_start",
+      message: { id: "r2", model: "grok-4.6" },
+    });
+    expect(frames[2]?.data).toMatchObject({ delta: { type: "text_delta", text: "OK" } });
+    expect(JSON.stringify(frames)).not.toContain("r1");
+    expect(JSON.stringify(frames)).not.toContain("discarded reasoning");
+  });
+
+  it("does not retry a near-match invalid_prompt failure", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(xaiResponse(xaiFrame(failed("invalid_prompt"))));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([failed("invalid_prompt")]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry server_error after text output commits the attempt", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(xaiResponse(
+      xaiFrame(responseCreated()),
+      xaiFrame(textDelta("partial")),
+      xaiFrame(failed()),
+    ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      responseCreated(),
+      textDelta("partial"),
+      failed(),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry server_error after a complete function call commits the attempt", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(xaiResponse(
+      xaiFrame(responseCreated()),
+      xaiFrame(functionCallAdded("call-1")),
+      xaiFrame(functionCallDone("call-1", 0, "{}")),
+      xaiFrame(failed()),
+    ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      responseCreated(),
+      functionCallAdded("call-1"),
+      argumentsDone("call-1", 0, "{}"),
+      functionCallDone("call-1", 0, "{}"),
+      failed(),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one two-call budget between fetch and stream retry", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(socketTermination())
+      .mockResolvedValueOnce(xaiResponse(xaiFrame(responseCreated()), xaiFrame(failed())));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([responseCreated(), failed()]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry caller aborts or unrelated transport errors", async () => {
+    const caller = new AbortController();
+    const callerError = new Error("caller abort");
+    caller.abort(callerError);
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(callerError);
+    await expect(new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), {
+      apiKey: "k",
+      signal: caller.signal,
+    })).rejects.toBe(callerError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const transport = new Error("other transport");
+    const unrelated = vi.fn<typeof fetch>().mockRejectedValue(transport);
+    await expect(new XaiResponsesAdapter({ fetch: unrelated }).stream(xaiRequest(), { apiKey: "k" }))
+      .rejects.toBe(transport);
+    expect(unrelated).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["return", "throw"] as const)("cancels a pending retry delay on iterator %s", async (method) => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(xaiResponse(xaiFrame(failed())));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    const iterator = response.events[Symbol.asyncIterator]();
+    const pendingNext = iterator.next().catch((error: unknown) => error);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    const closed = method === "return"
+      ? iterator.return?.().then(() => "closed" as const)
+      : iterator.throw?.(new Error("stop")).catch(() => "closed" as const);
+    await expect(Promise.race([
+      closed,
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 150)),
+    ])).resolves.toBe("closed");
+    await pendingNext;
+    await new Promise((resolve) => setTimeout(resolve, 225));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["return", "throw"] as const)("aborts an in-flight retry fetch on iterator %s", async (method) => {
+    let retryStarted: (() => void) | undefined;
+    const retryStart = new Promise<void>((resolve) => {
+      retryStarted = resolve;
+    });
+    let retryAborted = false;
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(xaiResponse(xaiFrame(failed())))
+      .mockImplementationOnce(async (_input, init) => {
+        retryStarted?.();
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            retryAborted = true;
+            reject(init.signal?.reason);
+          }, { once: true });
+        });
+      });
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    const iterator = response.events[Symbol.asyncIterator]();
+    const pendingNext = iterator.next().catch((error: unknown) => error);
+
+    await retryStart;
+    if (method === "return") {
+      await iterator.return?.();
+    } else {
+      await iterator.throw?.(new Error("stop")).catch(() => undefined);
+    }
+    await pendingNext;
+    expect(retryAborted).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["return", "throw"] as const)("cancels a pending initial read on iterator %s", async (method) => {
+    const controlled = controlledXaiResponse();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(controlled.response);
+    const response = await new XaiResponsesAdapter({
+      fetch: fetchMock,
+      idleTimeoutMs: 300,
+    }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    const iterator = response.events[Symbol.asyncIterator]();
+    const pendingNext = iterator.next().catch(() => undefined);
+    controlled.push(xaiFrame(responseCreated()));
+    await flushXaiStream();
+
+    const startedAt = Date.now();
+    if (method === "return") {
+      await iterator.return?.();
+    } else {
+      await iterator.throw?.(new Error("stop")).catch(() => undefined);
+    }
+    expect(Date.now() - startedAt).toBeLessThan(150);
+    await pendingNext;
+    expect(controlled.wasCancelled()).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry again when the stream retry fetch socket terminates", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(xaiResponse(xaiFrame(failed())))
+      .mockRejectedValueOnce(socketTermination());
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).rejects.toThrow("terminated");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts the upstream read when function-call assembly fails", async () => {
+    const controlled = controlledXaiResponse();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(controlled.response);
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    const events = collectXaiEvents(response.events);
+    controlled.push(xaiFrame(functionCallAdded("call-1")));
+    controlled.push(xaiFrame(responseCompleted()));
+
+    await expect(events).rejects.toThrow("response.completed arrived before");
+    expect(controlled.wasCancelled()).toBe(true);
+  });
+
+  it("writes only payload-light retry discard fields", async () => {
+    const wire = wireLogFixture("fleet-xai-retry-");
+    try {
+      const fetchMock = vi.fn<typeof fetch>()
+        .mockResolvedValueOnce(xaiResponse(xaiFrame(failed("server_error", "secret-id"))))
+        .mockResolvedValueOnce(xaiResponse(xaiFrame(textDelta("terminal"))));
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest({
+        input: [{ type: "message", role: "user", content: "secret prompt" }],
+      }), { apiKey: "secret-key" });
+      if (!response.ok) throw new Error("expected ok");
+      await collectXaiEvents(response.events);
+
+      const entries = wire.read().filter((entry) => entry.event === "xai-responses.retry.discarded");
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.payload).toEqual({ reason: "response.failed", errorTypes: ["server_error"] });
+      expect(JSON.stringify(entries)).not.toMatch(/secret|secret-id|prompt|raw|message|id|output/);
+    } finally {
+      wire.cleanup();
+    }
+  });
+
+  it("records one provider request for each retry attempt", async () => {
+    const wire = wireLogFixture("fleet-xai-retry-wire-");
+    try {
+      const fetchMock = vi.fn<typeof fetch>()
+        .mockResolvedValueOnce(xaiResponse(xaiFrame(failed())))
+        .mockResolvedValueOnce(xaiResponse(xaiFrame(responseCreated("r2")), xaiFrame(responseCompleted("r2"))));
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      await collectXaiEvents(response.events);
+
+      expect(wire.read().filter((entry) => entry.event === "xai-responses.wire.request")).toHaveLength(2);
+    } finally {
+      wire.cleanup();
+    }
+  });
+
+  it("preserves normal event order and successful lifecycle", async () => {
+    const events = [
+      responseCreated(),
+      reasoning(),
+      messageAdded(),
+      textDelta("x"),
+      textDone("x"),
+      responseCompleted(),
+    ];
+    const caller = new AbortController();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(xaiResponse(...events.map(xaiFrame)));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), {
+      apiKey: "k",
+      signal: caller.signal,
+    });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual(events);
+    expect(caller.signal.aborted).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Retry transient Grok server failures and `UND_ERR_SOCKET` terminations only before caller-visible output commits.
- Share one two-call budget across fetch and stream phases, and cancel pending reads, delays, and retry fetches on caller/iterator termination.
- Record payload-light retry diagnostics while preserving the existing XAI function-call assembly and wire semantics.

## Type of Change
- [x] fix — bug fix

## Scope
- [x] `packages/core-ai-gateway`

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway exec vitest run tests/xai.test.ts` — 53 passed
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 709 passed
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Live `claude-gateway--xai--grok-4.6` low provider loop, 3 operations × 5 trials — 15 calls/results, 0 caller errors, cleanup 5/5

## Changelog
- Grok turns recover from transient pre-commit server/socket failures instead of surfacing an incomplete-response API error.

## Notes for Reviewers
- The retry boundary is the Anthropic encoder's first semantically unreplayable output, not the first canonical setup/reasoning event.
- Live before/after samples had no transient failures; deterministic adapter tests exercise the recovery and all non-retry boundaries.