### PR TITLE
fix(fleet-console): unfocus War Room panels on empty click

### DIFF
--- a/.changelog.d/warroom-empty-unfocus.md
+++ b/.changelog.d/warroom-empty-unfocus.md
@@ -1,0 +1,8 @@
+---
+branch: warroom-empty-unfocus
+---
+
+### fleet-console
+#### Fixed
+- Clicking empty space in War Room now unfocuses a focused panel that is not on stage, the same way an empty Cruise map click does.
+  ko: War Room의 빈곳을 누르면 무대에 오르지 않은 포커스 패널이 풀립니다. Cruise에서 맵 빈곳을 누를 때와 같습니다.

--- a/runtime/fleet-console/core/client/src/active-operation-surface.ts
+++ b/runtime/fleet-console/core/client/src/active-operation-surface.ts
@@ -12,6 +12,24 @@ const KEEP_ACTIVE_SELECTOR = [
   "[data-keep-operation-active]",
 ].join(", ");
 
+// War Room은 캔버스 제스처 훅을 끄므로 Cruise의 onClick 빈 바다 해제가 닿지 않는다.
+// 덱·빈 판은 Map 표면(.operations-canvas) 안이라 문서 캡처 가드도 유지를 고른다.
+// 카드·점·패널·승격 면이 아닌 War Room 자리만 활성 해제의 빈곳으로 본다.
+const WAR_ROOM_EMPTY_SURFACE_SELECTOR = [
+  ".operations-canvas.is-triage",
+  ".canvas-triage-deck",
+  ".canvas-triage-clear",
+].join(", ");
+
+const WAR_ROOM_OWNED_SELECTOR = [
+  "[data-canvas-operation]",
+  "[data-triage-deck-card]",
+  "[data-triage-map-dot]",
+  ".canvas-triage-deck-pick",
+  ".canvas-minimap",
+  ".canvas-context-menu",
+].join(", ");
+
 export function isMapActivationSurface(target: EventTarget | null): boolean {
   return target instanceof Element && target.closest(".operations-canvas, [data-canvas-operation]") !== null;
 }
