### PR TITLE
fix(fleet-console): drop Chat EventSource on parked bodies

### DIFF
--- a/.changelog.d/chat-parked-stream-off.md
+++ b/.changelog.d/chat-parked-stream-off.md
@@ -4,5 +4,5 @@ branch: chat-parked-stream-off
 
 ### fleet-console
 #### Fixed
-- Chat Mode no longer holds a live stream for a parked, minimized, hidden, or deck-tile panel. Only a body the user can read keeps its EventSource, so close and Resume requests are not starved behind off-screen chat subscriptions.
-  ko: 채팅 모드가 주차·최소화·숨김·덱 타일 패널에 라이브 스트림을 붙들지 않습니다. 사용자가 읽는 본문만 EventSource를 열어, 화면 밖 채팅 구독 때문에 닫기·재개 요청이 줄 서지 않습니다.
+- Chat Mode no longer holds a live stream for a parked, minimized, or hidden panel. Only a body the user can read keeps its EventSource, so close and Resume requests are not starved behind off-screen chat subscriptions. War Room deck tiles stay subscribed because their bodies are painted.
+  ko: 채팅 모드가 주차·최소화·숨김 패널에 라이브 스트림을 붙들지 않습니다. 사용자가 읽는 본문만 EventSource를 열어, 화면 밖 채팅 구독 때문에 닫기·재개 요청이 줄 서지 않습니다. War Room 덱 타일은 본문이 그려지므로 구독을 유지합니다.

--- a/.changelog.d/chat-parked-stream-off.md
+++ b/.changelog.d/chat-parked-stream-off.md
@@ -1,0 +1,8 @@
+---
+branch: chat-parked-stream-off
+---
+
+### fleet-console
+#### Fixed
+- Chat Mode no longer holds a live stream for a parked, minimized, hidden, or deck-tile panel. Only a body the user can read keeps its EventSource, so close and Resume requests are not starved behind off-screen chat subscriptions.
+  ko: 채팅 모드가 주차·최소화·숨김·덱 타일 패널에 라이브 스트림을 붙들지 않습니다. 사용자가 읽는 본문만 EventSource를 열어, 화면 밖 채팅 구독 때문에 닫기·재개 요청이 줄 서지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -73,6 +73,7 @@ interface PluginOperationRendererProps {
   readonly companionsOpen: boolean;
   readonly hiddenCompanionPanelIds: readonly string[];
   readonly onSetCompanionPanelVisible: (companionPanelId: string, visible: boolean) => void;
+  readonly bodyLive?: boolean;
   readonly render: (context: OperationRenderContext) => unknown;
 }
 
