### PR TITLE
fix(fleet-console): render chat step commentary as markdown

### DIFF
--- a/.changelog.d/chat-step-commentary-markdown.md
+++ b/.changelog.d/chat-step-commentary-markdown.md
@@ -1,0 +1,8 @@
+---
+branch: chat-step-commentary-markdown
+---
+
+### fleet-console
+#### Fixed
+- Render Chat Mode step commentary as markdown instead of forcing the whole sentence into italics.
+  ko: 채팅 뷰의 단계 코멘터리를 이탤릭으로 강제하지 않고 마크다운으로 그립니다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1654,6 +1654,11 @@ describe("Instrument core design contract", () => {
     const chatView = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_VIEW_PATH), "utf8");
     const terminalEntry = fs.readFileSync(fileURLToPath(TERMINAL_AGENT_PATH), "utf8");
     expect(chatView).toContain('className="agent-chat-mode-chip"');
+    // 구간 문장은 답변과 같은 마크다운 경로다. italic을 통째로 씌우면 `**굵게**`가 별표로 남고
+    // 문장만 기울어진다 — 기울임은 문법(*강조*)이 질 몫이다.
+    expect(chatView).toContain('className="agent-chat-ledger-note markdown-body"');
+    expect(chat).toContain(".agent-chat .agent-chat-ledger-note.markdown-body");
+    expect(chat).not.toMatch(/\.agent-chat-ledger-note[^{]*\{[^}]*font-style:\s*italic/);
     expect(terminalEntry).toContain('className="agent-chat-mode-chip"');
     // 회신 버튼은 로그 위에 떠 있는 컨트롤이라 신호 채널을 쓰지 않는다 — brass(위치·포커스)만
     // hover/focus에 오르고, 쉬는 상태는 패널 위 한 칸 물러난 면과 hairline이 진다.

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
+
+import { AgentChatView } from "./chat-view.js";
+import type { AgentChatLogState, AgentChatTurn } from "./chat-events.js";
+
+const NOTE = "한 프로토콜로 통일한 뒤 **최신 로스터**를 읽고 `Fable`은 제외합니다.";
+
+let logState: AgentChatLogState;
+
+vi.mock("./chat-store.js", () => ({ useAgentChatStream: () => logState }));
+vi.mock("../api.js", () => ({
+  answerAgentChatAsk: async () => {},
+  stopAgentChatTurn: async () => {},
+  readAgentChatJobDetail: async () => null,
+}));
+vi.mock("@fleet-console/markdown/styles.css", () => ({}));
+vi.mock("./chat.css", () => ({}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function turn(overrides: Partial<AgentChatTurn> = {}): AgentChatTurn {
+  return {
+    dispatch: { text: "go" },
+    items: [
+      { type: "text", text: NOTE },
+      { type: "tool", name: "mcp__fleet__gateway_models", detail: "한 번", state: "ok" },
+    ],
+    state: "working",
+    toolCount: 1,
+    draft: "",
+    startedAt: 1,
+    ...overrides,
+  };
+}
+
+function stateWith(turns: readonly AgentChatTurn[]): AgentChatLogState {
+  return {
+    turns,
+    replaying: false,
+    replayedTurns: 0,
+    errorCode: null,
+    jobs: [],
+  };
+}
+
+beforeEach(() => {
+  logState = stateWith([turn()]);
+  vi.stubGlobal("ResizeObserver", class {
+    observe() { /* noop */ }
+    disconnect() { /* noop */ }
+  });
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 0; });
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.unstubAllGlobals();
+});
+
+function mount(): void {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  const context = {
+    operationId: "op-1",
+    theaterId: "theater-1",
+    pluginId: "terminal",
+    type: "agent",
+    language: "ko",
+    runtimeState: { lifecycle: "live", activity: "running" },
+  } as unknown as OperationRenderContext;
+  act(() => root?.render(createElement(AgentChatView, {
+    context,
+    onOpenTerminal: async () => {},
+    tourAnchors: false,
+  })));
+}
+
+function note(): HTMLElement | null {
+  return container?.querySelector<HTMLElement>(".agent-chat-ledger-note") ?? null;
+}
+
+describe("chat ledger commentary", () => {
+  it("renders a step note as markdown, not as forced italics wrapping raw marks", () => {
+    // 구간 문장은 답변과 같은 마크다운 경로다. italic 일반 텍스트로 그리면 `**굵게**`와
+    // `` `코드` ``가 문법 그대로 남고 문장만 기울어진다 — 스크린샷의 그 결함이다.
+    mount();
+    const el = note();
+    expect(el).not.toBeNull();
+    expect(el?.className).toContain("markdown-body");
+    expect(el?.querySelector("strong")?.textContent).toBe("최신 로스터");
+    expect(el?.querySelector("code")?.textContent).toBe("Fable");
+    expect(el?.textContent ?? "").not.toContain("**");
+    expect(el?.textContent ?? "").not.toContain("`Fable`");
+  });
+
+  it("keeps markdown on a settled turn inside the work fold", () => {
+    // 끝난 턴은 과정을 접는다. 접힘 안에서도 같은 렌더 경로를 타야 한다 — 라이브에서만
+    // 마크다운이고 접힘 안에서는 다시 italic 원문이 되면 같은 문장이 두 얼굴이 된다.
+    // jsdom 의 details 는 닫혀도 자식을 돔에 남긴다. 여기서 묻는 것은 가시성이 아니라 경로다.
+    logState = stateWith([turn({
+      state: "done",
+      durationMs: 74_000,
+      answer: "다모델 판정을 돌리는 중입니다.",
+    })]);
+    mount();
+    const fold = container?.querySelector("details.agent-chat-fold");
+    expect(fold).not.toBeNull();
+    const el = fold?.querySelector<HTMLElement>(".agent-chat-ledger-note") ?? null;
+    expect(el).not.toBeNull();
+    expect(el?.className).toContain("markdown-body");
+    expect(el?.querySelector("strong")?.textContent).toBe("최신 로스터");
+    expect(el?.querySelector("code")?.textContent).toBe("Fable");
+  });
+});

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -667,7 +667,14 @@ function Ledger({
     <div className="agent-chat-ledger">
       {segments.map((segment, index) => (
         <div className="agent-chat-segment" key={index}>
-          {segment.note !== undefined ? <div className="agent-chat-ledger-note">{segment.note}</div> : null}
+          {segment.note !== undefined ? (
+            <StreamedMarkdown
+              className="agent-chat-ledger-note markdown-body"
+              text={segment.note}
+              streaming={false}
+              language={language}
+            />
+          ) : null}
           <Tally groups={segment.groups} folded={segment.folded} language={language} jobsByToolUse={jobsByToolUse} onOpenJob={onOpenJob} />
           {segment.inline.map((item, at) => (item.type === "ask" && item.ask
             ? <AskCard key={`ask-${item.ask.id}`} operationId={operationId} ask={item.ask} language={language} />

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -1,7 +1,7 @@
 /* Chat Mode — Operation 본문의 읽기 전용 지휘 로그.
    색은 전부 테마 토큰이다: 상태는 신호 토큰(aurora/warn/coral/positive)만, 사용자 식별은
    --id-cerulean 워시 문법만 쓴다(단일 화자 표면이라 spine 띠는 두지 않는다 — 우측 정렬이
-   이미 화자를 말한다). 입력창은 없다 — 하단 스트립은 입력 경로 안내다. Answer는 공유
+   이미 화자를 말한다). 입력창은 없다 — 하단 스트립은 입력 경로 안내다. Answer와 구간 문장은 공유
    마크다운 컴포넌트(.markdown-body)로 렌더하고 여기서는 챗 밀도 스케일만 오버라이드한다. */
 
 .agent-chat {
@@ -233,13 +233,26 @@
   margin-top: var(--space-3);
 }
 
-.agent-chat-ledger-note {
-  font-size: 12.5px;
-  font-style: italic;
-  color: var(--text-tertiary);
-  white-space: pre-wrap;
+/* 구간의 문장은 공유 마크다운이 그린다. italic은 문법(*강조*)이 질 몫이지 과정 문장
+   전체에 씌우는 가죽이 아니다 — 강제하면 `**굵게**`가 별표 그대로 남고 문장만 기울어진다.
+   답변보다 한 단 작고 단락 잉크만 한 단 옅게 두어, 과정과 결론이 같은 무게로 읽히지 않게 한다. */
+.agent-chat .agent-chat-ledger-note.markdown-body {
+  --font-size-body: 12.5px;
   overflow-wrap: anywhere;
   padding: var(--space-1) 0;
+}
+
+.agent-chat .agent-chat-ledger-note.markdown-body > :first-child {
+  margin-top: 0;
+}
+
+.agent-chat .agent-chat-ledger-note.markdown-body > :last-child {
+  margin-bottom: 0;
+}
+
+.agent-chat .agent-chat-ledger-note.markdown-body p,
+.agent-chat .agent-chat-ledger-note.markdown-body li {
+  color: var(--text-tertiary);
 }
 
 /* 끝난 일상 스텝의 한 줄 집계 — 도구를 세우지 않고 "무엇을 몇 번 했는가"만 남긴다.


### PR DESCRIPTION
## Summary
- Chat Mode 구간 코멘터리를 italic 강제 원문이 아니라 답변과 같은 마크다운으로 그립니다.
- 과정과 결론의 구분은 크기와 잉크로만 유지하고, 기울임은 마크다운 강조 문법에 맡깁니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run client/agent/chat/chat-ledger-note.test.tsx` — 2 passed
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts` — 65 passed
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [ ] 채팅 뷰에서 도구 호출 전 코멘터리의 `**굵게**`와 `` `코드` ``가 렌더되는지 확인