### PR TITLE
fix(fleet-console): stage focused War Room panel on wait

### DIFF
--- a/.changelog.d/war-room-awaiting-stage.md
+++ b/.changelog.d/war-room-awaiting-stage.md
@@ -1,0 +1,8 @@
+---
+branch: war-room-awaiting-stage
+---
+
+### fleet-console
+#### Fixed
+- In War Room, a focused deck panel that starts waiting now comes up on stage without a pick.
+  ko: War Room에서 포커스된 덱 패널이 대기로 들어가면 지목 없이 무대로 올라옵니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -33,7 +33,7 @@ import { OperationFrame } from "./operation-frame.js";
 import { hasVisibleCanvasContent, OperationsCanvasEmptyState } from "./operations-canvas-empty-state.js";
 import { useCanvasInteraction } from "./use-canvas-interaction.js";
 import { modeSlotGeometryFor, operationWindowFrameFor, screenToCanvas, triageStageGeometryFor, type CanvasPoint, type CanvasRect } from "./coordinates.js";
-import { disarmTriageSetAside, dismissTriageOperation, forgetTriageOperation, getTriageEnteredAt, getTriagePick, getTriageSetAsideArmedId, getTriageSnapshot, isTriageActive, isTriageClearedTransition, isTriageOperationDeferred, isTriageOperationDismissed, isTriageWaitingOperation, pickTriageOperation, reconcileTriageStageCompanion, recordTriageStageTheater, resolveTriageQueue, scheduleTriageClear, subscribeTriage, useTriageActive, useTriageSpotlightEnabled, type TriageQueueEntry, type TriageStageIdentity } from "./triage-store.js";
+import { disarmTriageSetAside, dismissTriageOperation, forgetTriageOperation, getTriageEnteredAt, getTriagePick, getTriageSetAsideArmedId, getTriageSnapshot, isTriageActive, isTriageClearedTransition, isTriageOperationDeferred, isTriageOperationDismissed, isTriageWaitingOperation, pickTriageOperation, reconcileTriageStageCompanion, recordTriageStageTheater, resolveActiveAwaitingTriageEntry, resolveTriageQueue, scheduleTriageClear, subscribeTriage, useTriageActive, useTriageSpotlightEnabled, type TriageQueueEntry, type TriageStageIdentity } from "./triage-store.js";
 
 interface OperationsCanvasProps {
   readonly state: ConsoleState;
@@ -390,11 +390,15 @@ export function OperationsCanvas({
         picked: false,
       }
     : null;
+  // 캡션으로만 활성화된 패널이 대기로 전이하면 무대 후보가 된다. pick이 아니라서 미룸·치워둠을
+  // 풀지 않고, 스포트라이트 OFF 자동 등단도 강제하지 않는다. 명시적 지목·전이 유예·직전 무대
+  // 포커스 고정이 이 클레임보다 앞선다.
+  const activeAwaitingTriageEntry = resolveActiveAwaitingTriageEntry(state.operations, state.operationRuntime);
   // 최소화한 Operation은 판에서 내려간 것이므로 어떤 유지 경로로도 무대에 되살아나지 않는다.
   // previousTriageHasFocus가 치워둔 항목을 같은 이유로 이미 제외하지만, 최소화는 무대의 손잡이로
   // 실행되어 그 손잡이가 이전 프레임 안에서 포커스를 쥔 채 남는다 — 걸러내지 않으면 무대와 최소화
   // 선반에 같은 Operation이 동시에 선다. grace(전이 유예) 경로도 같은 이유로 함께 막는다.
-  const retainedTriageCandidate = graceTriageEntry ?? protectedTriageEntry;
+  const retainedTriageCandidate = graceTriageEntry ?? protectedTriageEntry ?? activeAwaitingTriageEntry;
   const retainedTriageEntry = retainedTriageCandidate && triageMinimizedSet.has(retainedTriageCandidate.operation.id)
     ? null
     : retainedTriageCandidate;

--- a/runtime/fleet-console/core/client/src/canvas/triage-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/triage-store.ts
@@ -53,6 +53,9 @@ const lastClearedAt = new Map<string, number>();
 const deferredAt = new Map<string, number>();
 const dismissed = new Set<string>();
 const seenAt = new Map<string, number>();
+// 캡션으로만 활성화된 패널이 대기로 전이하면 무대 후보로 남을 자격이 생긴다.
+// pick이 아니다 — 미룸·치워둠·무장을 건드리지 않고, 스포트라이트 OFF 자동 등단도 강제하지 않는다.
+let activeAwaitingClaimId: string | null = null;
 
 const TRIAGE_SPOTLIGHT_STORAGE_KEY = "fleet-console-triage-spotlight";
 let triageSpotlightEnabled = readStoredTriageSpotlight();
@@ -108,6 +111,7 @@ export function resetTriageSpotlightForTests(): void {
 }
 
 const activityByOperation = new Map<string, OperationActivityVisual>();
+const waitingByOperation = new Map<string, boolean>();
 const operationTheater = new Map<string, string>();
 // focus layer만 Theater 단위로 유지한다 — 진입 시점 활성 Theater와 선별 중 자동 전환으로
 // 방문한 Theater 각각의 스냅샷을 저장해 종료 시 한 번에 복원한다.
@@ -630,6 +634,7 @@ export function setTriageActive(active: boolean): void {
   triageActive = false;
   rememberWarRoomActive(false);
   pickedOperationId = null;
+  activeAwaitingClaimId = null;
   enteredAt = null;
   // 미룸·치워둠 같은 transient 판정은 세션이 아니라 진입에 붙는다 — 껐다 다시 켜면 큐는
   // 미룸·치워둠 없이 처음 순서로 돌아와야 한다(기존 per-Theater 종료의 transient 초기화와 같은 계약).
@@ -638,6 +643,8 @@ export function setTriageActive(active: boolean): void {
   lastClearedAt.clear();
   seenAt.clear();
   activityByOperation.clear();
+  // waitingByOperation은 전이 판정용 baseline이다. recordTriageActivity가 선별 밖에서도
+  // 갱신하므로 여기서 지우면 재진입 직후 첫 대기가 previousWaiting===undefined로 침묵한다.
   clearPendingSideBarRequests();
   if (getLoadedTheaterId() !== null && getTheaterFocusLayerSnapshot(getLoadedTheaterId()!)?.mode === "companion") {
     forceDropCompanionOperationId();
@@ -737,8 +744,10 @@ export function pickTriageOperation(operationId: string): void {
   if (operation) operationTheater.set(operationId, operation.theaterId);
   dismissed.delete(operationId);
   const wasDeferred = deferredAt.delete(operationId);
+  const claimDropped = activeAwaitingClaimId !== null && activeAwaitingClaimId !== operationId;
+  if (claimDropped) activeAwaitingClaimId = null;
   if (pickedOperationId === operationId) {
-    if (wasDeferred) emitTriage();
+    if (wasDeferred || claimDropped) emitTriage();
     return;
   }
   pickedOperationId = operationId;
@@ -749,11 +758,46 @@ export function getTriagePick(): string | null {
   return pickedOperationId;
 }
 
+export function getActiveAwaitingClaimId(): string | null {
+  return activeAwaitingClaimId;
+}
+
+export function resolveActiveAwaitingTriageEntry(
+  operations: readonly OperationNode[],
+  operationRuntime: Readonly<Record<string, OperationRuntimeState>>,
+): TriageQueueEntry | null {
+  if (activeAwaitingClaimId === null) return null;
+  const operation = operations.find((candidate) => candidate.id === activeAwaitingClaimId) ?? null;
+  if (!operation
+    || getState().activeOperationId !== operation.id
+    || !isTriageWaitingOperation(operation, operationRuntime)
+    || dismissed.has(operation.id)
+    || deferredAt.has(operation.id)) {
+    return null;
+  }
+  return {
+    operation,
+    activity: resolveOperationActivity(operation, operationRuntime),
+    picked: false,
+  };
+}
+
+// 빈곳 해제는 operations/runtime을 바꾸지 않아 recordTriageActivity가 안 돈다.
+// 활성이 떠난 클레임을 여기서 거두지 않으면, 같은 패널을 다시 캡션만 눌러도
+// 전이가 없는데 무대 후보가 되살아난다.
+export function releaseInactiveActiveAwaitingClaim(): void {
+  if (activeAwaitingClaimId === null) return;
+  if (getState().activeOperationId === activeAwaitingClaimId) return;
+  activeAwaitingClaimId = null;
+  emitTriage();
+}
+
 export function markTriageCleared(operationId: string): void {
   clearTriageSetAsideArm();
   deferredAt.delete(operationId);
   lastClearedAt.set(operationId, Date.now());
   if (pickedOperationId === operationId) pickedOperationId = null;
+  if (activeAwaitingClaimId === operationId) activeAwaitingClaimId = null;
   emitTriage();
 }
 
@@ -763,6 +807,7 @@ export function dismissTriageOperation(operationId: string): void {
   dismissed.add(operationId);
   clearIdleArrival(operationId);
   if (pickedOperationId === operationId) pickedOperationId = null;
+  if (activeAwaitingClaimId === operationId) activeAwaitingClaimId = null;
   emitTriage();
 }
 
@@ -773,6 +818,9 @@ export function resetTriageTheater(theaterId: string): void {
   }
   if (pickedOperationId !== null && operationTheater.get(pickedOperationId) === theaterId) {
     pickedOperationId = null;
+  }
+  if (activeAwaitingClaimId !== null && operationTheater.get(activeAwaitingClaimId) === theaterId) {
+    activeAwaitingClaimId = null;
   }
   focusLayerBeforeTriage.delete(theaterId);
   clearTheaterTransientOperations(theaterId);
@@ -786,9 +834,11 @@ export function forgetTriageOperation(operationId: string): void {
   deferredAt.delete(operationId);
   seenAt.delete(operationId);
   activityByOperation.delete(operationId);
+  waitingByOperation.delete(operationId);
   clearOperationStatusDetail(operationId);
   operationTheater.delete(operationId);
   if (pickedOperationId === operationId) pickedOperationId = null;
+  if (activeAwaitingClaimId === operationId) activeAwaitingClaimId = null;
   for (const [snapshotTheaterId, focusLayer] of focusLayerBeforeTriage) {
     if (focusLayer?.operationId === operationId) focusLayerBeforeTriage.set(snapshotTheaterId, null);
   }
@@ -834,6 +884,7 @@ export function deferTriageOperation(operationId: string, now = Date.now()): voi
     latestDeferredAt = Math.max(latestDeferredAt, timestamp);
   }
   deferredAt.set(operationId, Math.max(now, latestDeferredAt + 1));
+  if (activeAwaitingClaimId === operationId) activeAwaitingClaimId = null;
   emitTriage();
 }
 
@@ -856,19 +907,43 @@ export function recordTriageActivity(
   now = Date.now(),
 ): void {
   let changed = false;
+  const { activeOperationId } = getState();
   for (const operation of operations) {
     if (operationTheater.get(operation.id) !== operation.theaterId) {
       operationTheater.set(operation.id, operation.theaterId);
       changed = true;
     }
     const activity = resolveOperationActivity(operation, operationRuntime);
+    const waiting = isTriageWaitingOperation(operation, operationRuntime);
     if ((activity === "running" || activity === "background" || activity === "ended") && deferredAt.delete(operation.id)) {
       changed = true;
     }
-    if (activityByOperation.get(operation.id) === activity) continue;
-    activityByOperation.set(operation.id, activity);
-    recordOperationActivityTransition(operation.id, activity, now);
-    seenAt.set(operation.id, now);
+    const previousWaiting = waitingByOperation.get(operation.id);
+    if (previousWaiting === waiting && activityByOperation.get(operation.id) === activity) continue;
+    // 선별 중 이미 활성인 패널이 대기로 들어설 때만 클레임을 남긴다. 캡션 클릭 자체는
+    // 여기 오지 않고, pick도 아니다 — 미룸·치워둠·무장을 그대로 둔다.
+    if (
+      triageActive
+      && previousWaiting === false
+      && waiting
+      && operation.id === activeOperationId
+      && !dismissed.has(operation.id)
+      && !deferredAt.has(operation.id)
+    ) {
+      activeAwaitingClaimId = operation.id;
+    } else if (activeAwaitingClaimId === operation.id && !waiting) {
+      activeAwaitingClaimId = null;
+    }
+    waitingByOperation.set(operation.id, waiting);
+    if (activityByOperation.get(operation.id) !== activity) {
+      activityByOperation.set(operation.id, activity);
+      recordOperationActivityTransition(operation.id, activity, now);
+      seenAt.set(operation.id, now);
+    }
+    changed = true;
+  }
+  if (activeAwaitingClaimId !== null && !operations.some((operation) => operation.id === activeAwaitingClaimId)) {
+    activeAwaitingClaimId = null;
     changed = true;
   }
   if (!changed) return;
@@ -1012,6 +1087,7 @@ function clearTheaterTransientOperations(theaterId: string): void {
     deferredAt.delete(operationId);
     seenAt.delete(operationId);
     activityByOperation.delete(operationId);
+    waitingByOperation.delete(operationId);
     operationTheater.delete(operationId);
   }
 }

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -18,7 +18,7 @@ import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode } from "../canvas/operation-accent.js";
-import { armTriageSetAside, deferTriageOperation, disarmTriageSetAside, dismissTriageOperation, enterTriage, focusedTriageOperationId, forgetTriageOperation, getTriageSetAsideArmedId, isTriageActive, pickTriageOperation, recordTriageActivity, resolveTriageQueue, restoreTriageSession, setTriageActive, useTriageActive } from "../canvas/triage-store.js";
+import { armTriageSetAside, deferTriageOperation, disarmTriageSetAside, dismissTriageOperation, enterTriage, focusedTriageOperationId, forgetTriageOperation, getTriageSetAsideArmedId, isTriageActive, pickTriageOperation, recordTriageActivity, releaseInactiveActiveAwaitingClaim, resolveTriageQueue, restoreTriageSession, setTriageActive, useTriageActive } from "../canvas/triage-store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
@@ -100,6 +100,10 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
   useEffect(() => {
     recordTriageActivity(state.operations, state.operationRuntime);
   }, [state.operationRuntime, state.operations]);
+
+  useEffect(() => {
+    releaseInactiveActiveAwaitingClaim();
+  }, [state.activeOperationId]);
 
   useEffect(() => {
     if (!triageActive) setTriageOperationMenu(null);

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -48,6 +48,7 @@ import {
   enterTriage,
   focusedTriageOperationId,
   forgetTriageOperation,
+  getActiveAwaitingClaimId,
   getTriageDeckZoom,
   getTriagePick,
   getTriageSetAsideArmedId,
@@ -55,6 +56,7 @@ import {
   isTriageClearedTransition,
   isTriageDeckMapMode,
   isTriageDeckMapModeActive,
+  isTriageOperationDeferred,
   isTriageOperationDismissed,
   isTriageSpotlightEnabled,
   markTriageCleared,
@@ -63,9 +65,11 @@ import {
   recordTriageActivity,
   recordTriageStageTheater,
   reconcileTriageStageCompanion,
+  releaseInactiveActiveAwaitingClaim,
   resetTriageDeckZoomForTests,
   resetTriageSpotlightForTests,
   resetTriageTheater,
+  resolveActiveAwaitingTriageEntry,
   resolveTriageFleetZoneLayout,
   resolveTriageMapMarkerLayout,
   resolveTriageQueue,
@@ -320,6 +324,225 @@ describe("triage store", () => {
     expect(getTriagePick()).toBe(arrived.id);
     expect(resolveTriageQueue([arrived], operationRuntime)[0]?.operation.id)
       .toBe(arrived.id);
+  });
+
+  it("claims an already-active deck panel when it starts waiting, without picking it", () => {
+    const focused = operation("focused", 1);
+    const staged = operation("staged", 2);
+    const operationRuntime: Record<string, OperationRuntimeState> = {
+      focused: { lifecycle: "live", activity: "running" },
+      staged: { lifecycle: "live", activity: "awaiting" },
+    };
+    setConsoleState({
+      operations: [focused, staged],
+      activeOperationId: focused.id,
+      operationRuntime,
+    });
+    setTriageActive(true);
+    recordTriageActivity([focused, staged], operationRuntime, 1_000);
+
+    expect(getActiveAwaitingClaimId()).toBeNull();
+    expect(getTriagePick()).toBeNull();
+
+    const nextRuntime: Record<string, OperationRuntimeState> = {
+      focused: { lifecycle: "live", activity: "awaiting" },
+      staged: { lifecycle: "live", activity: "awaiting" },
+    };
+    recordTriageActivity([focused, staged], nextRuntime, 2_000);
+
+    expect(getActiveAwaitingClaimId()).toBe(focused.id);
+    expect(getTriagePick()).toBeNull();
+    expect(isTriageOperationDeferred(focused.id)).toBe(false);
+    const claimed = resolveActiveAwaitingTriageEntry([focused, staged], nextRuntime);
+    expect(claimed?.operation.id).toBe(focused.id);
+    expect(claimed?.picked).toBe(false);
+    // 큐 선두는 먼저 대기에 들어선 staged다 — 클레임은 pick이 아니라서 우선순위를 바꾸지 않는다.
+    expect(resolveTriageQueue([focused, staged], nextRuntime, 2_000).map((entry) => entry.operation.id))
+      .toEqual([staged.id, focused.id]);
+  });
+
+  it("does not claim a waiting transition on a panel that is not active", () => {
+    const idle = operation("idle", 1);
+    const focused = operation("focused", 2);
+    const operationRuntime: Record<string, OperationRuntimeState> = {
+      idle: { lifecycle: "live", activity: "running" },
+      focused: { lifecycle: "live", activity: "running" },
+    };
+    setConsoleState({
+      operations: [idle, focused],
+      activeOperationId: focused.id,
+      operationRuntime,
+    });
+    setTriageActive(true);
+    recordTriageActivity([idle, focused], operationRuntime);
+    recordTriageActivity([idle, focused], {
+      idle: { lifecycle: "live", activity: "awaiting" },
+      focused: { lifecycle: "live", activity: "running" },
+    });
+
+    expect(getActiveAwaitingClaimId()).toBeNull();
+  });
+
+  it("releases an active-awaiting claim when the panel loses activation", () => {
+    const focused = operation("focused", 1);
+    const staged = operation("staged", 2);
+    const operationRuntime: Record<string, OperationRuntimeState> = {
+      focused: { lifecycle: "live", activity: "running" },
+      staged: { lifecycle: "live", activity: "awaiting" },
+    };
+    setConsoleState({
+      operations: [focused, staged],
+      activeOperationId: focused.id,
+      operationRuntime,
+    });
+    setTriageActive(true);
+    recordTriageActivity([focused, staged], operationRuntime);
+    recordTriageActivity([focused, staged], {
+      focused: { lifecycle: "live", activity: "awaiting" },
+      staged: { lifecycle: "live", activity: "awaiting" },
+    });
+    expect(getActiveAwaitingClaimId()).toBe(focused.id);
+
+    setActiveOperation(null);
+    releaseInactiveActiveAwaitingClaim();
+
+    expect(getActiveAwaitingClaimId()).toBeNull();
+    expect(resolveActiveAwaitingTriageEntry([focused, staged], {
+      focused: { lifecycle: "live", activity: "awaiting" },
+      staged: { lifecycle: "live", activity: "awaiting" },
+    })).toBeNull();
+  });
+
+  it("still claims after leaving and re-entering War Room", () => {
+    const focused = operation("focused", 1);
+    const operationRuntime: Record<string, OperationRuntimeState> = {
+      focused: { lifecycle: "live", activity: "running" },
+    };
+    setConsoleState({ operations: [focused], activeOperationId: focused.id, operationRuntime });
+    setTriageActive(true);
+    recordTriageActivity([focused], operationRuntime);
+    setTriageActive(false);
+    setTriageActive(true);
+    recordTriageActivity([focused], { focused: { lifecycle: "live", activity: "awaiting" } });
+
+    expect(getActiveAwaitingClaimId()).toBe(focused.id);
+    expect(getTriagePick()).toBeNull();
+  });
+
+  it("does not claim a dismissed or deferred panel that starts waiting", () => {
+    const focused = operation("focused", 1);
+    const operationRuntime: Record<string, OperationRuntimeState> = {
+      focused: { lifecycle: "live", activity: "running" },
+    };
+    setConsoleState({ operations: [focused], activeOperationId: focused.id, operationRuntime });
+    setTriageActive(true);
+    recordTriageActivity([focused], operationRuntime);
+    dismissTriageOperation(focused.id);
+    recordTriageActivity([focused], { focused: { lifecycle: "live", activity: "awaiting" } });
+    expect(getActiveAwaitingClaimId()).toBeNull();
+
+    setTriageActive(false);
+    setTriageActive(true);
+    recordTriageActivity([focused], { focused: { lifecycle: "live", activity: "running" } });
+    deferTriageOperation(focused.id);
+    recordTriageActivity([focused], { focused: { lifecycle: "live", activity: "awaiting" } });
+    expect(getActiveAwaitingClaimId()).toBeNull();
+    expect(resolveActiveAwaitingTriageEntry([focused], {
+      focused: { lifecycle: "live", activity: "awaiting" },
+    })).toBeNull();
+  });
+
+  it("does not claim a caption-only activation of a panel that is already waiting", () => {
+    const waiting = operation("waiting", 1);
+    const operationRuntime: Readonly<Record<string, OperationRuntimeState>> = {
+      waiting: { lifecycle: "live", activity: "awaiting" },
+    };
+    setConsoleState({ operations: [waiting], operationRuntime });
+    setTriageActive(true);
+    recordTriageActivity([waiting], operationRuntime);
+    setActiveOperation(waiting.id);
+    recordTriageActivity([waiting], operationRuntime);
+
+    expect(getActiveAwaitingClaimId()).toBeNull();
+    expect(getTriagePick()).toBeNull();
+  });
+
+  it("does not claim an active awaiting transition outside War Room", () => {
+    const focused = operation("focused", 1);
+    const operationRuntime: Record<string, OperationRuntimeState> = {
+      focused: { lifecycle: "live", activity: "running" },
+    };
+    setConsoleState({ operations: [focused], activeOperationId: focused.id, operationRuntime });
+    recordTriageActivity([focused], operationRuntime);
+    recordTriageActivity([focused], { focused: { lifecycle: "live", activity: "awaiting" } });
+
+    expect(isTriageActive()).toBe(false);
+    expect(getActiveAwaitingClaimId()).toBeNull();
+    expect(getTriagePick()).toBeNull();
+  });
+
+  it("claims an active idle panel when it becomes an idle arrival", () => {
+    const focused = operation("focused", 1);
+    const operationRuntime: Readonly<Record<string, OperationRuntimeState>> = {
+      focused: { lifecycle: "live", activity: "idle" },
+    };
+    setConsoleState({ operations: [focused], activeOperationId: focused.id, operationRuntime });
+    setTriageActive(true);
+    recordTriageActivity([focused], operationRuntime);
+    markIdleArrival(focused.id);
+    recordTriageActivity([focused], operationRuntime);
+
+    expect(getActiveAwaitingClaimId()).toBe(focused.id);
+    expect(getTriagePick()).toBeNull();
+    expect(resolveActiveAwaitingTriageEntry([focused], operationRuntime)?.operation.id).toBe(focused.id);
+  });
+
+  it("drops an active-awaiting claim when the panel is deferred or another Operation is picked", () => {
+    const focused = operation("focused", 1);
+    const other = operation("other", 2);
+    const operationRuntime: Record<string, OperationRuntimeState> = {
+      focused: { lifecycle: "live", activity: "running" },
+      other: { lifecycle: "live", activity: "awaiting" },
+    };
+    setConsoleState({
+      operations: [focused, other],
+      activeOperationId: focused.id,
+      operationRuntime,
+    });
+    setTriageActive(true);
+    recordTriageActivity([focused, other], operationRuntime);
+    recordTriageActivity([focused, other], {
+      focused: { lifecycle: "live", activity: "awaiting" },
+      other: { lifecycle: "live", activity: "awaiting" },
+    });
+    expect(getActiveAwaitingClaimId()).toBe(focused.id);
+
+    deferTriageOperation(focused.id);
+    expect(getActiveAwaitingClaimId()).toBeNull();
+    expect(resolveActiveAwaitingTriageEntry([focused, other], {
+      focused: { lifecycle: "live", activity: "awaiting" },
+      other: { lifecycle: "live", activity: "awaiting" },
+    })).toBeNull();
+
+    setConsoleState({
+      operations: [focused, other],
+      activeOperationId: focused.id,
+      operationRuntime: {
+        focused: { lifecycle: "live", activity: "running" },
+        other: { lifecycle: "live", activity: "awaiting" },
+      },
+    });
+    recordTriageActivity([focused, other], {
+      focused: { lifecycle: "live", activity: "running" },
+      other: { lifecycle: "live", activity: "awaiting" },
+    });
+    recordTriageActivity([focused, other], {
+      focused: { lifecycle: "live", activity: "awaiting" },
+      other: { lifecycle: "live", activity: "awaiting" },
+    });
+    pickTriageOperation(other.id);
+    expect(getActiveAwaitingClaimId()).toBeNull();
+    expect(getTriagePick()).toBe(other.id);
   });
 
   it("does not let a focused non-waiting Operation displace another waiting Operation on entry", () => {
@@ -926,6 +1149,12 @@ describe("triage store", () => {
         expect(panel.matches(selector), `${selector} never matches the portaled panel`).toBe(true);
       }
     }
+  });
+
+  it("wires an active-awaiting claim behind grace and protected stage retention", () => {
+    const source = readFileSync("core/client/src/canvas/canvas.tsx", "utf8");
+    expect(source).toContain("resolveActiveAwaitingTriageEntry(state.operations, state.operationRuntime)");
+    expect(source).toContain("graceTriageEntry ?? protectedTriageEntry ?? activeAwaitingTriageEntry");
   });
 
   it("keeps the deck tile's own track from growing past the slot it stands in", () => {


### PR DESCRIPTION
## Summary
- War Room에서 캡션으로만 활성화된 덱 패널이 대기로 들어가면, 지목 없이 무대 후보가 됩니다.
- 캡션 클릭은 계속 포커스만 주고, 스포트라이트 OFF 자동 등단·미룸·치워둠·무장 계약은 그대로입니다.
- 활성이 풀리거나 다른 패널을 지목하면 클레임이 거둬집니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/triage-store.test.ts` (94 passed)
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] War Room에서 무대가 아닌 활성 패널이 AWAITING이 되면 무대에 오르는지 실측
- [ ] 캡션만 누른 이미 대기 중인 패널은 무대에 오르지 않는지 확인
- [ ] 스포트라이트 OFF에서 같은 전이가 자동 등단하지 않는지 확인