@@ -1334,6 +1335,7 @@ function renderPluginOperation(operation: OperationNode, options: {
               geometry,
               operation,
               runtimeState: options.runtimeState,
+              bodyLive: !options.minimized && !options.focusLayerHidden && options.deckSlot === null,
               theme: options.theme,
               language: options.language,
               zoom: options.viewportZoom,
@@ -1365,6 +1367,7 @@ function renderPluginOperation(operation: OperationNode, options: {
               companionsOpen={options.companion}
               hiddenCompanionPanelIds={options.hiddenCompanionPanelIds}
               onSetCompanionPanelVisible={onSetCompanionPanelVisible}
+              bodyLive={!options.minimized && !options.focusLayerHidden && options.deckSlot === null}
               render={descriptor.render}
             />
           </PluginErrorBoundary>
@@ -1447,6 +1450,7 @@ function PluginOperationRenderer({
   companionsOpen,
   hiddenCompanionPanelIds,
   onSetCompanionPanelVisible,
+  bodyLive,
   render,
 }: PluginOperationRendererProps) {
   return render({
@@ -1470,6 +1474,7 @@ function PluginOperationRenderer({
     settings: capabilities.settings,
     runtime: capabilities.runtime,
     runtimeState,
+    ...(bodyLive === undefined ? {} : { bodyLive }),
     statusDetail: capabilities.statusDetail,
     composer: capabilities.composer,
     onActivate,

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -1335,7 +1335,7 @@ function renderPluginOperation(operation: OperationNode, options: {
               geometry,
               operation,
               runtimeState: options.runtimeState,
-              bodyLive: !options.minimized && !options.focusLayerHidden && options.deckSlot === null,
+              bodyLive: !options.minimized && !options.focusLayerHidden,
               theme: options.theme,
               language: options.language,
               zoom: options.viewportZoom,
@@ -1367,7 +1367,7 @@ function renderPluginOperation(operation: OperationNode, options: {
               companionsOpen={options.companion}
               hiddenCompanionPanelIds={options.hiddenCompanionPanelIds}
               onSetCompanionPanelVisible={onSetCompanionPanelVisible}
-              bodyLive={!options.minimized && !options.focusLayerHidden && options.deckSlot === null}
+              bodyLive={!options.minimized && !options.focusLayerHidden}
               render={descriptor.render}
             />
           </PluginErrorBoundary>

--- a/runtime/fleet-console/core/client/src/mobile/mobile-session-view.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/mobile-session-view.tsx
@@ -88,6 +88,7 @@ export function MobileSessionView({ operation, theme, language, active, runtimeS
     geometry,
     operation,
     runtimeState,
+    bodyLive: true,
     theme,
     language,
     zoom: 1,

--- a/runtime/fleet-console/core/client/src/mobile/operation-body-pool.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/operation-body-pool.tsx
@@ -17,6 +17,8 @@ export interface OperationBodyConfig {
   readonly language: "en" | "ko";
   readonly zoom: number;
   readonly runtimeState: OperationRuntimeState | null;
+  /** Absent means live. Parked bodies force this off even when a slot later claims otherwise. */
+  readonly bodyLive?: boolean;
   readonly onActivate: () => void;
   readonly onClose: () => void;
   readonly onGeometryChange: (geometry: OperationGeometry) => void;
@@ -175,7 +177,8 @@ function sameBodyConfig(previous: OperationBodyConfig | undefined, next: Operati
     && previous.onRequestCompanions === next.onRequestCompanions
     && previous.companionsOpen === next.companionsOpen
     && previous.hiddenCompanionPanelIds === next.hiddenCompanionPanelIds
-    && previous.onSetCompanionPanelVisible === next.onSetCompanionPanelVisible;
+    && previous.onSetCompanionPanelVisible === next.onSetCompanionPanelVisible
+    && previous.bodyLive === next.bodyLive;
 }
 
 function PooledOperationBody({ operation, descriptor, config, capabilities, slot, parked, parkingSize }: {
@@ -238,6 +241,8 @@ function PooledOperationBody({ operation, descriptor, config, capabilities, slot
     settings: capabilities.settings,
     runtime: capabilities.runtime,
     runtimeState: current.runtimeState,
+    // 주차는 슬롯이 없다는 뜻이다. config가 live라고 말해도 화면 밖에 있으면 스트림을 열지 않는다.
+    bodyLive: parked ? false : current.bodyLive !== false,
     statusDetail: capabilities.statusDetail,
     composer: capabilities.composer,
     onActivate: () => configRef.current?.onActivate(),

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -640,6 +640,8 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
     geometry: operation.geometry ?? ensurePluginGeometry(operation),
     operation,
     runtimeState: pluginRuntimeState(state.operationRuntime, state.operationRuntimeHydration, operation.id),
+    // 슬롯이 붙기 전 주차 본문. 보이는 프레임이 publish하면 그 값이 이 기본을 덮는다.
+    bodyLive: false,
     theme: state.activeTheme,
     language,
     zoom: 1,

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -313,6 +313,12 @@ export interface OperationRenderContext extends OperationContext {
    * 판단하지 않고 이 값 하나를 읽어야 사이드바와 본문이 갈라지지 않는다.
    */
   readonly runtimeState: OperationRuntimeState | null;
+  /**
+   * Whether this body is on a surface the user can read. `undefined` is an older
+   * host and must be treated as live. `false` is a parked, minimized, hidden, or
+   * deck-tile body: the plugin must not hold a dedicated HTTP stream for it.
+   */
+  readonly bodyLive?: boolean;
   readonly onActivate: () => void;
   readonly onClose: () => void;
   readonly onGeometryChange: (geometry: OperationGeometry) => void;

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -315,8 +315,9 @@ export interface OperationRenderContext extends OperationContext {
   readonly runtimeState: OperationRuntimeState | null;
   /**
    * Whether this body is on a surface the user can read. `undefined` is an older
-   * host and must be treated as live. `false` is a parked, minimized, hidden, or
-   * deck-tile body: the plugin must not hold a dedicated HTTP stream for it.
+   * host and must be treated as live. `false` is a parked, minimized, or hidden
+   * body: the plugin must not hold a dedicated HTTP stream for it. A War Room
+   * deck tile stays live — its body is painted, even while inert.
    */
   readonly bodyLive?: boolean;
   readonly onActivate: () => void;

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAgentChatStream, type AgentChatViewState } from "./chat-store.js";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  readonly url: string;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((message: MessageEvent<string>) => void) | null = null;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = 2;
+  }
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let latest: AgentChatViewState | null = null;
+
+function Probe({ operationId, live }: { readonly operationId: string; readonly live: boolean }) {
+  latest = useAgentChatStream(operationId, live);
+  return null;
+}
+
+function mount(operationId: string, live: boolean): void {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(createElement(Probe, { operationId, live }));
+  });
+}
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  latest = null;
+  vi.stubGlobal("EventSource", FakeEventSource);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  latest = null;
+  vi.unstubAllGlobals();
+});
+
+describe("useAgentChatStream", () => {
+  it("opens one EventSource while the body is live", () => {
+    mount("op-live", true);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]?.url).toBe("/plugins/terminal/agent/sessions/op-live/chat-stream");
+    expect(FakeEventSource.instances[0]?.closed).toBe(false);
+    expect(latest?.connection).toBe("connecting");
+  });
+
+  it("does not open an EventSource while the body is parked", () => {
+    mount("op-parked", false);
+    expect(FakeEventSource.instances).toHaveLength(0);
+    expect(latest?.connection).toBe("idle");
+  });
+
+  it("closes the EventSource when the body leaves the live surface", () => {
+    mount("op-toggle", true);
+    const source = FakeEventSource.instances[0];
+    expect(source?.closed).toBe(false);
+    act(() => {
+      root!.render(createElement(Probe, { operationId: "op-toggle", live: false }));
+    });
+    expect(source?.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    // 화면 밖에서도 마지막 로그를 지키므로 lost로 뒤집지 않는다 — 다시 보이면 재접속이 저널을 되쓴다.
+    expect(latest?.connection).toBe("idle");
+  });
+
+  it("opens a new EventSource when a parked body becomes live", () => {
+    mount("op-return", false);
+    expect(FakeEventSource.instances).toHaveLength(0);
+    act(() => {
+      root!.render(createElement(Probe, { operationId: "op-return", live: true }));
+    });
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]?.url).toBe("/plugins/terminal/agent/sessions/op-return/chat-stream");
+    expect(latest?.connection).toBe("connecting");
+  });
+});

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
@@ -2,7 +2,7 @@ import { React } from "@fleet-console/sdk/plugin/browser";
 
 import { initialAgentChatLogState, readChatJournalEvent, reduceAgentChatLog, type AgentChatLogState } from "./chat-events.js";
 
-export type AgentChatConnection = "connecting" | "open" | "lost";
+export type AgentChatConnection = "connecting" | "open" | "lost" | "idle";
 
 export interface AgentChatViewState extends AgentChatLogState {
   readonly connection: AgentChatConnection;
@@ -14,12 +14,19 @@ export interface AgentChatViewState extends AgentChatLogState {
  * 서버는 접속(재접속 포함)마다 저널 전체를 되쓴다 — 저널의 첫 이벤트는 언제나 replay-start라
  * reducer가 스스로 초기화하지만, 저널이 상한으로 앞이 잘린 재접속에서도 상태가 겹으로 쌓이지
  * 않도록 open 시점에 로그 상태를 초기화한다. EventSource의 자동 재접속을 그대로 쓴다.
+ *
+ * `live`가 false면 소켓을 열지 않는다. 본문 풀이 주차·최소화·숨김·덱 타일 본문을 살려 두므로,
+ * 그때도 구독하면 화면 밖 패널마다 HTTP/1.1 슬롯을 하나씩 점유한다.
  */
-export function useAgentChatStream(operationId: string): AgentChatViewState {
-  const [connection, setConnection] = React.useState<AgentChatConnection>("connecting");
+export function useAgentChatStream(operationId: string, live = true): AgentChatViewState {
+  const [connection, setConnection] = React.useState<AgentChatConnection>(live ? "connecting" : "idle");
   const [log, setLog] = React.useState<AgentChatLogState>(initialAgentChatLogState);
 
   React.useEffect(() => {
+    if (!live) {
+      setConnection("idle");
+      return;
+    }
     setConnection("connecting");
     setLog(initialAgentChatLogState);
     const source = new EventSource(`/plugins/terminal/agent/sessions/${encodeURIComponent(operationId)}/chat-stream`);
@@ -39,7 +46,7 @@ export function useAgentChatStream(operationId: string): AgentChatViewState {
     return () => {
       source.close();
     };
-  }, [operationId]);
+  }, [operationId, live]);
 
   return React.useMemo(() => ({ ...log, connection }), [log, connection]);
 }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
@@ -15,8 +15,9 @@ export interface AgentChatViewState extends AgentChatLogState {
  * reducer가 스스로 초기화하지만, 저널이 상한으로 앞이 잘린 재접속에서도 상태가 겹으로 쌓이지
  * 않도록 open 시점에 로그 상태를 초기화한다. EventSource의 자동 재접속을 그대로 쓴다.
  *
- * `live`가 false면 소켓을 열지 않는다. 본문 풀이 주차·최소화·숨김·덱 타일 본문을 살려 두므로,
- * 그때도 구독하면 화면 밖 패널마다 HTTP/1.1 슬롯을 하나씩 점유한다.
+ * `live`가 false면 소켓을 열지 않는다. 본문 풀이 주차·최소화·숨김 본문을 살려 두므로,
+ * 그때도 구독하면 화면 밖 패널마다 HTTP/1.1 슬롯을 하나씩 점유한다. 덱 타일은 본문이
+ * 그려지므로 live로 남긴다.
  */
 export function useAgentChatStream(operationId: string, live = true): AgentChatViewState {
   const [connection, setConnection] = React.useState<AgentChatConnection>(live ? "connecting" : "idle");

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -51,7 +51,7 @@ export function AgentChatView({
   readonly leadingChip?: React.ReactNode;
 }) {
   const t = getT(context.language ?? "en");
-  const state = useAgentChatStream(context.operationId);
+  const state = useAgentChatStream(context.operationId, context.bodyLive !== false);
   // 현재 작업 여부의 권위는 호스트가 쥔 런타임 축 하나다 — 이 뷰가 따로 축을 주장하면 열려 있는
   // 동안만 정직해지고, 패널을 닫는 순간 사이드바가 다시 휴면으로 돌아간다. 축이 degraded면 호스트가
   // null 을 건네므로 진행 중이라고 주장하지 않는다(그 사실은 전역 배너가 말한다).


### PR DESCRIPTION
## Summary
- Chat Mode used to keep an EventSource open for every parked, minimized, hidden, or War Room deck-tile body. Those sockets filled Chromium's HTTP/1.1 per-host slots, so panel close and dormant Resume stayed pending while the visible chat stream kept flowing.
- The host now publishes `bodyLive` on the operation render context. Chat Mode opens `/chat-stream` only while the body is readable; an older host that omits the field still subscribes.
- Parked bodies keep the last journal in memory (`idle`, not `lost`) so returning to the panel does not flash a connection error before replay.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run client/agent/chat/chat-store.test.tsx client/agent/chat/chat-work-tab.test.tsx client/agent/chat/chat-scroll-anchor.test.tsx`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/companion-availability.test.tsx tests/operations-boot-minimization.integration.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc -p tsconfig.json --noEmit`
- [x] `pnpm --filter @fleet-plugins/terminal exec tsc -p tsconfig.json --noEmit`
- [ ] With several Chat Mode operations open, minimize or leave some off-screen, then close another panel and click Resume on a dormant one — both should settle instead of hanging on "재개 중…".