### PR TITLE
feat(fleet-cli): reserve host verbs so fleet is not Claude

### DIFF
--- a/.changelog.d/worktree-fleet-cli-honesty.md
+++ b/.changelog.d/worktree-fleet-cli-honesty.md
@@ -1,0 +1,19 @@
+---
+branch: worktree-fleet-cli-honesty
+---
+
+### fleet-cli
+#### Changed
+- `fleet --version`, `-v`, and `version` now print the Fleet package version and channel. Claude Code's version is still `fleet cli --version`.
+  ko: `fleet --version`, `-v`, `version`이 Fleet 패키지 버전과 채널을 출력합니다. Claude Code 버전은 그대로 `fleet cli --version`입니다.
+- `fleet auth login` and `logout` reject an unknown provider name instead of opening a picker.
+  ko: `fleet auth login`과 `logout`이 알 수 없는 공급자 이름을 픽커로 넘기지 않고 거절합니다.
+- `fleet doctor` reports the install, Claude Code on PATH, gateway auth, and Console health without changing anything. `fleet status` is the same as `fleet console status`.
+  ko: `fleet doctor`가 설치본, PATH의 Claude Code, 게이트웨이 인증, Console 상태를 바꾸지 않고 보고합니다. `fleet status`는 `fleet console status`와 같습니다.
+- `fleet update --check` reports whether a newer package is available without installing or stopping the Console.
+  ko: `fleet update --check`가 설치하거나 Console을 내리지 않고 새 패키지 여부만 보고합니다.
+
+### fleet-console
+#### Fixed
+- `fleet-console --help` now shows the installed version and channel instead of always saying `local`.
+  ko: `fleet-console --help`가 항상 `local`이라고 하지 않고 설치된 버전과 채널을 보여 줍니다.

--- a/runtime/fleet-console/README.md
+++ b/runtime/fleet-console/README.md
@@ -52,6 +52,7 @@ Codex/Fleet Wiki routes preserve the migrated wiki security boundary: Host allow
 ```bash
 fleet console
 fleet console status
+fleet console restart
 fleet console stop
 
 # transitional alias

--- a/runtime/fleet-console/cli/auth/dispatcher.ts
+++ b/runtime/fleet-console/cli/auth/dispatcher.ts
@@ -1,6 +1,6 @@
 import { cancel, isCancel, select } from "@clack/prompts";
 
-import { AUTH_CLI_DEFINITIONS, getAuthCliOptions, parseAuthCliId, runAuthLoginFlow } from "./login-flow.js";
+import { AUTH_CLI_DEFINITIONS, getAuthCliOptions, parseAuthCliId, resolveAuthCliId, runAuthLoginFlow } from "./login-flow.js";
 import type { AuthCommandDeps, AuthCommandIo } from "./types.js";
 
 const AUTH_HELP_TEXT = `fleet auth — Authentication