@@ -20,6 +38,13 @@ export function shouldReleaseActiveOperation(target: EventTarget | null, documen
   if (isBlockingDialogOpen(documentFor)) return false;
   if (!(target instanceof Element)) return false;
   return target.closest(KEEP_ACTIVE_SELECTOR) === null;
+}
+
+export function isWarRoomEmptyReleaseTarget(target: EventTarget | null, documentFor: Document = document): boolean {
+  if (isBlockingDialogOpen(documentFor)) return false;
+  if (!(target instanceof Element)) return false;
+  if (target.closest(WAR_ROOM_OWNED_SELECTOR) !== null) return false;
+  return target.closest(WAR_ROOM_EMPTY_SURFACE_SELECTOR) !== null;
 }
 
 export function blurActiveElement(): void {

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -10,7 +10,7 @@ import type { OperationRuntimeState, CompanionPanelDescriptor, ConsoleTheme, Fle
 import { fetchOperations } from "../api.js";
 import { availableCompanionPanels } from "../companion-shortcut.js";
 import { isBlockingDialogOpen } from "../focus-guards.js";
-import { clearActiveOperation } from "../active-operation-surface.js";
+import { clearActiveOperation, isWarRoomEmptyReleaseTarget } from "../active-operation-surface.js";
 import { flattenGroupedOrder, focusCycleOperationIds, hydrateOperations, requestOperationKeyboardFocus, requestOperationLaunchMenu, resolveOperationGroup, setActiveOperation } from "../store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
@@ -794,6 +794,11 @@ export function OperationsCanvas({
           // 캔버스 제어 메뉴가 어느 소유자(사이드바 포털/이 컴포넌트)로부터 열었든 Map 클릭으로 닫는다 —
           // pan의 preventDefault+포인터 캡처가 mousedown 합성을 끊어 포털의 외부-클릭 닫기가 못 잡는다.
           window.dispatchEvent(new Event("canvas-context-menu-close"));
+        }
+        // War Room은 제스처 훅을 끄므로 Cruise onClick 해제가 닿지 않는다. 덱이 덮은 빈
+        // 자리는 카드·점·패널이 아닌 곳에서 활성만 푼다 — 무대 지목은 그대로다.
+        if (triageActive && event.button === 0 && isWarRoomEmptyReleaseTarget(event.target)) {
+          clearActiveOperation();
         }
         interaction.onPointerDown(event as Parameters<typeof interaction.onPointerDown>[0]);
       }}

--- a/runtime/fleet-console/tests/active-operation-surface.test.ts
+++ b/runtime/fleet-console/tests/active-operation-surface.test.ts
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { isMapActivationSurface, shouldReleaseActiveOperation } from "../core/client/src/active-operation-surface.js";
+import { isMapActivationSurface, isWarRoomEmptyReleaseTarget, shouldReleaseActiveOperation } from "../core/client/src/active-operation-surface.js";
 
 function el(html: string): HTMLElement {
   const host = document.createElement("div");
@@ -81,5 +81,57 @@ describe("empty Map click clears activation", () => {
   it("clears the active Operation and blurs the terminal", () => {
     expect(source).toContain("onClick: clearActiveOperation");
     expect(source).not.toContain("onClick: blurActiveElement");
+  });
+
+  it("clears a focused War Room deck panel from the canvas pointerdown on empty space", () => {
+    expect(source).toContain("isWarRoomEmptyReleaseTarget(event.target)");
+    expect(source).toContain("clearActiveOperation()");
+  });
+});
+
+describe("isWarRoomEmptyReleaseTarget", () => {
+  it("releases on the War Room deck and its empty grid, not on a card or staged panel", () => {
+    const canvas = el(`<main class="operations-canvas is-triage">
+      <section class="canvas-triage-deck">
+        <div class="canvas-triage-deck-caption">Watching</div>
+        <div class="canvas-triage-deck-grid">
+          <div data-triage-deck-card="op-1">
+            <article class="canvas-operation is-deck-tile" data-canvas-operation data-operation-id="op-1"></article>
+            <button class="canvas-triage-deck-pick" type="button">Stage</button>
+          </div>
+        </div>
+      </section>
+      <article class="canvas-operation is-triage-stage" data-canvas-operation data-operation-id="op-2"></article>
+    </main>`);
+    document.body.append(canvas);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector(".canvas-triage-deck-grid"))).toBe(true);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector(".canvas-triage-deck-caption"))).toBe(true);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector("[data-triage-deck-card]"))).toBe(false);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector(".canvas-triage-deck-pick"))).toBe(false);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector("[data-canvas-operation]"))).toBe(false);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector(".is-triage-stage"))).toBe(false);
+    canvas.remove();
+  });
+
+  it("releases on an empty War Room map field, not on a map marker", () => {
+    const canvas = el(`<main class="operations-canvas is-triage">
+      <section class="canvas-triage-deck is-map-mode">
+        <div class="canvas-triage-map">
+          <button type="button" data-triage-map-dot="op-1">Alpha</button>
+        </div>
+      </section>
+    </main>`);
+    document.body.append(canvas);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector(".canvas-triage-map"))).toBe(true);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector("[data-triage-map-dot]"))).toBe(false);
+    canvas.remove();
+  });
+
+  it("does not treat Cruise empty sea as a War Room empty release", () => {
+    const canvas = el(`<main class="operations-canvas"><div class="operations-canvas-world"></div></main>`);
+    document.body.append(canvas);
+    expect(isWarRoomEmptyReleaseTarget(canvas.querySelector(".operations-canvas-world"))).toBe(false);
+    expect(isWarRoomEmptyReleaseTarget(canvas)).toBe(false);
+    canvas.remove();
   });
 });

