### PR TITLE
fix(fleet-console): let Bori return to idle after finish cheers

### DIFF
--- a/.changelog.d/fix-bori-alert-idle.md
+++ b/.changelog.d/fix-bori-alert-idle.md
@@ -1,0 +1,8 @@
+---
+branch: fix-bori-alert-idle
+---
+
+### fleet-console
+#### Fixed
+- Aide Bori cheers when a panel finishes, then returns to idle instead of freezing mid-pose.
+  ko: 패널이 끝나면 보리 부관이 만세를 한 뒤 유휴 자세로 돌아가며, 중간에 멈추지 않습니다.

--- a/runtime/fleet-console/core/client/src/floating-widget-layer.tsx
+++ b/runtime/fleet-console/core/client/src/floating-widget-layer.tsx
@@ -195,15 +195,14 @@ interface ManagedSignalsCapability {
 
 function readFleetSignals(): FloatingWidgetFleetSignals {
   const state = getState();
-  const idleArrivals = getIdleArrivalIds();
   let running = 0;
   let awaiting = 0;
   for (const operation of state.operations) {
     const activity = resolveOperationActivity(operation, state.operationRuntime);
     if (activity === "running") running += 1;
-    // 사이드바 STATUS 축과 같은 기준을 쓴다 — 확인하지 않은 도착도 사용자를 기다리는 상태다.
-    // 원시 status만 세면 콘솔이 AWAITING이라 표시한 Operation의 절반을 위젯이 놓친다.
-    else if (activity === "awaiting" || (activity === "idle" && idleArrivals.has(operation.id))) awaiting += 1;
+    // 확인하지 않은 완료 도착은 arrivals 채널과 만세 연출이 맡는다.
+    // 사이드바 STATUS 축처럼 awaiting에 섞으면 보리가 경보 포즈에 남아 idle로 돌아가지 않는다.
+    else if (activity === "awaiting") awaiting += 1;
   }
   return {
     running,
@@ -220,8 +219,8 @@ function signalsEqual(left: FloatingWidgetFleetSignals, right: FloatingWidgetFle
     && left.reducedMotion === right.reducedMotion;
 }
 
-// 함대 신호는 서로 다른 세 곳에서 바뀐다 — Operation 스토어, 도착 확인 채널, OS 모션 환경.
-// 셋을 한 구독으로 합쳐 위젯이 출처를 알 필요가 없게 한다.
+// 함대 신호는 Operation 스토어와 OS 모션 환경에서 바뀐다.
+// 완료 도착은 arrivals 채널이 따로 전하므로 여기 집계에 섞지 않는다.
 function createManagedSignalsCapability(): ManagedSignalsCapability {
   const activeSubscriptions = new Set<() => void>();
 
@@ -241,14 +240,11 @@ function createManagedSignalsCapability(): ManagedSignalsCapability {
       : null;
     motionQuery?.addEventListener("change", notifyIfChanged);
     const unsubscribeStore = subscribeStore(notifyIfChanged);
-    // 도착 확인 여부는 스토어 밖 채널이라 따로 구독해야 awaiting 집계가 갱신된다.
-    const unsubscribeIdleArrival = subscribeIdleArrival(notifyIfChanged);
     const unsubscribe = () => {
       if (!active) return;
       active = false;
       motionQuery?.removeEventListener("change", notifyIfChanged);
       unsubscribeStore();
-      unsubscribeIdleArrival();
       activeSubscriptions.delete(unsubscribe);
     };
 

--- a/runtime/fleet-console/tests/floating-widget-layer.test.tsx
+++ b/runtime/fleet-console/tests/floating-widget-layer.test.tsx
@@ -223,6 +223,70 @@ describe("FloatingWidgetLayer", () => {
 
     expect(received).toHaveLength(updateCountAfterUnmount);
   });
+
+  it("keeps idle arrivals out of awaiting so Bori can leave the alert pose", () => {
+    const received: Array<{ awaiting: number; running: number }> = [];
+    setState({
+      operations: [
+        operation("idle-done", "Idle done"),
+        operation("waiting", "Waiting"),
+      ],
+      operationRuntime: {
+        waiting: { lifecycle: "live", activity: "awaiting" },
+      },
+    });
+    markIdleArrival("idle-done");
+
+    const plugin: FleetClientPlugin = {
+      id: "signals",
+      floatingWidgets: [{
+        id: "observer",
+        render: (context) => {
+          useEffect(
+            () => context.signals.subscribe((signals) => {
+              received.push({ awaiting: signals.awaiting, running: signals.running });
+            }),
+            [context.signals],
+          );
+          return createElement("span", null, "Signal observer");
+        },
+      }],
+    };
+
+    renderLayer([plugin]);
+
+    expect(received.at(-1)).toEqual({ awaiting: 1, running: 0 });
+
+    act(() => markIdleArrival("waiting"));
+
+    expect(received.at(-1)).toEqual({ awaiting: 1, running: 0 });
+  });
+
+  it("counts a finished idle arrival as zero awaiting", () => {
+    const received: number[] = [];
+    setState({ operations: [operation("idle-done", "Idle done")] });
+    markIdleArrival("idle-done");
+
+    const plugin: FleetClientPlugin = {
+      id: "signals-idle",
+      floatingWidgets: [{
+        id: "observer",
+        render: (context) => {
+          useEffect(
+            () => context.signals.subscribe((signals) => {
+              received.push(signals.awaiting);
+            }),
+            [context.signals],
+          );
+          return createElement("span", null, "Idle signal observer");
+        },
+      }],
+    };
+
+    renderLayer([plugin]);
+
+    expect(received.at(-1)).toBe(0);
+  });
 });
 
 let lastPathname = "";

--- a/runtime/fleet-plugins/scuttlebutt/client/flock.tsx
+++ b/runtime/fleet-plugins/scuttlebutt/client/flock.tsx
@@ -493,6 +493,7 @@ export function ScuttlebuttFlock({ context }: { readonly context: FloatingWidget
         const visual = birdVisual({
           grabbed: grabbed[index] ?? false,
           oneShot: oneShots[index] ?? null,
+          // 보리는 입력 대기·단절만 경보로 든다. 완료 도착은 onShow 만세 뒤 idle로 돌아간다.
           alert: phase === "error"
             || (index === 1 && (fleetSignals.awaiting > 0 || fleetSignals.disconnected)),
           thinking: phase === "starting" || phase === "thinking"

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -312,7 +312,7 @@
   animation: scuttlebutt-qk-salute 1.7s ease-in-out infinite;
 }
 
-/* 보리는 경보 담당이라 도약·퍼덕임이 상시 소음이 된다. 느낌표만 켠다. */
+/* 보리는 경보 담당이라 도약·급한 퍼덕임이 상시 소음이 된다. 느낌표만 켜고 유휴 날갯짓은 남긴다. */
 .scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) {
   animation: scuttlebutt-qk-hop 0.58s cubic-bezier(0.3, 0.7, 0.3, 1) infinite;
 }
@@ -320,11 +320,6 @@
 .scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) .scuttlebutt-qk-wing-l,
 .scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) .scuttlebutt-qk-wing-r {
   animation-duration: 0.22s;
-}
-
-.scuttlebutt-bird.is-alert .scuttlebutt-qk[data-morph="bori"] .scuttlebutt-qk-wing-l,
-.scuttlebutt-bird.is-alert .scuttlebutt-qk[data-morph="bori"] .scuttlebutt-qk-wing-r {
-  animation: none;
 }
 
 .scuttlebutt-bird.is-alert .scuttlebutt-qk-mark {

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-quaker-figure.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-quaker-figure.test.ts
@@ -97,7 +97,8 @@ describe("Quaker admiral figures", () => {
     expect(styles).toMatch(
       /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk:not\(\[data-morph="bori"\]\) \.scuttlebutt-qk-wing-l/,
     );
-    expect(styles).toMatch(
+    // 날개 animation:none 은 만세·유휴 퍼덕임을 중간 프레임에 고정한다 — 느낌표만 켜고 퍼덕임은 유지한다.
+    expect(styles).not.toMatch(
       /\.scuttlebutt-bird\.is-alert \.scuttlebutt-qk\[data-morph="bori"\] \.scuttlebutt-qk-wing-l[\s\S]*?animation: none;/,
     );
     expect(styles).toMatch(


### PR DESCRIPTION
## Summary
- 패널 완료 도착을 함대 `awaiting`에서 빼, 보리가 만세 뒤 유휴로 돌아가게 합니다.
- 경보 중에도 보리의 유휴 날갯짓은 남기고 hop/mark-pop만 끕니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/scuttlebutt test`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/floating-widget-layer.test.tsx`
- [x] `pnpm --filter @fleet-plugins/scuttlebutt typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p tsconfig.json`
- [ ] 콘솔에서 패널이 끝나면 보리가 만세 후 유휴 퍼덕임으로 돌아가는지 확인