@@ -45,12 +45,14 @@ async function logoutAuthProvider(
   io: AuthCommandIo,
   deps: AuthCommandDeps,
 ): Promise<number> {
-  const selectedCli = parseAuthCliId(argv[0]) ?? await promptForLogoutCli();
-  if (!selectedCli) {
+  const selectedCli = resolveAuthCliId(argv[0], io);
+  if (selectedCli === "invalid") return 1;
+  const chosen = selectedCli ?? await promptForLogoutCli();
+  if (!chosen) {
     cancel("Authentication cancelled.");
     return 1;
   }
-  const definition = AUTH_CLI_DEFINITIONS[selectedCli];
+  const definition = AUTH_CLI_DEFINITIONS[chosen];
   await deps.authService.deleteApiKey(definition.providerId);
   io.stdout.write(`${definition.label} signed out.\n`);
   return 0;

--- a/runtime/fleet-console/cli/auth/login-flow.ts
+++ b/runtime/fleet-console/cli/auth/login-flow.ts
@@ -43,9 +43,11 @@ export async function runAuthLoginFlow(
   io: AuthCommandIo,
   deps: AuthCommandDeps,
 ): Promise<number> {
-  const selectedCli = parseAuthCliId(argv[0]) ?? await promptForCli();
-  if (!selectedCli) return cancelAuthCommand();
-  const definition = AUTH_CLI_DEFINITIONS[selectedCli];
+  const selectedCli = resolveAuthCliId(argv[0], io);
+  if (selectedCli === "invalid") return 1;
+  const chosen = selectedCli ?? await promptForCli();
+  if (!chosen) return cancelAuthCommand();
+  const definition = AUTH_CLI_DEFINITIONS[chosen];
 
   const apiKey = await password({
     message: `Enter the ${definition.shortName} API key`,
@@ -72,6 +74,17 @@ export function getAuthCliOptions(): readonly AuthCliId[] {
 
 export function parseAuthCliId(value: string | undefined): AuthCliId | undefined {
   return value !== undefined && value in AUTH_CLI_DEFINITIONS ? value as AuthCliId : undefined;
+}
+
+export function resolveAuthCliId(
+  value: string | undefined,
+  io: AuthCommandIo,
+): AuthCliId | "invalid" | undefined {
+  if (value === undefined) return undefined;
+  const parsed = parseAuthCliId(value);
+  if (parsed) return parsed;
+  io.stderr.write(`Unknown fleet auth provider: ${value}\nUse kimi or opencode.\n`);
+  return "invalid";
 }
 
 async function promptForCli(): Promise<AuthCliId | undefined> {

--- a/runtime/fleet-console/cli/cli-args.ts
+++ b/runtime/fleet-console/cli/cli-args.ts
@@ -17,6 +17,14 @@ export interface FleetCliOptions {
   readonly passthroughArgs: readonly string[];
 }
 
+export function isFleetVersionArg(value: string | undefined): boolean {
+  return value === "--version" || value === "-v" || value === "version";
+}
+
+export function buildFleetVersionText(release: FleetCliRelease = readFleetCliRelease()): string {
+  return `@dotobokuri/fleet-console ${release.version} (${release.channel})\nClaude Code version: fleet cli --version\n`;
+}
+
 export interface BuildFleetHelpTextOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly isTTY?: boolean;
@@ -49,16 +57,23 @@ export function buildFleetHelpText(options: BuildFleetHelpTextOptions = {}): str
     `  ${command("fleet cli", colorEnabled)} ${dim("[claude args...]", colorEnabled)}`,
     `  ${command("fleet console", colorEnabled)} ${dim("[start|stop|restart|status] [--help]", colorEnabled)}`,
     `  ${command("fleet auth", colorEnabled)} ${dim("login|list|logout", colorEnabled)}`,
-    `  ${command("fleet update", colorEnabled)}`,
+    `  ${command("fleet update", colorEnabled)} ${dim("[--check]", colorEnabled)}`,
+    `  ${command("fleet version", colorEnabled)}`,
+    `  ${command("fleet doctor", colorEnabled)}`,
+    `  ${command("fleet status", colorEnabled)}`,
     "",
     section("COMMANDS", colorEnabled),
     `  ${command("cli", colorEnabled)}                 ${dim("Launch Claude Code through the thin Fleet gateway (synonym of bare fleet).", colorEnabled)}`,
     `  ${command("console", colorEnabled)}             ${dim("Manage the local Fleet Console server.", colorEnabled)}`,
     `  ${command("auth", colorEnabled)}                ${dim("Manage AI Gateway provider authentication.", colorEnabled)}`,
     `  ${command("update", colorEnabled)}              ${dim("Update the Fleet Console package (owns fleet and fleet-console).", colorEnabled)}`,
+    `  ${command("version", colorEnabled)}             ${dim("Print the Fleet package version and exit.", colorEnabled)}`,
+    `  ${command("doctor", colorEnabled)}              ${dim("Report install, PATH, auth, and Console health without changing anything.", colorEnabled)}`,
+    `  ${command("status", colorEnabled)}              ${dim("Show the local Fleet Console server status (same as fleet console status).", colorEnabled)}`,
     "",
     section("OPTIONS", colorEnabled),
     `  ${option("-h, --help", colorEnabled)}          ${dim("Show this help message and exit.", colorEnabled)}`,
+    `  ${option("-v, --version", colorEnabled)}       ${dim("Print the Fleet package version and exit.", colorEnabled)}`,
     `  ${dim("Unrecognized arguments are passed through to Claude Code.", colorEnabled)}`,
     "",
   ];

--- a/runtime/fleet-console/cli/doctor.ts
+++ b/runtime/fleet-console/cli/doctor.ts
@@ -81,13 +81,27 @@ async function describeClaudeBinary(
   runVersion: (bin: string, args: readonly string[]) => Promise<string>,
 ): Promise<string> {
   if (!resolved) return `${CLAUDE_COMMAND} (not on PATH)`;
+  const displayPath = displayBinaryPath(resolved);
   try {
     const output = await runVersion(resolved.bin, [...resolved.prefixArgs, "--version"]);
     const version = output.match(SEMVER_PATTERN)?.[1];
-    return version ? `${resolved.bin} ${version}` : `${resolved.bin} (version unknown)`;
+    return version ? `${displayPath} ${version}` : `${displayPath} (version unknown)`;
   } catch {
-    return `${resolved.bin} (version unknown)`;
+    return `${displayPath} (version unknown)`;
   }
+}
+
+// Windows npm shim은 bin이 cmd.exe이고 실제 .cmd는 prefixArgs에 있다.
+// 실행은 wrap 그대로 두고, 진단 줄만 그 shim 경로를 말한다.
+function displayBinaryPath(resolved: ResolvedBinary): string {
+  const shim = [...resolved.prefixArgs]
+    .reverse()
+    .map((arg) => arg.trim())
+    .find((arg) => {
+      const lower = arg.toLowerCase();
+      return lower.endsWith(".cmd") || lower.endsWith(".bat");
+    });
+  return shim ?? resolved.bin;
 }
 
 function execFileVersion(bin: string, args: readonly string[]): Promise<string> {

--- a/runtime/fleet-console/cli/doctor.ts
+++ b/runtime/fleet-console/cli/doctor.ts
@@ -1,0 +1,115 @@
+import { execFile } from "node:child_process";
+
+import { resolvePathBinary, type ResolvedBinary } from "@dotobokuri/core-process";
+import { getFleetDataDir, type AuthService } from "@dotobokuri/core-infra";
+
+import { AUTH_CLI_DEFINITIONS } from "./auth/login-flow.js";
+import { readFleetCliRelease, type FleetCliRelease } from "./release.js";
+import { createConsolePaths } from "../core/host/paths.js";
+import { runConsoleStatus } from "../core/host/console-lifecycle.js";
+
+const CLAUDE_COMMAND = "claude";
+const SEMVER_PATTERN = /(\d+\.\d+\.\d+)/;
+const VERSION_PROBE_TIMEOUT_MS = 5_000;
+const DOCTOR_HELP_TEXT = `fleet doctor — Diagnose Fleet
+
+Usage:
+  fleet doctor
+`;
+
+export interface DoctorIo {
+  readonly stdout: Pick<NodeJS.WriteStream, "write">;
+  readonly stderr: Pick<NodeJS.WriteStream, "write">;
+}
+
+export interface DoctorDeps {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly release?: FleetCliRelease;
+  readonly authService: Pick<AuthService, "listProviderIds">;
+  readonly resolveBinary?: (command: string, env: NodeJS.ProcessEnv) => ResolvedBinary | undefined;
+  readonly runVersion?: (bin: string, args: readonly string[]) => Promise<string>;
+  readonly readConsoleStatus?: () => Promise<string>;
+  readonly dataDir?: string;
+  readonly lockFile?: string;
+}
+
+export async function dispatchDoctorCommand(
+  argv: readonly string[],
+  io: DoctorIo,
+  deps: DoctorDeps,
+): Promise<number> {
+  const extra = argv[1];
+  if (extra === "--help" || extra === "-h") {
+    io.stdout.write(DOCTOR_HELP_TEXT);
+    return 0;
+  }
+  if (extra !== undefined) {
+    io.stderr.write(`Unknown fleet doctor command: ${extra}\n`);
+    io.stdout.write(DOCTOR_HELP_TEXT);
+    return 1;
+  }
+  io.stdout.write(`${await buildFleetDoctorText(deps)}\n`);
+  return 0;
+}
+
+export async function buildFleetDoctorText(deps: DoctorDeps): Promise<string> {
+  const env = deps.env ?? process.env;
+  const release = deps.release ?? readFleetCliRelease();
+  const dataDir = deps.dataDir ?? getFleetDataDir(env);
+  const lockFile = deps.lockFile ?? createConsolePaths({ env }).lockFile;
+  const resolveBinary = deps.resolveBinary ?? ((command, processEnv) => resolvePathBinary(command, processEnv));
+  const runVersion = deps.runVersion ?? execFileVersion;
+  const readConsoleStatus = deps.readConsoleStatus ?? runConsoleStatus;
+
+  const signedIn = new Set(await deps.authService.listProviderIds());
+  const binary = await describeClaudeBinary(resolveBinary(CLAUDE_COMMAND, env), runVersion);
+  const consoleLine = firstLine(await readConsoleStatus());
+
+  return [
+    formatRow("package", `@dotobokuri/fleet-console ${release.version} (${release.channel})`),
+    formatRow("data", dataDir),
+    formatRow("binary", binary),
+    formatRow("kimi", signedIn.has(AUTH_CLI_DEFINITIONS.kimi.providerId) ? "signed in" : "signed out"),
+    formatRow("opencode", signedIn.has(AUTH_CLI_DEFINITIONS.opencode.providerId) ? "signed in" : "signed out"),
+    formatRow("console", stripConsolePrefix(consoleLine)),
+    formatRow("lock", lockFile),
+  ].join("\n");
+}
+
+async function describeClaudeBinary(
+  resolved: ResolvedBinary | undefined,
+  runVersion: (bin: string, args: readonly string[]) => Promise<string>,
+): Promise<string> {
+  if (!resolved) return `${CLAUDE_COMMAND} (not on PATH)`;
+  try {
+    const output = await runVersion(resolved.bin, [...resolved.prefixArgs, "--version"]);
+    const version = output.match(SEMVER_PATTERN)?.[1];
+    return version ? `${resolved.bin} ${version}` : `${resolved.bin} (version unknown)`;
+  } catch {
+    return `${resolved.bin} (version unknown)`;
+  }
+}
+
+function execFileVersion(bin: string, args: readonly string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(bin, [...args], { timeout: VERSION_PROBE_TIMEOUT_MS }, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(`${stdout}${stderr}`);
+    });
+  });
+}
+
+function formatRow(key: string, value: string): string {
+  return `${key.padEnd(10)}${value}`;
+}
+
+function firstLine(text: string): string {
+  return text.split("\n")[0] ?? text;
+}
+
+function stripConsolePrefix(line: string): string {
+  return line.replace(/^Fleet Console server:\s*/, "");
+}

--- a/runtime/fleet-console/cli/doctor.ts
+++ b/runtime/fleet-console/cli/doctor.ts
@@ -63,7 +63,7 @@ export async function buildFleetDoctorText(deps: DoctorDeps): Promise<string> {
 
   const signedIn = new Set(await deps.authService.listProviderIds());
   const binary = await describeClaudeBinary(resolveBinary(CLAUDE_COMMAND, env), runVersion);
-  const consoleLine = firstLine(await readConsoleStatus());
+  const consoleLine = await readConsoleStatusLine(readConsoleStatus);
 
   return [
     formatRow("package", `@dotobokuri/fleet-console ${release.version} (${release.channel})`),
@@ -118,6 +118,17 @@ function execFileVersion(bin: string, args: readonly string[]): Promise<string> 
 
 function formatRow(key: string, value: string): string {
   return `${key.padEnd(10)}${value}`;
+}
+
+async function readConsoleStatusLine(
+  readConsoleStatus: () => Promise<string>,
+): Promise<string> {
+  try {
+    return firstLine(await readConsoleStatus());
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return `unreadable (${firstLine(reason)})`;
+  }
 }
 
 function firstLine(text: string): string {

--- a/runtime/fleet-console/cli/fleet-dispatch.ts
+++ b/runtime/fleet-console/cli/fleet-dispatch.ts
@@ -2,7 +2,9 @@ import { createInfraServices } from "@dotobokuri/core-infra";
 
 import { runApp } from "./app.js";
 import { dispatchAuthCommand } from "./auth/dispatcher.js";
-import { buildFleetHelpText } from "./cli-args.js";
+import { buildFleetHelpText, buildFleetVersionText, isFleetVersionArg } from "./cli-args.js";
+import { dispatchDoctorCommand } from "./doctor.js";
+import { readFleetCliRelease } from "./release.js";
 import {
   buildConsoleHelpText,
   openFleetConsole,
@@ -19,7 +21,9 @@ export type FleetDispatch =
   | { readonly kind: "update"; readonly argv: readonly string[] }
   | { readonly kind: "auth"; readonly argv: readonly string[] }
   | { readonly kind: "console"; readonly consoleArgv: readonly string[] }
+  | { readonly kind: "doctor"; readonly argv: readonly string[] }
   | { readonly kind: "help"; readonly passthroughArgs: readonly string[] }
+  | { readonly kind: "version" }
   | { readonly kind: "passthrough"; readonly passthroughArgs: readonly string[] };
 
 export interface FleetDispatchOptions {
@@ -39,18 +43,24 @@ export interface FleetDispatchOptions {
 }
 
 /**
- * Exact fleet.mjs precedence: update > auth > console > cli > help > Claude passthrough.
- * `cli` is stripped before help/passthrough classification.
+ * Exact fleet.mjs precedence: update > auth > console > doctor > status > cli > help > version > Claude passthrough.
+ * `cli` is stripped before help/passthrough classification. Reserved words after `cli`
+ * stay Claude passthrough so `fleet cli status` still asks Claude Code.
  */
 export function classifyFleetArgv(argv: readonly string[]): FleetDispatch {
   const command = argv[0];
   if (command === "update") return { kind: "update", argv };
   if (command === "auth") return { kind: "auth", argv };
   if (command === "console") return { kind: "console", consoleArgv: argv.slice(1) };
+  if (command === "doctor") return { kind: "doctor", argv };
+  if (command === "status") return { kind: "console", consoleArgv: ["status", ...argv.slice(1)] };
 
   const passthroughArgv = command === "cli" ? argv.slice(1) : argv;
   if (passthroughArgv[0] === "--help" || passthroughArgv[0] === "-h") {
     return { kind: "help", passthroughArgs: passthroughArgv.slice(1) };
+  }
+  if (command !== "cli" && isFleetVersionArg(passthroughArgv[0])) {
+    return { kind: "version" };
   }
   return { kind: "passthrough", passthroughArgs: [...passthroughArgv] };
 }
@@ -78,11 +88,16 @@ export async function dispatchFleetArgv(
     return await auth(dispatch.argv, io, createInfra());
   }
 
+  if (dispatch.kind === "doctor") {
+    return await dispatchDoctorCommand(dispatch.argv, io, { env, authService: createInfra().authService });
+  }
+
   if (dispatch.kind === "console") {
     try {
       const mode = parseConsoleCliMode(dispatch.consoleArgv);
       if (mode === "help") {
-        io.stdout.write(`${buildConsoleHelpText({ env, isTTY: io.stdout.isTTY })}\n`);
+        const release = readFleetCliRelease();
+        io.stdout.write(`${buildConsoleHelpText({ env, isTTY: io.stdout.isTTY, release: `${release.version} · ${release.channel}` })}\n`);
         return 0;
       }
       if (mode === "status") {
@@ -109,6 +124,11 @@ export async function dispatchFleetArgv(
 
   if (dispatch.kind === "help") {
     io.stdout.write(buildFleetHelpText({ env, isTTY: io.stdout.isTTY }));
+    return 0;
+  }
+
+  if (dispatch.kind === "version") {
+    io.stdout.write(buildFleetVersionText());
     return 0;
   }
 

--- a/runtime/fleet-console/cli/update/check-report.ts
+++ b/runtime/fleet-console/cli/update/check-report.ts
@@ -1,0 +1,22 @@
+import { readFleetCliRelease } from "../release.js";
+import { checkUpdateStatus } from "./check.js";
+import type { UpdateCommandIo } from "./types.js";
+
+export async function runFleetUpdateCheck(io: UpdateCommandIo): Promise<number> {
+  const release = readFleetCliRelease();
+  if (release.channel === "local") {
+    io.stdout.write(`Fleet is running from a local development build (v${release.version}) — nothing to update here.\n`);
+    return 0;
+  }
+  const result = await checkUpdateStatus(release, { forceRefresh: true }).catch(() => ({ status: "unavailable" as const }));
+  if (result.status === "current") {
+    io.stdout.write(`Fleet is already on the latest version (v${release.version}).\n`);
+    return 0;
+  }
+  if (result.status === "update") {
+    io.stdout.write(`A newer Fleet version is available: v${result.latest} (installed v${release.version}).\nRun fleet update to install it.\n`);
+    return 0;
+  }
+  io.stdout.write("Could not reach the npm registry to check for updates.\n");
+  return 1;
+}

--- a/runtime/fleet-console/cli/update/dispatcher.ts
+++ b/runtime/fleet-console/cli/update/dispatcher.ts
@@ -4,6 +4,7 @@ const UPDATE_HELP_TEXT = `fleet update — Update Fleet
 
 Usage:
   fleet update
+  fleet update --check
 `;
 
 export async function dispatchUpdateCommand(
@@ -15,6 +16,15 @@ export async function dispatchUpdateCommand(
   if (command === "--help" || command === "-h") {
     io.stdout.write(UPDATE_HELP_TEXT);
     return 0;
+  }
+  if (command === "--check") {
+    if (argv[2] !== undefined) {
+      io.stderr.write(`Unknown fleet update option: ${argv[2]}\n`);
+      io.stdout.write(UPDATE_HELP_TEXT);
+      return 1;
+    }
+    const { runFleetUpdateCheck } = await import("./check-report.js");
+    return runFleetUpdateCheck(io);
   }
   if (command !== undefined) {
     io.stderr.write(`Unknown fleet update command: ${command}\n`);

--- a/runtime/fleet-console/core/host/console-lifecycle.ts
+++ b/runtime/fleet-console/core/host/console-lifecycle.ts
@@ -22,6 +22,7 @@ import {
   section,
   stripAnsi,
 } from "../../cli/styles/index.js";
+import { readFleetCliRelease } from "../../cli/release.js";
 import { createConsoleLock } from "./lock.js";
 import { createConsolePaths } from "./paths.js";
 import { createConsoleServer } from "./server.js";
@@ -81,7 +82,6 @@ export interface BuildConsoleHelpTextOptions {
 
 const FIXED_HOST = "127.0.0.1";
 const HELP_BANNER_INDENT = "  ";
-const DEFAULT_HELP_RELEASE = "local";
 // background-spawn/background-stop은 더 이상 렌더되지 않지만, 업그레이드 시점에 이미 살아 있는 세션의
 // hooks.json이 여전히 그 이름으로 이 실행 파일을 호출한다(경로가 제자리 덮어써지므로 구 세션이 새 바이너리를 부른다).
 // 이름을 지우면 in-flight 세션의 hook이 예외로 죽으므로 계속 받아주고, 본문도 퇴역 당시 형식을 그대로 보낸다.
@@ -131,7 +131,8 @@ export function parseConsoleHookCommand(argv: readonly string[]): ConsoleHookCom
 
 export function buildConsoleHelpText(options: BuildConsoleHelpTextOptions = {}): string {
   const colorEnabled = resolveColorEnabled(options);
-  const subtitle = `Fleet Console · ${options.release ?? DEFAULT_HELP_RELEASE}`;
+  const release = options.release ?? formatConsoleHelpRelease();
+  const subtitle = `Fleet Console · ${release}`;
   const lines = [
     ...ASCII_FLEET_BANNER.map(
       (line, index) => `${HELP_BANNER_INDENT}${paint(GRADIENT_COLORS[index] ?? FLEET_COMMAND, line, colorEnabled)}`,
@@ -163,6 +164,11 @@ export function buildConsoleHelpText(options: BuildConsoleHelpTextOptions = {}):
   ];
   const text = lines.join("\n");
   return colorEnabled ? text : stripAnsi(text);
+}
+
+function formatConsoleHelpRelease(): string {
+  const release = readFleetCliRelease();
+  return `${release.version} · ${release.channel}`;
 }
 
 export function createConsoleDaemonLifecycle(deps: ConsoleDaemonLifecycleDeps = {}) {

--- a/runtime/fleet-console/tests/cli.test.ts
+++ b/runtime/fleet-console/tests/cli.test.ts
@@ -226,6 +226,7 @@ describe("fleet console CLI", () => {
     expect(helpText).toContain("stop");
     expect(helpText).toContain("restart");
     expect(helpText).toContain("status");
+    expect(helpText).toMatch(/Fleet Console · .+ · (local|stable)/);
     expect(helpText).not.toContain("Gateway");
   });
 

--- a/runtime/fleet-console/tests/fleet-cli/auth/dispatcher.test.ts
+++ b/runtime/fleet-console/tests/fleet-cli/auth/dispatcher.test.ts
@@ -15,6 +15,12 @@ vi.mock("../../../cli/auth/login-flow.js", () => ({
   },
   getAuthCliOptions: () => ["kimi", "opencode"],
   parseAuthCliId: (value: string | undefined) => value === "kimi" || value === "opencode" ? value : undefined,
+  resolveAuthCliId: (value: string | undefined, io: { stderr: { write(chunk: string): boolean } }) => {
+    if (value === undefined) return undefined;
+    if (value === "kimi" || value === "opencode") return value;
+    io.stderr.write(`Unknown fleet auth provider: ${value}\nUse kimi or opencode.\n`);
+    return "invalid";
+  },
   runAuthLoginFlow: mocks.runAuthLoginFlow,
 }));
 
@@ -51,6 +57,14 @@ describe("auth dispatcher", () => {
     await expect(dispatchAuthCommand(["auth", "logout", "opencode"], io, createDeps())).resolves.toBe(0);
     expect(mocks.deleteApiKey).toHaveBeenCalledWith("Claude Code with OpenCode Go");
     expect(io.stdout.output).toContain("OpenCode Go for AI Gateway signed out");
+  });
+
+  it("rejects an unknown logout provider without prompting", async () => {
+    const io = createIo();
+    await expect(dispatchAuthCommand(["auth", "logout", "bogus"], io, createDeps())).resolves.toBe(1);
+    expect(mocks.deleteApiKey).not.toHaveBeenCalled();
+    expect(io.stderr.output).toContain("Unknown fleet auth provider: bogus");
+    expect(io.stderr.output).toContain("Use kimi or opencode.");
   });
 });
 

--- a/runtime/fleet-console/tests/fleet-cli/auth/login-flow.test.ts
+++ b/runtime/fleet-console/tests/fleet-cli/auth/login-flow.test.ts
@@ -45,6 +45,14 @@ describe("Kimi auth login flow", () => {
     expect(mocks.setApiKey).not.toHaveBeenCalled();
     expect(io.stderr.output).toContain("rejected");
   });
+
+  it("rejects an unknown provider argument instead of opening a picker", async () => {
+    const io = createIo();
+    await expect(runAuthLoginFlow(["bogus"], io, createDeps())).resolves.toBe(1);
+    expect(mocks.password).not.toHaveBeenCalled();
+    expect(mocks.setApiKey).not.toHaveBeenCalled();
+    expect(io.stderr.output).toBe("Unknown fleet auth provider: bogus\nUse kimi or opencode.\n");
+  });
 });
 
 function createIo() {

--- a/runtime/fleet-console/tests/fleet-cli/cli-args.test.ts
+++ b/runtime/fleet-console/tests/fleet-cli/cli-args.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildFleetHelpText, parseFleetCliOptions } from "../../cli/cli-args.js";
+import { buildFleetHelpText, buildFleetVersionText, isFleetVersionArg, parseFleetCliOptions } from "../../cli/cli-args.js";
 
 describe("fleet CLI args", () => {
   it("passes every argument through by default", () => {
@@ -35,10 +35,27 @@ describe("fleet CLI args", () => {
     expect(helpText).toContain("fleet cli [claude args...]");
     expect(helpText).toContain("fleet console [start|stop|restart|status] [--help]");
     expect(helpText).toContain("fleet auth login|list|logout");
-    expect(helpText).toContain("fleet update");
+    expect(helpText).toContain("fleet update [--check]");
+    expect(helpText).toContain("fleet version");
+    expect(helpText).toContain("fleet doctor");
+    expect(helpText).toContain("fleet status");
     expect(helpText).toContain("-h, --help");
+    expect(helpText).toContain("-v, --version");
     expect(helpText).toContain("Unrecognized arguments are passed through to Claude Code.");
     expect(helpText).not.toContain("desktop");
     expect(helpText).not.toContain("\x1b[");
+  });
+
+  it("recognizes Fleet version tokens", () => {
+    expect(isFleetVersionArg("--version")).toBe(true);
+    expect(isFleetVersionArg("-v")).toBe(true);
+    expect(isFleetVersionArg("version")).toBe(true);
+    expect(isFleetVersionArg("--help")).toBe(false);
+  });
+
+  it("prints the Fleet package version, not Claude Code", () => {
+    expect(buildFleetVersionText({ version: "1.62.0", channel: "local" })).toBe(
+      "@dotobokuri/fleet-console 1.62.0 (local)\nClaude Code version: fleet cli --version\n",
+    );
   });
 });

--- a/runtime/fleet-console/tests/fleet-cli/doctor.test.ts
+++ b/runtime/fleet-console/tests/fleet-cli/doctor.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildFleetDoctorText, dispatchDoctorCommand } from "../../cli/doctor.js";
+
+describe("fleet doctor", () => {
+  it("prints help and exits 0", async () => {
+    const io = createIo();
+    await expect(dispatchDoctorCommand(["doctor", "--help"], io, createDeps())).resolves.toBe(0);
+    expect(io.stdout.output).toContain("fleet doctor");
+    expect(io.stdout.output).toContain("Usage:");
+  });
+
+  it("rejects extra arguments without probing", async () => {
+    const io = createIo();
+    const deps = createDeps();
+    await expect(dispatchDoctorCommand(["doctor", "fix"], io, deps)).resolves.toBe(1);
+    expect(deps.authService.listProviderIds).not.toHaveBeenCalled();
+    expect(io.stderr.output).toContain("Unknown fleet doctor command: fix");
+  });
+
+  it("reports package, data, PATH, auth, console, and lock without changing state", async () => {
+    const text = await buildFleetDoctorText(createDeps());
+    expect(text).toBe([
+      "package   @dotobokuri/fleet-console 1.62.0 (local)",
+      "data      /tmp/fleet-root",
+      "binary    /usr/bin/claude 2.1.233",
+      "kimi      signed in",
+      "opencode  signed out",
+      "console   running (pid 12)",
+      "lock      /tmp/console.lock",
+    ].join("\n"));
+  });
+
+  it("never prints raw --version stdout when no semver is present", async () => {
+    const deps = createDeps();
+    deps.runVersion = vi.fn(async () => "/Users/sbluemin/.local/bin/claude (dev)\n");
+    const text = await buildFleetDoctorText(deps);
+    expect(text).toContain("binary    /usr/bin/claude (version unknown)");
+    expect(text).not.toContain("/Users/sbluemin");
+  });
+});
+
+function createIo() {
+  const stdout = { output: "", write(chunk: string) { stdout.output += chunk; return true; } };
+  const stderr = { output: "", write(chunk: string) { stderr.output += chunk; return true; } };
+  return { stdout, stderr };
+}
+
+function createDeps() {
+  return {
+    release: { version: "1.62.0", channel: "local" as const },
+    authService: {
+      listProviderIds: vi.fn(async () => ["Claude Code with Moonshot Kimi"]),
+    },
+    resolveBinary: vi.fn(() => ({ bin: "/usr/bin/claude", prefixArgs: [] })),
+    runVersion: vi.fn(async () => "2.1.233 (Claude Code)\n"),
+    readConsoleStatus: vi.fn(async () => "Fleet Console server: running (pid 12)\n  endpoint   http://127.0.0.1:9/"),
+    dataDir: "/tmp/fleet-root",
+    lockFile: "/tmp/console.lock",
+  };
+}

--- a/runtime/fleet-console/tests/fleet-cli/doctor.test.ts
+++ b/runtime/fleet-console/tests/fleet-cli/doctor.test.ts
@@ -38,6 +38,21 @@ describe("fleet doctor", () => {
     expect(text).toContain("binary    /usr/bin/claude (version unknown)");
     expect(text).not.toContain("/Users/sbluemin");
   });
+
+  it("reports the Windows npm shim path while still probing through cmd.exe", async () => {
+    const deps = createDeps();
+    deps.resolveBinary = vi.fn(() => ({
+      bin: "C:\\Windows\\System32\\cmd.exe",
+      prefixArgs: ["/d", "/s", "/c", "call", "C:\\npm\\claude.cmd "],
+    }));
+    const text = await buildFleetDoctorText(deps);
+    expect(text).toContain("binary    C:\\npm\\claude.cmd 2.1.233");
+    expect(text).not.toContain("cmd.exe");
+    expect(deps.runVersion).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\cmd.exe",
+      ["/d", "/s", "/c", "call", "C:\\npm\\claude.cmd ", "--version"],
+    );
+  });
 });
 
 function createIo() {

--- a/runtime/fleet-console/tests/fleet-cli/doctor.test.ts
+++ b/runtime/fleet-console/tests/fleet-cli/doctor.test.ts
@@ -39,6 +39,18 @@ describe("fleet doctor", () => {
     expect(text).not.toContain("/Users/sbluemin");
   });
 
+  it("keeps the rest of the report when console status cannot be read", async () => {
+    const deps = createDeps();
+    deps.readConsoleStatus = vi.fn(async () => {
+      throw new Error("Refusing symbolic console lock: /tmp/console.lock");
+    });
+    const text = await buildFleetDoctorText(deps);
+    expect(text).toContain("package   @dotobokuri/fleet-console 1.62.0 (local)");
+    expect(text).toContain("binary    /usr/bin/claude 2.1.233");
+    expect(text).toContain("console   unreadable (Refusing symbolic console lock: /tmp/console.lock)");
+    expect(text).toContain("lock      /tmp/console.lock");
+  });
+
   it("reports the Windows npm shim path while still probing through cmd.exe", async () => {
     const deps = createDeps();
     deps.resolveBinary = vi.fn(() => ({

--- a/runtime/fleet-console/tests/fleet-cli/update-check-report.test.ts
+++ b/runtime/fleet-console/tests/fleet-cli/update-check-report.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dispatchUpdateCommand } from "../../cli/update/dispatcher.js";
+import { readFleetCliRelease } from "../../cli/release.js";
+import { checkUpdateStatus } from "../../cli/update/check.js";
+
+vi.mock("../../cli/release.js", () => ({
+  readFleetCliRelease: vi.fn(),
+}));
+
+vi.mock("../../cli/update/check.js", () => ({
+  checkUpdateStatus: vi.fn(),
+  resolveUpdateChannel: vi.fn(() => "latest"),
+}));
+
+const mockedReadFleetCliRelease = vi.mocked(readFleetCliRelease);
+const mockedCheckUpdateStatus = vi.mocked(checkUpdateStatus);
+
+describe("fleet update --check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedReadFleetCliRelease.mockReturnValue({ channel: "stable", version: "1.2.0" });
+    mockedCheckUpdateStatus.mockResolvedValue({ status: "current", latest: "1.2.0" });
+  });
+
+  it("documents --check in help", async () => {
+    const io = createIo();
+    await expect(dispatchUpdateCommand(["update", "--help"], io)).resolves.toBe(0);
+    expect(io.stdout.output).toContain("fleet update --check");
+  });
+
+  it("still rejects the bare check verb", async () => {
+    const io = createIo();
+    await expect(dispatchUpdateCommand(["update", "check"], io)).resolves.toBe(1);
+    expect(io.stderr.output).toContain("Unknown fleet update command: check");
+    expect(mockedCheckUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it("reports a newer version without installing", async () => {
+    const io = createIo();
+    mockedCheckUpdateStatus.mockResolvedValue({ status: "update", latest: "1.3.0" });
+    await expect(dispatchUpdateCommand(["update", "--check"], io)).resolves.toBe(0);
+    expect(io.stdout.output).toBe(
+      "A newer Fleet version is available: v1.3.0 (installed v1.2.0).\nRun fleet update to install it.\n",
+    );
+    expect(mockedCheckUpdateStatus).toHaveBeenCalledWith({ channel: "stable", version: "1.2.0" }, { forceRefresh: true });
+  });
+
+  it("does not contact the registry for a local build", async () => {
+    const io = createIo();
+    mockedReadFleetCliRelease.mockReturnValue({ channel: "local", version: "1.62.0" });
+    await expect(dispatchUpdateCommand(["update", "--check"], io)).resolves.toBe(0);
+    expect(io.stdout.output).toContain("local development build (v1.62.0)");
+    expect(mockedCheckUpdateStatus).not.toHaveBeenCalled();
+  });
+});
+
+function createIo() {
+  const stdout = { output: "", write(chunk: string) { stdout.output += chunk; return true; } };
+  const stderr = { output: "", write(chunk: string) { stderr.output += chunk; return true; } };
+  return { stdout, stderr };
+}

--- a/runtime/fleet-console/tests/fleet-entry-dispatch.test.ts
+++ b/runtime/fleet-console/tests/fleet-entry-dispatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { dispatchFleetArgv } from "../cli/fleet-dispatch.js";
+import { classifyFleetArgv, dispatchFleetArgv } from "../cli/fleet-dispatch.js";
 
 function createIo() {
   let stdout = "";
@@ -109,6 +109,64 @@ describe("dual-entry dispatch", () => {
     });
     expect(passthrough).toBe(0);
     expect(runApp).toHaveBeenCalledWith({ passthroughArgs: ["--model", "sonnet"] });
+  });
+
+  it("prints the Fleet package version without Claude passthrough", async () => {
+    const io = createIo();
+    const runApp = vi.fn(async () => undefined);
+    for (const argv of [["--version"], ["-v"], ["version"]] as const) {
+      io.stdout.write("");
+      const status = await dispatchFleetArgv([...argv], {
+        stdout: io.stdout,
+        stderr: io.stderr,
+        env: {},
+        runApp: runApp as never,
+        createInfraServices: (() => ({})) as never,
+        dispatchAuthCommand: (async () => 0) as never,
+        dispatchUpdateCommand: (async () => 0) as never,
+      });
+      expect(status).toBe(0);
+    }
+    expect(io.stdout.toString()).toContain("@dotobokuri/fleet-console");
+    expect(io.stdout.toString()).toContain("Claude Code version: fleet cli --version");
+    expect(runApp).not.toHaveBeenCalled();
+  });
+
+  it("aliases fleet status to console status without Claude passthrough", async () => {
+    expect(classifyFleetArgv(["status"])).toEqual({ kind: "console", consoleArgv: ["status"] });
+    expect(classifyFleetArgv(["status", "--help"])).toEqual({ kind: "console", consoleArgv: ["status", "--help"] });
+    expect(classifyFleetArgv(["cli", "status"])).toEqual({
+      kind: "passthrough",
+      passthroughArgs: ["status"],
+    });
+  });
+
+  it("reserves fleet doctor without Claude passthrough", async () => {
+    expect(classifyFleetArgv(["doctor"])).toEqual({ kind: "doctor", argv: ["doctor"] });
+    expect(classifyFleetArgv(["cli", "doctor"])).toEqual({
+      kind: "passthrough",
+      passthroughArgs: ["doctor"],
+    });
+  });
+
+  it("keeps fleet cli --version as Claude passthrough", async () => {
+    expect(classifyFleetArgv(["cli", "--version"])).toEqual({
+      kind: "passthrough",
+      passthroughArgs: ["--version"],
+    });
+    const io = createIo();
+    const runApp = vi.fn(async () => undefined);
+    const status = await dispatchFleetArgv(["cli", "--version"], {
+      stdout: io.stdout,
+      stderr: io.stderr,
+      env: {},
+      runApp: runApp as never,
+      createInfraServices: (() => ({})) as never,
+      dispatchAuthCommand: (async () => 0) as never,
+      dispatchUpdateCommand: (async () => 0) as never,
+    });
+    expect(status).toBe(0);
+    expect(runApp).toHaveBeenCalledWith({ passthroughArgs: ["--version"] });
   });
 
   it("keeps entry isolation: fleet entry never imports the direct-run-guarded Console entry", async () => {


### PR DESCRIPTION
## Summary
- `fleet --version`, `-v`, and `version` now print the Fleet package. Claude Code still answers `fleet cli --version`.
- Unknown `fleet auth` provider names are rejected. `fleet-console --help` shows the installed version and channel.
- `fleet doctor` reports install, PATH, auth, and Console health without changing state. `fleet status` is `fleet console status`. `fleet update --check` reports without installing or stopping the daemon.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run` on the fleet CLI unit files (52 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p tsconfig.json`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node runtime/fleet-console/dist/fleet.mjs --version` prints `@dotobokuri/fleet-console 1.62.0 (local)`
- [x] `node runtime/fleet-console/dist/cli.mjs --help` subtitle is `Fleet Console · 1.62.0 · local`
- [x] `fleet update --check` on a local build does not install; `fleet update check` stays unknown
- [x] `fleet doctor` is read-only and does not start or stop a Console daemon