--- a/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
@@ -23,6 +23,7 @@ vi.mock("../core/client/src/plugin-registry.js", () => ({
 import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
 import { loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
 import { isTriageDeckMapMode, resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoom } from "../core/client/src/canvas/triage-store.js";
+import { getState, setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
 
 type OperationsCanvasLaunchKind = Parameters<typeof OperationsCanvas>[0]["onLaunchKind"];
@@ -187,6 +188,114 @@ describe("War Room canvas controls reach", () => {
     // 터미널 안은 복사·붙여넣기가 있는 자리다 — 우리 메뉴가 그것을 빼앗지 않는다.
     expect(panelMenu.defaultPrevented).toBe(false);
     expect(container!.querySelector(".canvas-context-menu")).toBeNull();
+  });
+});
+
+describe("War Room empty space releases a focused deck panel", () => {
+  const idleState: ConsoleState = {
+    ...STATE,
+    operationRuntime: {
+      [OPERATION.id]: { lifecycle: "live", activity: "idle" },
+      [OPERATION_B.id]: { lifecycle: "live", activity: "idle" },
+    },
+  };
+
+  it("clears store activation from the deck grid without staging the focused panel", () => {
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        setConsoleState({ activeOperationId: OPERATION.id, activeOperationAcknowledged: true });
+        root!.render(createElement(OperationsCanvas, {
+          state: idleState,
+          catalog: CATALOG,
+          canLaunch: true,
+          renderKindIcon: () => null,
+          onLaunchKind: () => {},
+          onLaunchAtGeometry: () => {},
+          onClose: () => {},
+          onFocus: () => {},
+          onRename: () => {},
+          onSetAccent: () => {},
+        }));
+      });
+      act(() => { vi.advanceTimersByTime(2_000); });
+
+      expect(container!.querySelector(".canvas-operation.is-triage-stage")).toBeNull();
+      expect(getState().activeOperationId).toBe(OPERATION.id);
+
+      const grid = container!.querySelector<HTMLElement>(".canvas-triage-deck-grid");
+      expect(grid, "idle fleet must keep the deck mounted").not.toBeNull();
+      grid!.tabIndex = -1;
+      act(() => { grid!.focus(); });
+      expect(document.activeElement).toBe(grid);
+      act(() => grid!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 })));
+      expect(getState().activeOperationId).toBeNull();
+      expect(document.activeElement === grid).toBe(false);
+      expect(container!.querySelector(".canvas-operation.is-triage-stage")).toBeNull();
+    } finally {
+      act(() => { setActiveOperation(null); });
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not clear activation when the pointer lands on a deck card", () => {
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        setConsoleState({ activeOperationId: OPERATION.id, activeOperationAcknowledged: true });
+        root!.render(createElement(OperationsCanvas, {
+          state: idleState,
+          catalog: CATALOG,
+          canLaunch: true,
+          renderKindIcon: () => null,
+          onLaunchKind: () => {},
+          onLaunchAtGeometry: () => {},
+          onClose: () => {},
+          onFocus: () => {},
+          onRename: () => {},
+          onSetAccent: () => {},
+        }));
+      });
+      act(() => { vi.advanceTimersByTime(2_000); });
+
+      const card = container!.querySelector<HTMLElement>(`[data-triage-deck-card="${OPERATION.id}"]`);
+      expect(card).not.toBeNull();
+      act(() => card!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 })));
+      expect(getState().activeOperationId).toBe(OPERATION.id);
+    } finally {
+      act(() => { setActiveOperation(null); });
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not clear activation on a non-primary empty-space click", () => {
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        setConsoleState({ activeOperationId: OPERATION.id, activeOperationAcknowledged: true });
+        root!.render(createElement(OperationsCanvas, {
+          state: idleState,
+          catalog: CATALOG,
+          canLaunch: true,
+          renderKindIcon: () => null,
+          onLaunchKind: () => {},
+          onLaunchAtGeometry: () => {},
+          onClose: () => {},
+          onFocus: () => {},
+          onRename: () => {},
+          onSetAccent: () => {},
+        }));
+      });
+      act(() => { vi.advanceTimersByTime(2_000); });
+
+      const grid = container!.querySelector<HTMLElement>(".canvas-triage-deck-grid");
+      expect(grid).not.toBeNull();
+      act(() => grid!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 2 })));
+      expect(getState().activeOperationId).toBe(OPERATION.id);
+    } finally {
+      act(() => { setActiveOperation(null); });
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- War Room에서 무대에 오르지 않은 포커스 패널을 빈곳 클릭으로 해제합니다. Cruise 맵 빈곳과 같은 계약입니다.
- 원인은 War Room이 캔버스 제스처 훅을 끄고, 문서 가드가 `.operations-canvas`를 유지 표면으로 두어 `clearActiveOperation`이 닿지 않던 점입니다.
- 좌클릭 빈곳(덱 그리드·캡션·맵 필드)만 활성을 풉니다. 카드·점·패널·승격 면과 무대 지목은 그대로입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/active-operation-surface.test.ts tests/warroom-canvas-context-menu.test.tsx`
- [x] 격리 콘솔 e2e: Cruise 맵 빈곳 언포커스, War Room 캡션 포커스(무대 없음) 후 덱 빈곳 언포커스, 승격 면 클릭은 무대 유지
- [x] 사용자 격리 콘솔에서 동일 시나리오 확인