### PR TITLE
style(fleet-console): put type size and radius on one token vocabulary

### DIFF
--- a/.changelog.d/design-type-scale.md
+++ b/.changelog.d/design-type-scale.md
@@ -1,0 +1,12 @@
+---
+branch: design-type-scale
+---
+
+### fleet-console
+#### Changed
+- Right Rail panels now share one body text size, so switching between Repository, Quota, Skills, Ledger, and Files no longer changes the type you are reading.
+  ko: 우현 레일 패널이 본문 활자 크기를 공유해, 저장소·사용 한도·스킬·원장·파일을 오가도 읽던 글자 크기가 바뀌지 않습니다.
+- Command Band controls now sit on one height, so the local chip, breadcrumb, and mode switch line up on a single baseline.
+  ko: 커맨드 밴드 컨트롤이 한 높이에 서서, 로컬 칩·브레드크럼·모드 스위치가 같은 기준선에 정렬됩니다.
+- Code highlighting in the file preview now uses its own colour channel instead of borrowing the status colours, so a string no longer reads as "complete" or a number as "in progress".
+  ko: 파일 미리보기의 코드 하이라이팅이 상태색을 빌리지 않고 자기 색 채널을 써서, 문자열이 "완료"로 숫자가 "진행 중"으로 읽히지 않습니다.

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -81,7 +81,7 @@ kbd {
   align-items: center;
   gap: var(--space-1);
   padding: var(--space-1) 10px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
   color: var(--text-tertiary);
@@ -121,7 +121,7 @@ kbd {
 
 .nav-tab {
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-body);
@@ -185,7 +185,7 @@ kbd {
   width: 100%;
   padding: 10px 11px;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-primary);
   font-family: inherit;
@@ -223,7 +223,7 @@ kbd {
   color: var(--text-tertiary);
   background: color-mix(in oklch, var(--ink-mid) 70%, transparent);
   border: 1px solid var(--surface-rim);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 2px 7px;
 }
 
@@ -241,7 +241,7 @@ kbd {
   gap: var(--space-2);
   min-width: 0;
   padding: 9px 10px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-size: var(--font-size-md);
   letter-spacing: -0.005em;
@@ -395,7 +395,7 @@ kbd {
 .workspace-path {
   margin: 0;
   padding: 6px 12px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--surface-rim);
   background: color-mix(in oklch, var(--ink-deep) 60%, transparent);
   color: var(--text-secondary);
@@ -498,7 +498,7 @@ kbd {
   width: 6px;
   height: 6px;
   margin-right: var(--space-2);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--brass);
   box-shadow: 0 0 10px var(--brass-glow);
   vertical-align: 0.08em;
@@ -576,7 +576,7 @@ kbd {
 .manifest-card,
 .toc-panel {
   padding: var(--space-6);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
   box-shadow: var(--shadow-soft);
@@ -648,7 +648,7 @@ kbd {
   height: 18px;
   flex: 0 0 auto;
   margin-top: 2px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid color-mix(in oklch, var(--brass) 45%, transparent);
   background: color-mix(in oklch, var(--ink-deep) 64%, transparent);
 }
@@ -660,7 +660,7 @@ kbd {
   inset: 50% auto auto 50%;
   width: 8px;
   height: 1px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--brass-bright);
   transform: translate(-50%, -50%);
 }
@@ -822,7 +822,7 @@ kbd {
 .command-card {
   width: min(1080px, 100%);
   padding: var(--space-3);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-rim-strong);
   background: var(--surface-pillar);
   box-shadow: var(--shadow-floating);
@@ -1099,14 +1099,14 @@ kbd {
 .raw-divider {
   height: 2px;
   width: 96px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: linear-gradient(90deg, var(--brass) 0, var(--aurora) 60%, transparent);
 }
 
 .raw-document {
   position: relative;
   padding: clamp(28px, 4vw, 48px);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
   box-shadow: var(--shadow-soft);
@@ -1158,7 +1158,7 @@ kbd {
   justify-content: center;
   width: 32px;
   height: 32px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--surface-rim);
   background: color-mix(in oklch, var(--ink-deep) 70%, transparent);
   color: var(--text-tertiary);
@@ -1192,7 +1192,7 @@ kbd {
   align-items: center;
   gap: var(--space-2);
   padding: 9px 10px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-size: var(--font-size-md);
   letter-spacing: -0.005em;
@@ -1252,7 +1252,7 @@ kbd {
   min-width: 18px;
   height: 18px;
   padding: 0 5px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--brass) 18%, transparent);
   border: 1px solid color-mix(in oklch, var(--brass) 40%, transparent);
   color: var(--brass-bright);
@@ -1270,7 +1270,7 @@ kbd {
   align-items: center;
   gap: 5px;
   padding: 4px 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   border: 1px solid color-mix(in oklch, var(--brass) 35%, transparent);
   color: var(--brass-bright);
@@ -1342,7 +1342,7 @@ kbd {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   padding: 7px 14px;
   color: var(--text-tertiary);
   font-family: var(--font-body);
@@ -1373,7 +1373,7 @@ kbd {
   min-width: 18px;
   height: 18px;
   padding: 0 5px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--brass) 18%, transparent);
   border: 1px solid color-mix(in oklch, var(--brass) 40%, transparent);
   color: var(--brass-bright);
@@ -1483,7 +1483,7 @@ kbd {
   display: grid;
   gap: var(--space-3);
   padding: var(--space-4) var(--space-5);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: var(--surface-glass);
   border: 1px solid transparent;
   box-shadow: var(--shadow-soft);
@@ -1649,7 +1649,7 @@ kbd {
   flex-direction: column;
   gap: var(--space-4);
   padding: var(--space-5);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
   box-shadow: var(--shadow-soft);
@@ -2086,7 +2086,7 @@ kbd {
 .conflict-section {
   margin-top: var(--space-5);
   padding: var(--space-5);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
   box-shadow: var(--shadow-soft);
@@ -2170,7 +2170,7 @@ kbd {
   outline: none;
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   padding: 0;
 }
 
@@ -2192,10 +2192,10 @@ kbd {
   padding: var(--space-1) var(--space-2);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   cursor: pointer;
   transition: background var(--duration-base) var(--ease-spring);
 }
@@ -2215,7 +2215,7 @@ kbd {
   background: color-mix(in oklch, var(--brass) 20%, transparent);
   border-radius: 8px;
   color: var(--brass-bright);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   line-height: 1;
 }
@@ -2231,7 +2231,7 @@ kbd {
   background: color-mix(in oklch, var(--warn) 5%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: var(--t-2xs);
   line-height: 1.35;
 }
 
@@ -2243,7 +2243,7 @@ kbd {
   width: 6px;
   height: 6px;
   flex: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--warn);
   box-shadow: 0 0 8px color-mix(in oklch, var(--warn) 45%, transparent);
 }
@@ -2334,7 +2334,7 @@ kbd {
 
 .codex-nav-list-eyebrow {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2349,7 +2349,7 @@ kbd {
   gap: 2px;
   padding: 2px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-glass);
 }
 
@@ -2360,7 +2360,7 @@ kbd {
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: var(--t-2xs);
   cursor: pointer;
 }
 
@@ -2421,7 +2421,7 @@ kbd {
   background: transparent;
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2439,7 +2439,7 @@ kbd {
   overflow: hidden;
   color: var(--text-tertiary);
   font-family: var(--font-body);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   line-height: 1.4;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
@@ -2448,7 +2448,7 @@ kbd {
 
 .codex-nav-entry .meta {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   color: var(--text-tertiary);
   white-space: nowrap;
   overflow: hidden;
@@ -2468,10 +2468,10 @@ kbd {
   padding: 1px var(--space-1);
   background: transparent;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.04em;
   cursor: pointer;
 }
@@ -2497,7 +2497,7 @@ kbd {
 .codex-nav-empty {
   padding: var(--space-4) var(--space-3);
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   text-align: center;
 }
@@ -2530,10 +2530,10 @@ kbd {
 .cowork-ghost,
 .cowork-solid {
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   cursor: pointer;
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   padding: var(--space-1) var(--space-3);
   transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
@@ -2563,13 +2563,13 @@ kbd {
   align-items: center;
   gap: var(--space-1);
   border: 1px solid color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-veil) 96%, var(--brass));
   box-shadow: 0 2px 6px color-mix(in oklch, var(--ink-abyss) 45%, transparent), 0 12px 32px -8px color-mix(in oklch, var(--ink-abyss) 80%, transparent);
   color: var(--text-primary);
   cursor: pointer;
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   padding: var(--space-1) var(--space-3);
   user-select: none;
@@ -2585,7 +2585,7 @@ kbd {
   gap: var(--space-2);
   width: min(340px, 86%);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-veil) 97%, var(--ink-deep));
   box-shadow: 0 2px 8px color-mix(in oklch, var(--ink-abyss) 50%, transparent), 0 24px 48px -12px color-mix(in oklch, var(--ink-abyss) 85%, transparent);
   padding: var(--space-3);
@@ -2637,7 +2637,7 @@ kbd {
   width: min(560px, 100%);
   overflow: hidden;
   border: 1px solid color-mix(in oklch, var(--aurora) 34%, var(--surface-rim));
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-veil) 94%, var(--ink-deep));
   box-shadow: 0 22px 46px -24px color-mix(in oklch, var(--ink-abyss) 88%, transparent);
 }
@@ -2692,12 +2692,12 @@ kbd {
 .cowork-revision-output.markdown-body p { margin-bottom: var(--space-3); }
 .cowork-revision-output.markdown-body :is(ul, ol) { margin-bottom: var(--space-3); padding-left: var(--space-5); }
 .cowork-revision-output.markdown-body li + li { margin-top: var(--space-1); }
-.cowork-revision-output.markdown-body table { margin-block: var(--space-3); font-size: 10px; }
+.cowork-revision-output.markdown-body table { margin-block: var(--space-3); font-size: var(--t-2xs); }
 .cowork-revision-output.markdown-body table :is(th, td) { padding: var(--space-2) var(--space-3); }
 .cowork-revision-output.markdown-body :is(blockquote, .code-block, .diagram-block) { margin-block: var(--space-3); }
 .cowork-revision-output.markdown-body blockquote { padding: var(--space-2) var(--space-3); }
 .cowork-revision-output.markdown-body .code-block code { padding: var(--space-3); }
-.cowork-revision-output.markdown-body .copy-code { font-size: 12px; }
+.cowork-revision-output.markdown-body .copy-code { font-size: var(--t-sm); }
 .cowork-revision-output::before { content: "✳"; position: absolute; left: 1px; top: 1px; color: var(--aurora-ink); }
 .cowork-revision-status { display: flex; align-items: center; gap: var(--space-2); border-top: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--aurora) 5%, var(--ink-deep)); padding: var(--space-2) var(--space-3); }
 .cowork-revision-status i { position: relative; width: 16px; height: 16px; flex: none; border: 1px solid var(--aurora); border-radius: 50%; animation: cowork-revision-pulse 1.4s var(--ease-glide) infinite; }
@@ -2713,7 +2713,7 @@ kbd {
   gap: var(--space-1);
   width: min(560px, 100%);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-veil) 97%, var(--ink-deep));
   box-shadow: 0 2px 8px color-mix(in oklch, var(--ink-abyss) 50%, transparent), 0 20px 48px -12px color-mix(in oklch, var(--ink-abyss) 85%, transparent);
   overflow: hidden;
@@ -2738,12 +2738,12 @@ kbd {
   align-items: center;
   gap: var(--space-1);
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   padding: var(--space-1) var(--space-2);
   transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
@@ -2773,7 +2773,7 @@ kbd {
   display: grid;
   place-items: center;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--brass);
   color: var(--text-on-brass);
   cursor: pointer;
@@ -2792,11 +2792,11 @@ kbd {
   align-items: center;
   gap: var(--space-2);
   border: 1px solid color-mix(in oklch, var(--brass) 35%, var(--surface-rim));
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--ink-veil) 94%, var(--brass));
   box-shadow: 0 12px 32px -10px color-mix(in oklch, var(--ink-abyss) 80%, transparent);
   color: var(--text-primary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   padding: var(--space-1) var(--space-1) var(--space-1) var(--space-3);
 }
 .cowork-review-count { display: inline-flex; align-items: center; gap: var(--space-1); font-weight: var(--weight-medium); }
@@ -2810,7 +2810,7 @@ kbd {
   max-height: 320px;
   overflow: auto;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-veil) 97%, var(--ink-deep));
   box-shadow: 0 24px 48px -12px color-mix(in oklch, var(--ink-abyss) 85%, transparent);
   padding: var(--space-2);
@@ -2839,7 +2839,7 @@ kbd {
 }
 .cowork-card textarea {
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-abyss) 78%, transparent);
   color: var(--text-primary);
   font: inherit;
@@ -2867,7 +2867,7 @@ kbd {
   gap: var(--space-2);
   min-width: 224px;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
@@ -2903,7 +2903,7 @@ kbd {
   left: calc(100% + var(--space-2));
   width: max-content;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-veil) 97%, var(--ink-deep));
   box-shadow: 0 24px 48px -12px color-mix(in oklch, var(--ink-abyss) 85%, transparent);
   padding: var(--space-2) var(--space-3);
@@ -2922,7 +2922,7 @@ kbd {
   gap: var(--space-2);
   width: min(560px, 100%);
   border: 1px solid color-mix(in oklch, var(--aurora) 28%, var(--surface-rim));
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-veil) 96%, var(--aurora));
   box-shadow: 0 16px 40px -12px color-mix(in oklch, var(--ink-abyss) 80%, transparent);
   color: var(--text-primary);

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -10876,7 +10876,9 @@ body[data-codex-side="true"] .command-card {
   margin: 0;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: clamp(20px, 2vw, 28px);
+  /* 반응형 제목의 하한은 사다리 최상단(--t-xl)이다 — 좁은 화면에서만 서는 값이라고 사다리
+     밖에 두면, 그 화면에서는 제목만 어휘를 벗어난 크기로 선다. 상한은 디스플레이 영역이다. */
+  font-size: clamp(var(--t-xl), 2vw, 28px);
   font-weight: var(--weight-medium);
   letter-spacing: 0;
   line-height: 1.05;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6,7 +6,7 @@
 }
 
 .stage {
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
 }
 
 
@@ -74,10 +74,10 @@
 /* Shared button variants — controls use compact radii; brass marks hover/focus location and coral remains danger-only. */
 .fc-btn {
   font-family: var(--font-body);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   padding: 8px 14px;
   cursor: pointer;
   transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
@@ -162,7 +162,7 @@
   min-height: 16px;
   color: var(--aurora-ink);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -186,7 +186,7 @@
   overflow-y: auto;
   padding: 8px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--surface-glass);
   box-shadow: var(--shadow-soft);
 }
@@ -231,7 +231,7 @@
   overflow: hidden;
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 20px;
+  font-size: var(--t-xl);
   font-weight: var(--weight-regular);
   letter-spacing: -0.01em;
   text-overflow: ellipsis;
@@ -248,7 +248,7 @@
   overflow: hidden;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.08em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -264,7 +264,7 @@
   padding: 0 var(--space-2);
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -284,7 +284,7 @@
   padding: 0 var(--space-3);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -303,7 +303,7 @@
   gap: var(--space-5);
   padding: var(--space-6);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--surface-glass);
   box-shadow: var(--shadow-soft);
 }
@@ -360,7 +360,7 @@
   margin: 0;
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -370,7 +370,7 @@
   margin: 0;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.6;
 }
 
@@ -386,7 +386,7 @@
   border-top: 1px solid color-mix(in oklch, var(--surface-rim) 40%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.55;
 }
 
@@ -399,14 +399,14 @@
   border-bottom: 1px solid color-mix(in oklch, var(--coral) 48%, var(--surface-rim));
   background: color-mix(in oklch, var(--coral) 10%, transparent);
   color: var(--coral-ink);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .operations-mutation-retry {
   border: 1px solid color-mix(in oklch, var(--coral) 40%, var(--surface-rim));
   background: transparent;
   color: var(--coral-ink);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   padding: 2px 8px;
 }
 
@@ -418,7 +418,7 @@
   background: color-mix(in oklch, var(--coral) 10%, transparent);
   color: var(--coral-ink);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.5;
 }
 
@@ -437,7 +437,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   white-space: nowrap;
   transition:
@@ -521,7 +521,7 @@
 .console-port-input-label {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -532,11 +532,11 @@
   min-height: 38px;
   padding: 8px var(--space-3);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 86%, transparent);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 14px;
+  font-size: var(--t-base);
   letter-spacing: 0.04em;
   transition:
     border-color var(--duration-fast) var(--ease-spring),
@@ -566,7 +566,7 @@
 .console-port-hint {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.03em;
 }
 
@@ -602,7 +602,7 @@
   margin: 0;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -612,7 +612,7 @@
   margin: 0;
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--t-md);
   letter-spacing: 0.04em;
 }
 
@@ -631,7 +631,7 @@
   background: var(--warn-glow);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.6;
 }
 
@@ -644,7 +644,7 @@
   margin: 0;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.55;
 }
 
@@ -665,7 +665,7 @@
 .remote-access-fingerprint-label {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -675,7 +675,7 @@
   overflow-wrap: anywhere;
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
 }
 
@@ -690,11 +690,11 @@
   min-height: 34px;
   padding: 0 var(--space-4);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 78%, transparent);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   letter-spacing: 0.04em;
 }
 
@@ -718,18 +718,18 @@
   flex: 1 1 auto;
   min-width: 0;
   max-width: none;
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .remote-access-link-field button {
   flex: none;
   padding: 0 var(--space-3);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 78%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -754,7 +754,7 @@
   border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   transition: background var(--duration-fast) var(--ease-spring), border-color var(--duration-fast) var(--ease-spring), color var(--duration-fast) var(--ease-spring);
 }
 
@@ -806,7 +806,7 @@
   padding: var(--space-2) var(--space-3) var(--space-1);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -818,7 +818,7 @@
   gap: var(--space-3);
   padding: var(--space-2) var(--space-3);
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--text-secondary);
   font: inherit;
@@ -844,7 +844,7 @@
   border-radius: var(--radius-pill);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   white-space: nowrap;
 }
@@ -864,7 +864,7 @@
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--warn) 34%, transparent);
   color: var(--warn-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -873,9 +873,9 @@
 }
 
 .host-switcher-entry { display: flex; min-width: 0; flex-direction: column; }
-.host-switcher-entry small { color: var(--text-tertiary); font-family: var(--font-mono); font-size: 11px; }
+.host-switcher-entry small { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }
 .host-switcher-divider { height: 1px; margin: var(--space-2) var(--space-3); background: var(--surface-rim); }
-.host-switcher-link { color: var(--aurora-ink); font-size: 13px; }
+.host-switcher-link { color: var(--aurora-ink); font-size: var(--t-md); }
 
 /* ── 집이 펼친 호스트 목록 표면 ────────────────────────────────────────
    원격 콘솔을 보고 있을 때 목록은 집이 그려 이 위에 얹힌다. 판 자체는 위와 같은 문법을 쓰고,
@@ -933,7 +933,7 @@
   width: min(520px, 94vw);
   padding: var(--space-5);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 팝업 판독성 계약: glass 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
@@ -948,7 +948,7 @@
   margin: 0;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 19px;
+  font-size: var(--t-xl);
   font-weight: var(--weight-medium);
   line-height: 1.2;
 }
@@ -960,7 +960,7 @@
   height: 28px;
   place-items: center;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--text-tertiary);
   font-size: 16px;
@@ -973,7 +973,7 @@
   color: var(--brass-bright);
 }
 
-.add-host-lede { margin: 0; color: var(--text-secondary); font-size: 12.5px; line-height: 1.55; }
+.add-host-lede { margin: 0; color: var(--text-secondary); font-size: var(--t-md); line-height: 1.55; }
 
 .add-host-field { display: flex; flex-direction: column; gap: var(--space-3); }
 
@@ -982,11 +982,11 @@
   min-height: 40px;
   padding: 8px var(--space-3);
   border: 1px solid color-mix(in oklch, var(--brass) 45%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-abyss) 70%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .add-host-field input::placeholder { color: var(--text-tertiary); }
@@ -999,11 +999,11 @@
   min-height: 32px;
   padding: 0 var(--space-4);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 78%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 /* 링크를 실제로 붙이는 버튼만 채워진 brass다 — 한 장에 주 동작은 하나다. */
@@ -1016,8 +1016,8 @@
 .add-host-cancel:hover, .add-host-submit:hover:not(:disabled) { border-color: color-mix(in oklch, var(--brass) 46%, var(--surface-rim)); }
 .add-host-submit:disabled { cursor: not-allowed; opacity: 0.55; }
 
-.add-host-error { margin: 0; color: var(--coral-ink); font-size: 12.5px; line-height: 1.55; }
-.add-host-note { margin: 0; color: var(--text-tertiary); font-size: 11.5px; line-height: 1.55; }
+.add-host-error { margin: 0; color: var(--coral-ink); font-size: var(--t-md); line-height: 1.55; }
+.add-host-note { margin: 0; color: var(--text-tertiary); font-size: var(--t-sm); line-height: 1.55; }
 
 @media (prefers-reduced-motion: reduce) {
   .add-host-card { animation: none; }
@@ -1055,7 +1055,7 @@
   padding: var(--space-5);
   overflow-y: auto;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 팝업 판독성 계약: glass 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
@@ -1070,7 +1070,7 @@
   margin: 0;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 19px;
+  font-size: var(--t-xl);
   font-weight: var(--weight-medium);
   line-height: 1.2;
 }
@@ -1082,7 +1082,7 @@
   height: 28px;
   place-items: center;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--text-tertiary);
   font-size: 16px;
@@ -1103,7 +1103,7 @@
   margin: 0;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   letter-spacing: 0.06em;
 }
 
@@ -1113,7 +1113,7 @@
 .qr-plate {
   display: grid;
   place-items: center;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--qr-field);
 }
 
@@ -1129,11 +1129,11 @@
   grid-template-columns: 18px minmax(0, 1fr);
   gap: var(--space-2);
   color: var(--text-secondary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   line-height: 1.55;
 }
 
-.pair-step-index { color: var(--brass); font-family: var(--font-mono); font-size: 11px; }
+.pair-step-index { color: var(--brass); font-family: var(--font-mono); font-size: var(--t-xs); }
 
 .pair-expiry { display: flex; flex-direction: column; gap: var(--space-2); }
 .pair-expiry-row { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3); }
@@ -1141,7 +1141,7 @@
 .pair-expiry-label {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -1149,7 +1149,7 @@
 .pair-expiry-time {
   color: var(--brass);
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-variant-numeric: tabular-nums;
 }
 
@@ -1167,9 +1167,9 @@
   margin: 0;
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1.5;
 }
 
@@ -1185,7 +1185,7 @@
   color: var(--coral-ink);
 }
 
-.pair-warning { margin: 0; color: var(--text-tertiary); font-size: 11.5px; line-height: 1.55; }
+.pair-warning { margin: 0; color: var(--text-tertiary); font-size: var(--t-sm); line-height: 1.55; }
 
 .pair-fallback { display: flex; flex-direction: column; gap: var(--space-2); }
 
@@ -1193,11 +1193,11 @@
   align-self: flex-start;
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide);
 }
 
@@ -1210,22 +1210,22 @@
   min-width: 0;
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-abyss) 70%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .pair-link-field button {
   flex: none;
   padding: var(--space-2) var(--space-4);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide);
 }
 
@@ -1243,7 +1243,7 @@
 .remote-section-head h3 {
   margin: 0;
   color: var(--text-primary);
-  font-size: 19px;
+  font-size: var(--t-xl);
   font-weight: var(--weight-bold);
   letter-spacing: -0.01em;
 }
@@ -1251,7 +1251,7 @@
 .remote-section-head p {
   margin: var(--space-2) 0 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--t-md);
   line-height: 1.55;
 }
 
@@ -1267,7 +1267,7 @@
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--positive) 10%, transparent);
   color: var(--text-secondary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   line-height: 1.6;
 }
 
@@ -1290,7 +1290,7 @@
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--coral) 10%, transparent);
   color: var(--text-secondary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   line-height: 1.6;
 }
 
@@ -1308,9 +1308,9 @@
 }
 
 .remote-card-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-4); }
-.remote-card-title { margin: 0; color: var(--text-primary); font-size: 15px; font-weight: var(--weight-bold); }
-.remote-card-help { margin: 0; color: var(--text-secondary); font-size: 12.5px; line-height: 1.55; }
-.remote-card-alert { margin: 0; color: var(--warn-ink); font-family: var(--font-mono); font-size: 11.5px; }
+.remote-card-title { margin: 0; color: var(--text-primary); font-size: var(--t-lg); font-weight: var(--weight-bold); }
+.remote-card-help { margin: 0; color: var(--text-secondary); font-size: var(--t-md); line-height: 1.55; }
+.remote-card-alert { margin: 0; color: var(--warn-ink); font-family: var(--font-mono); font-size: var(--t-sm); }
 
 /* 켜고 끄는 스위치는 상태 하나만 말한다 — 세그먼트 두 칸보다 이쪽이 시안의 문법이다. */
 .remote-switch {
@@ -1341,13 +1341,13 @@
 .remote-endpoint-grid { display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--space-3); }
 .remote-public-endpoint-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-4); padding-top: var(--space-3); border-top: 1px solid var(--surface-rim); }
 .remote-listen-address-control { display: flex; flex-direction: column; gap: var(--space-2); min-width: 0; }
-.remote-field { display: flex; flex-direction: column; gap: var(--space-2); color: var(--text-secondary); font-size: 12px; }
-.remote-field-legend { margin: 0; color: var(--text-secondary); font-size: 12px; }
-.remote-requirements { margin: 0; padding-left: 18px; color: var(--text-secondary); font-size: 12.5px; line-height: 1.6; }
+.remote-field { display: flex; flex-direction: column; gap: var(--space-2); color: var(--text-secondary); font-size: var(--t-sm); }
+.remote-field-legend { margin: 0; color: var(--text-secondary); font-size: var(--t-sm); }
+.remote-requirements { margin: 0; padding-left: 18px; color: var(--text-secondary); font-size: var(--t-md); line-height: 1.6; }
 /* 트랙 폭이 같아야 인터페이스 이름 길이에 따라 줄이 들쭉날쭉해지지 않는다. */
 .remote-interface-presets { display: grid; grid-template-columns: repeat(auto-fit, minmax(196px, 1fr)); gap: var(--space-2); }
-.remote-interface-preset { display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-1); min-width: 0; padding: var(--space-2) var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: color-mix(in oklch, var(--ink-abyss) 32%, transparent); color: var(--text-secondary); text-align: left; }
-.remote-interface-preset code { color: var(--text-primary); font-family: var(--font-mono); font-size: 11.5px; overflow-wrap: anywhere; }
+.remote-interface-preset { display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-1); min-width: 0; padding: var(--space-2) var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 32%, transparent); color: var(--text-secondary); text-align: left; }
+.remote-interface-preset code { color: var(--text-primary); font-family: var(--font-mono); font-size: var(--t-sm); overflow-wrap: anywhere; }
 .remote-interface-preset:hover, .remote-interface-preset.is-selected { border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); background: color-mix(in oklch, var(--brass) 10%, transparent); }
 .remote-interface-preset.is-selected { box-shadow: inset 3px 0 0 var(--brass); }
 .remote-field input, .remote-port-control input[type="number"] {
@@ -1355,7 +1355,7 @@
   min-height: 36px;
   padding: 7px var(--space-3);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-abyss) 48%, transparent);
   color: var(--text-primary);
   font-family: var(--font-mono);
@@ -1363,55 +1363,55 @@
 .remote-field input[aria-invalid="true"], .remote-port-control input[aria-invalid="true"] { border-color: color-mix(in oklch, var(--coral) 55%, var(--surface-rim-strong)); }
 
 /* 내용 높이만 차지한다 — 이웃 칸을 따라 늘어나지 않으므로 legend와 컨트롤이 붙어 있다. */
-.remote-port-control { display: flex; flex-direction: column; gap: var(--space-2); align-self: start; margin: 0; padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); }
-.remote-port-control legend { padding: 0 var(--space-1); color: var(--text-secondary); font-size: 12px; }
-.remote-port-control label { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--text-secondary); font-size: 12px; }
+.remote-port-control { display: flex; flex-direction: column; gap: var(--space-2); align-self: start; margin: 0; padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); }
+.remote-port-control legend { padding: 0 var(--space-1); color: var(--text-secondary); font-size: var(--t-sm); }
+.remote-port-control label { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--text-secondary); font-size: var(--t-sm); }
 .remote-port-control input[type="radio"], .remote-acknowledgment input { accent-color: var(--brass); }
 .remote-port-control input[type="number"] { width: 110px; }
 .remote-port-modes { display: flex; flex-wrap: wrap; gap: var(--space-3); }
 .remote-port-value { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
-.remote-port-auto { color: var(--text-primary); font-family: var(--font-mono); font-size: 12.5px; }
-.remote-port-error { margin: 0; color: var(--coral-ink); font-size: 11.5px; }
+.remote-port-auto { color: var(--text-primary); font-family: var(--font-mono); font-size: var(--t-md); }
+.remote-port-error { margin: 0; color: var(--coral-ink); font-size: var(--t-sm); }
 
 /* 경로는 이 카드에서 한 번만 그린다. 두 곳에서 그리면 같은 값이 두 서식으로 어긋난다. */
-.remote-route-preview { display: flex; flex-direction: column; gap: var(--space-1); margin: 0; padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: color-mix(in oklch, var(--ink-abyss) 30%, transparent); color: var(--text-secondary); font-size: 12px; }
-.remote-route-caption { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: var(--space-2); margin: 0 0 var(--space-1); color: var(--text-primary); font-size: 12.5px; font-weight: var(--weight-bold); }
-.remote-route-caption span { color: var(--text-secondary); font-family: var(--font-mono); font-size: 10.5px; font-weight: var(--weight-regular); letter-spacing: 0.12em; text-transform: uppercase; }
+.remote-route-preview { display: flex; flex-direction: column; gap: var(--space-1); margin: 0; padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 30%, transparent); color: var(--text-secondary); font-size: var(--t-sm); }
+.remote-route-caption { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: var(--space-2); margin: 0 0 var(--space-1); color: var(--text-primary); font-size: var(--t-md); font-weight: var(--weight-bold); }
+.remote-route-caption span { color: var(--text-secondary); font-family: var(--font-mono); font-size: var(--t-xs); font-weight: var(--weight-regular); letter-spacing: 0.12em; text-transform: uppercase; }
 .remote-route-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-2); margin: 0; }
-.remote-route-row span { flex: none; font-size: 11.5px; }
-.remote-route-preview code { color: var(--aurora-ink); font-family: var(--font-mono); font-size: 12.5px; overflow-wrap: anywhere; }
+.remote-route-row span { flex: none; font-size: var(--t-sm); }
+.remote-route-preview code { color: var(--aurora-ink); font-family: var(--font-mono); font-size: var(--t-md); overflow-wrap: anywhere; }
 
 /* 라우터 설정 화면의 칸 이름과 값을 1:1로 세운다 — 산문으로 풀면 외부·내부 포트를 같은 값으로 넣게 된다. */
-.remote-forward-rule { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: color-mix(in oklch, var(--ink-abyss) 30%, transparent); }
-.remote-forward-rule-title { margin: 0; color: var(--text-primary); font-size: 12.5px; font-weight: var(--weight-bold); }
+.remote-forward-rule { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 30%, transparent); }
+.remote-forward-rule-title { margin: 0; color: var(--text-primary); font-size: var(--t-md); font-weight: var(--weight-bold); }
 .remote-forward-rule dl { display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: var(--space-1) var(--space-3); margin: 0; }
 .remote-forward-rule dl > div { display: contents; }
-.remote-forward-rule dt { color: var(--text-secondary); font-size: 12px; }
+.remote-forward-rule dt { color: var(--text-secondary); font-size: var(--t-sm); }
 .remote-forward-rule dd { margin: 0; min-width: 0; }
-.remote-forward-rule dd code { color: var(--aurora-ink); font-family: var(--font-mono); font-size: 12.5px; overflow-wrap: anywhere; }
-.remote-forward-rule-note { margin: 0; color: var(--warn-ink); font-size: 11.5px; }
+.remote-forward-rule dd code { color: var(--aurora-ink); font-family: var(--font-mono); font-size: var(--t-md); overflow-wrap: anywhere; }
+.remote-forward-rule-note { margin: 0; color: var(--warn-ink); font-size: var(--t-sm); }
 
-.remote-acknowledgment { display: flex; align-items: flex-start; gap: var(--space-2); padding: var(--space-3); border: 1px solid color-mix(in oklch, var(--coral) 35%, transparent); border-radius: var(--radius-sm); background: color-mix(in oklch, var(--coral) 8%, transparent); color: var(--text-secondary); font-size: 12px; line-height: 1.5; }
-.remote-status-note { margin: 0; color: var(--text-secondary); font-size: 12px; }
+.remote-acknowledgment { display: flex; align-items: flex-start; gap: var(--space-2); padding: var(--space-3); border: 1px solid color-mix(in oklch, var(--coral) 35%, transparent); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--coral) 8%, transparent); color: var(--text-secondary); font-size: var(--t-sm); line-height: 1.5; }
+.remote-status-note { margin: 0; color: var(--text-secondary); font-size: var(--t-sm); }
 .remote-status-note strong { color: var(--text-primary); }
 
 /* 설정이 갖춰졌는지와 리스너가 살아 있는지는 다른 사실이라 색이 아니라 상태로 갈린다. */
-.remote-lozenge { flex: none; padding: 3px var(--space-3); border: 1px solid var(--surface-rim-strong); border-radius: 999px; color: var(--text-secondary); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; white-space: nowrap; }
+.remote-lozenge { flex: none; padding: 3px var(--space-3); border: 1px solid var(--surface-rim-strong); border-radius: var(--radius-pill); color: var(--text-secondary); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: 0.12em; text-transform: uppercase; white-space: nowrap; }
 .remote-lozenge[data-remote-state="listening"] { border-color: color-mix(in oklch, var(--positive) 55%, transparent); background: color-mix(in oklch, var(--positive) 10%, transparent); color: var(--positive-ink); }
 .remote-lozenge[data-remote-state="failed"] { border-color: color-mix(in oklch, var(--coral) 55%, transparent); background: color-mix(in oklch, var(--coral) 10%, transparent); color: var(--coral-ink); }
 
-.remote-stale { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3); border: 1px solid color-mix(in oklch, var(--warn) 45%, transparent); border-radius: var(--radius-sm); background: var(--warn-glow); color: var(--warn-ink); font-size: 12px; }
+.remote-stale { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3); border: 1px solid color-mix(in oklch, var(--warn) 45%, transparent); border-radius: var(--radius-xs); background: var(--warn-glow); color: var(--warn-ink); font-size: var(--t-sm); }
 
 /* 적용이 무엇을 끊는지 먼저 말한다. 재시작과 신원 교체는 잃는 것이 달라 한 색으로 덮지 않는다. */
-.remote-consequence { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); color: var(--text-secondary); font-size: 12px; line-height: 1.55; }
+.remote-consequence { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); color: var(--text-secondary); font-size: var(--t-sm); line-height: 1.55; }
 .remote-consequence p { margin: 0; }
-.remote-consequence-title { color: var(--text-primary); font-size: 12.5px; font-weight: var(--weight-bold); }
+.remote-consequence-title { color: var(--text-primary); font-size: var(--t-md); font-weight: var(--weight-bold); }
 .remote-consequence-actions { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-1); }
 .remote-consequence.is-restart { border-color: color-mix(in oklch, var(--warn) 45%, transparent); background: var(--warn-glow); }
 .remote-consequence.is-identity, .remote-consequence.is-stop { border-color: color-mix(in oklch, var(--coral) 45%, transparent); background: color-mix(in oklch, var(--coral) 8%, transparent); }
 
 .remote-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--surface-rim); }
-.remote-actions-note { min-width: 0; color: var(--text-secondary); font-size: 12px; }
+.remote-actions-note { min-width: 0; color: var(--text-secondary); font-size: var(--t-sm); }
 .remote-actions-buttons { display: flex; flex-wrap: wrap; gap: var(--space-2); }
 .remote-create.is-quiet { border-color: var(--surface-rim-strong); background: transparent; color: var(--text-primary); }
 .remote-create.is-quiet:hover:not(:disabled) { border-color: color-mix(in oklch, var(--brass) 55%, transparent); }
@@ -1421,7 +1421,7 @@
   overflow-wrap: anywhere;
   color: var(--aurora-ink);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1.7;
   letter-spacing: 0.06em;
 }
@@ -1431,11 +1431,11 @@
   min-height: 32px;
   padding: 0 var(--space-4);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 78%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .remote-create { border-color: color-mix(in oklch, var(--brass) 55%, transparent); background: color-mix(in oklch, var(--brass) 16%, transparent); color: var(--brass-bright); }
@@ -1449,27 +1449,27 @@
   min-height: 38px;
   padding: 8px var(--space-3);
   border: 1px solid color-mix(in oklch, var(--brass) 45%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-abyss) 70%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .remote-link-field button {
   flex: none;
   padding: 0 var(--space-3);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 78%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 /* 다른 콘솔 목록 — 고르는 것은 연결 방식이 아니라 콘솔이므로 각 줄이 하나의 호스트다. */
 .remote-hosts { display: flex; flex-direction: column; gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
-.remote-hosts-empty { margin: 0; color: var(--text-tertiary); font-size: 12.5px; }
+.remote-hosts-empty { margin: 0; color: var(--text-tertiary); font-size: var(--t-md); }
 
 .remote-host {
   display: grid;
@@ -1478,7 +1478,7 @@
   gap: var(--space-3);
   padding: var(--space-3);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 55%, transparent);
 }
 
@@ -1493,34 +1493,34 @@
   background: none;
   color: var(--text-primary);
   font: inherit;
-  font-size: 13.5px;
+  font-size: var(--t-base);
 }
 
 .remote-host-name:focus { outline: 1px solid color-mix(in oklch, var(--brass) 55%, transparent); outline-offset: 3px; }
-.remote-host-text small { color: var(--text-tertiary); font-family: var(--font-mono); font-size: 11px; }
+.remote-host-text small { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }
 
 .remote-host-open {
   padding: 4px var(--space-3);
   border: 1px solid color-mix(in oklch, var(--brass) 50%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--brass) 14%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .remote-host-open:disabled { cursor: not-allowed; opacity: 0.5; }
 
-.remote-monitoring { display: flex; align-items: center; gap: var(--space-3); color: var(--text-secondary); font-size: 12.5px; }
+.remote-monitoring { display: flex; align-items: center; gap: var(--space-3); color: var(--text-secondary); font-size: var(--t-md); }
 .remote-monitoring input { accent-color: var(--brass); }
 
-.remote-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.remote-table { width: 100%; border-collapse: collapse; font-size: var(--t-md); }
 .remote-table th {
   padding: 0 0 var(--space-2);
   border-bottom: 1px solid var(--surface-rim);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-align: left;
@@ -1528,7 +1528,7 @@
 }
 
 .remote-table td { padding: var(--space-3) 0; border-bottom: 1px solid color-mix(in oklch, var(--surface-rim) 55%, transparent); color: var(--text-primary); }
-.remote-table td:nth-child(3) { color: var(--text-secondary); font-family: var(--font-mono); font-size: 11.5px; }
+.remote-table td:nth-child(3) { color: var(--text-secondary); font-family: var(--font-mono); font-size: var(--t-sm); }
 .remote-table td:last-child { text-align: right; }
 .remote-table-empty { color: var(--text-tertiary); }
 
@@ -1539,7 +1539,7 @@
   border-radius: var(--radius-pill);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
 }
 
@@ -1550,7 +1550,7 @@
   background: none;
   color: var(--coral-ink);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .remote-revoke:disabled { cursor: not-allowed; opacity: 0.5; }
@@ -1566,7 +1566,7 @@
   background: none;
   color: var(--text-secondary);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .remote-disconnect:disabled { cursor: not-allowed; opacity: 0.5; }
@@ -1618,7 +1618,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   cursor: pointer;
   transition:
@@ -1705,7 +1705,7 @@
   background: color-mix(in oklch, var(--surface-glass-strong) 55%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   cursor: pointer;
   transition:
@@ -1742,7 +1742,7 @@
   height: 10px;
   flex: none;
   border: 1px solid var(--surface-rim);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 .theme-card-label {
@@ -1769,11 +1769,11 @@
   min-height: 34px;
   padding: 7px var(--space-3);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-glass-strong) 55%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   transition:
     border-color var(--duration-fast) var(--ease-spring),
@@ -1802,7 +1802,7 @@
   background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   line-height: 1.2;
@@ -1831,7 +1831,7 @@
 .current-readout .cr-label {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -1839,7 +1839,7 @@
 .current-readout .cr-value {
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
 }
 
@@ -1904,7 +1904,7 @@
   justify-content: space-between;
   gap: var(--space-2);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
 }
 
@@ -1920,7 +1920,7 @@
 
 .font-card .fc-sample {
   color: var(--text-secondary);
-  font-size: 19px;
+  font-size: var(--t-xl);
   letter-spacing: 0.01em;
   line-height: 1.25;
 }
@@ -1934,14 +1934,14 @@
 .font-card .fc-meta {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.05em;
 }
 
 .font-card .fc-bundled {
   color: var(--positive-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -1973,7 +1973,7 @@
   gap: 10px;
   padding: 0 12px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-pillar);
   transition:
     border-color var(--duration-base) var(--ease-spring),
@@ -1994,7 +1994,7 @@
   background: transparent;
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--t-md);
 }
 
 .font-field input::placeholder {
@@ -2004,7 +2004,7 @@
 .font-field .field-icon {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--t-md);
 }
 
 .resolve-chip {
@@ -2013,9 +2013,9 @@
   gap: 7px;
   width: fit-content;
   padding: 6px 11px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.02em;
   transition:
     color var(--duration-base) var(--ease-spring),
@@ -2060,7 +2060,7 @@
 
 .size-label {
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 /* 터미널 렌더러 — 2지선다 세그먼트 컨트롤. 트랙 위 활성 세그먼트만 brass로 채운다. */
@@ -2086,7 +2086,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   white-space: nowrap;
   cursor: pointer;
@@ -2128,7 +2128,7 @@
 .model-auth-name {
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -2140,7 +2140,7 @@
   gap: 8px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2179,7 +2179,7 @@
   background: color-mix(in oklch, var(--surface-glass) 60%, transparent);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   letter-spacing: 0.04em;
 }
 
@@ -2214,7 +2214,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   white-space: nowrap;
   cursor: pointer;
@@ -2287,7 +2287,7 @@
   margin: 0;
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 15px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-bold);
   letter-spacing: 0.04em;
 }
@@ -2311,7 +2311,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-align: left;
@@ -2401,7 +2401,7 @@
   border-radius: var(--radius-xs);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   line-height: 1.2;
@@ -2412,7 +2412,7 @@
   overflow-wrap: anywhere;
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.02em;
 }
 
@@ -2421,7 +2421,7 @@
   min-width: 0;
   color: var(--text-tertiary);
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1.45;
 }
 
@@ -2431,7 +2431,7 @@
   justify-self: end;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.45;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2488,7 +2488,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   white-space: nowrap;
   cursor: pointer;
@@ -2582,7 +2582,7 @@
   width: 8px;
   height: 8px;
   flex: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--ink-rim);
 }
 
@@ -2652,7 +2652,7 @@
 .job-summary-eyebrow {
   margin: 2px var(--space-2) var(--space-3);
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -2685,7 +2685,7 @@
   place-items: center;
   /* Theater 박스(theater-trigger)와 같은 글라스 웰 + 중립 헤어라인 + 브래스 아이콘 언어를 공유한다. */
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
   color: var(--brass-ink);
   transition:
@@ -2766,7 +2766,7 @@
   contain: paint;
   border: 1px solid var(--surface-rim);
   border-left-color: transparent;
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--canvas-abyss);
   box-shadow: none;
   touch-action: none;
@@ -2874,7 +2874,7 @@
   z-index: 76;
   pointer-events: none;
   border: 1px solid color-mix(in oklch, var(--brass) 16%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   /* 물러남은 즉시, 복귀는 패널이 슬롯에 안착한 뒤다. 복원은 geometry를 --duration-slow 동안
      되돌리므로 경계선이 먼저 돌아오면 줄어드는 패널 위에 브래킷이 찍힌다 — 아래 규칙이 없애는
      겹침이 매 복원마다 잠깐 재현된다(실측: 복원 직후 캡션이 프레임 윗변보다 10px 위, ~140ms 지속).
@@ -2964,7 +2964,7 @@
 .canvas-mode-curtain-kicker {
   color: color-mix(in oklch, var(--brass) 72%, var(--ink-fog));
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
 }
@@ -2985,7 +2985,7 @@
 .canvas-mode-curtain > span:last-child {
   max-width: 560px;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--t-md);
   line-height: 1.5;
 }
 
@@ -3017,7 +3017,7 @@
   /* Doctrine exception: empty-slot numbering is brass grid instrumentation, not body copy. */
   color: color-mix(in oklch, var(--brass) 52%, var(--ink-fog));
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .operations-canvas.is-formation-entering .canvas-formation-guide {
@@ -3041,7 +3041,7 @@
 .canvas-triage-clear > span {
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -3058,7 +3058,7 @@
   max-width: 620px;
   margin: 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--t-md);
   line-height: 1.55;
 }
 
@@ -3088,7 +3088,7 @@
   min-width: 0;
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -3239,7 +3239,7 @@
   white-space: nowrap;
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
   text-align: center;
@@ -3260,7 +3260,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 220px;
-  font-size: 12px;
+  font-size: var(--t-sm);
   letter-spacing: 0.14em;
 }
 
@@ -3418,7 +3418,7 @@
   overflow: hidden;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   text-overflow: ellipsis;
   white-space: nowrap;
   transform: translateY(-50%);
@@ -3458,7 +3458,7 @@
   min-width: 0;
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -3474,7 +3474,7 @@
   background: color-mix(in oklch, var(--brass) 16%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
 }
 
@@ -3565,7 +3565,7 @@
   place-items: center;
   padding: 0 12px;
   border: 1px dashed var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: var(--surface-panel);
 }
 
@@ -3590,7 +3590,7 @@
   z-index: 5;
   padding: 0;
   border: 0;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: transparent;
   cursor: pointer;
 }
@@ -3817,7 +3817,7 @@
   align-items: center;
   justify-content: center;
   height: 26px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
 }
 
@@ -3863,7 +3863,7 @@
   position: absolute;
   right: -1px;
   width: 2px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--scrollbar-thumb-hover);
 }
 
@@ -3897,7 +3897,7 @@
   margin: 0;
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   /* 팝업 판독성 계약: .theater-menu와 같은 불투명 --ink-deep 언더레이 위에 선다. */
   background:
     linear-gradient(
@@ -3907,7 +3907,7 @@
     var(--ink-deep);
   box-shadow: var(--shadow-floating);
   font-family: var(--font-body);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   line-height: 1.4;
   color: var(--text-secondary);
   pointer-events: none;
@@ -3943,7 +3943,7 @@
   padding-left: var(--space-2);
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -3999,7 +3999,7 @@
   color: var(--text-secondary);
   box-shadow: 0 1px 0 color-mix(in oklch, var(--ink-abyss) 70%, transparent);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   line-height: 1.25;
 }
@@ -4007,7 +4007,7 @@
 .canvas-shortcuts-entry dd {
   margin: 0;
   color: var(--text-tertiary);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   line-height: 1.4;
 }
 
@@ -4019,7 +4019,7 @@
   bottom: var(--space-4);
   z-index: 14;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
   box-shadow: var(--shadow-floating);
   overflow: hidden;
@@ -4038,7 +4038,7 @@
   left: 12px;
   z-index: 3;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -4115,7 +4115,7 @@
   width: 24px;
   height: 24px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
   color: var(--text-tertiary);
   transition:
@@ -4135,7 +4135,7 @@
   width: 32px;
   height: 32px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
   color: var(--text-tertiary);
   box-shadow: var(--shadow-floating);
@@ -4182,7 +4182,7 @@
   overflow: visible;
   border: 1px solid var(--surface-rim);
   /* 상단 모서리는 캡션이 잇는다 — 본문이 따로 둥글면 두 개의 창처럼 읽힌다. */
-  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
   /* 패널의 유일한 면은 --surface-panel — 캡션·본문·채팅 로그가 같은 값을 칠해 창 하나로 읽힌다. */
   background: var(--surface-panel);
   box-shadow: var(--shadow-soft);
@@ -4248,16 +4248,16 @@ body[data-side-bar-animating="true"] .canvas-operation {
    클립과 일치해 검은 갭 없이 단일 표면을 유지한다.
    드래그/리사이즈가 차단된 상태이므로 코너 필의 grab 어포던스 커서도 기본값으로 되돌린다. */
 .canvas-operation.is-maximized {
-  border-radius: 0 0 calc(var(--radius-xl) - 1px) calc(var(--radius-xl) - 1px);
+  border-radius: 0 0 calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px);
 }
 
 .canvas-operation.is-maximized .canvas-operation-titlebar {
   cursor: default;
-  border-radius: calc(var(--radius-xl) - 1px) calc(var(--radius-xl) - 1px) 0 0;
+  border-radius: calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px) 0 0;
 }
 
 .canvas-operation.is-maximized .canvas-operation-terminal {
-  border-radius: 0 0 calc(var(--radius-xl) - 2px) calc(var(--radius-xl) - 2px);
+  border-radius: 0 0 calc(var(--radius-md) - 2px) calc(var(--radius-md) - 2px);
 }
 
 .canvas-operation.is-triage-stage {
@@ -4284,7 +4284,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   grid-template-rows: auto minmax(0, 1fr);
   border-top-width: 1px;
   border-top-style: solid;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 자리 이동은 칸이 지므로 좌표 전이를 두지 않는다 — 남기면 grid 재배치마다 패널이 뒤늦게 따라온다. */
   transition:
     border-color var(--duration-base) var(--ease-spring),
@@ -4298,12 +4298,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   left: auto;
   right: auto;
   border: 0;
-  border-radius: calc(var(--radius-lg) - 1px) calc(var(--radius-lg) - 1px) 0 0;
+  border-radius: calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px) 0 0;
   cursor: default;
 }
 
 .canvas-operation.is-deck-tile > .canvas-operation-terminal {
-  border-radius: 0 0 calc(var(--radius-lg) - 1px) calc(var(--radius-lg) - 1px);
+  border-radius: 0 0 calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px);
 }
 
 
@@ -4327,7 +4327,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--brass) 8%, transparent);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
 }
@@ -4336,7 +4336,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: none;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
 }
@@ -4355,7 +4355,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   left: 0;
   right: 0;
   border-bottom: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 
 .operations-canvas.is-companion-layout .canvas-operation-titlebar {
@@ -4450,7 +4450,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: 1px solid var(--surface-rim);
   border-bottom-width: 0;
   border-bottom-style: none;
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   background: var(--surface-panel);
   background-clip: padding-box;
   color: var(--text-tertiary);
@@ -4460,7 +4460,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .canvas-companion-caption-title {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.2em;
   text-transform: uppercase;
 }
@@ -4473,7 +4473,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .canvas-companion-caption-dot {
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--aurora);
   box-shadow: 0 0 8px var(--aurora-glow);
 }
@@ -4540,7 +4540,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   white-space: nowrap;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.06em;
   color: var(--text-tertiary);
@@ -4555,7 +4555,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: none;
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--group-mark);
 }
 
@@ -4575,7 +4575,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-2);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-soft);
 }
 
@@ -4599,7 +4599,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   /* 좌측 가장자리·하단 Global Navigation에 밀착 — 바깥(왼쪽)·하단 모서리는 각지게, 안쪽 상단만 둥글게. */
   border-left: none;
   border-bottom: none;
-  border-radius: 0 var(--radius-xl) 0 0;
+  border-radius: 0 var(--radius-md) 0 0;
   box-shadow: var(--shadow-soft);
   transition: width 200ms ease, border-color 200ms ease, visibility 0s linear 0s;
 }
@@ -4646,7 +4646,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-1) var(--space-3);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.08em;
 }
@@ -4688,7 +4688,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: var(--space-2);
   color: var(--coral-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   line-height: 1.45;
 }
 
@@ -4764,7 +4764,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   color: var(--text-tertiary);
   cursor: grab;
   font-family: var(--font-body);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
   letter-spacing: normal;
   text-transform: none;
@@ -4806,7 +4806,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--brass) 16%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
 }
 
@@ -4824,7 +4824,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-body);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
   text-align: left;
 }
@@ -4940,7 +4940,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   right: -2px;
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--aurora);
   animation: aurora-pulse 1.8s infinite;
 }
@@ -5017,7 +5017,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 6px var(--space-2);
   margin: 0 var(--space-1);
   border: 1px solid transparent;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: transparent;
   cursor: pointer;
   white-space: nowrap;
@@ -5112,7 +5112,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 0;
   cursor: pointer;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   transition:
     border-color var(--duration-fast) var(--ease-spring),
@@ -5148,7 +5148,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   text-overflow: ellipsis;
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
   color: var(--text-secondary);
   opacity: 1;
@@ -5164,7 +5164,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--ink-deep) 84%, var(--surface-glass));
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
   outline: none;
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 12%, transparent);
@@ -5180,7 +5180,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-chip-count {
   flex: none;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   color: var(--text-tertiary);
   min-width: 16px;
@@ -5206,7 +5206,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-radius: 3px;
   color: var(--ink-muted);
   font-family: var(--font-mono);
-  font-size: 8.5px;
+  font-size: var(--t-2xs);
   line-height: 13px;
   letter-spacing: 0.06em;
   white-space: nowrap;
@@ -5222,7 +5222,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   width: 7px;
   height: 7px;
   margin-left: auto;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--positive);
   box-shadow: 0 0 7px var(--positive-glow);
 }
@@ -5234,7 +5234,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: none;
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--group-mark);
 }
 
@@ -5245,12 +5245,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.04em;
   padding: 2px 7px;
   border: 1px solid color-mix(in oklch, var(--group-mark) 34%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: color-mix(in oklch, var(--group-mark) 85%, var(--text-primary));
   background: color-mix(in oklch, var(--group-mark) 13%, transparent);
 }
@@ -5264,12 +5264,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.04em;
   padding: 2px 7px;
   border: 1px solid var(--surface-rim);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-tertiary);
   background: color-mix(in oklch, var(--surface-glass) 70%, transparent);
 }
@@ -5373,7 +5373,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: 1px solid color-mix(in oklch, var(--coral) 50%, transparent);
   color: var(--coral-ink);
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   width: auto;
   height: 20px;
@@ -5444,7 +5444,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--status-color) 8%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
 }
@@ -5464,7 +5464,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
@@ -5489,7 +5489,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: none;
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--status-color);
 }
 
@@ -5540,14 +5540,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
   content: "";
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--positive);
   box-shadow: 0 0 6px var(--positive-glow);
 }
 
 .side-bar-status-empty-hint {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-style: italic;
   color: var(--ink-muted);
   padding: 6px 12px 8px 27px;
@@ -5661,7 +5661,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
@@ -5716,7 +5716,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -5726,7 +5726,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-group-header__count {
   flex: none;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   color: var(--text-tertiary);
   min-width: 14px;
@@ -5751,7 +5751,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-ungrouped-label {
   padding: 2px var(--space-1) 2px var(--space-2);
   font-family: var(--font-body);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -5808,7 +5808,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: 1px solid var(--surface-rim);
   border-bottom-width: 0;
   border-bottom-style: none;
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   overflow: visible;
   background: var(--surface-panel);
   background-clip: padding-box;
@@ -5953,7 +5953,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   padding: 4px 0;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-secondary);
   background: transparent;
   cursor: inherit;
@@ -5975,7 +5975,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   width: min(28ch, 34vw);
   padding: 3px 6px;
   border: 1px solid color-mix(in oklch, var(--brass) 68%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-primary);
   background: var(--ink-deep);
   outline: none;
@@ -5999,7 +5999,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 0;
   cursor: pointer;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   transition:
     border-color var(--duration-fast) var(--ease-spring),
@@ -6047,7 +6047,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .group-context-menu-section-label {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -6061,12 +6061,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
   padding: 5px 8px;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   cursor: pointer;
   text-align: left;
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   color: var(--text-secondary);
   transition:
@@ -6139,11 +6139,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   box-sizing: border-box;
   padding: 4px 8px;
   border: 1px solid color-mix(in oklch, var(--ink-fog) 30%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-md);
   outline: none;
 }
 
@@ -6197,7 +6197,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 5px 9px;
   cursor: pointer;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   text-align: left;
 }
@@ -6233,7 +6233,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .accent-tone-name {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -6248,10 +6248,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: none;
   padding: 4px 7px;
   border: 1px solid color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   line-height: 1;
 }
@@ -6289,7 +6289,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 0;
   overflow: hidden;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   background: transparent;
   opacity: 1;
@@ -6331,7 +6331,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--coral) 20%, transparent);
   color: var(--coral-ink);
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   opacity: 1;
   pointer-events: auto;
@@ -6384,7 +6384,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-2) calc(var(--space-3) + var(--space-1));
   overflow: hidden;
   border: 1px solid var(--hairline-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   background: color-mix(in oklch, var(--ink-deep) 94%, transparent);
   opacity: 0;
@@ -6475,7 +6475,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  border-radius: 0 0 calc(var(--radius-lg) - 1px) calc(var(--radius-lg) - 1px);
+  border-radius: 0 0 calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px);
   /* terminal-shell의 8px 패딩이 xterm 뷰포트를 사방에서 감싸므로 이 면은 실제로 보이는 띠다 —
      캡션·작업면과 다른 값을 주면 창 안에 액자 테가 생긴다. 패널 면 하나를 그대로 쓴다. */
   background: var(--surface-panel);
@@ -6548,7 +6548,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .canvas-operation-dormant-status {
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-align: center;
@@ -6563,7 +6563,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
   color: var(--brass-bright);
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
   text-align: center;
   box-shadow: 0 0 18px color-mix(in oklch, var(--brass) 12%, transparent);
@@ -6603,7 +6603,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   max-width: 34ch;
   margin: 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--t-md);
   line-height: 1.5;
   text-align: center;
 }
@@ -6731,7 +6731,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   width: min(460px, calc(100% - var(--space-10)));
   padding: var(--space-4);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--surface-glass) 82%, var(--ink-deep));
   color: var(--text-secondary);
   box-shadow: var(--shadow-soft);
@@ -6746,7 +6746,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .operations-canvas-empty-ghost {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -6754,7 +6754,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .operations-canvas-empty-headline {
   color: var(--text-primary);
-  font-size: 15px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-bold);
 }
 
@@ -6795,7 +6795,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: none;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
 }
@@ -6807,7 +6807,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--brass) 10%, var(--surface-glass));
   color: var(--brass-bright);
-  font: var(--weight-bold) 11px/1.2 var(--font-mono);
+  font: var(--weight-bold) var(--t-xs)/1.2 var(--font-mono);
 }
 
 .operations-canvas-empty-standby-chip:hover,
@@ -6834,27 +6834,27 @@ body[data-side-bar-animating="true"] .canvas-operation {
   align-items: center;
   gap: 4px;
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .operations-canvas-empty-hints kbd {
   padding: 2px 5px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 80%, transparent);
   color: var(--text-secondary);
-  font: var(--weight-bold) 9px/1.2 var(--font-mono);
+  font: var(--weight-bold) var(--t-2xs)/1.2 var(--font-mono);
 }
 
 .operations-canvas-empty-guide {
   color: var(--text-tertiary);
-  font-size: 9px;
+  font-size: var(--t-2xs);
 }
 
 .operations-canvas-empty-mark {
   width: 44px;
   height: 3px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: linear-gradient(90deg, var(--brass), var(--aurora));
   box-shadow: 0 0 18px color-mix(in oklch, var(--aurora) 34%, transparent);
 }
@@ -6862,7 +6862,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .operations-canvas-error {
   color: var(--coral-ink);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .theater-menu-new-group {
@@ -6913,7 +6913,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: 0;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 22px;
+  font-size: var(--t-xl);
   font-variation-settings: "opsz" 30;
   font-weight: var(--weight-medium);
   line-height: 1.15;
@@ -6927,14 +6927,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
   margin: var(--space-1) 0 0;
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .job-status,
 .track-status {
   font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
-  font-size: 10px;
+  font-size: var(--t-2xs);
   text-transform: uppercase;
 }
 
@@ -6964,7 +6964,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .stage-idle {
@@ -6993,12 +6993,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   max-width: 430px;
   margin: 0;
   color: var(--text-tertiary);
-  font-size: 13px;
+  font-size: var(--t-md);
 }
 
 .stage-idle code {
   color: var(--brass-bright);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
 }
 
 .stage-idle-mark {
@@ -7016,7 +7016,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
   margin: var(--space-2);
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -7032,7 +7032,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   margin: 0;
   color: var(--text-primary);
-  font-size: 13.5px;
+  font-size: var(--t-base);
   font-weight: var(--weight-bold);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -7044,7 +7044,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -7058,13 +7058,13 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .track-status {
   flex: none;
   margin-left: auto;
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
 }
 
 .track-subtitle {
   margin: var(--space-2) 0 0;
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .track-request {
@@ -7075,11 +7075,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: var(--space-3) 0 0;
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 78%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   line-height: 1.6;
 }
 
@@ -7090,7 +7090,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .thought-fold {
   margin-top: var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 .thought-fold.is-open {
@@ -7105,7 +7105,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 4px var(--space-2);
   border-radius: var(--radius-xs);
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
@@ -7125,10 +7125,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: var(--space-1) 0 0;
   padding: var(--space-3);
   border-left: 2px solid var(--brass);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 82%, transparent);
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-style: italic;
   line-height: 1.7;
   white-space: pre-wrap;
@@ -7151,9 +7151,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
   padding: 3px 10px;
   border: 1px solid var(--surface-rim);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .tool-chip-glyph {
@@ -7222,7 +7222,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: 0;
   padding: var(--space-4);
   color: var(--text-secondary);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   line-height: 1.72;
   letter-spacing: -0.01em;
   white-space: pre-wrap;
@@ -7250,17 +7250,17 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .track-notice {
   margin: var(--space-3) 0 0;
   color: var(--warn-ink);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .track-error {
   margin: var(--space-3) 0 0;
   padding: var(--space-2) var(--space-3);
   border: 1px solid color-mix(in oklch, var(--coral) 35%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--coral-glow);
   color: var(--coral-ink);
-  font-size: 11px;
+  font-size: var(--t-xs);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -7268,7 +7268,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .timeline-dock {
   margin: 0 var(--space-4) var(--space-4);
   overflow: hidden;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
 }
 
 .timeline-dock.is-open {
@@ -7283,7 +7283,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
   padding: 10px var(--space-4);
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   transition: color var(--duration-fast) var(--ease-spring);
 }
@@ -7302,8 +7302,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin-left: auto;
   padding: 1px 8px;
   border: 1px solid var(--surface-rim);
-  border-radius: 999px;
-  font-size: 9.5px;
+  border-radius: var(--radius-pill);
+  font-size: var(--t-2xs);
 }
 
 .timeline {
@@ -7320,7 +7320,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .timeline-empty {
   padding: var(--space-2) 0;
   color: var(--text-tertiary);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
 }
 
 .timeline-row {
@@ -7334,13 +7334,13 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .timeline-time {
   color: var(--text-tertiary);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
 }
 
 .timeline-type {
   overflow: hidden;
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -7349,7 +7349,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .timeline-payload {
   overflow: hidden;
   color: var(--text-tertiary);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -7366,7 +7366,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .theater-eyebrow {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   line-height: 1;
@@ -7387,11 +7387,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 0 calc(var(--space-2) + 14px);
   /* 휴지 상태는 GNB의 조용한 언어에 맞춰 중립 헤어라인 + 살짝 가라앉은 글라스 웰로 둔다 — 발광하지 않는 계기판 필드. */
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -7452,7 +7452,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   z-index: 40;
   padding: var(--space-2);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 팝업 판독성 계약: glass/pillar 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의
      canonical 주석 참조) — operation-launch·캔버스 컨텍스트 메뉴가 이 규칙을 상속한다. */
   background:
@@ -7478,10 +7478,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
   width: 100%;
   padding: var(--space-2);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
   text-align: left;
   transition:
@@ -7542,7 +7542,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-2);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
 }
 
@@ -7562,7 +7562,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding-left: var(--space-2);
   flex: none;
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -7600,7 +7600,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0;
   color: color-mix(in oklch, var(--text-tertiary) 82%, transparent);
 }
@@ -7629,7 +7629,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .operation-launch-menu-description {
   color: var(--text-tertiary);
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0;
   line-height: 1.35;
   white-space: normal;
@@ -7671,7 +7671,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-1) var(--space-2);
   color: color-mix(in oklch, var(--brass) 72%, var(--text-tertiary));
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -7749,11 +7749,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
   width: 100%;
   padding: 6px var(--space-1);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   text-align: left;
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -7795,14 +7795,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .quick-launch-variant-star {
   color: var(--brass);
   font-family: var(--font-body);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   line-height: 1;
 }
 
 .operation-launch-variant-chevron,
 .quick-launch-variant-chevron {
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1;
 }
 
@@ -7890,7 +7890,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--brass) 8%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.35;
   text-wrap: pretty;
 }
@@ -7948,7 +7948,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   display: flex;
   align-items: center;
   border: 1px solid var(--surface-rim);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--surface-pillar) 55%, transparent);
   cursor: pointer;
   touch-action: none;
@@ -7976,7 +7976,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   left: 1px;
   top: 1px;
   bottom: 1px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   /* 광택 스윕은 이 상자 안에서만 지나간다 — 가두지 않으면 트랙 밖 빈자리에 흰 띠로 남는다. */
   overflow: hidden;
   background: var(--brass);
@@ -7999,7 +7999,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: linear-gradient(
     100deg,
     transparent 35%,
@@ -8128,11 +8128,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 26px;
   padding: 0;
   border: 1px dashed color-mix(in oklch, var(--text-tertiary) 65%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1;
   cursor: pointer;
   transition:
@@ -8158,7 +8158,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex-basis: 18px;
   width: 18px;
   border-color: transparent;
-  font-size: 13px;
+  font-size: var(--t-md);
 }
 
 .effort-track-apex-toggle[data-open="true"]:hover {
@@ -8191,7 +8191,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 20px;
   margin: -10px 0 0 -10px;
   border: 2px solid var(--apex);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   opacity: 0;
   animation: effort-track-apex-burst 620ms var(--ease-spring) 1;
   pointer-events: none;
@@ -8215,7 +8215,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   width: 3px;
   height: 3px;
   margin: -1.5px 0 0 -1.5px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--text-tertiary);
   transition:
     transform var(--duration-fast) var(--ease-spring),
@@ -8261,7 +8261,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   width: 20px;
   height: 20px;
   margin: -10px 0 0 -10px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--text-primary);
   box-shadow: 0 1px 3px oklch(0% 0 0 / 55%);
   transition:
@@ -8323,7 +8323,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   min-width: 9.5ch;
   color: var(--effort-tone, var(--text-secondary));
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
   text-align: center;
   text-transform: uppercase;
@@ -8410,7 +8410,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .operation-launch-variant-effort {
   color: var(--effort-tone, var(--brass-ink));
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   transition: color var(--duration-fast) var(--ease-spring);
@@ -8488,7 +8488,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-1) var(--space-2);
   color: var(--coral-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   line-height: 1.45;
   word-break: break-word;
 }
@@ -8520,7 +8520,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .codex-empty-eyebrow {
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -8530,7 +8530,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: 0;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -8561,7 +8561,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
      5.3%p·Carbon 6.6%p의 계단으로 남는다. 카드의 정체는 테두리가 지고 면은 터미널에 넘긴다. */
   background: var(--surface-panel);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-soft);
 }
 
@@ -8572,7 +8572,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
   padding: var(--space-1) var(--space-2);
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-tertiary);
@@ -8581,7 +8581,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .terminal-status-dot {
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--warn);
 }
 
@@ -8604,14 +8604,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-1) var(--space-2);
   border-bottom: 1px solid color-mix(in oklch, var(--warn) 52%, var(--surface-rim));
   background: var(--warn-glow);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
 }
 
 .terminal-viewer-badge-dot {
   width: 8px;
   height: 8px;
   flex: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--warn);
 }
 
@@ -8629,11 +8629,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   min-height: 22px;
   padding: 0 var(--space-2);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-glass);
   color: var(--text-primary);
   font-family: inherit;
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   cursor: pointer;
   transition: border-color var(--duration-fast) var(--ease-glide);
@@ -8724,7 +8724,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: 0 1 auto;
   max-width: 28%;
   color: var(--text-secondary);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
 }
 
@@ -8736,7 +8736,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: 1 1 auto;
   color: color-mix(in oklch, var(--aurora) 72%, var(--text-tertiary));
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.01em;
 }
 
@@ -8744,14 +8744,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: 0 1 auto;
   max-width: 30%;
   color: var(--text-tertiary);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.02em;
 }
 
 .terminal-job-line-sep {
   flex: 0 0 auto;
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .commissioning-overlay {
@@ -8782,7 +8782,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-6);
   overflow: hidden;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background:
     radial-gradient(120% 80% at 50% -12%, color-mix(in oklch, var(--brass) 10%, transparent), transparent 58%),
     radial-gradient(70% 80% at 100% 20%, color-mix(in oklch, var(--aurora) 8%, transparent), transparent 62%),
@@ -8801,7 +8801,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .commissioning-eyebrow {
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -8822,7 +8822,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   max-width: 560px;
   margin: 0;
   color: var(--text-secondary);
-  font-size: 16px;
+  font-size: var(--t-lg);
   line-height: 1.55;
 }
 
@@ -8872,7 +8872,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   color: var(--brass-bright);
   box-shadow: var(--shadow-anchor);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
 }
@@ -8898,7 +8898,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: 0;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 22px;
+  font-size: var(--t-xl);
   font-variation-settings: "opsz" 36;
   font-weight: var(--weight-medium);
   letter-spacing: 0;
@@ -8908,7 +8908,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   max-width: 620px;
   margin: 0;
   color: var(--text-tertiary);
-  font-size: 14px;
+  font-size: var(--t-base);
   line-height: 1.6;
 }
 
@@ -8933,7 +8933,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--aurora) 18%, transparent);
   color: var(--text-primary);
   box-shadow: 0 0 0 1px color-mix(in oklch, var(--aurora) 14%, transparent), 0 0 20px -8px var(--aurora-glow);
-  font-size: 11px;
+  font-size: var(--t-xs);
   transition:
     border-color var(--duration-fast) var(--ease-glide),
     background var(--duration-fast) var(--ease-glide);
@@ -8943,7 +8943,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   content: "";
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--aurora);
   box-shadow: 0 0 0 0 var(--aurora-glow);
   animation: aurora-pulse 1.4s var(--ease-glide) infinite;
@@ -8965,7 +8965,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 0 var(--space-3);
   color: var(--brass-bright);
   background: color-mix(in oklch, var(--brass) 10%, transparent);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   line-height: 32px;
   transition:
     border-color var(--duration-fast) var(--ease-glide),
@@ -8981,7 +8981,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .commissioning-error {
   color: var(--coral-ink) !important;
   font-family: var(--font-mono);
-  font-size: 11px !important;
+  font-size: var(--t-xs) !important;
 }
 
 .commissioning-footer {
@@ -8996,7 +8996,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .commissioning-footer p {
   margin: 0;
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1.5;
 }
 
@@ -9037,7 +9037,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 팝업 판독성 계약: glass 층 + 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
@@ -9068,7 +9068,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   width: 8px;
   height: 8px;
   flex: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--ink-rim);
 }
 
@@ -9102,7 +9102,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .app-toast-title {
   margin: 0;
   color: var(--text-primary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
 }
 
@@ -9110,7 +9110,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: 0;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.5;
   word-break: break-word;
 }
@@ -9121,7 +9121,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 2px;
   margin-top: var(--space-2);
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--brass) 14%, transparent);
 }
 
@@ -9141,7 +9141,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: 1px solid color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
   border-radius: var(--radius-xs);
   color: var(--text-primary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
 }
 
@@ -9186,7 +9186,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   width: min(920px, 100%);
   padding: var(--space-3);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 팝업 판독성 계약: pillar 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(
@@ -9227,7 +9227,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: transparent;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 17px;
+  font-size: var(--t-lg);
   letter-spacing: 0;
 }
 
@@ -9247,7 +9247,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--surface-glass) 72%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -9279,7 +9279,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-3) var(--space-4) var(--space-2);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.12em;
   line-height: 1;
@@ -9363,7 +9363,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 16px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-medium);
   letter-spacing: 0;
   line-height: 1.3;
@@ -9377,7 +9377,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -9388,7 +9388,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.08em;
   text-overflow: ellipsis;
   text-transform: uppercase;
@@ -9403,7 +9403,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -9435,7 +9435,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: none;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 14px;
+  font-size: var(--t-base);
   line-height: 1;
 }
 
@@ -9461,7 +9461,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: none;
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -9489,7 +9489,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--brass) 8%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.12em;
   line-height: 1.2;
@@ -9500,7 +9500,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-5) var(--space-4);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   letter-spacing: 0.04em;
 }
 
@@ -9534,7 +9534,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-5) var(--space-5) var(--space-4);
   overflow: hidden;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background:
     radial-gradient(120% 80% at 50% -10%, color-mix(in oklch, var(--brass) 9%, transparent), transparent 60%),
     linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
@@ -9574,7 +9574,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   display: block;
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.2em;
   text-transform: uppercase;
@@ -9584,7 +9584,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: 0;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 23px;
+  font-size: var(--t-xl);
   font-weight: var(--weight-medium);
   letter-spacing: 0;
   line-height: 1.1;
@@ -9596,7 +9596,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 32px;
   place-items: center;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-glass-strong) 82%, transparent);
   color: var(--text-tertiary);
   font-size: 18px;
@@ -9634,11 +9634,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   min-height: 28px;
   padding: 0 var(--space-3);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-mid) 42%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
@@ -9682,7 +9682,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: 0 1px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .directory-browser-crumb {
@@ -9694,7 +9694,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
   transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
@@ -9755,7 +9755,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: transparent;
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--t-md);
 }
 
 .directory-browser-filter-input::placeholder {
@@ -9776,7 +9776,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide);
 }
@@ -9813,7 +9813,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--ink-deep) 46%, transparent);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   transition: border-color var(--duration-fast) var(--ease-glide), box-shadow var(--duration-fast) var(--ease-glide);
 }
 
@@ -9835,7 +9835,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
 }
@@ -9865,7 +9865,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   min-height: 0;
   padding: var(--space-2);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background-color: color-mix(in oklch, var(--ink-abyss) 32%, transparent);
   background-image:
     linear-gradient(color-mix(in oklch, var(--brass) 5%, transparent) 1px, transparent 1px),
@@ -9881,7 +9881,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-3);
   padding: 9px var(--space-3);
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-secondary);
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
@@ -9901,7 +9901,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .directory-browser-sector-name {
   overflow: hidden;
-  font-size: 13.5px;
+  font-size: var(--t-base);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -9955,7 +9955,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: 4px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -9973,7 +9973,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-4) var(--space-3);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .directory-browser-state.is-live {
@@ -9994,7 +9994,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin: 0;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .directory-browser-actions {
@@ -10018,7 +10018,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .directory-browser-target-label {
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -10028,7 +10028,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -10047,7 +10047,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
 }
@@ -10086,7 +10086,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   }
 
   .job-title {
-    font-size: 19px;
+    font-size: var(--t-xl);
   }
 
   .timeline-row {
@@ -10159,7 +10159,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   display: block;
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.2em;
   text-transform: uppercase;
@@ -10170,7 +10170,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 18px;
+  font-size: var(--t-xl);
   font-weight: var(--weight-medium);
   line-height: 1.15;
   text-overflow: ellipsis;
@@ -10183,10 +10183,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 32px;
   place-items: center;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-glass-strong) 82%, transparent);
   color: var(--text-tertiary);
-  font-size: 17px;
+  font-size: var(--t-lg);
   line-height: 1;
   transition:
     color var(--duration-fast) var(--ease-glide),
@@ -10217,7 +10217,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .codex-side-panel .codex-surface-host {
   overflow: hidden;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-deep) 38%, transparent);
 }
 
@@ -10250,7 +10250,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 100%;
   padding: var(--space-4);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--surface-glass) 88%, var(--ink-deep));
   box-shadow: var(--shadow-floating);
   pointer-events: auto;
@@ -10264,7 +10264,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   width: 11px;
   height: 100%;
   cursor: ew-resize;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   transition: background var(--duration-fast) var(--ease-glide);
   touch-action: none;
@@ -10292,7 +10292,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-3) var(--space-2);
   border: 1px solid var(--surface-rim);
   border-right: none;
-  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
   background: color-mix(in oklch, var(--surface-glass) 88%, var(--ink-deep));
   box-shadow: var(--shadow-floating);
   color: var(--text-tertiary);
@@ -10328,7 +10328,7 @@ body:has([aria-modal="true"]:not([hidden])) .codex-edge-handle {
 
 .codex-edge-handle-label {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   writing-mode: vertical-rl;
   text-orientation: mixed;
 }
@@ -10384,7 +10384,7 @@ body[data-codex-side="true"] .command-overlay {
   padding: 0;
   place-items: stretch;
   background: color-mix(in oklch, var(--ink-abyss) 30%, transparent);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
 }
 
 body[data-codex-side="true"] .command-card {
@@ -10431,7 +10431,7 @@ body[data-codex-side="true"] .command-card {
   max-height: min(82vh, 780px);
   overflow: hidden;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background:
     linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
     var(--ink-deep);
@@ -10467,11 +10467,11 @@ body[data-codex-side="true"] .command-card {
   min-height: 30px;
   padding: 0 10px;
   border: 1px solid color-mix(in oklch, var(--brass) 34%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--brass) 10%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
@@ -10480,7 +10480,7 @@ body[data-codex-side="true"] .command-card {
   display: block;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   letter-spacing: 0;
 }
@@ -10497,7 +10497,7 @@ body[data-codex-side="true"] .command-card {
 .whatsnew-error {
   color: var(--warn-ink);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
@@ -10511,7 +10511,7 @@ body[data-codex-side="true"] .command-card {
   width: 32px;
   height: 32px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
@@ -10554,11 +10554,11 @@ body[data-codex-side="true"] .command-card {
 .whatsnew-refresh {
   min-height: 34px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
@@ -10580,7 +10580,7 @@ body[data-codex-side="true"] .command-card {
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   cursor: pointer;
 }
 
@@ -10600,7 +10600,7 @@ body[data-codex-side="true"] .command-card {
   padding: 2px 7px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .whatsnew-version-select {
@@ -10636,12 +10636,12 @@ body[data-codex-side="true"] .command-card {
   flex: none;
   min-height: 34px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   padding: 0 10px;
   background: color-mix(in oklch, var(--ink-mid) 62%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   white-space: nowrap;
 }
@@ -10684,7 +10684,7 @@ body[data-codex-side="true"] .command-card {
 .whatsnew-overview-label,
 .whatsnew-overview-count {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
 }
 
@@ -10711,11 +10711,11 @@ body[data-codex-side="true"] .command-card {
   min-width: 32px;
   min-height: 34px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   line-height: 1;
 }
@@ -10735,7 +10735,7 @@ body[data-codex-side="true"] .command-card {
   min-width: 44px;
   text-align: center;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   color: var(--text-tertiary);
 }
@@ -10759,11 +10759,11 @@ body[data-codex-side="true"] .command-card {
   min-height: 28px;
   padding: 0 10px;
   border: 1px solid var(--whatsnew-section-border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--whatsnew-section-bg);
   color: var(--whatsnew-section-color);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -10776,11 +10776,11 @@ body[data-codex-side="true"] .command-card {
   margin: 0 6px 2px 0;
   padding: 0 7px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0;
   vertical-align: middle;
@@ -10792,7 +10792,7 @@ body[data-codex-side="true"] .command-card {
   margin: 0;
   padding: 0 0 0 18px;
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: var(--t-base);
   line-height: 1.68;
 }
 
@@ -10843,11 +10843,11 @@ body[data-codex-side="true"] .command-card {
   min-height: 34px;
   padding: 0 18px;
   border: 1px solid color-mix(in oklch, var(--brass) 36%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--brass) 14%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
 }
 
@@ -10869,7 +10869,7 @@ body[data-codex-side="true"] .command-card {
   display: grid;
   gap: var(--space-4);
   padding: var(--space-5);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
 }
 
 .fc-settings-card__title {
@@ -10885,7 +10885,7 @@ body[data-codex-side="true"] .command-card {
 .fc-settings-card__desc {
   margin: 0;
   color: var(--text-tertiary);
-  font-size: 13px;
+  font-size: var(--t-md);
   letter-spacing: 0;
 }
 
@@ -10914,7 +10914,7 @@ body[data-codex-side="true"] .command-card {
 .fc-settings-select__label,
 .fc-settings-field__label {
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
@@ -10923,7 +10923,7 @@ body[data-codex-side="true"] .command-card {
 .fc-settings-field__hint {
   margin: 4px 0 0;
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   letter-spacing: 0;
 }
 
@@ -10955,7 +10955,7 @@ body[data-codex-side="true"] .command-card {
   width: 42px;
   height: 24px;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 84%, transparent);
 }
 
@@ -10966,7 +10966,7 @@ body[data-codex-side="true"] .command-card {
   left: 3px;
   width: 16px;
   height: 16px;
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--ink-fog);
   box-shadow: 0 4px 10px -6px oklch(0% 0 0 / 72%);
   transition:
@@ -11001,7 +11001,7 @@ body[data-codex-side="true"] .command-card {
   width: 100%;
   min-height: 38px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-mid) 78%, transparent);
   color: var(--text-primary);
   font-weight: var(--weight-regular);
@@ -11026,7 +11026,7 @@ body[data-codex-side="true"] .command-card {
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--coral) 12%, var(--surface-glass));
   color: color-mix(in oklch, var(--coral) 72%, var(--text-primary));
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
@@ -11083,7 +11083,7 @@ body[data-codex-side="true"] .command-card {
   .whatsnew-card {
     width: 100%;
     max-height: calc(100vh - 24px);
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-md);
   }
 
   .whatsnew-header {
@@ -11114,7 +11114,7 @@ body[data-codex-side="true"] .command-card {
   position: fixed;
   inset: 0;
   z-index: var(--z-codex-reading-scrim);
-  background: oklch(10% 0.03 250 / 55%);
+  background: color-mix(in oklch, var(--ink-abyss) 55%, transparent);
 }
 
 .codex-reading-sheet {
@@ -11128,7 +11128,7 @@ body[data-codex-side="true"] .command-card {
   display: flex;
   flex-direction: column;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   overflow: hidden;
   /* Reading 오버레이는 우현 rail 카드와 동일한 carbon glass 표면을 쓴다(별도 블루
      그라디언트는 콘솔의 carbon dark 톤과 어긋났음): surface-glass-strong + ink-deep
@@ -11250,7 +11250,7 @@ body[data-codex-side="true"] .command-card {
   display: block;
   padding: var(--space-1) 0 var(--space-1) var(--space-3);
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   text-decoration: none;
   border-left: 2px solid transparent;
@@ -11272,7 +11272,7 @@ body[data-codex-side="true"] .command-card {
 
 .codex-reading-sheet-toc .toc-empty {
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   padding: var(--space-2);
 }
@@ -11282,7 +11282,7 @@ body[data-codex-side="true"] .command-card {
 .codex-reader-empty {
   padding: var(--space-6) var(--space-4);
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   text-align: center;
 }
@@ -11290,7 +11290,7 @@ body[data-codex-side="true"] .command-card {
 .codex-reader-error {
   padding: var(--space-4) var(--space-4);
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--coral-ink);
 }
 
@@ -11472,7 +11472,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   border-left: 2px solid transparent;
   color: var(--text-tertiary);
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   text-decoration: none;
   transition: color var(--duration-fast);
 }
@@ -11542,7 +11542,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   max-width: min(280px, calc(100vw - 16px));
   padding: 4px;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   /* 팝업 판독성 계약: glass 층 + 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
@@ -11559,7 +11559,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   border-radius: var(--radius-xs);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   text-align: left;
 }
@@ -11580,7 +11580,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
   color: var(--text-secondary);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
 }
 
@@ -11612,7 +11612,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
 }
 
 .command-band-github-stars svg { width: 12px; height: 12px; }
@@ -11625,7 +11625,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   color: var(--text-secondary);
 }
 
-.command-band-github-version { margin-left: auto; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; white-space: nowrap; }
+.command-band-github-version { margin-left: auto; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); white-space: nowrap; }
 
 .keyboard-shortcuts-scrim { position: fixed; inset: 0; z-index: 80; display: grid; place-items: center; background: color-mix(in oklch, var(--ink-abyss) 64%, transparent); }
 .keyboard-shortcuts-dialog { width: min(520px, calc(100vw - 48px)); max-height: min(680px, calc(100vh - 64px)); overflow: auto; padding: 12px; border: 1px solid var(--surface-rim-strong); border-radius: var(--radius-md); background: var(--ink-deep); box-shadow: var(--shadow-floating); outline: none; }
@@ -11633,19 +11633,19 @@ body[data-codex-reading="true"] .operations-side-bar {
 .keyboard-shortcuts-dialog-head button { width: 24px; height: 24px; border-radius: var(--radius-xs); color: var(--text-tertiary); }
 .keyboard-shortcuts-dialog-head button:hover { background: var(--surface-glass); color: var(--text-primary); }
 .keyboard-shortcuts-group { margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--surface-rim); }
-.keyboard-shortcuts-group h3 { margin: 0 0 5px; color: var(--brass-ink); font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; }
+.keyboard-shortcuts-group h3 { margin: 0 0 5px; color: var(--brass-ink); font-family: var(--font-mono); font-size: var(--t-2xs); letter-spacing: 0.1em; }
 .keyboard-shortcuts-group dl { margin: 0; }
-.keyboard-shortcuts-group dl > div { display: grid; grid-template-columns: minmax(130px, auto) 1fr; gap: 12px; padding: 4px; color: var(--text-secondary); font-size: 12px; }
+.keyboard-shortcuts-group dl > div { display: grid; grid-template-columns: minmax(130px, auto) 1fr; gap: 12px; padding: 4px; color: var(--text-secondary); font-size: var(--t-sm); }
 .keyboard-shortcuts-group dt { color: var(--text-tertiary); }
 .keyboard-shortcuts-group dd { margin: 0; }
-.keyboard-shortcuts-group kbd { margin-right: 3px; padding: 1px 4px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); color: var(--text-primary); font-family: var(--font-mono); font-size: 10px; }
+.keyboard-shortcuts-group kbd { margin-right: 3px; padding: 1px 4px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); color: var(--text-primary); font-family: var(--font-mono); font-size: var(--t-2xs); }
 
 /* v5: 비-Operations 라우트의 복귀 링크 — GNB 부재 보완 */
 .page-back-link {
   display: inline-block;
   margin-bottom: 6px;
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   border-radius: var(--radius-xs);
 }
 
@@ -11667,7 +11667,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 100%; min-height: 42px; display: flex; align-items: center; justify-content: space-between; gap: var(--space-2);
   border: 1px solid var(--surface-rim); border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 48%, transparent);
-  color: var(--text-primary); font-weight: var(--weight-medium); font-size: 13px; line-height: 1.2; font-family: var(--font-body); padding: 0 13px; cursor: pointer;
+  color: var(--text-primary); font-weight: var(--weight-medium); font-size: var(--t-md); line-height: 1.2; font-family: var(--font-body); padding: 0 13px; cursor: pointer;
   box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);
   transition: border-color var(--duration-fast) var(--ease-glide);
 }
@@ -11675,7 +11675,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .fc-select__trigger:focus-visible { outline: none; border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); }
 .fc-select__trigger[aria-expanded="true"] { border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); }
 .fc-select__trigger:disabled { opacity: 0.45; cursor: default; }
-.fc-select__caret { color: var(--text-tertiary); font-size: 11px; transition: transform var(--duration-fast) var(--ease-glide); }
+.fc-select__caret { color: var(--text-tertiary); font-size: var(--t-xs); transition: transform var(--duration-fast) var(--ease-glide); }
 .fc-select__trigger[aria-expanded="true"] .fc-select__caret { transform: rotate(180deg); }
 .fc-select__popup {
   position: absolute; z-index: var(--z-select-popover); inset-inline: 0; top: calc(100% + 6px);
@@ -11692,12 +11692,12 @@ body[data-codex-reading="true"] .operations-side-bar {
 .fc-select__option {
   display: flex; align-items: center; justify-content: space-between; gap: var(--space-2);
   padding: 8px 10px; border-radius: var(--radius-xs);
-  color: var(--text-secondary); font-weight: var(--weight-medium); font-size: 13px; line-height: 1.3; font-family: var(--font-body); cursor: pointer;
+  color: var(--text-secondary); font-weight: var(--weight-medium); font-size: var(--t-md); line-height: 1.3; font-family: var(--font-body); cursor: pointer;
   transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
 .fc-select__option[data-active="true"] { background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--text-primary); }
 .fc-select__option[aria-selected="true"] { color: var(--brass-bright); }
-.fc-select__option[aria-selected="true"]::after { content: "✓"; font-size: 11px; color: var(--brass-bright); }
+.fc-select__option[aria-selected="true"]::after { content: "✓"; font-size: var(--t-xs); color: var(--brass-bright); }
 .fc-select__option[aria-disabled="true"] { color: var(--text-tertiary); cursor: default; font-style: italic; }
 .fc-select__option[aria-disabled="true"][data-active="true"] { background: transparent; color: var(--text-tertiary); }
 
@@ -11708,7 +11708,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .fc-select--compact .fc-select__trigger {
   min-height: 0; border: 0; box-shadow: none; background: transparent;
   font-weight: var(--weight-regular);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1;
   font-family: var(--font-mono); color: var(--fc-select-compact-tone, var(--text-secondary)); padding: 7px 16px 7px 10px;
 }
@@ -11760,7 +11760,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   margin: 0;
   color: var(--brass-ink);
   font-family: var(--font-body);
-  font-size: 17px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-bold);
   line-height: 1.2;
 }
@@ -11768,7 +11768,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .feature-tour-card p {
   margin: var(--space-2) 0 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--t-md);
   line-height: 1.55;
 }
 
@@ -11777,7 +11777,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   margin-bottom: var(--space-2);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
 }
 
@@ -11793,11 +11793,11 @@ body[data-codex-reading="true"] .operations-side-bar {
   min-height: 32px;
   padding: 0 var(--space-3);
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--t-sm);
   cursor: pointer;
 }
 
@@ -11860,7 +11860,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   min-width: 0;
   max-width: 100%;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 팝업 판독성 계약: pillar 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(
@@ -11920,7 +11920,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   z-index: 2;
   background: radial-gradient(circle, color-mix(in oklch, var(--apex) 70%, var(--ink-pearl)) 0 28%, transparent 70%);
   filter: drop-shadow(0 0 6px var(--apex-glow));
-  offset-path: inset(-1px round calc(var(--radius-lg) + 1px));
+  offset-path: inset(-1px round calc(var(--radius-md) + 1px));
   offset-anchor: center;
   animation: quick-launch-ultracode-bead 900ms var(--ease-glide) both;
 }
@@ -11929,7 +11929,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   content: "";
   position: absolute;
   inset: -1px;
-  border-radius: calc(var(--radius-lg) + 1px);
+  border-radius: calc(var(--radius-md) + 1px);
   padding: 1px;
   pointer-events: none;
   background: conic-gradient(
@@ -12010,7 +12010,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   gap: var(--space-2);
   margin: 0;
   padding: var(--space-2) var(--space-4) 0;
-  font-size: 12.5px;
+  font-size: var(--t-md);
   color: color-mix(in oklch, var(--apex) 72%, var(--text-secondary));
 }
 
@@ -12019,7 +12019,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 }
 
 .quick-launch-ultracode-glyph {
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1;
 }
 
@@ -12041,7 +12041,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   gap: var(--space-2);
   margin: 0;
   padding: var(--space-2) var(--space-4) 0;
-  font-size: 12.5px;
+  font-size: var(--t-md);
   color: color-mix(in oklch, var(--apex) 72%, var(--text-secondary));
 }
 
@@ -12140,7 +12140,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   background: transparent;
   color: var(--text-secondary);
   font-family: inherit;
-  font-size: 13.5px;
+  font-size: var(--t-base);
   text-align: left;
 }
 
@@ -12170,7 +12170,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   gap: var(--space-1);
   color: var(--brass);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
   white-space: nowrap;
 }
@@ -12196,7 +12196,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 32px;
   height: 32px;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-tertiary);
   transition:
@@ -12259,7 +12259,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   background: transparent;
   color: var(--text-primary);
   font-family: inherit;
-  font-size: 16.5px;
+  font-size: var(--t-lg);
   line-height: 1.55;
   resize: none;
   overflow-y: auto;
@@ -12282,7 +12282,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   padding: 0;
   border: 0;
   font-family: inherit;
-  font-size: 16.5px;
+  font-size: var(--t-lg);
   line-height: 1.55;
   /* textarea는 UA 기본값이라 조상의 자간을 물려받지 않는다. 미러만 물려받으면 긴 줄에서
      글자가 조금씩 밀린다(-0.07px 실측). 같은 기준으로 눕힌다. */
@@ -12366,14 +12366,14 @@ body[data-codex-reading="true"] .operations-side-bar {
 .quick-launch-attachment-thumb-button:focus-visible {
   outline: 2px solid var(--brass);
   outline-offset: 2px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 .quick-launch-attachment-thumb {
   width: 52px;
   height: 52px;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   object-fit: cover;
   display: block;
   background: var(--ink-veil);
@@ -12395,7 +12395,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 
 .quick-launch-attachment-wait::after {
   content: "…";
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .quick-launch-attachment-remove {
@@ -12409,7 +12409,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   border-radius: 50%;
   background: var(--ink-deep);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1;
   cursor: pointer;
 }
@@ -12449,7 +12449,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   display: block;
   max-width: min(420px, 70vw);
   max-height: 320px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 /* 파일 픽커 — 고정 토글과 같은 무채 유틸 버튼 문법. */
@@ -12461,7 +12461,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   height: 30px;
   padding: 0;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -12503,7 +12503,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   flex: none;
   max-width: 45%;
   color: var(--brass);
-  font-size: 16.5px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-medium);
   line-height: 1.55;
   white-space: nowrap;
@@ -12543,7 +12543,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   padding: var(--space-2) var(--space-2) 4px;
   color: var(--brass);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -12561,11 +12561,11 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 100%;
   padding: 7px var(--space-2);
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--t-md);
   text-align: left;
 }
 
@@ -12629,7 +12629,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   flex: none;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   white-space: nowrap;
 }
@@ -12642,7 +12642,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   margin: 0;
   padding: var(--space-2);
   color: var(--text-tertiary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
 }
 
 /* ── '/' 커맨드 덱 ──────────────────────────────────────────────────────
@@ -12675,14 +12675,14 @@ body[data-codex-reading="true"] .operations-side-bar {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .quick-launch-command-token {
   flex: none;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .quick-launch-command-row.is-active .quick-launch-command-token {
@@ -12717,7 +12717,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .quick-launch-command-row.is-gate .quick-launch-mention-name {
   color: var(--apex-ink);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.08em;
 }
 
@@ -12728,7 +12728,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 18px;
   height: 18px;
   color: var(--apex-ink);
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1;
 }
 
@@ -12876,7 +12876,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   gap: 7px;
   color: var(--brass);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -12937,11 +12937,11 @@ body[data-codex-reading="true"] .operations-side-bar {
   max-width: 100%;
   padding: 6px 11px;
   border: 1px solid var(--surface-rim);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--surface-pillar) 40%, transparent);
   color: var(--text-secondary);
   font-family: inherit;
-  font-size: 12.5px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   white-space: nowrap;
   transition:
@@ -12978,7 +12978,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .quick-launch-caret {
   flex: none;
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 /* 실행 종류 글리프는 캔버스 메뉴의 아이콘 슬롯과 같은 치수·색을 쓴다. */
@@ -13004,7 +13004,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 17px;
   height: 17px;
   flex: none;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-pillar) 70%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-mono);
@@ -13025,7 +13025,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 32px;
   height: 32px;
   border: 1px solid var(--brass);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--brass);
   color: var(--text-on-brass);
   transition:
@@ -13083,11 +13083,11 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 100%;
   padding: var(--space-2);
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--t-md);
   text-align: left;
 }
 
@@ -13107,7 +13107,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 
 .quick-launch-pop-check {
   color: var(--brass);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .quick-launch-pop-band {
@@ -13118,7 +13118,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   padding: var(--space-2) var(--space-2) 6px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -13135,11 +13135,11 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 100%;
   padding: 7px var(--space-2);
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   text-align: left;
 }
@@ -13287,7 +13287,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: min(620px, 100%);
   overflow: hidden;
   border: 1px solid color-mix(in oklch, var(--warn) 48%, var(--surface-rim));
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-floating), 0 0 44px -24px var(--warn-glow);
   animation: fleet-pop var(--duration-slow) var(--ease-spring) both;
 }
@@ -13306,7 +13306,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .control-curtain-signal,
 .control-reclaimed-signal {
   display: block;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--warn);
   box-shadow: 0 0 22px var(--warn-glow);
 }
@@ -13328,7 +13328,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .control-reclaimed-eyebrow {
   color: var(--warn-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -13348,7 +13348,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .control-reclaimed-card p {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 15px;
+  font-size: var(--t-lg);
   line-height: 1.6;
 }
 
@@ -13366,7 +13366,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-md);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   transition:
     border-color var(--duration-fast) var(--ease-spring),
@@ -13404,7 +13404,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .control-curtain-error {
   margin: var(--space-4) 0 0;
   color: var(--warn-ink);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
 }
 
@@ -13436,7 +13436,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   align-items: baseline;
   gap: var(--space-2);
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .control-bar-copy strong {
@@ -13505,7 +13505,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .quick-launch-overflow {
   color: var(--warn);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
 }
 
@@ -13514,7 +13514,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   min-width: 0;
   overflow: hidden;
   color: var(--coral);
-  font-size: 12px;
+  font-size: var(--t-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -13537,20 +13537,20 @@ body[data-codex-reading="true"] .operations-side-bar {
 .fc-failure__title {
   margin: 0;
   color: var(--text-primary);
-  font-size: 13px; font-weight: var(--weight-medium); line-height: 1.35;
+  font-size: var(--t-md); font-weight: var(--weight-medium); line-height: 1.35;
 }
 .fc-failure__cause {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 12.5px; line-height: 1.5;
+  font-size: var(--t-sm); line-height: 1.5;
 }
 .fc-failure__actions { display: flex; flex-wrap: wrap; gap: var(--space-2); }
 .fc-failure__action {
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-primary);
-  font-family: var(--font-body); font-size: 12px; line-height: 1.2;
+  font-family: var(--font-body); font-size: var(--t-sm); line-height: 1.2;
   padding: 6px 12px; cursor: pointer;
   transition: border-color var(--duration-fast) var(--ease-glide);
 }
@@ -13565,6 +13565,6 @@ body[data-codex-reading="true"] .operations-side-bar {
 .fc-failure__diagnostic {
   margin: 0;
   color: var(--text-tertiary);
-  font-family: var(--font-mono); font-size: 10.5px; line-height: 1.5;
+  font-family: var(--font-mono); font-size: var(--t-xs); line-height: 1.5;
   overflow-wrap: anywhere;
 }

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -44,7 +44,7 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
   border-bottom: 1px solid color-mix(in oklch, var(--coral) 55%, var(--surface-rim));
   background: var(--coral-glow);
   color: var(--coral-ink);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
 }
 
@@ -203,24 +203,27 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 
 .command-band-brand-wordmark {
   font-family: var(--font-display);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   letter-spacing: 0.01em;
 }
 
 /* 환경 표시는 상태가 아니라 정보다 — warn 신호·글로우 금지, 중립 잉크 필로 침묵한다. */
+/* 밴드 컨트롤은 24px 한 단에 선다 — 고정 높이가 없으면 높이를 내용이 정하고, 그 값은
+   같은 줄 이웃과 어긋난 소수점(실측 28.6px)으로 착지한다. 세로 패딩 대신 높이로 세운다. */
 .command-band-local-chip {
   display: inline-flex;
   align-items: center;
   gap: 5px;
   flex: none;
-  padding: 4px 7px;
+  height: 24px;
+  padding: 0 7px;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-glass);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0.01em;
 }
@@ -244,9 +247,9 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   flex: none;
   padding: 4px 7px;
   border: 1px solid currentColor;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   line-height: 1;
   white-space: nowrap;
@@ -292,14 +295,14 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   background: var(--surface-band);
   box-shadow: 0 12px 30px color-mix(in oklch, var(--ink-deep) 70%, transparent);
   color: var(--text-primary);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .command-band-environment-title {
   margin-bottom: var(--space-2);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -320,7 +323,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-environment-row button { padding: 2px 5px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--surface-glass); color: var(--text-secondary); font-weight: var(--weight-regular); font-size: inherit; line-height: inherit; font-family: inherit; cursor: pointer; }
 .command-band-environment-row button:hover,
 .command-band-environment-row button:focus-visible { border-color: color-mix(in oklch, var(--ink-fog) 55%, var(--surface-rim)); outline: none; }
-.command-band-environment-footer { margin-top: var(--space-2); color: var(--text-tertiary); font-size: 10px; }
+.command-band-environment-footer { margin-top: var(--space-2); color: var(--text-tertiary); font-size: var(--t-2xs); }
 
 /* 좁은 뷰에서는 칩 앵커(x≈80~160) + 520px 폭이 우측을 벗어나 Copy 버튼이 잘린다 —
    앵커 대신 viewport gutter에 고정해 전체 행이 항상 화면 안에 남게 한다. */
@@ -447,7 +450,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   color: var(--text-tertiary);
   white-space: nowrap;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
 }
 
@@ -505,7 +508,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 
 .command-band-mode-tool.is-valued span {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   font-variant-numeric: tabular-nums;
 }
@@ -537,9 +540,10 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   align-items: center;
   gap: 6px;
   min-width: 0;
+  height: 24px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .command-band-theater-mark {
@@ -547,7 +551,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   border-radius: var(--radius-xs);
   background: var(--brass-glow);
   color: var(--brass-ink);
-  font-size: 9px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
 }
 
@@ -559,7 +563,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   color: var(--text-primary);
   line-height: inherit;
   font-family: inherit;
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -575,7 +579,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   color: var(--text-primary);
   line-height: inherit;
   font-family: inherit;
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
 }
 
@@ -625,9 +629,12 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 .command-band-trigger-caret svg { display: block; width: 10px; height: 10px; }
 
 .command-band-operation-placeholder {
+  display: inline-flex;
+  align-items: center;
+  height: 24px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .command-band-menu {
@@ -641,7 +648,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   overflow-y: auto;
   padding: var(--space-2);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 팝업 판독성 계약: pillar 믹스 아래 불투명 --ink-deep 언더레이(components.css whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(
@@ -658,10 +665,10 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   gap: var(--space-2);
   width: 100%;
   padding: var(--space-2);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
   text-align: left;
   transition:
@@ -719,7 +726,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   padding-left: var(--space-2);
   flex: none;
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -735,7 +742,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   padding: var(--space-2);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -76,7 +76,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--text-primary);
-  font-size: 15px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-bold);
   text-align: center;
   text-overflow: ellipsis;
@@ -114,7 +114,7 @@
   border: 1px solid color-mix(in oklch, var(--coral) 50%, transparent);
   background: color-mix(in oklch, var(--coral) 20%, transparent);
   color: var(--coral-ink);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   animation: chip-close-arm 1.5s linear forwards;
 }
@@ -140,7 +140,7 @@
 .mobile-simple-panel h1 {
   margin: 0;
   color: var(--text-primary);
-  font-size: 18px;
+  font-size: var(--t-xl);
   font-weight: var(--weight-bold);
 }
 
@@ -152,7 +152,7 @@
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
-  font-size: 16px;
+  font-size: var(--t-lg);
 }
 
 .mobile-list-theater-label {
@@ -166,7 +166,7 @@
   padding: 1px 4px;
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   background: var(--brass-glow);
   border-radius: var(--radius-xs);
@@ -219,7 +219,7 @@
   min-height: 40px;
   padding: 0;
   color: var(--brass);
-  font-size: 22px;
+  font-size: var(--t-xl);
   font-weight: var(--weight-medium);
   background: color-mix(in srgb, var(--brass) 12%, transparent);
   border: 1px solid color-mix(in srgb, var(--brass) 40%, var(--hairline));
@@ -248,7 +248,7 @@
 
 .mobile-status-section h2 {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-bold);
 }
 
@@ -307,7 +307,7 @@
 
 .mobile-operation-card-copy span {
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .mobile-operation-alert-mark {
@@ -376,7 +376,7 @@
 .mobile-theater-copy strong {
   overflow: hidden;
   color: var(--text-primary);
-  font-size: 15px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -387,7 +387,7 @@
   gap: var(--space-3);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 /* Waiting is a state, so it speaks on the signal channel — not on brass, which carries location. */
@@ -398,7 +398,7 @@
 .mobile-theater-here {
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
 }
 
@@ -409,7 +409,7 @@
   min-height: 48px;
   padding: var(--space-3);
   color: var(--brass-ink);
-  font-size: 14px;
+  font-size: var(--t-base);
   text-align: left;
   background: transparent;
   border: 1px dashed var(--hairline-strong);
@@ -424,7 +424,7 @@
 .mobile-theater-error {
   margin: 0;
   color: var(--coral-ink);
-  font-size: 13px;
+  font-size: var(--t-md);
 }
 
 .mobile-tab-bar {
@@ -443,11 +443,11 @@
   min-width: 40px;
   min-height: 48px;
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   background: transparent;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 .mobile-tab.is-active {
@@ -495,7 +495,7 @@
   text-align: left;
   background: var(--ink-deep);
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 /* ===== Settings — 목록 화면과 상세 화면 ===== */
@@ -568,7 +568,7 @@
   flex: none;
   color: var(--aurora-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -591,7 +591,7 @@
   padding: 0 var(--space-1);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -661,7 +661,7 @@
 .mobile-settings-row-copy span {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 /*
@@ -815,12 +815,12 @@
   }
 
   .mobile-session-title {
-    font-size: 14px;
+    font-size: var(--t-base);
   }
 
   .mobile-list-header h1,
   .mobile-simple-panel h1 {
-    font-size: 16px;
+    font-size: var(--t-lg);
   }
 
   .mobile-total-count {

--- a/runtime/fleet-console/core/client/src/styles/rail-alerts.css
+++ b/runtime/fleet-console/core/client/src/styles/rail-alerts.css
@@ -28,7 +28,7 @@
 
 .alerts-panel-tally-empty {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
 }
 
@@ -38,7 +38,7 @@
   justify-content: center;
   width: 24px;
   height: 24px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   transition: background var(--duration-fast) var(--ease-glide),
     color var(--duration-fast) var(--ease-glide);
@@ -70,7 +70,7 @@
   min-width: 14px;
   height: 14px;
   padding: 0 3px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-family: var(--font-mono);
   font-size: 9px;
   font-weight: var(--weight-bold);
@@ -109,9 +109,9 @@
   min-width: 22px;
   height: 19px;
   padding: 0 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   line-height: 1;
 }
@@ -120,7 +120,7 @@
   content: "";
   width: 5px;
   height: 5px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: currentColor;
 }
 
@@ -141,7 +141,7 @@
   margin: 0;
   padding: var(--space-6) 0;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--text-tertiary);
@@ -180,7 +180,7 @@
   flex: 1;
   min-width: 0;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.09em;
@@ -197,9 +197,9 @@
   min-width: 18px;
   height: 18px;
   padding: 0 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   color: var(--text-secondary);
   background: color-mix(in oklch, var(--ink-fog) 15%, transparent);
@@ -232,7 +232,7 @@
 .notification-row-beacon {
   width: 9px;
   height: 9px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   flex-shrink: 0;
 }
 
@@ -256,7 +256,7 @@
 
 .notification-row-op {
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   color: var(--text-primary);
   white-space: nowrap;
@@ -266,7 +266,7 @@
 
 .notification-row-state {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.11em;
@@ -285,7 +285,7 @@
   padding: 4px 11px;
   border-radius: var(--radius-xs);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   letter-spacing: 0.01em;
   color: var(--text-tertiary);
@@ -316,7 +316,7 @@
 .notification-cluster-settings-eyebrow {
   margin: var(--space-1) 0 2px;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -329,7 +329,7 @@
   gap: var(--space-2);
   padding: var(--space-1);
   border-radius: var(--radius-xs);
-  font-size: 13px;
+  font-size: var(--t-md);
   color: var(--text-secondary);
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-glide);

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -18,7 +18,7 @@
      우상단 brass 코너 조명 + glass 본체, 부유 그림자, 단일 blur 레이어.
      자식(panel-slot·icons)은 표면을 갖지 않고 이 카드 위에 투명하게 얹힌다.
      우측 가장자리·하단 Global Navigation에 밀착 — 바깥(오른쪽)·하단 모서리는 각지게, 안쪽 상단만 둥글게. */
-  border-radius: var(--radius-lg) 0 0 0;
+  border-radius: var(--radius-md) 0 0 0;
   border: 1px solid var(--surface-rim);
   border-right: none;
   border-bottom: none;
@@ -71,7 +71,7 @@
   border-left: 1px solid var(--surface-rim);
   /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
   box-shadow: -24px 0 48px -24px oklch(0% 0 0 / 70%);
-  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
 }
 
 .right-rail.is-overlay .right-rail-panel-slot::before {
@@ -160,7 +160,7 @@
   flex: 0 1 auto;
   max-width: 50%;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--text-tertiary);
@@ -176,7 +176,7 @@
   display: inline-grid;
   place-items: center;
   padding: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--surface-rim-strong);
   background: transparent;
   color: var(--text-tertiary);
@@ -215,7 +215,7 @@
   align-items: center;
   gap: 6px;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   padding: 0 6px;
   height: 20px;
 }
@@ -292,7 +292,7 @@
 .right-rail-alpha-value {
   flex: none;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   color: var(--brass-ink);
   width: 30px;
   text-align: right;
@@ -305,7 +305,7 @@
   flex: none;
   display: inline-grid;
   place-items: center;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: none;
   border: 1px solid transparent;
   color: var(--text-tertiary);
@@ -365,12 +365,12 @@
 }
 
 .right-rail-stale-veil strong {
-  font-size: 13px;
+  font-size: var(--t-md);
 }
 
 .right-rail-stale-veil span {
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 /* ── 아이콘 레일 ────────────────────────────────────────────────── */
@@ -404,7 +404,7 @@
   color: var(--text-tertiary);
   cursor: pointer;
   position: relative;
-  font-size: 14px;
+  font-size: var(--t-base);
   transition:
     color var(--duration-fast) var(--ease-glide),
     background var(--duration-fast) var(--ease-glide),

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -154,11 +154,11 @@
   --scrollbar-thumb-hover: oklch(70% 0.05 248 / 50%);
   --scrollbar-thumb-classic: oklch(50% 0.04 248 / 45%);
 
+  /* 라운드 어휘는 세 개뿐이다 — 컨트롤(xs)·면(md)·캡슐(pill). 이름이 값보다 많으면
+     새 규칙이 어느 이름을 골라야 하는지 규칙이 없어지고, 나중에 카드 라운드만 재조율하려
+     할 때 어느 이름을 움직여야 하는지도 알 수 없다(구 sm=xs, lg=xl=md 중복은 그렇게 생겼다). */
   --radius-xs: 6px;
-  --radius-sm: 6px;
   --radius-md: 10px;
-  --radius-lg: 10px;
-  --radius-xl: 10px;
   /* 999px는 도트·비콘·상태 캡슐 전용 — 컨트롤(버튼/칩)에는 쓰지 않는다. */
   --radius-pill: 999px;
 
@@ -178,6 +178,34 @@
   --font-body: "Manrope Variable", "Manrope", "Pretendard Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   --font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
   --font-body-size: 14px;
+
+  /* 크기도 굵기와 같은 이유로 사다리 하나만 쓴다 — 굵기를 3티어로 묶어 놓고 크기를 raw px로
+     열어 두면, 표면마다 자기 스케일을 발명해 같은 역할(칩·버튼·라벨)이 화면마다 다른 크기로
+     선다. 실측에서 그 분산은 크기 32종·반픽셀 151회였고, 같은 Rail 슬롯을 공유하는 패널들의
+     본문이 10.5~13px로 갈려 패널을 바꾸는 일이 "다른 앱으로 건너가는" 것처럼 읽혔다.
+     단은 실측 주력값에서 유도했다 — 새 단을 늘리기 전에 기존 단으로 표현되는지 먼저 볼 것.
+     사다리 밖(24px 이상 디스플레이)과 도형 크기 지정은 계약 테스트의 명시적 예외 목록이 진다. */
+  --t-2xs: 10px;
+  --t-xs: 11px;
+  --t-sm: 12px;
+  --t-md: 13px;
+  --t-base: 14px;
+  --t-lg: 17px;
+  --t-xl: 22px;
+
+  /* 신택스 역할색은 상태도 위치도 아니다 — 문자열은 "완료"가 아니고 숫자는 "진행 중"이
+     아니므로 신호 채널(positive/warn/coral/aurora)을 빌리면 채널 침범이다. 그렇다고 자기
+     리터럴을 들면 테마를 따라오지 못하므로, 이미 테마별로 재조율되는 정체성 8톤(--id-*)에서
+     톤만 빌려 자기 채널 이름으로 감싼다. base에만 정의해 네 테마가 자동으로 따라온다.
+     markdown/styles.css의 hljs 팔레트는 별도 독트린 예외이며 이 채널과 무관하다. */
+  --syntax-key: var(--id-amber);
+  --syntax-string: var(--id-moss);
+  --syntax-number: var(--id-plum);
+  --syntax-function: var(--id-cerulean);
+  --syntax-tag: var(--id-crimson);
+  --syntax-attr: var(--id-teal);
+  --syntax-comment: var(--text-tertiary);
+  --syntax-punct: var(--text-tertiary);
 
   /* 굵기는 3티어만 쓴다 — 가변 서체가 임의 축값을 허용한다고 해서 위계가 늘어나지는 않는다.
      regular=본문, medium=강조·컨트롤 라벨, bold=제목·주요 액션. 세 티어 밖의 값은
@@ -538,7 +566,7 @@ a {
 ::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb);
   border: 2px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background-clip: padding-box;
 }
 

--- a/runtime/fleet-console/font-picker/styles.css
+++ b/runtime/fleet-console/font-picker/styles.css
@@ -97,7 +97,7 @@
 .fc-font-browser__preview { display: grid; align-content: start; gap: var(--space-3, 12px); }
 .fc-font-browser__preview-head,
 .fc-font-browser__size-control { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2, 8px); }
-.fc-font-browser__availability { padding: 0.1em 0.55em; border: 1px solid var(--surface-rim-strong); border-radius: 999px; color: var(--text-secondary); }
+.fc-font-browser__availability { padding: 0.1em 0.55em; border: 1px solid var(--surface-rim-strong); border-radius: var(--radius-pill); color: var(--text-secondary); }
 .fc-font-browser__availability--unavailable { color: var(--warn-ink); }
 .fc-font-browser__preview-copy { min-height: 5em; margin: 0; color: var(--text-primary); overflow-wrap: anywhere; }
 .fc-font-browser__stepper { min-width: 2.2em; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs, 8px); background: color-mix(in oklab, var(--surface-glass-strong) 78%, transparent); color: var(--text-primary); }

--- a/runtime/fleet-console/markdown/styles.css
+++ b/runtime/fleet-console/markdown/styles.css
@@ -213,7 +213,7 @@ code.hljs {
   top: 0.35em;
   bottom: 0.3em;
   width: var(--space-hair);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: linear-gradient(180deg, var(--brass) 30%, var(--brass-deep));
   box-shadow: 0 0 8px var(--brass-glow);
 }
@@ -502,7 +502,7 @@ code.hljs {
   max-width: none;
   margin: var(--space-6) 0;
   padding: clamp(40px, 5vw, 56px) clamp(20px, 3vw, 32px) clamp(20px, 3vw, 28px);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
   box-shadow: var(--shadow-soft);
@@ -533,7 +533,7 @@ code.hljs {
   z-index: 2;
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.22em;
   text-transform: uppercase;
@@ -690,7 +690,7 @@ code.hljs {
   grid-template-rows: auto minmax(0, 1fr);
   width: min(1600px, 96vw);
   height: min(920px, 92dvh);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-rim-strong);
   background: var(--surface-pillar);
   box-shadow: var(--shadow-floating);
@@ -772,7 +772,7 @@ code.hljs {
   min-width: 44px;
   min-height: 44px;
   padding: 0 var(--space-4);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   color: var(--brass-bright);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -75,6 +75,14 @@ const ACHROMATIC_CHROMA_CEILING = 0.03;
 const ACHROMATIC_CHANNEL_SPREAD = 12;
 // hsl 표기는 채도를 직접 적으므로 그 값으로 같은 경계를 판정한다.
 const ACHROMATIC_SATURATION_CEILING_PERCENT = 10;
+// rem은 root 기준이고 이 셸은 root 크기를 재정의하지 않으므로 브라우저 기본값이 환산 기준이다.
+const ROOT_FONT_SIZE_PX = 16;
+// 색을 싣는 속성만 검사한다 — font-family 등에 낱말이 스쳐도 색 리터럴이 아니다.
+const COLOR_BEARING_PROPERTY_PATTERN =
+  "color|background|background-color|border-color|border|outline-color|outline|fill|stroke|box-shadow|text-shadow|caret-color|accent-color|column-rule-color";
+// 무채색 낱말(black/white/gray/transparent/currentColor)은 깊이 리터럴과 같은 이유로 통과시킨다.
+const CHROMATIC_COLOR_KEYWORDS =
+  /\b(?:red|blue|green|yellow|orange|purple|pink|brown|cyan|magenta|teal|olive|navy|maroon|lime|aqua|fuchsia|gold|coral|salmon|crimson|indigo|violet|khaki|plum|orchid|tomato|turquoise|rebeccapurple|firebrick|forestgreen|goldenrod|hotpink|lavender|peru|sienna|skyblue|tan|thistle|wheat|chocolate|darkred|darkblue|darkgreen|lightblue|lightgreen|steelblue|seagreen|slateblue|springgreen|deeppink|deepskyblue|dodgerblue|mediumpurple|palegreen|royalblue|tomato)\b/i;
 // font-size가 텍스트가 아니라 도형을 재는 자리들 — 글리프 문자('×' '✦' '↻' 꺾쇠)의 크기이거나,
 // 치수가 박힌 상자(아바타·숫자 배지·이니셜 마크) 안이라 사다리로 올리면 넘치거나 잘린다.
 const RAW_FONT_SIZE_EXEMPT_SELECTORS = [
@@ -91,6 +99,7 @@ const RAW_FONT_SIZE_EXEMPT_SELECTORS = [
   ".directory-browser-close",
   ".directory-browser-sector-advance",
   ".whatsnew-close",
+  ".skills-overlay-close",
   ".quick-launch-mark",
   ".alerts-icon-badge",
   ".fexp-refresh-btn",
@@ -645,20 +654,32 @@ describe("Instrument core design contract", () => {
       const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
       const masked = maskFontFaceBlocks(css);
       const record = (index: number, value: string) => {
-        if (Number(value) >= DISPLAY_SIZE_FLOOR_PX) return;
         const line = lineAt(css, index);
         const selector = selectorAt(masked, index);
         if (RAW_FONT_SIZE_EXEMPT_SELECTORS.some((exempt) => selector.includes(exempt))) return;
         violations.push(`${consoleRelativePath(file)}:${line} ${css.split("\n")[line - 1]!.trim()}`);
       };
+      // 단위는 px 하나가 아니다 — rem은 root 기준의 절대값이라 px와 등가이고, 그대로 두면 한
+      // 플러그인만 다른 단위 체계에 남는다. em/%/ch는 부모 상대라는 다른 축이므로 사다리가
+      // 관여하지 않고, 계산 함수는 그 안의 px만 본다.
+      const offLadder = (value: string): boolean => {
+        if (/var\(\s*--t-(?:2xs|xs|sm|md|base|lg|xl)\s*\)/.test(value)) return false;
+        if (/var\(\s*--font-body-size\s*\)/.test(value)) return false;
+        // 절대 크기가 하나라도 적혀 있으면 그 값이 판정을 진다. 상대 단위가 섞인 계산 함수
+        // (clamp(11px, 2vw, 15px))를 상대 축으로 놓아 주면 그 안의 절대 하한이 게이트를 빠져나간다.
+        const sizes = [...value.matchAll(/([0-9.]+)(px|rem)\b/g)].map(([, amount, unit]) =>
+          unit === "rem" ? Number(amount) * ROOT_FONT_SIZE_PX : Number(amount),
+        );
+        // 절대 크기가 없으면 부모 상대(em·%·ch) 축이다 — 사다리가 관여하지 않는다.
+        if (sizes.length === 0) return false;
+        return Math.min(...sizes) < DISPLAY_SIZE_FLOOR_PX;
+      };
       for (const declaration of cssDeclarations(masked, "font-size")) {
-        const match = /^([0-9.]+)px/.exec(declaration.value);
-        if (match) record(declaration.index, match[1]!);
+        if (offLadder(declaration.value)) record(declaration.index, declaration.value);
       }
       // font 단축 표기도 같은 축이다 — 여기로 새면 게이트가 절반만 지킨다.
       for (const declaration of cssDeclarations(masked, "font")) {
-        const match = /([0-9.]+)px/.exec(declaration.value.split("/", 1)[0]!);
-        if (match) record(declaration.index, match[1]!);
+        if (offLadder(declaration.value.split("/", 1)[0]!)) record(declaration.index, declaration.value);
       }
     }
     expect(violations).toEqual([]);
@@ -717,6 +738,14 @@ describe("Instrument core design contract", () => {
       }
       for (const match of masked.matchAll(/\b(?:color|lab|lch|hwb)\(/g)) {
         report(match.index, match[0]);
+      }
+      // 명명색도 리터럴이다. 단 토큰 이름 자체가 색 낱말을 품고 있으므로(--coral·--id-plum·
+      // --id-teal), var() 참조를 먼저 지운 값에서만 낱말을 찾는다 — 지우지 않으면 정상 토큰
+      // 소비가 통째로 위반으로 잡힌다.
+      for (const declaration of cssDeclarations(masked, COLOR_BEARING_PROPERTY_PATTERN)) {
+        const stripped = declaration.value.replace(/var\(\s*--[A-Za-z0-9_-]+/g, " ");
+        const named = CHROMATIC_COLOR_KEYWORDS.exec(stripped);
+        if (named) report(declaration.index, named[0]);
       }
     }
     expect(violations).toEqual([]);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -66,6 +66,35 @@ const OWNED_SOURCES = [
 ] as const;
 
 const FORBIDDEN_DECORATION = /radar-sweep|operations-radar|BACKGROUND_ANIMATION_STORAGE_KEY|PERIMETER_ANIMATION_STORAGE_KEY|Panel pulse|perimeter-orbit|notification-wake-pulse|AnchorIcon/;
+// 활자 사다리의 최대 단은 --t-xl(22px)이다. 그 위는 브랜드 워드마크·빈 상태 일러스트처럼
+// 소비처가 한 곳뿐이고 서로 다른 이유로 존재하는 디스플레이 크기라 사다리 밖에 둔다.
+const DISPLAY_SIZE_FLOOR_PX = 24;
+// 스켈레톤은 C≈0.012~0.02의 저채도 대역에 산다. 그 위의 유채색은 theme.css에서만 정의된다.
+const ACHROMATIC_CHROMA_CEILING = 0.03;
+// font-size가 텍스트가 아니라 도형을 재는 자리들 — 글리프 문자('×' '✦' '↻' 꺾쇠)의 크기이거나,
+// 치수가 박힌 상자(아바타·숫자 배지·이니셜 마크) 안이라 사다리로 올리면 넘치거나 잘린다.
+const RAW_FONT_SIZE_EXEMPT_SELECTORS = [
+  ".add-host-close",
+  ".pair-close",
+  ".settings-disclosure-toggle::after",
+  ".canvas-shortcuts-or",
+  ".thought-chevron",
+  ".tool-chip-glyph",
+  ".timeline-chevron",
+  ".effort-track-fill::after",
+  ".effort-track-fill::before",
+  ".app-toast-close",
+  ".directory-browser-close",
+  ".directory-browser-sector-advance",
+  ".whatsnew-close",
+  ".quick-launch-mark",
+  ".alerts-icon-badge",
+  ".fexp-refresh-btn",
+  ".history-commit-avatar",
+  ".session-analyst__receipt-chev",
+  ".session-analyst__ev",
+  ".agent-chat-fold-chev",
+] as const;
 const RAW_TEXT_INK_TOKENS = /var\(\s*--ink-(?:fog|rim|spectral|pearl)\b/;
 const NUMERIC_FONT_WEIGHT = /^(?:[1-9]\d{0,2}|1000)\b/;
 const RUNTIME_CUSTOM_PROPERTY_ALLOWLIST = new Set([
@@ -274,6 +303,15 @@ function cssDeclarations(css: string, property: string): Array<{ index: number; 
 
 function lineAt(text: string, index: number): number {
   return text.slice(0, index).split("\n").length;
+}
+
+// 선언이 속한 규칙의 선택자. 예외를 파일:줄로 적으면 그 위에 한 줄만 들어와도 조용히 빗나가므로,
+// 무엇을 면제했는지가 이름으로 남는 선택자를 기준으로 삼는다.
+function selectorAt(masked: string, index: number): string {
+  const blockStart = masked.lastIndexOf("{", index);
+  if (blockStart === -1) return "";
+  const selectorStart = Math.max(masked.lastIndexOf("}", blockStart), masked.lastIndexOf("{", blockStart - 1)) + 1;
+  return masked.slice(selectorStart, blockStart).trim();
 }
 
 function customPropertyDefinitions(css: string): Set<string> {
@@ -550,6 +588,69 @@ describe("Instrument core design contract", () => {
         if (!/(?:^|\s)(?:[1-9]\d{0,2}|1000)(?=\s|$)/.test(beforeLineHeight)) continue;
         const line = lineAt(css, declaration.index);
         violations.push(`${consoleRelativePath(file)}:${line} ${css.split("\n")[line - 1]!.trim()}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  // 굵기를 3티어로 묶어 놓고 크기를 raw px로 열어 두면, 표면마다 자기 스케일을 발명해 같은
+  // 역할이 화면마다 다른 크기로 선다(실측 32종·반픽셀 151회, 같은 Rail 슬롯 본문이 10.5~13px).
+  // 사다리 최대가 22px이므로 24px 이상은 디스플레이 영역으로 사다리 밖에 둔다.
+  it("keeps product font size on the type-scale token ladder", () => {
+    const violations: string[] = [];
+    for (const file of listProductCssFiles()) {
+      const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+      const masked = maskFontFaceBlocks(css);
+      const record = (index: number, value: string) => {
+        if (Number(value) >= DISPLAY_SIZE_FLOOR_PX) return;
+        const line = lineAt(css, index);
+        const selector = selectorAt(masked, index);
+        if (RAW_FONT_SIZE_EXEMPT_SELECTORS.some((exempt) => selector.includes(exempt))) return;
+        violations.push(`${consoleRelativePath(file)}:${line} ${css.split("\n")[line - 1]!.trim()}`);
+      };
+      for (const declaration of cssDeclarations(masked, "font-size")) {
+        const match = /^([0-9.]+)px/.exec(declaration.value);
+        if (match) record(declaration.index, match[1]!);
+      }
+      // font 단축 표기도 같은 축이다 — 여기로 새면 게이트가 절반만 지킨다.
+      for (const declaration of cssDeclarations(masked, "font")) {
+        const match = /([0-9.]+)px/.exec(declaration.value.split("/", 1)[0]!);
+        if (match) record(declaration.index, match[1]!);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  // 라운드 어휘는 xs·md·pill 셋뿐이다. raw 999px가 살아 있으면 같은 캡슐을 두 이름으로 부르게 되고,
+  // 퇴역한 sm·lg·xl이 되살아나면 이름이 다시 값보다 많아진다.
+  it("keeps border radius on the three-name vocabulary", () => {
+    const violations: string[] = [];
+    for (const file of listProductCssFiles()) {
+      const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+      const masked = maskCssCommentsAndStrings(css);
+      for (const declaration of cssDeclarations(masked, "border-radius")) {
+        if (!/999px|--radius-(?:sm|lg|xl)\b/.test(declaration.value)) continue;
+        const line = lineAt(css, declaration.index);
+        violations.push(`${consoleRelativePath(file)}:${line} ${css.split("\n")[line - 1]!.trim()}`);
+      }
+      for (const match of masked.matchAll(/var\(\s*--radius-(?:sm|lg|xl)\b/g)) {
+        violations.push(`${consoleRelativePath(file)}:${lineAt(css, match.index)} retired radius token`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  // 유채색 raw 리터럴은 두 규칙을 한 번에 깬다 — 스켈레톤의 채도 봉투를 넘고, 테마별 재조율을 받지 못한다.
+  // 깊이를 나르는 근사 무채색(그림자·스크림·시트)은 console CLAUDE.md가 명시한 예외라 통과시킨다.
+  it("keeps chromatic color literals inside theme.css", () => {
+    const violations: string[] = [];
+    for (const file of listProductCssFiles()) {
+      if (CSS_THEME_SOURCES.some((theme) => fileURLToPath(theme) === file)) continue;
+      const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+      const masked = maskCssCommentsAndStrings(css);
+      for (const match of masked.matchAll(/oklch\(\s*[0-9.]+%?\s+([0-9.]+)\s/g)) {
+        if (Number(match[1]) < ACHROMATIC_CHROMA_CEILING) continue;
+        violations.push(`${consoleRelativePath(file)}:${lineAt(css, match.index)} ${match[0].trim()}`);
       }
     }
     expect(violations).toEqual([]);
@@ -1332,7 +1433,7 @@ describe("Instrument core design contract", () => {
     expect(components).not.toMatch(/^\.operations-side-bar\.is-expanded \{/m);
     expect(layout).toContain(".command-band.is-fullscreen {");
     // 접거나 풀스크린이면 상단 캡이 없으므로 부유 카드 문법이 그대로 남는다.
-    expect(components).toContain("border-radius: 0 var(--radius-xl) 0 0;");
+    expect(components).toContain("border-radius: 0 var(--radius-md) 0 0;");
     expect(layout).toContain(".command-band-left.is-collapsed {");
     expect(components).not.toContain(".float-handle");
     expect(components).not.toContain("focus-mode-reveal");
@@ -1981,7 +2082,7 @@ describe("Instrument core design contract", () => {
     expect(captionSeamBlock).toContain("border-top-width: 0;");
     expect(captionSeamBlock).toContain("border-top-style: none;");
     expect(captionSeamBlock).not.toContain("border-top: none;");
-    expect(components).toContain("border-radius: 999px;");
+    expect(components).toContain("border-radius: var(--radius-pill);");
     expect(components).toContain("color: var(--text-secondary);");
     // 캡션 구조 선은 본문과 같은 --surface-rim을 직접 칠한다. inherit와
     // 1px solid inherit 단축은 선언이 버려지거나 계산색이 갈라진다.
@@ -2094,7 +2195,7 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain("border: 1px solid var(--surface-rim);");
     expect(selectBlock).toContain("background: color-mix(in oklch, var(--ink-mid) 48%, transparent);");
     expect(selectBlock).toContain("color: var(--text-primary);");
-    expect(selectBlock).toContain("font-weight: var(--weight-medium); font-size: 13px; line-height: 1.2; font-family: var(--font-body);");
+    expect(selectBlock).toContain("font-weight: var(--weight-medium); font-size: var(--t-md); line-height: 1.2; font-family: var(--font-body);");
     expect(selectBlock).toContain("padding: 0 13px;");
     expect(selectBlock).toContain("box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);");
     expect(selectBlock).toContain("border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));");
@@ -2104,7 +2205,7 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain(".fc-select--compact .fc-select__trigger {");
     // compact 트리거는 칩 문법의 모노 티어(11px)를 쓴다 — 본문 14px 옆에서 9px는 라벨이 아니라 흔적이 된다.
     expect(selectBlock).toContain(
-      "font-weight: var(--weight-regular);\n  font-size: 11px;\n  line-height: 1;\n  font-family: var(--font-mono);",
+      "font-weight: var(--weight-regular);\n  font-size: var(--t-xs);\n  line-height: 1;\n  font-family: var(--font-mono);",
     );
     // 호출부가 트리거 글자색을 자기 채널로 넘겨받는 유일한 통로 — 미설정이면 기본 티어를 그대로 쓴다.
     expect(selectBlock).toContain("color: var(--fc-select-compact-tone, var(--text-secondary));");
@@ -2262,7 +2363,7 @@ describe("Effort track interaction grammar", () => {
     const undoBlock = undo.slice(0, undo.indexOf("}"));
     expect(undoBlock).toContain("background: none;");
     expect(undoBlock).toContain("border: 0;");
-    expect(undoBlock).not.toContain("border-radius: 999px;");
+    expect(undoBlock).not.toContain("border-radius: var(--radius-pill);");
 
     // 시작 뷰 선택은 실행 종류가 스스로 선언했을 때만 선다 — core가 어느 플러그인이 채팅을
     // 아는지 알면 안 된다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -71,6 +71,10 @@ const FORBIDDEN_DECORATION = /radar-sweep|operations-radar|BACKGROUND_ANIMATION_
 const DISPLAY_SIZE_FLOOR_PX = 24;
 // 스켈레톤은 C≈0.012~0.02의 저채도 대역에 산다. 그 위의 유채색은 theme.css에서만 정의된다.
 const ACHROMATIC_CHROMA_CEILING = 0.03;
+// sRGB 표기(hex·rgb)에서 같은 경계 — 세 채널의 폭이 이보다 좁으면 색이 아니라 깊이를 나른다.
+const ACHROMATIC_CHANNEL_SPREAD = 12;
+// hsl 표기는 채도를 직접 적으므로 그 값으로 같은 경계를 판정한다.
+const ACHROMATIC_SATURATION_CEILING_PERCENT = 10;
 // font-size가 텍스트가 아니라 도형을 재는 자리들 — 글리프 문자('×' '✦' '↻' 꺾쇠)의 크기이거나,
 // 치수가 박힌 상자(아바타·숫자 배지·이니셜 마크) 안이라 사다리로 올리면 넘치거나 잘린다.
 const RAW_FONT_SIZE_EXEMPT_SELECTORS = [
@@ -303,6 +307,45 @@ function cssDeclarations(css: string, property: string): Array<{ index: number; 
 
 function lineAt(text: string, index: number): number {
   return text.slice(0, index).split("\n").length;
+}
+
+// 깊이 리터럴은 채널이 서로 같다(검정·흰색 계열). 색을 띠기 시작하면 채널이 갈라지므로,
+// 세 채널의 최대-최소 폭으로 무채색 여부를 가른다 — oklch의 chroma 상한과 같은 역할이다.
+function isAchromaticChannels(channels: number[]): boolean {
+  if (channels.length < 3 || channels.some((value) => !Number.isFinite(value))) return false;
+  const [red, green, blue] = channels as [number, number, number];
+  return Math.max(red, green, blue) - Math.min(red, green, blue) <= ACHROMATIC_CHANNEL_SPREAD;
+}
+
+function isAchromaticHex(digits: string): boolean {
+  const expand = (value: string) => Number.parseInt(value.length === 1 ? value.repeat(2) : value, 16);
+  if (digits.length === 3 || digits.length === 4) {
+    return isAchromaticChannels([...digits.slice(0, 3)].map(expand));
+  }
+  if (digits.length === 6 || digits.length === 8) {
+    return isAchromaticChannels([0, 2, 4].map((offset) => expand(digits.slice(offset, offset + 2))));
+  }
+  return false;
+}
+
+function isAchromaticRgb(args: string): boolean {
+  const channels = args
+    .split("/", 1)[0]!
+    .split(/[\s,]+/)
+    .filter((token) => token.length > 0)
+    .slice(0, 3)
+    .map((token) => (token.endsWith("%") ? (Number.parseFloat(token) * 255) / 100 : Number.parseFloat(token)));
+  return isAchromaticChannels(channels);
+}
+
+function isAchromaticHsl(args: string): boolean {
+  const saturation = args
+    .split("/", 1)[0]!
+    .split(/[\s,]+/)
+    .filter((token) => token.length > 0)[1];
+  if (saturation === undefined) return false;
+  const value = Number.parseFloat(saturation);
+  return Number.isFinite(value) && value <= ACHROMATIC_SATURATION_CEILING_PERCENT;
 }
 
 // 선언이 속한 규칙의 선택자. 예외를 파일:줄로 적으면 그 위에 한 줄만 들어와도 조용히 빗나가므로,
@@ -642,15 +685,38 @@ describe("Instrument core design contract", () => {
 
   // 유채색 raw 리터럴은 두 규칙을 한 번에 깬다 — 스켈레톤의 채도 봉투를 넘고, 테마별 재조율을 받지 못한다.
   // 깊이를 나르는 근사 무채색(그림자·스크림·시트)은 console CLAUDE.md가 명시한 예외라 통과시킨다.
+  // 문법은 oklch 하나가 아니다 — hex·rgb·hsl로 적은 유채색도 같은 두 규칙을 깨므로 함께 막고,
+  // 채널을 해석할 수 없는 함수형(color()/lab()/lch())은 통과시키지 않는다.
   it("keeps chromatic color literals inside theme.css", () => {
     const violations: string[] = [];
     for (const file of listProductCssFiles()) {
       if (CSS_THEME_SOURCES.some((theme) => fileURLToPath(theme) === file)) continue;
+      // markdown/styles.css는 vendored highlight.js 팔레트(github-dark ↔ github) 전체가 파일 상단
+      // doctrine 주석으로 예외 선언된 표면이다. 신택스 역할색은 --syntax-* 채널이 따로 지고 있다.
+      if (file === fileURLToPath(new URL("markdown/styles.css", CONSOLE_ROOT))) continue;
       const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
       const masked = maskCssCommentsAndStrings(css);
+      const report = (index: number, snippet: string) => {
+        violations.push(`${consoleRelativePath(file)}:${lineAt(css, index)} ${snippet}`);
+      };
       for (const match of masked.matchAll(/oklch\(\s*[0-9.]+%?\s+([0-9.]+)\s/g)) {
         if (Number(match[1]) < ACHROMATIC_CHROMA_CEILING) continue;
-        violations.push(`${consoleRelativePath(file)}:${lineAt(css, match.index)} ${match[0].trim()}`);
+        report(match.index, match[0].trim());
+      }
+      for (const match of masked.matchAll(/#([0-9a-fA-F]{3,8})\b/g)) {
+        if (isAchromaticHex(match[1]!)) continue;
+        report(match.index, match[0]);
+      }
+      for (const match of masked.matchAll(/\brgba?\(([^)]*)\)/g)) {
+        if (isAchromaticRgb(match[1]!)) continue;
+        report(match.index, match[0]);
+      }
+      for (const match of masked.matchAll(/\bhsla?\(([^)]*)\)/g)) {
+        if (isAchromaticHsl(match[1]!)) continue;
+        report(match.index, match[0]);
+      }
+      for (const match of masked.matchAll(/\b(?:color|lab|lch|hwb)\(/g)) {
+        report(match.index, match[0]);
       }
     }
     expect(violations).toEqual([]);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -80,9 +80,37 @@ const ROOT_FONT_SIZE_PX = 16;
 // 색을 싣는 속성만 검사한다 — font-family 등에 낱말이 스쳐도 색 리터럴이 아니다.
 const COLOR_BEARING_PROPERTY_PATTERN =
   "color|background|background-color|border-color|border|outline-color|outline|fill|stroke|box-shadow|text-shadow|caret-color|accent-color|column-rule-color";
-// 무채색 낱말(black/white/gray/transparent/currentColor)은 깊이 리터럴과 같은 이유로 통과시킨다.
-const CHROMATIC_COLOR_KEYWORDS =
-  /\b(?:red|blue|green|yellow|orange|purple|pink|brown|cyan|magenta|teal|olive|navy|maroon|lime|aqua|fuchsia|gold|coral|salmon|crimson|indigo|violet|khaki|plum|orchid|tomato|turquoise|rebeccapurple|firebrick|forestgreen|goldenrod|hotpink|lavender|peru|sienna|skyblue|tan|thistle|wheat|chocolate|darkred|darkblue|darkgreen|lightblue|lightgreen|steelblue|seagreen|slateblue|springgreen|deeppink|deepskyblue|dodgerblue|mediumpurple|palegreen|royalblue|tomato)\b/i;
+// CSS 명명색 전체 집합. 손으로 고른 일부만 적으면 빠뜨린 낱말(chartreuse·cornflowerblue…)이
+// 그대로 통과해 게이트가 지키는 척만 한다 — 목록은 전수여야 판정에 쓸 수 있다.
+const CSS_NAMED_COLORS = new Set([
+  "aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige", "bisque", "black",
+  "blanchedalmond", "blue", "blueviolet", "brown", "burlywood", "cadetblue", "chartreuse",
+  "chocolate", "coral", "cornflowerblue", "cornsilk", "crimson", "cyan", "darkblue", "darkcyan",
+  "darkgoldenrod", "darkgray", "darkgreen", "darkgrey", "darkkhaki", "darkmagenta",
+  "darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon", "darkseagreen",
+  "darkslateblue", "darkslategray", "darkslategrey", "darkturquoise", "darkviolet", "deeppink",
+  "deepskyblue", "dimgray", "dimgrey", "dodgerblue", "firebrick", "floralwhite", "forestgreen",
+  "fuchsia", "gainsboro", "ghostwhite", "gold", "goldenrod", "gray", "green", "greenyellow",
+  "grey", "honeydew", "hotpink", "indianred", "indigo", "ivory", "khaki", "lavender",
+  "lavenderblush", "lawngreen", "lemonchiffon", "lightblue", "lightcoral", "lightcyan",
+  "lightgoldenrodyellow", "lightgray", "lightgreen", "lightgrey", "lightpink", "lightsalmon",
+  "lightseagreen", "lightskyblue", "lightslategray", "lightslategrey", "lightsteelblue",
+  "lightyellow", "lime", "limegreen", "linen", "magenta", "maroon", "mediumaquamarine",
+  "mediumblue", "mediumorchid", "mediumpurple", "mediumseagreen", "mediumslateblue",
+  "mediumspringgreen", "mediumturquoise", "mediumvioletred", "midnightblue", "mintcream",
+  "mistyrose", "moccasin", "navajowhite", "navy", "oldlace", "olive", "olivedrab", "orange",
+  "orangered", "orchid", "palegoldenrod", "palegreen", "paleturquoise", "palevioletred",
+  "papayawhip", "peachpuff", "peru", "pink", "plum", "powderblue", "purple", "rebeccapurple",
+  "red", "rosybrown", "royalblue", "saddlebrown", "salmon", "sandybrown", "seagreen", "seashell",
+  "sienna", "silver", "skyblue", "slateblue", "slategray", "slategrey", "snow", "springgreen",
+  "steelblue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white",
+  "whitesmoke", "yellow", "yellowgreen",
+]);
+// 세 채널이 같은(또는 거의 같은) 명명색은 깊이 리터럴과 같은 이유로 통과시킨다.
+const ACHROMATIC_NAMED_COLORS = new Set([
+  "black", "white", "gray", "grey", "darkgray", "darkgrey", "dimgray", "dimgrey",
+  "lightgray", "lightgrey", "silver", "gainsboro", "whitesmoke", "snow",
+]);
 // font-size가 텍스트가 아니라 도형을 재는 자리들 — 글리프 문자('×' '✦' '↻' 꺾쇠)의 크기이거나,
 // 치수가 박힌 상자(아바타·숫자 배지·이니셜 마크) 안이라 사다리로 올리면 넘치거나 잘린다.
 const RAW_FONT_SIZE_EXEMPT_SELECTORS = [
@@ -665,6 +693,14 @@ describe("Instrument core design contract", () => {
       const offLadder = (value: string): boolean => {
         if (/var\(\s*--t-(?:2xs|xs|sm|md|base|lg|xl)\s*\)/.test(value)) return false;
         if (/var\(\s*--font-body-size\s*\)/.test(value)) return false;
+        // Codex 서브앱이 자기 --font-size-* 스케일을 갖고 있고, 공유 마크다운과 코어 일부가
+        // 그 토큰을 함께 소비한다(총 113곳). 두 어휘를 합칠지는 이 사다리와 별개의 결정이라
+        // 아직 내려지지 않았으므로 여기 이름으로 적어 둔다 — 조용한 통과가 아니라 선언된
+        // 미결 사항으로 남기고, 합치기로 하면 이 한 줄이 사라진다.
+        if (/var\(\s*--font-size-[a-z0-9-]+\s*\)/.test(value)) return false;
+        // 그 밖의 커스텀 프로퍼티는 새 어휘를 여는 통로다 — 별칭 하나가 자기 스케일을 열면
+        // 사다리는 이름만 남는다. 값을 읽을 수 없으므로 참조 자체를 거부한다.
+        if (/var\(\s*--/.test(value)) return true;
         // 절대 크기가 하나라도 적혀 있으면 그 값이 판정을 진다. 상대 단위가 섞인 계산 함수
         // (clamp(11px, 2vw, 15px))를 상대 축으로 놓아 주면 그 안의 절대 하한이 게이트를 빠져나간다.
         const sizes = [...value.matchAll(/([0-9.]+)(px|rem)\b/g)].map(([, amount, unit]) =>
@@ -744,8 +780,12 @@ describe("Instrument core design contract", () => {
       // 소비가 통째로 위반으로 잡힌다.
       for (const declaration of cssDeclarations(masked, COLOR_BEARING_PROPERTY_PATTERN)) {
         const stripped = declaration.value.replace(/var\(\s*--[A-Za-z0-9_-]+/g, " ");
-        const named = CHROMATIC_COLOR_KEYWORDS.exec(stripped);
-        if (named) report(declaration.index, named[0]);
+        for (const word of stripped.matchAll(/[A-Za-z]{3,}/g)) {
+          const name = word[0]!.toLowerCase();
+          if (!CSS_NAMED_COLORS.has(name) || ACHROMATIC_NAMED_COLORS.has(name)) continue;
+          report(declaration.index, name);
+          break;
+        }
       }
     }
     expect(violations).toEqual([]);

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -118,12 +118,12 @@
   width: 100%;
   padding: 6px 9px;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   text-align: left;
   white-space: nowrap;
 }
@@ -163,7 +163,7 @@
     var(--ink-deep);
   box-shadow: var(--shadow-anchor);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   pointer-events: none;
   text-align: center;
   animation: fexp-toast-enter var(--duration-fast) var(--ease-spring);
@@ -205,7 +205,7 @@
 .fexp-viewer-filename {
   flex: 1;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -218,10 +218,10 @@
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
-  font-size: 14px;
+  font-size: var(--t-base);
   line-height: 1;
   padding: 4px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   transition: color 0.12s;
 }
 
@@ -238,7 +238,7 @@
 .fexp-viewer-error {
   padding: 16px;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
 }
 
@@ -275,7 +275,7 @@
 .fexp-filter-scan {
   padding: 0 12px 6px;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
 }
 
@@ -283,16 +283,16 @@
   margin: 0 10px 8px;
   padding: 4px 8px;
   border: 1px solid color-mix(in oklch, var(--warn) 30%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--warn) 9%, transparent);
   color: var(--warn-ink);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .fexp-git-note {
   padding: 0 12px 6px;
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--warn-ink);
 }
 
@@ -304,7 +304,7 @@
   border-radius: var(--radius-xs);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   padding: 3px 8px;
   outline: none;
   transition: border-color 140ms;
@@ -320,7 +320,7 @@
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   padding: 2px 4px;
   border-radius: var(--radius-xs);
   line-height: 1;
@@ -347,7 +347,7 @@
   cursor: pointer;
   text-align: left;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
 }
 
@@ -366,7 +366,7 @@
   border: none;
   cursor: pointer;
   text-align: left;
-  font-size: 13px;
+  font-size: var(--t-sm);
   color: var(--text-secondary);
   transition: background 0.1s;
 }
@@ -391,7 +391,7 @@
   align-items: center;
   justify-content: center;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   width: 16px;
   height: 16px;
@@ -413,12 +413,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-sm);
 }
 
 .fexp-tree-spin {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   animation: none;
 }
@@ -431,7 +431,7 @@
   padding-top: 0;
   padding-bottom: 0;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--warn-ink);
   background: color-mix(in oklch, var(--warn) 8%, transparent);
   white-space: nowrap;
@@ -446,7 +446,7 @@
   height: 30px;
   padding-top: 0;
   padding-bottom: 0;
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   white-space: nowrap;
   overflow: hidden;
@@ -458,7 +458,7 @@
   flex: 0 0 12px;
   margin-left: auto;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   line-height: 1;
   text-align: center;
@@ -472,7 +472,7 @@
 .fexp-tree-loading,
 .fexp-tree-error {
   padding: 16px 12px;
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
 }
 
@@ -489,7 +489,7 @@
 .fexp-truncated-badge {
   flex-shrink: 0;
   padding: 4px 12px;
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--warn-ink);
   background: color-mix(in oklch, var(--warn) 12%, transparent);
   border-bottom: 1px solid var(--surface-rim);
@@ -504,7 +504,7 @@
   border-collapse: collapse;
   width: 100%;
   font-family: var(--font-mono);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   line-height: 1.6;
 }
 
@@ -526,14 +526,17 @@
 }
 
 /* 구문강조 토큰 팔레트 */
-.syn-key  { color: var(--brass-bright, var(--brass)); font-weight: var(--weight-medium); }
-.syn-str  { color: var(--positive-ink); }
-.syn-num  { color: var(--warn-ink); }
-.syn-com  { color: var(--text-tertiary); font-style: italic; }
-.syn-fn   { color: var(--aurora-ink); }
-.syn-tag  { color: var(--coral-ink); }
-.syn-attr { color: var(--brass-ink); }
-.syn-punct { color: var(--text-tertiary); }
+/* 신택스 역할색은 --syntax-* 채널이 진다 — 문자열이 "완료"를, 숫자가 "진행 중"을 뜻하지
+   않으므로 신호 토큰(positive/warn/coral/aurora)도, 위치를 말하는 brass도 빌리지 않는다.
+   채널 정의와 톤 배정은 theme.css 한 곳이며 네 테마가 함께 재조율된다. */
+.syn-key  { color: var(--syntax-key); font-weight: var(--weight-medium); }
+.syn-str  { color: var(--syntax-string); }
+.syn-num  { color: var(--syntax-number); }
+.syn-com  { color: var(--syntax-comment); font-style: italic; }
+.syn-fn   { color: var(--syntax-function); }
+.syn-tag  { color: var(--syntax-tag); }
+.syn-attr { color: var(--syntax-attr); }
+.syn-punct { color: var(--syntax-punct); }
 
 /* ── 마크다운 뷰어 ── */
 .fexp-md-wrap {
@@ -555,10 +558,10 @@
   min-height: 24px;
   padding: 3px 8px;
   border: 1px dashed color-mix(in oklch, var(--ink-fog) 48%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.4;
   vertical-align: middle;
 }
@@ -583,7 +586,7 @@
     color-mix(in oklch, var(--ink-fog) 15%, transparent) 0% 25%,
     transparent 0% 50%
   ) 0 0 / 16px 16px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   overflow: hidden;
   width: 100%;
   max-height: 360px;
@@ -598,7 +601,7 @@
 
 .fexp-img-caption {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   text-align: center;
 }
@@ -622,14 +625,14 @@
 
 .fexp-bin-name {
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--t-sm);
   color: var(--text-secondary);
   margin: 0;
 }
 
 .fexp-bin-meta,
 .fexp-bin-hint {
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   margin: 0;
 }

--- a/runtime/fleet-plugins/ledger/client/ledger.css
+++ b/runtime/fleet-plugins/ledger/client/ledger.css
@@ -18,7 +18,7 @@
   gap: 2px;
   padding: 2px;
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-glass);
 }
 
@@ -29,7 +29,7 @@
   background: transparent;
   color: var(--text-secondary);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   cursor: pointer;
   transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
@@ -72,7 +72,7 @@
 .ledger-summary > p {
   margin: var(--space-1) 0 var(--space-3);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .ledger-total-token {
@@ -87,12 +87,12 @@
 
 .ledger-total-token > span:first-child {
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
 }
 
 .ledger-total-token > .ledger-value {
-  font-size: 16px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-bold);
 }
 
@@ -114,7 +114,7 @@
 .ledger-metric span {
   overflow: hidden;
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -122,7 +122,7 @@
 .ledger-metric strong {
   margin-top: 2px;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
 }
 
@@ -137,7 +137,7 @@
 .ledger-source h3 {
   margin: 0 0 var(--space-2);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: .08em;
   text-transform: uppercase;
@@ -167,7 +167,7 @@
   min-height: 22px;
   padding: 0 var(--space-2);
   overflow: hidden;
-  font-size: 10px;
+  font-size: var(--t-2xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -180,7 +180,7 @@
 .ledger-clients-description {
   margin: calc(-1 * var(--space-1)) 0 var(--space-3);
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.5;
 }
 
@@ -229,7 +229,7 @@
   background: var(--ink-veil);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   line-height: 1.3;
   white-space: nowrap;
   pointer-events: none;
@@ -251,13 +251,13 @@
   margin-top: var(--space-1);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .ledger-trend-summary {
   margin-top: var(--space-2);
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .ledger-trend-summary > span:last-child {
@@ -273,7 +273,7 @@
 .ledger-trend-scale-note {
   margin: var(--space-2) 0 0;
   color: var(--text-tertiary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .ledger-daily-detail {
@@ -295,7 +295,7 @@
   min-height: 54px;
   overflow: hidden;
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-glass);
 }
 
@@ -344,14 +344,14 @@
 
 .ledger-client-copy strong {
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
 }
 
 .ledger-client-copy small {
   margin-top: 2px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .ledger-client-values {
@@ -359,7 +359,7 @@
   justify-items: end;
   gap: 2px;
   padding-right: var(--space-3);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   font-variant-numeric: tabular-nums;
 }
@@ -384,27 +384,27 @@
 .ledger-coverage-more {
   margin-top: var(--space-1);
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   text-align: center;
 }
 
 .ledger-inline-empty {
   padding: var(--space-4);
   border: 1px dashed var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-secondary);
   text-align: center;
 }
 
 .ledger-inline-empty strong {
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
 }
 
 .ledger-inline-empty p {
   margin: var(--space-1) 0 0;
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .ledger-source {
@@ -414,7 +414,7 @@
   padding: var(--space-3);
   border-top: 1px solid var(--hairline);
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .ledger-source > div {
@@ -431,7 +431,7 @@
   grid-column: 1 / -1;
   margin: var(--space-1) 0 0;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.55;
 }
 
@@ -445,7 +445,7 @@
   justify-content: space-between;
   padding: var(--space-3);
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .ledger-button {
@@ -474,7 +474,7 @@
 
 .ledger-state p {
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.55;
 }
 

--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -472,8 +472,10 @@
   font-size: var(--t-sm);
 }
 
+/* 바닥 행의 퍼센트는 기본(--t-sm)보다 한 단 작다 — 반 픽셀 차이는 보이지 않아 규칙이
+   있으나 마나였고, 한 단 내려야 "여기서는 작게"라는 의도가 실제로 읽힌다. */
 .quota-meter__foot .quota-meter__percent {
-  font-size: 11.5px;
+  font-size: var(--t-xs);
 }
 
 .quota-meter--warning .quota-meter__percent,

--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -39,7 +39,7 @@
   background: transparent;
   font: inherit;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   line-height: 1;
   cursor: pointer;
 }
@@ -64,7 +64,7 @@
   margin-left: auto;
   padding: 11px 13px;
   border: 1px solid var(--hairline-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--ink-mid);
   box-shadow: var(--shadow-floating);
   opacity: 0;
@@ -88,7 +88,7 @@
   gap: 8px;
   margin: 0 0 8px;
   color: var(--text-tertiary);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   line-height: 1.45;
 }
 
@@ -103,7 +103,7 @@
   padding-top: 9px;
   border-top: 1px solid var(--hairline);
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.45;
 }
 
@@ -269,14 +269,14 @@
 
 .quota-state > strong {
   display: block;
-  font-size: 13.5px;
+  font-size: var(--t-base);
   font-weight: var(--weight-medium);
 }
 
 .quota-state > p {
   margin: 6px 0 0;
   color: var(--text-tertiary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   line-height: 1.5;
 }
 
@@ -292,7 +292,7 @@
 .quota-provider__header h3,
 .quota-connect-card h3 {
   margin: 0;
-  font-size: 13.5px;
+  font-size: var(--t-base);
   font-weight: var(--weight-medium);
 }
 
@@ -335,7 +335,7 @@
   padding: 2px 9px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.08em;
 }
 
@@ -346,7 +346,7 @@
   color: var(--text-tertiary);
   background: transparent;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--t-xs);
   cursor: pointer;
 }
 
@@ -377,14 +377,14 @@
 
 .quota-meter__label {
   color: var(--text-secondary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
 }
 
 .quota-meter__window {
   margin-left: 5px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .quota-meter__percent,
@@ -392,7 +392,7 @@
 .quota-meter__reset {
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .quota-meter--warning {
@@ -454,7 +454,7 @@
 
 .quota-meter__risk {
   color: var(--text-tertiary);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
 }
 
 .quota-meter--warning .quota-meter__risk {
@@ -469,7 +469,7 @@
   margin-left: auto;
   color: var(--text-tertiary);
   text-align: right;
-  font-size: 11.5px;
+  font-size: var(--t-sm);
 }
 
 .quota-meter__foot .quota-meter__percent {
@@ -508,7 +508,7 @@
   padding: 2px 9px 2px 7px;
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.02em;
   white-space: nowrap;
 }
@@ -516,7 +516,7 @@
 .quota-credits small {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   white-space: nowrap;
 }
 
@@ -530,24 +530,24 @@
 .quota-connect-card p {
   margin: 7px 0 12px;
   color: var(--text-tertiary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   line-height: 1.5;
 }
 
 .quota-connect-card .quota-connect-card__hint {
   margin-top: -5px;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .quota-button {
   padding: 6px 12px;
   border: 1px solid var(--hairline-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-primary);
   background: var(--ink-veil);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   cursor: pointer;
 }
@@ -567,9 +567,9 @@
   margin-top: 12px;
   padding: 8px 12px;
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .quota-strip--expired {
@@ -591,7 +591,7 @@
 .quota-signed-out {
   margin-top: 12px;
   color: var(--text-tertiary);
-  font-size: 12.5px;
+  font-size: var(--t-md);
 }
 
 .quota-error {
@@ -612,18 +612,18 @@
   gap: 10px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
 }
 
 .quota-refresh {
   padding: 4px 6px;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-secondary);
   background: transparent;
   font: inherit;
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   cursor: pointer;
 }
 

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -101,7 +101,7 @@
   border-radius: var(--radius-xs);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   padding: 3px 8px;
   outline: none;
   transition: border-color 140ms;
@@ -120,7 +120,7 @@
   border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1;
   padding: 2px 4px;
   transition: color 0.1s;
@@ -144,7 +144,7 @@
 .repository-toolbar-label {
   flex: 1;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-tertiary);
@@ -189,14 +189,14 @@
 
 .repository-sections-loading {
   padding: 16px 12px;
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
 }
 
 .repository-sections-error {
   padding: 16px 12px;
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--coral-ink);
   font-family: var(--font-mono);
   display: flex;
@@ -206,7 +206,7 @@
 
 .repository-sections-notice {
   padding: 16px 12px;
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-family: var(--font-mono);
   display: flex;
   flex-direction: column;
@@ -265,7 +265,7 @@
 .repository-section-name {
   flex: 1;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -274,11 +274,11 @@
 
 .repository-count-badge {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   color: var(--text-tertiary);
   background: color-mix(in oklch, var(--ink-fog) 16%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 1px 8px;
   min-width: 20px;
   text-align: center;
@@ -292,7 +292,7 @@
 .repository-empty-row {
   padding: 8px 12px;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
 }
 
@@ -324,7 +324,7 @@
 
 .repository-status-glyph {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   text-align: center;
 }
@@ -346,7 +346,7 @@
 
 .repository-file-fn {
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-md);
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -359,7 +359,7 @@
 
 .repository-file-dir {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -372,7 +372,7 @@
   display: inline-flex;
   gap: 6px;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
 }
 
 .repository-additions {
@@ -427,7 +427,7 @@
 
 .repository-folder-name {
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--t-md);
   color: var(--text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -436,7 +436,7 @@
 
 .repository-folder-count {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   color: var(--text-tertiary);
   padding-left: 8px;
 }
@@ -445,9 +445,9 @@
 .repository-refresh-btn {
   background: none;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   padding: 3px 8px;
 }
@@ -459,7 +459,7 @@
 .repository-truncated-badge {
   flex-shrink: 0;
   padding: 4px 12px;
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   background: color-mix(in oklch, var(--ink-fog) 8%, transparent);
   border-bottom: 1px solid var(--surface-rim);
@@ -483,7 +483,7 @@
 .repository-hunk-filename {
   flex: 1;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -497,13 +497,13 @@
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
-  font-size: 14px;
+  font-size: var(--t-base);
   line-height: 1;
   min-width: 32px;
   min-height: 32px;
   display: inline-grid;
   place-items: center;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   transition: color 0.12s;
 }
 
@@ -521,7 +521,7 @@
 .repository-hunk-error {
   padding: 16px;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
 }
 
@@ -546,7 +546,7 @@
   border-collapse: collapse;
   width: 100%;
   font-family: var(--font-mono);
-  font-size: 12.5px;
+  font-size: var(--t-md);
   line-height: 1.6;
 }
 
@@ -565,7 +565,7 @@
 .repository-line-meta {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .repository-line-meta td {
@@ -610,7 +610,7 @@
 /* ── 라인번호 거터 ── */
 .repository-gutter {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   text-align: right;
   padding: 0 6px 0 4px;
@@ -622,7 +622,7 @@
 
 .repository-marker {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   text-align: center;
   padding: 0 3px;
   user-select: none;
@@ -642,7 +642,7 @@
 .repository-line-label {
   padding: 2px 10px;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
 }
 
@@ -656,7 +656,7 @@
 .repository-line-file-label .repository-line-code,
 .repository-line-file-label td {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-secondary);
   padding: 3px 10px;
 }
@@ -729,11 +729,11 @@
   flex: none;
   min-width: 22px;
   padding: 1px 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--ink-fog) 16%, transparent);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   text-align: center;
 }
 
@@ -746,12 +746,12 @@
   flex: none;
   padding: 3px 8px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .history-order-toggle:hover {
@@ -861,7 +861,7 @@
   background: color-mix(in oklch, var(--badge-tone) 22%, transparent);
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.01em;
   line-height: 1.5;
@@ -910,7 +910,7 @@
   white-space: nowrap;
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 12.5px;
+  font-size: var(--t-md);
 }
 
 /* Fork 문법 — Conventional Commit 접두만 한 티어 올려, 스캔할 때 커밋 종류가 먼저 읽힌다. */
@@ -921,7 +921,7 @@
 
 .history-commit-body-mark {
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1;
 }
 
@@ -956,7 +956,7 @@
   white-space: nowrap;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
 }
 
 .history-commit-sha,
@@ -971,7 +971,7 @@
   padding: 14px 12px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .history-error {
@@ -1029,7 +1029,7 @@
   height: 32px;
   place-items: center;
   border: none;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--text-tertiary);
   cursor: pointer;
@@ -1066,32 +1066,32 @@
 .history-commit-time { grid-column: 7; grid-row: 1; }
 .history-inspector { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
 .history-segmented { display: flex; gap: 4px; padding: 8px 12px; border-bottom: 1px solid var(--surface-rim); }
-.history-segmented button { flex: 1; border: 1px solid transparent; border-radius: var(--radius-sm); background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: 11px; letter-spacing: .01em; padding: 6px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
+.history-segmented button { flex: 1; border: 1px solid transparent; border-radius: var(--radius-xs); background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .01em; padding: 6px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
 .history-segmented button[aria-pressed="true"] { border-color: color-mix(in oklch, var(--brass) 40%, transparent); background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--text-secondary); }
-.history-segmented span { color: var(--text-tertiary); font-size: 10px; }
+.history-segmented span { color: var(--text-tertiary); font-size: var(--t-2xs); }
 .history-segmented .history-inspector-close { flex: 0 0 auto; width: 24px; min-width: 24px; height: 24px; padding: 0; border-color: transparent; }
 .history-details-tab { display: grid; min-height: 0; overflow: hidden; }
 .history-divider--horizontal { width: auto; height: 4px; cursor: row-resize; touch-action: none; }
 .history-inspector-head { min-height: 0; overflow: auto; padding: 14px 16px; border-bottom: 1px solid var(--surface-rim); }
-.history-inspector-subject { color: var(--text-secondary); font-size: 13.5px; font-weight: var(--weight-medium); line-height: 1.35; }
-.history-inspector-message { margin: 6px 0 0; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 11.5px; line-height: 1.5; white-space: pre-wrap; }
-.history-author { display: flex; align-items: center; gap: 8px; margin-top: 12px; color: var(--text-secondary); font-size: 12px; }
+.history-inspector-subject { color: var(--text-secondary); font-size: var(--t-base); font-weight: var(--weight-medium); line-height: 1.35; }
+.history-inspector-message { margin: 6px 0 0; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-sm); line-height: 1.5; white-space: pre-wrap; }
+.history-author { display: flex; align-items: center; gap: 8px; margin-top: 12px; color: var(--text-secondary); font-size: var(--t-sm); }
 .history-author > span:nth-child(2) { display: grid; gap: 1px; }
-.history-author b { font-weight: var(--weight-medium); }.history-author small, .history-author time { color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10.5px; }
+.history-author b { font-weight: var(--weight-medium); }.history-author small, .history-author time { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }
 .history-author time { margin-left: auto; }
-.history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: color-mix(in oklch, var(--ink-fog) 24%, var(--ink-veil)); color: var(--text-secondary); font-family: var(--font-mono); font-size: 10px; font-weight: var(--weight-bold); }
+.history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: color-mix(in oklch, var(--ink-fog) 24%, var(--ink-veil)); color: var(--text-secondary); font-family: var(--font-mono); font-size: var(--t-2xs); font-weight: var(--weight-bold); }
 .history-inspector-ids, .history-ref-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
-.history-sha-copy, .history-parent { border-radius: var(--radius-sm); background: none; cursor: pointer; font-family: var(--font-mono); font-size: 10.5px; padding: 3px 8px; }
+.history-sha-copy, .history-parent { border-radius: var(--radius-xs); background: none; cursor: pointer; font-family: var(--font-mono); font-size: var(--t-xs); padding: 3px 8px; }
 .history-sha-copy { border: 1px solid var(--surface-rim); color: var(--text-secondary); }.history-sha-copy span { color: var(--text-tertiary); margin-left: 7px; }.history-sha-copy.is-copied { border-color: var(--positive); color: var(--positive-ink); }
 .history-parent { border: 1px solid var(--surface-rim); color: var(--text-secondary); }
 /* min-width/열 minmax가 없으면 섹션의 자동 최소 크기가 min-content(가장 긴 경로)로 굳어
    grid 트랙을 무시하고 옆 diff 열 위로 넘친다 — 폭 조절이 화면에 반영되지 않는 원인. */
 .history-commit-files { display: grid; grid-template-rows: auto minmax(0, 1fr); grid-template-columns: minmax(0, 1fr); min-width: 0; min-height: 0; overflow: hidden; }
-.history-files-title { display: flex; gap: 8px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; }.history-files-stats { margin-left: auto; letter-spacing: 0; }.history-files-title i { color: var(--positive-ink); font-style: normal; }.history-files-title em { color: var(--coral-ink); font-style: normal; }.history-files-view-toggle { margin-left: 0; }
+.history-files-title { display: flex; gap: 8px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .1em; text-transform: uppercase; }.history-files-stats { margin-left: auto; letter-spacing: 0; }.history-files-title i { color: var(--positive-ink); font-style: normal; }.history-files-title em { color: var(--coral-ink); font-style: normal; }.history-files-view-toggle { margin-left: 0; }
 .history-files-scroll { min-height: 0; overflow: auto; }.history-commit-files .repository-file-row { padding-left: 14px; }
 .history-changes-tab { min-height: 0; overflow: hidden; }.history-changes-columns { display: grid; min-height: 0; height: 100%; }.history-changes-columns > .history-commit-files { border-right: 1px solid var(--surface-rim); }
-.history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: 11px; }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 24px; height: 24px; border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: none; color: var(--text-tertiary); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
-.history-inspector-empty { padding: 16px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 12px; }.history-inspector-error { color: var(--coral-ink); }
+.history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 24px; height: 24px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: none; color: var(--text-tertiary); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
+.history-inspector-empty { padding: 16px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-sm); }.history-inspector-error { color: var(--coral-ink); }
 /* 진행형 축소 — 컨테이너(패널·트리 리사이즈)가 좁아질수록 작성자 → 시간 → sha → 뱃지 순으로 양보한다.
    숨긴 셀은 grid item에서 빠지므로 그 자리의 트랙까지 함께 걷어내야 한다(7ch 같은 고정 트랙은 비어도 폭을 잡는다).
    제목은 어느 폭에서도 한 줄을 유지한다(기본 규칙의 nowrap+ellipsis): 행 높이는 그래프 gutter의
@@ -1116,17 +1116,17 @@
 .repository-identity { display: flex; align-items: center; gap: 8px; min-height: 34px; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 72%, transparent); color: var(--text-secondary); flex: none; }
 .repository-identity.is-subcontext { box-shadow: inset 2px 0 0 var(--brass); }
 .repository-identity svg { width: 15px; height: 15px; flex: none; opacity: .85; }
-.repository-identity strong { min-width: 0; overflow: hidden; color: var(--text-primary); font-size: 12.5px; font-weight: var(--weight-medium); text-overflow: ellipsis; white-space: nowrap; }
+.repository-identity strong { min-width: 0; overflow: hidden; color: var(--text-primary); font-size: var(--t-md); font-weight: var(--weight-medium); text-overflow: ellipsis; white-space: nowrap; }
 /* 브랜치는 정체의 일부라 이름 옆에 붙인다 — margin-left:auto로 밀면 넓은 레일에서 이름과의 연관이 끊긴다.
    brass는 location 채널이므로 "어느 체크아웃인가"를 칠하는 데 쓴다. */
-.repository-identity span { min-width: 0; overflow: hidden; color: var(--brass-ink); flex: 0 1 auto; font-family: var(--font-mono); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
-.repository-sync-button { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; padding: 4px 7px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--text-tertiary); cursor: pointer; flex: none; font: inherit; font-size: 12px; }
+.repository-identity span { min-width: 0; overflow: hidden; color: var(--brass-ink); flex: 0 1 auto; font-family: var(--font-mono); font-size: var(--t-2xs); text-overflow: ellipsis; white-space: nowrap; }
+.repository-sync-button { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; padding: 4px 7px; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; color: var(--text-tertiary); cursor: pointer; flex: none; font: inherit; font-size: var(--t-sm); }
 .repository-sync-button:hover:not(:disabled) { border-color: var(--surface-rim); background: color-mix(in oklch, var(--ink-fog) 9%, transparent); color: var(--text-primary); }
 .repository-sync-button:disabled { cursor: default; opacity: .7; }
 /* 아이콘은 ↻와 ✓를 같은 자리에 겹쳐 두는 13px 슬롯이다 — 글리프를 교체하면 버튼 폭이 흔들려
    옆의 라벨이 밀린다. 회전은 계속 슬롯 자체에 걸어 두 글리프가 같은 축을 돈다. */
-.repository-identity .repository-sync-icon { position: relative; display: inline-block; width: 13px; height: 13px; min-width: auto; overflow: visible; color: inherit; flex: none; font: inherit; font-size: 13px; line-height: 1; }
-.repository-identity .repository-sync-glyph { position: absolute; inset: 0; display: grid; min-width: auto; overflow: visible; place-items: center; color: inherit; font: inherit; font-size: 13px; line-height: 1; opacity: 0; transform: scale(.72); transition: opacity 150ms ease, transform 190ms cubic-bezier(.2, 1.5, .4, 1); }
+.repository-identity .repository-sync-icon { position: relative; display: inline-block; width: 13px; height: 13px; min-width: auto; overflow: visible; color: inherit; flex: none; font: inherit; font-size: var(--t-md); line-height: 1; }
+.repository-identity .repository-sync-glyph { position: absolute; inset: 0; display: grid; min-width: auto; overflow: visible; place-items: center; color: inherit; font: inherit; font-size: var(--t-md); line-height: 1; opacity: 0; transform: scale(.72); transition: opacity 150ms ease, transform 190ms cubic-bezier(.2, 1.5, .4, 1); }
 /* ✓는 "가져올 것이 없었다"는 상태이므로 positive 신호 채널을 쓴다 — brass(위치·포커스)를 쓰면 채널이 섞인다. */
 .repository-identity .repository-sync-glyph-settled { color: var(--positive-ink); }
 .repository-sync-icon:not(.is-settled) .repository-sync-glyph-idle,
@@ -1141,32 +1141,32 @@
 /* 숨김-마운트 래퍼가 높이 문맥을 끊으면 history-root의 height:100%가 내용 높이로 풀려 내부 스크롤이 죽는다 */
 .repository-source-fill { height: 100%; min-width: 0; min-height: 0; }
 .repository-discovery { display: flex; align-items: center; gap: 8px; flex: none; padding: 6px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
-.repository-discovery-depth { display: inline-flex; align-items: center; gap: 3px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; }
-.repository-depth-step { border: 0; background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: 12px; padding: 0 3px; }
+.repository-discovery-depth { display: inline-flex; align-items: center; gap: 3px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); letter-spacing: .1em; text-transform: uppercase; }
+.repository-depth-step { border: 0; background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: var(--t-sm); padding: 0 3px; }
 .repository-depth-step:hover:not(:disabled) { color: var(--text-primary); }
 .repository-depth-step:disabled { opacity: .4; cursor: default; }
-.repository-depth-value { border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); padding: 0 6px; color: var(--text-secondary); font-family: var(--font-mono); font-size: 11px; }
-.repository-scan-count { margin-left: auto; min-width: 0; overflow: hidden; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.repository-depth-value { border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); padding: 0 6px; color: var(--text-secondary); font-family: var(--font-mono); font-size: var(--t-xs); }
+.repository-scan-count { margin-left: auto; min-width: 0; overflow: hidden; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); text-overflow: ellipsis; white-space: nowrap; }
 .repository-ref-list { padding: var(--space-2); display: grid; gap: 2px; }
 .repository-ref-group { display: grid; gap: 2px; }
-.repository-ref-group-label { padding: 8px 10px 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; font-weight: var(--weight-regular); letter-spacing: .18em; text-transform: uppercase; }
+.repository-ref-group-label { padding: 8px 10px 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); font-weight: var(--weight-regular); letter-spacing: .18em; text-transform: uppercase; }
 .repository-ref-row { display: flex; align-items: center; gap: 9px; width: 100%; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); cursor: pointer; font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit; text-align: left; padding: 7px 10px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
 .repository-ref-row:hover { background: color-mix(in oklch, var(--ink-fog) 9%, transparent); color: var(--text-primary); }
 .repository-ref-row:disabled { cursor: default; }
 .repository-ref-row.is-current { color: var(--text-primary); }
 .repository-ref-row.is-current:hover { color: var(--text-primary); }
 .repository-ref-row svg { width: 13px; height: 13px; flex: none; opacity: .85; }
-.repository-ref-name { min-width: 0; overflow: hidden; font-size: 12.5px; font-weight: var(--weight-medium); text-overflow: ellipsis; white-space: nowrap; }
+.repository-ref-name { min-width: 0; overflow: hidden; font-size: var(--t-md); font-weight: var(--weight-medium); text-overflow: ellipsis; white-space: nowrap; }
 /* 현재 체크아웃 마크 = 위치 채널 */
-.repository-ref-mark { flex: none; color: var(--brass-ink); font-size: 11px; }
+.repository-ref-mark { flex: none; color: var(--brass-ink); font-size: var(--t-xs); }
 /* 매칭 글자 = 포커스 채널(brass) */
 .repository-ref-hl { color: var(--brass-ink); font-weight: var(--weight-bold); }
-.repository-ref-sub { margin-left: auto; color: var(--text-tertiary); flex: none; font-family: var(--font-mono); font-size: 10px; }
+.repository-ref-sub { margin-left: auto; color: var(--text-tertiary); flex: none; font-family: var(--font-mono); font-size: var(--t-2xs); }
 .repository-ref-row.is-current .repository-ref-sub { color: var(--brass-ink); }
 .repository-wip-row, .repository-ref-chip { border: 0; background: transparent; color: var(--text-secondary); font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit; text-align: left; padding: 7px 10px; }
 .repository-wip-row { color: var(--brass-ink); }
 .repository-wip-row { width: 100%; border-bottom: 1px dashed var(--surface-rim); }
-.repository-wip-row span { float: right; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; }
+.repository-wip-row span { float: right; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); }
 /* hidden 속성은 UA display:none이라 .repository-root의 display:grid에 진다 — 소스 상호 배제 가드 */
 .repository-unified [hidden] { display: none !important; }
 
@@ -1230,7 +1230,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: .14em;
   cursor: pointer;
   text-align: left;
@@ -1270,7 +1270,7 @@
   color: var(--text-secondary);
   cursor: pointer;
   font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit;
-  font-size: 12px;
+  font-size: var(--t-sm);
   text-align: left;
   transition: color var(--duration-base) var(--ease-spring), background var(--duration-base) var(--ease-spring);
 }
@@ -1335,7 +1335,7 @@
   color: var(--text-tertiary);
   flex: none;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-style: normal;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1352,13 +1352,13 @@
   margin-left: auto;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
   cursor: pointer;
   flex: none;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1;
 }
 
@@ -1413,12 +1413,12 @@
   width: 100%;
   padding: 6px 9px;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--t-sm);
   text-align: left;
   white-space: nowrap;
 }
@@ -1448,7 +1448,7 @@
   padding: 4px 10px 2px 20px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: .12em;
 }
 
@@ -1459,7 +1459,7 @@
   padding: 5px 10px 5px 18px;
   color: var(--coral-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
 }
 
 .repository-ws-tree-error button {
@@ -1583,9 +1583,9 @@
 }
 
 /* ── Compare 뷰 ── */
-.repository-compare-swap { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; padding: 0; border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: none; color: var(--text-tertiary); cursor: pointer; flex: none; font-size: 12px; }
+.repository-compare-swap { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; padding: 0; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: none; color: var(--text-tertiary); cursor: pointer; flex: none; font-size: var(--t-sm); }
 .repository-compare-swap:hover:not(:disabled) { color: var(--text-secondary); }
-.repository-compare-meta { flex: none; padding: 5px 10px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; }
+.repository-compare-meta { flex: none; padding: 5px 10px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); }
 .repository-compare-meta span { color: var(--text-secondary); }
 
 /* ═══ in-history compare (anchor grammar) — history-panel 소유 구역 ═══ */
@@ -1600,12 +1600,12 @@
   height: 22px;
   padding: 0;
   border: 1px solid color-mix(in oklch, var(--aurora) 42%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--ink-mid);
   color: var(--aurora);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1;
   transform: translateY(-50%);
 }
@@ -1615,7 +1615,7 @@
 .history-row-compare:focus-visible { border-color: var(--aurora); background: color-mix(in oklch, var(--aurora) 12%, var(--ink-mid)); color: var(--text-primary); outline: none; }
 .history-commit-row.is-picked { background: color-mix(in oklch, var(--aurora) 9%, transparent); box-shadow: inset 2px 0 0 var(--aurora); }
 .history-commit-row.is-picked .history-commit-sha { color: var(--aurora); }
-.repository-pin-chip { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 42%, transparent); border-radius: var(--radius-sm); color: var(--aurora); cursor: pointer; }
+.repository-pin-chip { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 42%, transparent); border-radius: var(--radius-xs); color: var(--aurora); cursor: pointer; }
 .repository-pin-chip:hover { background: color-mix(in oklch, var(--aurora) 10%, transparent); color: var(--text-primary); }
 .history-inspector-compare { position: absolute; top: 8px; right: 45px; z-index: 1; }
 .repository-ws-dock-meta .history-inspector-head { padding-right: 210px; }
@@ -1625,7 +1625,7 @@
 .history-compare-result-head { min-height: 34px; padding: 7px 10px; }
 .history-compare-result-head .history-files-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-transform: none; letter-spacing: 0; }
 .history-compare-meta { display: flex; align-items: center; min-height: 38px; padding: 6px 45px 6px 12px; }
-.history-compare-pair { min-width: 0; overflow: hidden; color: var(--text-secondary); font-family: var(--font-mono); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.history-compare-pair { min-width: 0; overflow: hidden; color: var(--text-secondary); font-family: var(--font-mono); font-size: var(--t-xs); text-overflow: ellipsis; white-space: nowrap; }
 .history-compare-meta .repository-compare-swap { margin-left: 8px; }
 /* 좁은 독(파일 열 250px가 컨테이너를 초과)에서 main 열이 0으로 붕괴하던 선존 결함 —
    detail pane을 컨테이너로 삼아 세로 스택으로 전환한다(커밋 검사기·비교 드로어 공용).
@@ -1647,8 +1647,8 @@
   margin: 0 10px 8px;
   padding: 6px 8px;
   border: 1px solid;
-  border-radius: var(--radius-sm);
-  font-size: 12px;
+  border-radius: var(--radius-xs);
+  font-size: var(--t-sm);
 }
 .repository-sync-toast.is-error {
   border-color: color-mix(in oklch, var(--coral) 45%, transparent);
@@ -1689,7 +1689,7 @@
   background: var(--ink-veil);
   color: var(--text-primary);
   font-family: inherit;
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   line-height: 1.4;
   white-space: normal;
   text-align: left;

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -229,10 +229,10 @@ describe("Repository design grammar", () => {
       expect(blocksOf(".history-badge").concat(blocksOf(".history-badge-mark")).some((body) => body.includes(`${property}:`) && body.includes("var(--badge-tone)")), property).toBe(true);
     }
     // 알약이 아니라 라운드 사각 + 볼드 sans — Fork가 뱃지를 라벨이 아닌 표식으로 읽히게 하는 축.
-    expect(badge).not.toContain("border-radius: 999px");
+    expect(badge).not.toContain("border-radius: var(--radius-pill)");
     expect(badge).toContain("border-radius: var(--radius-xs)");
     expect(badge).toContain("font-family: var(--font-body)");
-    expect(badge).toContain("font-size: 11px");
+    expect(badge).toContain("font-size: var(--t-xs)");
     expect(badge).toContain("font-weight: var(--weight-bold)");
     expect(badge).toContain("var(--badge-tone) 82%");
     expect(badge).toContain("var(--badge-tone) 22%");

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -39,7 +39,7 @@
   border: 1px solid var(--hairline);
   border-radius: var(--radius-pill);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   padding: 1px var(--space-2);
   white-space: nowrap;
@@ -66,7 +66,7 @@
   border: 1px solid color-mix(in oklch, var(--brass) 45%, var(--hairline));
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   padding: var(--space-1) var(--space-3);
   white-space: nowrap;
@@ -388,7 +388,7 @@
     var(--ink-deep);
   box-shadow: var(--shadow-floating);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   line-height: 1.35;
   text-align: left;
@@ -408,7 +408,7 @@
   min-width: 0;
   padding: 0;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: inherit;
   cursor: pointer;
@@ -429,7 +429,7 @@
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
   cursor: pointer;
@@ -467,7 +467,7 @@
     var(--ink-deep);
   box-shadow: var(--shadow-floating);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1.45;
   text-align: left;
   animation: scuttlebutt-arrival-in var(--duration-base) var(--ease-spring);
@@ -499,7 +499,7 @@
   gap: var(--space-2);
   color: var(--brass);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -527,7 +527,7 @@
 .scuttlebutt-answer-working {
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
 }
 
@@ -541,7 +541,7 @@
   color: var(--brass);
   cursor: pointer;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--t-xs);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
@@ -559,7 +559,7 @@
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
   cursor: pointer;
@@ -599,7 +599,7 @@
 .scuttlebutt-arrival-label {
   color: color-mix(in oklch, var(--positive) 72%, var(--text-secondary));
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.1em;
   line-height: 1.2;
@@ -648,7 +648,7 @@
     var(--ink-deep);
   box-shadow: var(--shadow-floating);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   line-height: 1.35;
   text-align: left;
@@ -667,7 +667,7 @@
   min-width: 0;
   padding: 0;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: inherit;
   cursor: pointer;
@@ -688,7 +688,7 @@
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
   cursor: pointer;
@@ -708,7 +708,7 @@
 .scuttlebutt-departure-label {
   color: var(--warn-ink);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-medium);
   letter-spacing: 0.1em;
   line-height: 1.2;
@@ -742,7 +742,7 @@
   flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   /* 팝업 판독성 계약: glass 층 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
@@ -769,14 +769,14 @@
   border-radius: var(--radius-pill);
   background: var(--brass-glow);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--t-sm);
 }
 
 .scuttlebutt-chat-who {
   flex: 1;
   min-width: 0;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
 }
 
@@ -793,7 +793,7 @@
   color: var(--text-tertiary);
   cursor: pointer;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   white-space: nowrap;
 }
@@ -849,7 +849,7 @@
 .scuttlebutt-chat-tuck {
   padding: 2px var(--space-1);
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
   cursor: pointer;
@@ -875,7 +875,7 @@
   overflow-y: auto;
   padding: var(--space-4);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--t-md);
 }
 
 .scuttlebutt-message-user {
@@ -915,14 +915,14 @@
 .scuttlebutt-status-row {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-regular);
 }
 
 .scuttlebutt-status-row.is-error {
   padding: var(--space-1) var(--space-2);
   border: 1px solid color-mix(in oklch, var(--coral) 30%, transparent);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--coral) 8%, transparent);
   color: color-mix(in oklch, var(--coral) 72%, var(--text-secondary));
 }
@@ -934,7 +934,7 @@
   gap: var(--space-2);
   padding: 0 var(--space-4) var(--space-3);
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-regular);
 }
 
@@ -970,11 +970,11 @@
   flex: 1 1 auto;
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--ink-abyss);
   color: var(--text-primary);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-regular);
 }
 
@@ -987,12 +987,12 @@
 .scuttlebutt-send {
   padding: var(--space-2) var(--space-4);
   border: 0;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--brass);
   color: var(--text-on-brass);
   cursor: pointer;
   font: inherit;
-  font-size: 12.5px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
 }
 

--- a/runtime/fleet-plugins/skills/client/skills.css
+++ b/runtime/fleet-plugins/skills/client/skills.css
@@ -116,7 +116,7 @@
   border-radius: var(--radius-md);
   color: var(--text-primary);
   font-family: inherit;
-  font-size: 0.8125rem;
+  font-size: var(--t-md);
   padding: var(--space-2) var(--space-3);
   width: 100%;
   box-sizing: border-box;
@@ -134,7 +134,7 @@
 
 .skills-empty-state {
   color: var(--text-tertiary);
-  font-size: 0.8125rem;
+  font-size: var(--t-md);
   padding: var(--space-4) var(--space-2);
   text-align: center;
 }
@@ -171,7 +171,7 @@
   color: var(--text-primary);
   cursor: pointer;
   font-family: inherit;
-  font-size: 0.875rem;
+  font-size: var(--t-base);
   font-weight: var(--weight-medium);
   padding: 0;
   text-align: left;
@@ -181,7 +181,7 @@
 
 .skills-card-scope-badge {
   border-radius: var(--radius-xs);
-  font-size: 0.625rem;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   padding: 2px 5px;
@@ -200,14 +200,14 @@
 
 .skills-card-meta {
   color: var(--text-tertiary);
-  font-size: 0.75rem;
+  font-size: var(--t-sm);
 }
 
 .skills-card-agents { font-style: italic; }
 
 .skills-card-installs {
   color: var(--text-tertiary);
-  font-size: 0.75rem;
+  font-size: var(--t-sm);
   margin-left: auto;
 }
 
@@ -290,7 +290,7 @@
 
 .skills-dock-log {
   font-family: "JetBrains Mono Variable", monospace;
-  font-size: 0.6875rem;
+  font-size: var(--t-xs);
   line-height: 1.5;
   max-height: 150px;
   overflow-y: auto;
@@ -373,7 +373,7 @@
 .skills-dock-label {
   color: var(--text-secondary);
   flex: 1;
-  font-size: 0.78rem;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
 }
 
@@ -384,7 +384,7 @@
 .skills-dock-count {
   color: var(--text-tertiary);
   font-family: "JetBrains Mono Variable", monospace;
-  font-size: 0.6875rem;
+  font-size: var(--t-xs);
 }
 
 .skills-dock-dismiss {
@@ -392,7 +392,7 @@
   border: none;
   color: var(--text-tertiary);
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: var(--t-base);
   line-height: 1;
   padding: 0 2px;
 }
@@ -410,7 +410,7 @@
   border-radius: var(--radius-md);
   color: var(--coral-ink);
   cursor: pointer;
-  font-size: 0.6875rem;
+  font-size: var(--t-xs);
   font-weight: var(--weight-medium);
   padding: 2px 8px;
 }
@@ -422,7 +422,7 @@
 
 .skills-dock-chevron {
   color: var(--text-tertiary);
-  font-size: 0.72rem;
+  font-size: var(--t-sm);
   pointer-events: none;
   transition: transform var(--duration-base) ease;
 }
@@ -482,7 +482,7 @@
 
 .skills-permission-warning {
   color: var(--text-tertiary);
-  font-size: 0.6875rem;
+  font-size: var(--t-xs);
   line-height: 1.45;
   margin: 0;
 }
@@ -530,14 +530,14 @@
 .skills-overlay-title {
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 1rem;
+  font-size: var(--t-lg);
   font-weight: var(--weight-medium);
   white-space: nowrap;
 }
 
 .skills-overlay-meta {
   color: var(--text-tertiary);
-  font-size: 0.75rem;
+  font-size: var(--t-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -548,7 +548,9 @@
   border: none;
   color: var(--text-tertiary);
   cursor: pointer;
-  font-size: 1rem;
+  /* 내용이 '✕' 글리프라 이 값은 활자가 아니라 도형의 크기다 — 다른 닫기 버튼들과 같은 대역에
+     둔다. 계약 테스트의 글리프 예외 목록이 이 선택자를 함께 면제한다. */
+  font-size: 16px;
   line-height: 1;
   margin-left: auto;
   padding: var(--space-1);
@@ -591,7 +593,7 @@
   border-radius: var(--radius-md);
   bottom: var(--space-3);
   color: var(--aurora-ink);
-  font-size: 0.8125rem;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   left: var(--space-3);
   padding: var(--space-2) var(--space-3);

--- a/runtime/fleet-plugins/skills/client/skills.css
+++ b/runtime/fleet-plugins/skills/client/skills.css
@@ -25,7 +25,7 @@
   color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0.01em;
   line-height: 1;
@@ -71,7 +71,7 @@
   display: flex;
   background: color-mix(in srgb, var(--surface-glass) 60%, transparent);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   padding: 2px;
   gap: 2px;
   flex-shrink: 0;
@@ -85,7 +85,7 @@
   cursor: pointer;
   flex: 1;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0.01em;
   padding: 4px var(--space-2);
@@ -152,7 +152,7 @@
 .skills-card {
   background: color-mix(in srgb, var(--surface-glass) 50%, transparent);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
@@ -180,7 +180,7 @@
 .skills-card-name-btn:hover { color: var(--brass-ink); }
 
 .skills-card-scope-badge {
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   font-size: 0.625rem;
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
@@ -225,7 +225,7 @@
   border-radius: var(--radius-xs);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0.01em;
   padding: 4px var(--space-3);
@@ -456,7 +456,7 @@
   color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0.01em;
   padding: 3px var(--space-2);
@@ -506,7 +506,7 @@
     linear-gradient(var(--surface-glass), var(--surface-glass)),
     var(--ink-deep);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-md);
   display: flex;
   flex-direction: column;
   /* 확정 높이가 필수 — content-driven 높이에서는 body의 flex-grow가 분배할 공간이

--- a/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
+++ b/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
@@ -22,7 +22,7 @@
 .agent-cli-name {
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -38,7 +38,7 @@
 .agent-cli-version {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
 }
 
@@ -48,7 +48,7 @@
   gap: 8px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -75,7 +75,7 @@
 .agent-cli-path-status {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .agent-cli-configured-path {
@@ -98,13 +98,13 @@
   gap: var(--space-3);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .agent-cli-path-input {
   width: 100%;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   padding: 8px 10px;
   background: var(--surface-glass);
   color: var(--text-primary);
@@ -124,12 +124,12 @@
 .agent-cli-path-button {
   width: fit-content;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   padding: 6px 10px;
   background: var(--surface-glass);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   cursor: pointer;
 }
@@ -152,13 +152,13 @@
 .agent-cli-path-error {
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .agent-cli-searched-paths {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .agent-cli-searched-paths summary {
@@ -224,7 +224,7 @@
 .ai-gateway-provider-name {
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -234,7 +234,7 @@
   margin-left: auto;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
 }
 
@@ -275,14 +275,14 @@
 .ai-gateway-model-name {
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
 }
 
 .ai-gateway-model-id {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   overflow-wrap: anywhere;
 }
 
@@ -297,7 +297,7 @@
   border-radius: var(--radius-pill);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.1em;
   line-height: 1.5;
@@ -336,7 +336,7 @@
   border-radius: var(--radius-pill);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -351,7 +351,7 @@
 .ai-gateway-field-label {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -370,7 +370,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -414,7 +414,7 @@
   border-radius: var(--radius-xs);
   background: var(--ink-veil);
   color: var(--text-primary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0;
   line-height: 1.4;
   text-align: left;
@@ -453,7 +453,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -499,7 +499,7 @@
   border-radius: var(--radius-xs);
   background: var(--ink-veil);
   color: var(--text-primary);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0;
   line-height: 1.4;
   text-align: left;
@@ -521,7 +521,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   cursor: pointer;
 }
 
@@ -551,7 +551,7 @@
   padding: 0 5px 0 var(--space-2);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -564,7 +564,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -615,7 +615,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   cursor: pointer;
 }
@@ -641,7 +641,7 @@
 .ai-gateway-composer-note {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
 }
 
 .ai-gateway-add-button {
@@ -652,7 +652,7 @@
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   color: var(--brass-ink);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -674,7 +674,7 @@
 .compact-timing-preview-label {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -701,7 +701,7 @@
   top: 11px;
   height: 6px;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--ink-rim) 55%, transparent);
 }
 
@@ -722,7 +722,7 @@
   height: 20px;
   margin-left: -10px;
   border: 2px solid var(--brass);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--ink-deep);
   box-shadow: 0 0 0 4px var(--brass-glow);
   pointer-events: none;
@@ -750,7 +750,7 @@
   justify-content: space-between;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   font-variant-numeric: tabular-nums;
 }
 
@@ -776,14 +776,14 @@
   display: block;
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 18px;
+  font-size: var(--t-xl);
   font-variant-numeric: tabular-nums;
 }
 
 .compact-timing-stat span {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -796,7 +796,7 @@
   background: color-mix(in oklch, var(--positive) 8%, transparent);
   color: var(--positive-ink);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.5;
 }
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -13,7 +13,7 @@
   .session-analyst__chip { padding: 5px 8px; }
   .session-analyst__chip-state { display: none; }
 }
-.session-analyst__chip { display: inline-flex; align-items: center; gap: var(--space-2); border: 1px solid var(--hairline-strong); border-radius: var(--radius-sm); background: var(--ink-mid); color: var(--text-secondary); padding: 5px 10px; font-family: var(--font-mono); font-size: 11px; line-height: 1; letter-spacing: .06em; white-space: nowrap; transition: border-color var(--duration-fast), color var(--duration-fast), box-shadow var(--duration-fast); }
+.session-analyst__chip { display: inline-flex; align-items: center; gap: var(--space-2); border: 1px solid var(--hairline-strong); border-radius: var(--radius-xs); background: var(--ink-mid); color: var(--text-secondary); padding: 5px 10px; font-family: var(--font-mono); font-size: var(--t-xs); line-height: 1; letter-spacing: .06em; white-space: nowrap; transition: border-color var(--duration-fast), color var(--duration-fast), box-shadow var(--duration-fast); }
 .session-analyst__chip-cluster { display: inline-flex; gap: var(--space-2); flex: none; }
 /* 정체성은 캡션 밴드의 이름줄이다 — 밴드 안에서 다시 상자를 두르면 머리 안에 머리가 하나 더 생긴다. */
 .session-analyst__chip--id { min-width: 0; overflow: hidden; border-color: transparent; background: transparent; padding: 0; color: var(--text-secondary); white-space: nowrap; text-overflow: ellipsis; }
@@ -28,13 +28,13 @@ button.session-analyst__chip { cursor: pointer; }
 button.session-analyst__chip:hover:not(:disabled) { border-color: var(--brass); color: var(--brass-ink); box-shadow: 0 0 14px var(--brass-glow); }
 button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: default; }
 /* 모드 세그먼트 — [Chat | Artifacts·n]. 선택 표시는 brass(위치 채널)만 쓴다. */
-.session-analyst__modechip { display: inline-flex; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: var(--radius-sm); background: var(--ink-mid); font-family: var(--font-mono); font-size: 11px; letter-spacing: .06em; }
+.session-analyst__modechip { display: inline-flex; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: var(--radius-xs); background: var(--ink-mid); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .06em; }
 .session-analyst__modechip button { display: inline-flex; align-items: center; gap: 6px; border: 0; background: transparent; color: var(--text-tertiary); padding: 5px 9px; font: inherit; letter-spacing: inherit; line-height: 1; cursor: pointer; }
 .session-analyst__modechip button + button { border-left: 1px solid var(--hairline); }
 .session-analyst__modechip button[aria-pressed="true"] { background: var(--brass-glow); color: var(--brass-ink); }
 .session-analyst__modechip button:disabled { color: var(--text-tertiary); opacity: .5; cursor: default; }
 /* 카운트 배지 — 기존 세로 핸들의 aurora 배지 톤을 승계한다. */
-.session-analyst__chip-count { display: grid; place-items: center; min-width: 15px; min-height: 15px; border-radius: var(--radius-pill); background: color-mix(in oklch, var(--aurora) 16%, transparent); color: var(--aurora-ink); font-weight: var(--weight-bold); font-size: 9.5px; line-height: 1; }
+.session-analyst__chip-count { display: grid; place-items: center; min-width: 15px; min-height: 15px; border-radius: var(--radius-pill); background: color-mix(in oklch, var(--aurora) 16%, transparent); color: var(--aurora-ink); font-weight: var(--weight-bold); font-size: var(--t-2xs); line-height: 1; }
 .session-analyst__chip-count.is-pulsing { animation: analyst-artifact-count-pulse var(--duration-slow) var(--ease-glide); }
 .session-analyst__modechip button.is-authoring .session-analyst__chip-count { border: 1px dashed var(--aurora); background: transparent; animation: analyst-authoring-breathe 1.4s var(--ease-glide) infinite; }
 
@@ -46,29 +46,29 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__hero-wrap { margin: auto 0; display: grid; gap: var(--space-4); }
 .session-analyst__chat-pane.is-initial .session-analyst__hero-wrap { margin: 0; }
 .session-analyst__hero { text-align: center; padding: 0 var(--space-2); }
-.session-analyst__sigil { display: block; color: var(--aurora-ink); font-size: 22px; line-height: 1; opacity: .85; margin-bottom: var(--space-3); }
-.session-analyst__hero h2 { margin: 0 0 var(--space-2); font-family: var(--font-display); font-weight: var(--weight-medium); font-size: 19px; letter-spacing: .005em; }
-.session-analyst__hero p { margin: 0 auto; color: var(--text-tertiary); font-size: 12.5px; line-height: 1.55; max-width: 36ch; }
+.session-analyst__sigil { display: block; color: var(--aurora-ink); font-size: var(--t-xl); line-height: 1; opacity: .85; margin-bottom: var(--space-3); }
+.session-analyst__hero h2 { margin: 0 0 var(--space-2); font-family: var(--font-display); font-weight: var(--weight-medium); font-size: var(--t-xl); letter-spacing: .005em; }
+.session-analyst__hero p { margin: 0 auto; color: var(--text-tertiary); font-size: var(--t-md); line-height: 1.55; max-width: 36ch; }
 .session-analyst__suggestions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); align-content: start; }
-.session-analyst__suggestions button { display: flex; align-items: center; gap: 10px; text-align: left; font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; line-height: 1.4; font-family: inherit; font-size: 12.5px; color: var(--text-secondary); background: var(--surface-panel-raised); border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 11px 12px; cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
+.session-analyst__suggestions button { display: flex; align-items: center; gap: 10px; text-align: left; font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; line-height: 1.4; font-family: inherit; font-size: var(--t-md); color: var(--text-secondary); background: var(--surface-panel-raised); border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 11px 12px; cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
 .session-analyst__suggestions button:hover { border-color: color-mix(in oklch, var(--aurora) 45%, var(--hairline)); color: var(--text-primary); transform: translateY(-1px); }
-.session-analyst__suggestion-icon { font-size: 12px; line-height: 1; flex: none; }
+.session-analyst__suggestion-icon { font-size: var(--t-sm); line-height: 1; flex: none; }
 .session-analyst__suggestion-icon[data-tone="aurora"] { color: var(--aurora-ink); }
 .session-analyst__suggestion-icon[data-tone="coral"] { color: var(--coral-ink); }
 .session-analyst__suggestion-icon[data-tone="brass"] { color: var(--brass-ink); }
 .session-analyst__chat-pane :is(button, select) { user-select: none; }
 
 .session-analyst__queue { display: grid; gap: 6px; padding: 0 14px var(--space-2); }
-.session-analyst__queue-item { display: flex; align-items: center; gap: var(--space-2); min-width: 0; border: 1px dashed color-mix(in oklch, var(--aurora) 40%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 5%, var(--surface-panel-raised)); padding: 7px 10px; color: var(--text-secondary); font-size: 11.5px; animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__queue-tag { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 45%, transparent); border-radius: 999px; color: var(--aurora-ink); padding: 3px 7px; font-weight: var(--weight-bold); font-size: 10px; line-height: 1; font-family: var(--font-mono); letter-spacing: .12em; }
+.session-analyst__queue-item { display: flex; align-items: center; gap: var(--space-2); min-width: 0; border: 1px dashed color-mix(in oklch, var(--aurora) 40%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 5%, var(--surface-panel-raised)); padding: 7px 10px; color: var(--text-secondary); font-size: var(--t-sm); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
+.session-analyst__queue-tag { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 45%, transparent); border-radius: var(--radius-pill); color: var(--aurora-ink); padding: 3px 7px; font-weight: var(--weight-bold); font-size: var(--t-2xs); line-height: 1; font-family: var(--font-mono); letter-spacing: .12em; }
 .session-analyst__queue-text { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.session-analyst__queue-item button { flex: none; border: 0; background: transparent; color: var(--text-tertiary); padding: 2px; font-size: 13px; line-height: 1; cursor: pointer; transition: color var(--duration-base) var(--ease-glide); }
+.session-analyst__queue-item button { flex: none; border: 0; background: transparent; color: var(--text-tertiary); padding: 2px; font-size: var(--t-md); line-height: 1; cursor: pointer; transition: color var(--duration-base) var(--ease-glide); }
 .session-analyst__queue-item button:hover { color: var(--coral-ink); }
 
 .session-analyst__followups { display: grid; gap: var(--space-2); padding: 0 14px var(--space-2); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__followups-label { color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); letter-spacing: .14em; }
+.session-analyst__followups-label { color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: var(--t-2xs); line-height: 1; font-family: var(--font-mono); letter-spacing: .14em; }
 .session-analyst__followups-row { display: flex; flex-wrap: wrap; gap: var(--space-2); }
-.session-analyst__followups-row button { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: var(--surface-panel-raised); color: var(--text-secondary); padding: 6px 12px; font-weight: var(--weight-medium); font-size: 11.5px; line-height: 1.2; font-family: var(--font-body); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
+.session-analyst__followups-row button { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--hairline); border-radius: var(--radius-xs); background: var(--surface-panel-raised); color: var(--text-secondary); padding: 6px 12px; font-weight: var(--weight-medium); font-size: var(--t-sm); line-height: 1.2; font-family: var(--font-body); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
 .session-analyst__followups-row button:hover { border-color: color-mix(in oklch, var(--aurora) 45%, var(--hairline)); color: var(--text-primary); transform: translateY(-1px); }
 
 /* ── 트랜스크립트 — 채팅 뷰의 턴 문법 ── */
@@ -80,9 +80,9 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 /* 사용자 질문 — 디스패치 버블 문법: 메타는 버블 밖 위, 정체성은 --id-cerulean 워시,
    우하단 radius를 조여 발화 원점(하단 컴포저)을 가리킨다. */
 .session-analyst__message--user { display: flex; flex-direction: column; align-items: flex-end; }
-.session-analyst__ask-meta { display: flex; gap: var(--space-2); margin: 0 var(--space-1) 4px 0; font-family: var(--font-mono); font-size: 10px; letter-spacing: .08em; color: var(--text-tertiary); }
+.session-analyst__ask-meta { display: flex; gap: var(--space-2); margin: 0 var(--space-1) 4px 0; font-family: var(--font-mono); font-size: var(--t-2xs); letter-spacing: .08em; color: var(--text-tertiary); }
 .session-analyst__ask-meta .session-analyst__ask-who { color: color-mix(in oklch, var(--id-cerulean) 75%, var(--text-tertiary)); }
-.session-analyst__ask-bubble { max-width: 64ch; background: color-mix(in oklch, var(--id-cerulean) 10%, var(--surface-panel-raised)); border: 1px solid color-mix(in oklch, var(--id-cerulean) 18%, var(--hairline)); border-radius: 14px 14px 5px 14px; padding: var(--space-2) var(--space-3); color: var(--text-primary); font-size: 13.5px; line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
+.session-analyst__ask-bubble { max-width: 64ch; background: color-mix(in oklch, var(--id-cerulean) 10%, var(--surface-panel-raised)); border: 1px solid color-mix(in oklch, var(--id-cerulean) 18%, var(--hairline)); border-radius: 14px 14px 5px 14px; padding: var(--space-2) var(--space-3); color: var(--text-primary); font-size: var(--t-base); line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
 
 /* 분석가 턴 — 좌측 스파인 노드가 상태를 신호 토큰으로만 말한다. */
 .session-analyst__message--analyst { display: grid; grid-template-columns: 14px minmax(0, 1fr); gap: var(--space-3); animation: analyst-answer-rise var(--duration-base) var(--ease-glide) both; }
@@ -93,39 +93,39 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__message--analyst.is-working .session-analyst__turn-spine::before { background: color-mix(in oklch, var(--aurora) 40%, var(--hairline)); }
 .session-analyst__message--analyst.is-error .session-analyst__turn-node { border-color: var(--coral); }
 .session-analyst__message--analyst.is-stopped .session-analyst__turn-node { border-color: var(--text-tertiary); }
-.session-analyst__turn-head { display: flex; align-items: baseline; flex-wrap: wrap; gap: var(--space-2); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .06em; color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
+.session-analyst__turn-head { display: flex; align-items: baseline; flex-wrap: wrap; gap: var(--space-2); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .06em; color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
 
 /* 진행 펄스 행 — 채팅 뷰의 agent-chat-pulse와 한 계열. 정직성 마이크로카피가 아래에 붙는다. */
-.session-analyst__pulse { margin-top: var(--space-2); display: flex; align-items: center; gap: var(--space-3); border: 1px solid color-mix(in oklch, var(--aurora) 24%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 4%, var(--surface-panel-raised)); padding: var(--space-2) var(--space-3); font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
+.session-analyst__pulse { margin-top: var(--space-2); display: flex; align-items: center; gap: var(--space-3); border: 1px solid color-mix(in oklch, var(--aurora) 24%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 4%, var(--surface-panel-raised)); padding: var(--space-2) var(--space-3); font-family: var(--font-mono); font-size: var(--t-xs); color: var(--text-secondary); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
 .session-analyst__pulse.is-error { border-color: color-mix(in oklch, var(--coral) 55%, var(--hairline)); background: var(--coral-glow); }
 .session-analyst__pulse-orbit { width: 10px; height: 10px; flex: none; border-radius: var(--radius-pill); border: 2px solid color-mix(in oklch, var(--aurora) 35%, transparent); border-top-color: var(--aurora); animation: analyst-orbit 0.9s linear infinite; }
 .session-analyst__pulse.is-error .session-analyst__pulse-orbit { border-color: color-mix(in oklch, var(--coral) 35%, transparent); border-top-color: var(--coral); animation: none; }
 .session-analyst__pulse-copy { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .session-analyst__pulse-copy strong { font-weight: var(--weight-medium); overflow-wrap: anywhere; animation: analyst-stage-enter var(--duration-base) var(--ease-glide) both; }
-.session-analyst__pulse-copy small { font-family: var(--font-body); font-size: 11px; color: var(--text-tertiary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.session-analyst__pulse time { margin-left: auto; color: var(--aurora-ink); font-size: 10px; }
+.session-analyst__pulse-copy small { font-family: var(--font-body); font-size: var(--t-xs); color: var(--text-tertiary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-analyst__pulse time { margin-left: auto; color: var(--aurora-ink); font-size: var(--t-2xs); }
 .session-analyst__pulse.is-error time { color: var(--coral-ink); }
-.session-analyst__truth-mark { display: block; margin: var(--space-1) 0 0 2px; color: var(--text-tertiary); font-size: 10px; }
+.session-analyst__truth-mark { display: block; margin: var(--space-1) 0 0 2px; color: var(--text-tertiary); font-size: var(--t-2xs); }
 
 /* 완료 턴의 과정 영수증 — 접힌 한 줄, 펼치면 도구 단계. 채팅 뷰 agent-chat-receipt와 동형. */
 .session-analyst__receipt { margin-top: var(--space-2); }
-.session-analyst__receipt > summary { list-style: none; cursor: pointer; display: inline-flex; align-items: center; gap: var(--space-2); font-family: var(--font-mono); font-size: 11px; color: var(--text-tertiary); padding: 4px var(--space-3); border: 1px solid var(--hairline); border-radius: var(--radius-pill); background: var(--surface-panel-raised); transition: color var(--duration-fast), border-color var(--duration-fast); }
+.session-analyst__receipt > summary { list-style: none; cursor: pointer; display: inline-flex; align-items: center; gap: var(--space-2); font-family: var(--font-mono); font-size: var(--t-xs); color: var(--text-tertiary); padding: 4px var(--space-3); border: 1px solid var(--hairline); border-radius: var(--radius-pill); background: var(--surface-panel-raised); transition: color var(--duration-fast), border-color var(--duration-fast); }
 .session-analyst__receipt > summary:hover { color: var(--text-secondary); border-color: var(--hairline-strong); }
 .session-analyst__receipt > summary::-webkit-details-marker { display: none; }
 .session-analyst__receipt-mark { color: var(--positive); }
 .session-analyst__receipt-chev { font-size: 9px; transition: transform var(--duration-fast); }
 .session-analyst__receipt[open] .session-analyst__receipt-chev { transform: rotate(90deg); }
 .session-analyst__receipt-body { padding: var(--space-1) 0 0 var(--space-3); }
-.session-analyst__receipt-step { display: flex; align-items: center; gap: var(--space-2); min-width: 0; margin-top: var(--space-1); font-family: var(--font-mono); font-size: 11px; color: var(--text-tertiary); padding: 4px var(--space-3); background: var(--surface-panel-raised); border: 1px solid var(--hairline); border-radius: var(--radius-sm); }
+.session-analyst__receipt-step { display: flex; align-items: center; gap: var(--space-2); min-width: 0; margin-top: var(--space-1); font-family: var(--font-mono); font-size: var(--t-xs); color: var(--text-tertiary); padding: 4px var(--space-3); background: var(--surface-panel-raised); border: 1px solid var(--hairline); border-radius: var(--radius-xs); }
 .session-analyst__receipt-step strong { color: var(--text-secondary); font-weight: var(--weight-medium); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-analyst__receipt-step small { color: var(--text-tertiary); white-space: nowrap; }
 /* 중단 영수증 — 진행이 멎은 자리의 기록. */
 .session-analyst__stopped.is-error { border-left-color: var(--coral); color: var(--coral-ink); }
-.session-analyst__stopped { display: flex; align-items: center; gap: var(--space-2); min-height: 30px; margin-top: var(--space-2); border-left: 2px solid var(--text-tertiary); background: var(--surface-panel-raised); padding: 0 var(--space-3); color: var(--text-tertiary); font-weight: var(--weight-regular); font-size: 10px; line-height: 1.3; font-family: var(--font-mono); animation: analyst-receipt-settle var(--duration-base) var(--ease-glide) both; }
+.session-analyst__stopped { display: flex; align-items: center; gap: var(--space-2); min-height: 30px; margin-top: var(--space-2); border-left: 2px solid var(--text-tertiary); background: var(--surface-panel-raised); padding: 0 var(--space-3); color: var(--text-tertiary); font-weight: var(--weight-regular); font-size: var(--t-2xs); line-height: 1.3; font-family: var(--font-mono); animation: analyst-receipt-settle var(--duration-base) var(--ease-glide) both; }
 
 /* Answer — 확정 응답의 전용 문법. 본문은 공유 마크다운 컴포넌트가 렌더한다. */
 .session-analyst__answer { margin-top: var(--space-2); }
-.session-analyst__answer-kicker { display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2); font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; color: var(--text-tertiary); }
+.session-analyst__answer-kicker { display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2); font-family: var(--font-mono); font-size: var(--t-2xs); letter-spacing: .1em; text-transform: uppercase; color: var(--text-tertiary); }
 .session-analyst__answer-kicker::after { content: ""; flex: 1; height: 1px; background: var(--hairline); }
 /* 공유 .markdown-body를 채팅 뷰 Answer와 같은 밀도로 오버라이드한다 — measure는 드로어 전폭. */
 .session-analyst__response.markdown-body {
@@ -155,7 +155,7 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__response.markdown-body p { margin-bottom: var(--space-3); }
 .session-analyst__response.markdown-body :is(ul, ol) { margin-bottom: var(--space-3); padding-left: var(--space-5); }
 .session-analyst__response.markdown-body li + li { margin-top: var(--space-1); }
-.session-analyst__response.markdown-body table { margin-block: var(--space-3); font-size: 11px; }
+.session-analyst__response.markdown-body table { margin-block: var(--space-3); font-size: var(--t-xs); }
 .session-analyst__response table { display: block; max-width: 100%; overflow-x: auto; }
 .session-analyst__response.markdown-body table :is(th, td) { padding: var(--space-2) var(--space-3); }
 .session-analyst__response.markdown-body :is(blockquote, .code-block, .diagram-block) { margin-block: var(--space-3); }
@@ -166,7 +166,7 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 
 /* 증거 인용 칩 — [eN]을 시각 어휘로 승격한다. 클릭은 점프가 아니라 질문이다:
    컴포저에 근거 질문을 프리필해 분석가의 session_read 경로로 맥락을 보여준다. */
-.session-analyst__ev { display: inline-grid; place-items: center; min-width: 20px; height: 15px; padding: 0 4px; margin: 0 1px; vertical-align: 2px; border: 1px solid color-mix(in oklch, var(--aurora) 40%, var(--hairline)); border-radius: var(--radius-sm); background: color-mix(in oklch, var(--aurora) 8%, transparent); color: var(--aurora-ink); font-family: var(--font-mono); font-weight: var(--weight-medium); font-size: 9px; line-height: 1; cursor: pointer; transition: border-color var(--duration-fast), background var(--duration-fast); }
+.session-analyst__ev { display: inline-grid; place-items: center; min-width: 20px; height: 15px; padding: 0 4px; margin: 0 1px; vertical-align: 2px; border: 1px solid color-mix(in oklch, var(--aurora) 40%, var(--hairline)); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--aurora) 8%, transparent); color: var(--aurora-ink); font-family: var(--font-mono); font-weight: var(--weight-medium); font-size: 9px; line-height: 1; cursor: pointer; transition: border-color var(--duration-fast), background var(--duration-fast); }
 /* 호버 델타는 위치/호버 채널(brass) — 칩의 바탕 aurora는 인용 표식으로 남는다. */
 .session-analyst__ev:hover { border-color: var(--brass); color: var(--brass-ink); background: color-mix(in oklch, var(--brass) 10%, transparent); }
 
@@ -174,15 +174,15 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__author-card { min-width: 0; flex: none; margin: var(--space-4) 0 0 26px; overflow: hidden; border: 1px solid var(--hairline); border-radius: var(--radius-md); background: var(--surface-panel-raised); padding: var(--space-3); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
 .session-analyst__author-card.is-authoring { border-color: color-mix(in oklch, var(--aurora) 35%, var(--hairline)); background: color-mix(in oklch, var(--aurora) 5%, var(--surface-panel-raised)); }
 .session-analyst__author-head { display: flex; align-items: center; gap: var(--space-2); min-width: 0; }
-.session-analyst__author-sigil { flex: none; color: var(--aurora-ink); font-size: 13px; line-height: 1; }
-.session-analyst__author-title { min-width: 0; flex: 1; overflow-wrap: anywhere; color: var(--text-primary); font-size: 12.5px; line-height: 1.4; }
-.session-analyst__author-time { flex: none; color: var(--aurora-ink); font-weight: var(--weight-medium); font-size: 10px; line-height: 1.3; font-family: var(--font-mono); }
-.session-analyst__author-sub { margin: var(--space-2) 0 0 21px; color: var(--text-tertiary); font-size: 10.5px; line-height: 1.4; }
+.session-analyst__author-sigil { flex: none; color: var(--aurora-ink); font-size: var(--t-md); line-height: 1; }
+.session-analyst__author-title { min-width: 0; flex: 1; overflow-wrap: anywhere; color: var(--text-primary); font-size: var(--t-md); line-height: 1.4; }
+.session-analyst__author-time { flex: none; color: var(--aurora-ink); font-weight: var(--weight-medium); font-size: var(--t-2xs); line-height: 1.3; font-family: var(--font-mono); }
+.session-analyst__author-sub { margin: var(--space-2) 0 0 21px; color: var(--text-tertiary); font-size: var(--t-xs); line-height: 1.4; }
 .session-analyst__author-track { height: 3px; margin: var(--space-3) 0 0 21px; overflow: hidden; border-radius: 2px; background: color-mix(in oklch, var(--aurora) 14%, var(--surface-panel-raised)); }
 .session-analyst__author-track span { display: block; width: 34%; height: 100%; border-radius: inherit; background: var(--aurora); animation: analyst-author-slide 1.5s var(--ease-glide) infinite; }
 .session-analyst__author-card.is-done { border-color: color-mix(in oklch, var(--positive) 35%, var(--hairline)); background: color-mix(in oklch, var(--positive) 5%, var(--surface-panel-raised)); }
 .session-analyst__author-card.is-done :is(.session-analyst__author-sigil, .session-analyst__author-time, .session-analyst__author-open) { color: var(--positive-ink); }
-.session-analyst__author-open { flex: none; border: 1px solid var(--hairline-strong); border-radius: var(--radius-sm); background: transparent; padding: 5px 9px; font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); white-space: nowrap; cursor: pointer; }
+.session-analyst__author-open { flex: none; border: 1px solid var(--hairline-strong); border-radius: var(--radius-xs); background: transparent; padding: 5px 9px; font-weight: var(--weight-medium); font-size: var(--t-2xs); line-height: 1; font-family: var(--font-mono); white-space: nowrap; cursor: pointer; }
 .session-analyst__author-open:hover { background: color-mix(in oklch, var(--positive) 10%, transparent); }
 
 /* ── 컴포저 — radius-pill은 컨트롤 금지 관례라 radius-md 면으로 정렬한다. ── */
@@ -195,25 +195,25 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__composer.is-initial .session-analyst__composer-surface { flex-direction: column; align-items: stretch; gap: 6px; padding: 8px 8px 7px; }
 .session-analyst__composer-tools { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; min-width: 0; }
 /* 저장 표식은 자리를 늘 차지한다 — 나타날 때 줄이 밀리면 그 흔들림이 알림보다 크게 읽힌다. */
-.session-analyst__saved { flex: none; inline-size: 4.5em; text-align: center; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; line-height: 1; }
-.session-analyst__slash-hint { flex: none; border: 1px dashed var(--hairline); border-radius: var(--radius-sm); background: transparent; color: var(--text-tertiary); padding: 5px 8px; font-family: var(--font-mono); font-size: 10px; line-height: 1; cursor: pointer; transition: border-color var(--duration-fast), color var(--duration-fast); }
+.session-analyst__saved { flex: none; inline-size: 4.5em; text-align: center; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); line-height: 1; }
+.session-analyst__slash-hint { flex: none; border: 1px dashed var(--hairline); border-radius: var(--radius-xs); background: transparent; color: var(--text-tertiary); padding: 5px 8px; font-family: var(--font-mono); font-size: var(--t-2xs); line-height: 1; cursor: pointer; transition: border-color var(--duration-fast), color var(--duration-fast); }
 .session-analyst__slash-hint:hover { border-color: var(--hairline-strong); color: var(--text-secondary); }
 .session-analyst__composer-surface:focus-within { border-color: color-mix(in oklch, var(--aurora) 48%, var(--hairline-strong)); }
-.session-analyst__composer textarea { display: block; box-sizing: border-box; width: auto; min-width: 3rem; min-height: 36px; height: 36px; max-height: calc(1.5em * 6 + 16px); flex: 1 1 auto; resize: none; overflow-x: hidden; overflow-y: hidden; white-space: pre-wrap; border: 0; outline: 0; background: transparent; color: var(--text-primary); padding: 8px 6px; font-weight: var(--weight-regular); font-size: 13px; line-height: 1.5; font-family: var(--font-body); transition: opacity var(--duration-base) var(--ease-glide); }
+.session-analyst__composer textarea { display: block; box-sizing: border-box; width: auto; min-width: 3rem; min-height: 36px; height: 36px; max-height: calc(1.5em * 6 + 16px); flex: 1 1 auto; resize: none; overflow-x: hidden; overflow-y: hidden; white-space: pre-wrap; border: 0; outline: 0; background: transparent; color: var(--text-primary); padding: 8px 6px; font-weight: var(--weight-regular); font-size: var(--t-md); line-height: 1.5; font-family: var(--font-body); transition: opacity var(--duration-base) var(--ease-glide); }
 .session-analyst__composer textarea::placeholder { color: var(--text-tertiary); }
 .session-analyst__slash { position: absolute; z-index: 5; right: 14px; bottom: calc(100% - 4px); left: 14px; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: var(--radius-md); /* 팝업 판독성 계약: raised 층 + 불투명 --ink-deep 언더레이 */ background: linear-gradient(var(--surface-panel-raised), var(--surface-panel-raised)), var(--ink-deep); box-shadow: var(--shadow-floating); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__slash-heading { display: block; border-bottom: 1px solid var(--hairline); padding: 8px 12px 6px; color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); letter-spacing: .14em; text-transform: uppercase; }
-.session-analyst__slash button { display: flex; align-items: baseline; gap: var(--space-3); width: 100%; border: 0; background: transparent; color: var(--text-secondary); padding: 9px 12px; text-align: left; cursor: pointer; font-weight: var(--weight-medium); font-size: 12px; line-height: 1.3; font-family: var(--font-body); }
-.session-analyst__slash button > span { min-width: 76px; color: var(--aurora-ink); font-weight: var(--weight-bold); font-size: 11px; line-height: 1; font-family: var(--font-mono); }
-.session-analyst__slash button small { color: var(--text-tertiary); font-size: 10.5px; }
+.session-analyst__slash-heading { display: block; border-bottom: 1px solid var(--hairline); padding: 8px 12px 6px; color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: var(--t-2xs); line-height: 1; font-family: var(--font-mono); letter-spacing: .14em; text-transform: uppercase; }
+.session-analyst__slash button { display: flex; align-items: baseline; gap: var(--space-3); width: 100%; border: 0; background: transparent; color: var(--text-secondary); padding: 9px 12px; text-align: left; cursor: pointer; font-weight: var(--weight-medium); font-size: var(--t-sm); line-height: 1.3; font-family: var(--font-body); }
+.session-analyst__slash button > span { min-width: 76px; color: var(--aurora-ink); font-weight: var(--weight-bold); font-size: var(--t-xs); line-height: 1; font-family: var(--font-mono); }
+.session-analyst__slash button small { color: var(--text-tertiary); font-size: var(--t-2xs); }
 .session-analyst__slash button:is(.is-selected, :hover) { background: color-mix(in oklch, var(--aurora) 10%, transparent); color: var(--text-primary); }
-.session-analyst__composer-hint { padding: 6px 4px 0; color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: 10px; line-height: 1.4; font-family: var(--font-mono); }
+.session-analyst__composer-hint { padding: 6px 4px 0; color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: var(--t-2xs); line-height: 1.4; font-family: var(--font-mono); }
 /* 선택 컨트롤 — 컴포저 면 안의 칩이다. 파이프 구분선은 상자 안에 있을 때의 문법이라 걷는다. */
-.session-analyst__select { position: relative; display: inline-flex; min-width: 0; border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: var(--surface-panel); transition: border-color var(--duration-base) var(--ease-glide); }
+.session-analyst__select { position: relative; display: inline-flex; min-width: 0; border: 1px solid var(--hairline); border-radius: var(--radius-xs); background: var(--surface-panel); transition: border-color var(--duration-base) var(--ease-glide); }
 .session-analyst__select:focus-within { border-color: color-mix(in oklch, var(--aurora) 48%, var(--hairline-strong)); }
 /* 강도는 제품 공용 톤 사다리를 탄다 — Quick Launch 덱과 같은 언어로 읽히게 한다. */
 .session-analyst__select[data-effort-level]:not([data-effort-level="auto"]) { --fc-select-compact-tone: var(--effort-tone, var(--text-secondary)); border-color: color-mix(in oklch, var(--effort-tone, var(--text-secondary)) 32%, var(--hairline)); }
-.session-analyst__send { display: grid; place-items: center; width: 30px; height: 30px; flex: none; margin-left: auto; border: 1px solid var(--hairline-strong); border-radius: var(--radius-sm); background: var(--ink-mid); color: var(--text-secondary); cursor: pointer; transition: border-color var(--duration-fast), color var(--duration-fast); }
+.session-analyst__send { display: grid; place-items: center; width: 30px; height: 30px; flex: none; margin-left: auto; border: 1px solid var(--hairline-strong); border-radius: var(--radius-xs); background: var(--ink-mid); color: var(--text-secondary); cursor: pointer; transition: border-color var(--duration-fast), color var(--duration-fast); }
 .session-analyst__send:not(:disabled) { border-color: var(--brass); background: var(--brass); color: var(--text-on-brass); }
 .session-analyst__send:hover:not(:disabled) { box-shadow: 0 0 14px var(--brass-glow); }
 .session-analyst__send:disabled { opacity: .42; cursor: default; }
@@ -229,44 +229,44 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 /* ── Artifacts 컴패니언 — 같은 창 면 + 슬림 툴바(72px 밴드 폐기). ── */
 .session-analyst__artifacts { container-type: inline-size; position: relative; box-sizing: border-box; display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto minmax(0, 1fr); width: 100%; height: 100%; min-width: 0; min-height: 0; overflow: hidden; color: var(--text-primary); background: var(--surface-panel); }
 .session-analyst__panel-head--artifacts { position: relative; z-index: 2; display: flex; align-items: center; gap: var(--space-2); min-height: 44px; flex: none; border-bottom: 1px solid var(--hairline); background: transparent; padding: 6px 12px; }
-.session-analyst__panel-mark--artifact { flex: none; color: var(--brass-ink); font-size: 13px; line-height: 1; }
+.session-analyst__panel-mark--artifact { flex: none; color: var(--brass-ink); font-size: var(--t-md); line-height: 1; }
 .session-analyst__panel-copy { display: grid; min-width: 0; gap: 2px; }
-.session-analyst__panel-copy strong { color: var(--text-primary); font-size: 12px; line-height: 1.25; letter-spacing: -.01em; }
-.session-analyst__panel-copy small { overflow: hidden; color: var(--text-tertiary); font-size: 10px; line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
+.session-analyst__panel-copy strong { color: var(--text-primary); font-size: var(--t-sm); line-height: 1.25; letter-spacing: -.01em; }
+.session-analyst__panel-copy small { overflow: hidden; color: var(--text-tertiary); font-size: var(--t-2xs); line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
 .session-analyst__artifact-list-shell { position: relative; margin-left: auto; }
-.session-analyst__artifact-count { display: inline-flex; align-items: baseline; gap: 4px; min-height: 30px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--text-secondary); padding: 5px 9px 5px 11px; font-family: var(--font-mono); white-space: nowrap; cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide); }
-.session-analyst__artifact-count strong { color: var(--text-primary); font-size: 13px; line-height: 1; }
-.session-analyst__artifact-count span { font-size: 10px; }
+.session-analyst__artifact-count { display: inline-flex; align-items: baseline; gap: 4px; min-height: 30px; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); padding: 5px 9px 5px 11px; font-family: var(--font-mono); white-space: nowrap; cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide); }
+.session-analyst__artifact-count strong { color: var(--text-primary); font-size: var(--t-md); line-height: 1; }
+.session-analyst__artifact-count span { font-size: var(--t-2xs); }
 .session-analyst__artifact-count i { width: 6px; height: 6px; margin: 0 2px 2px 4px; border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor; transform: rotate(45deg); transition: transform var(--duration-base) var(--ease-glide); }
 .session-analyst__artifact-count[aria-expanded="true"] { border-color: var(--hairline); background: var(--surface-panel-raised); color: var(--text-primary); }
 .session-analyst__artifact-count[aria-expanded="true"] i { transform: translateY(3px) rotate(-135deg); }
 .session-analyst__artifact-count:hover:not(:disabled) { border-color: var(--hairline); background: var(--surface-panel-raised); color: var(--text-primary); }
 .session-analyst__artifact-count:disabled { opacity: .42; cursor: default; }
 .session-analyst__export-shell { position: relative; }
-.session-analyst__export { border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: transparent; color: var(--text-secondary); padding: 5px 10px; cursor: pointer; font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); }
+.session-analyst__export { border: 1px solid var(--hairline); border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); padding: 5px 10px; cursor: pointer; font-weight: var(--weight-medium); font-size: var(--t-2xs); line-height: 1; font-family: var(--font-mono); }
 .session-analyst__export:hover:not(:disabled) { background: var(--surface-panel-raised); }
 .session-analyst__export:disabled { opacity: .4; cursor: default; }
 .session-analyst__export-menu { position: absolute; z-index: 4; top: calc(100% + 8px); right: 0; display: grid; gap: 5px; width: max-content; min-width: 150px; border: 1px solid var(--hairline-strong); border-radius: var(--radius-md); /* 팝업 판독성 계약: raised 층 + 불투명 --ink-deep 언더레이 */ background: linear-gradient(var(--surface-panel-raised), var(--surface-panel-raised)), var(--ink-deep); padding: 6px; box-shadow: var(--shadow-floating); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__export-menu button { width: 100%; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--text-secondary); padding: 8px; text-align: left; cursor: pointer; font-weight: var(--weight-medium); font-size: 10.5px; line-height: 1.3; font-family: var(--font-body); }
+.session-analyst__export-menu button { width: 100%; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); padding: 8px; text-align: left; cursor: pointer; font-weight: var(--weight-medium); font-size: var(--t-xs); line-height: 1.3; font-family: var(--font-body); }
 .session-analyst__export-menu button:hover { background: var(--surface-glass); color: var(--text-primary); }
-.session-analyst__clear { border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: transparent; color: var(--text-secondary); padding: 5px 10px; cursor: pointer; font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); }
+.session-analyst__clear { border: 1px solid var(--hairline); border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); padding: 5px 10px; cursor: pointer; font-weight: var(--weight-medium); font-size: var(--t-2xs); line-height: 1; font-family: var(--font-mono); }
 .session-analyst__clear:hover:not(:disabled) { background: var(--surface-panel-raised); }
 .session-analyst__clear:disabled { opacity: .4; cursor: default; }
-.session-analyst__artifacts-empty { display: grid; place-items: center; align-content: center; color: var(--text-tertiary); padding: var(--space-5); text-align: center; font-size: 11.5px; line-height: 1.55; }
-.session-analyst__artifacts-empty strong { display: block; margin-bottom: 5px; color: var(--text-secondary); font-size: 12.5px; }
+.session-analyst__artifacts-empty { display: grid; place-items: center; align-content: center; color: var(--text-tertiary); padding: var(--space-5); text-align: center; font-size: var(--t-sm); line-height: 1.55; }
+.session-analyst__artifacts-empty strong { display: block; margin-bottom: 5px; color: var(--text-secondary); font-size: var(--t-md); }
 .session-analyst__artifact-content { display: grid; grid-template-rows: minmax(10rem, 1fr); min-height: 0; overflow: hidden; padding: 12px; }
 .session-analyst__artifact-menu { position: absolute; z-index: 4; top: calc(100% + 8px); right: 0; display: grid; gap: 5px; width: min(360px, 72cqw); min-width: min(260px, 72cqw); max-height: 15rem; overflow: auto; border: 1px solid var(--hairline-strong); border-radius: var(--radius-md); /* 팝업 판독성 계약: raised 층 + 불투명 --ink-deep 언더레이 */ background: linear-gradient(var(--surface-panel-raised), var(--surface-panel-raised)), var(--ink-deep); padding: 6px; box-shadow: var(--shadow-floating); scrollbar-width: thin; animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__artifact-menu button { display: grid; grid-template-columns: 24px minmax(0, 1fr) auto; gap: 9px; align-items: center; width: 100%; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--text-secondary); padding: 8px; text-align: left; cursor: pointer; }
+.session-analyst__artifact-menu button { display: grid; grid-template-columns: 24px minmax(0, 1fr) auto; gap: 9px; align-items: center; width: 100%; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); padding: 8px; text-align: left; cursor: pointer; }
 .session-analyst__artifact-menu button:hover { background: var(--surface-glass); }
 .session-analyst__artifact-menu button.is-active { border-color: color-mix(in oklch, var(--brass) 38%, var(--hairline)); background: color-mix(in oklch, var(--brass) 7%, transparent); }
-.session-analyst__artifact-list-mark { display: grid; place-items: center; width: 24px; height: 24px; border-radius: var(--radius-sm); background: var(--surface-panel-raised); color: var(--brass-bright); font-size: 12px; }
-.session-analyst__artifact-menu button strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 10.5px; }
-.session-analyst__artifact-menu time, .session-analyst__artifacts article time { color: var(--text-tertiary); font-weight: var(--weight-regular); font-size: 10px; line-height: 1.3; font-family: var(--font-mono); white-space: nowrap; }
+.session-analyst__artifact-list-mark { display: grid; place-items: center; width: 24px; height: 24px; border-radius: var(--radius-xs); background: var(--surface-panel-raised); color: var(--brass-bright); font-size: var(--t-sm); }
+.session-analyst__artifact-menu button strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--t-xs); }
+.session-analyst__artifact-menu time, .session-analyst__artifacts article time { color: var(--text-tertiary); font-weight: var(--weight-regular); font-size: var(--t-2xs); line-height: 1.3; font-family: var(--font-mono); white-space: nowrap; }
 .session-analyst__artifacts article { min-height: 0; display: flex; flex-direction: column; overflow: hidden; border: 1px solid var(--hairline); border-radius: var(--radius-md); background: var(--surface-panel-raised); }
 .session-analyst__artifacts article header { display: flex; align-items: center; gap: var(--space-2); min-height: 34px; border-bottom: 1px solid var(--hairline); padding: 0 11px; background: var(--canvas-sea-core); }
-.session-analyst__artifact-title { overflow: hidden; color: var(--text-secondary); font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+.session-analyst__artifact-title { overflow: hidden; color: var(--text-secondary); font-size: var(--t-xs); text-overflow: ellipsis; white-space: nowrap; }
 .session-analyst__artifacts article time { margin-left: auto; }
-.session-analyst__artifacts article p[role="alert"] { margin: 0; padding: var(--space-3); color: var(--coral-ink); font-size: 12px; }
+.session-analyst__artifacts article p[role="alert"] { margin: 0; padding: var(--space-3); color: var(--coral-ink); font-size: var(--t-sm); }
 .session-analyst__artifacts iframe { display: block; width: 100%; flex: 1; min-height: 0; border: 0; background: var(--ink-veil); }
 
 @keyframes analyst-orbit { to { transform: rotate(360deg); } }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -67,7 +67,7 @@
   align-items: center;
   gap: var(--space-3);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
 }
 
@@ -94,7 +94,7 @@
   display: flex;
   gap: var(--space-2);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
   color: var(--text-tertiary);
   margin: 0 var(--space-1) 4px 0;
@@ -111,7 +111,7 @@
   border-radius: 14px 14px 5px 14px;
   padding: var(--space-2) var(--space-3);
   color: var(--text-primary);
-  font-size: 13.5px;
+  font-size: var(--t-base);
   line-height: 1.55;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -175,7 +175,7 @@
   flex-wrap: wrap;
   gap: var(--space-2);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
   color: var(--text-tertiary);
   /* 매초 갱신되는 티커가 흔들리지 않게 숫자 폭을 고정한다. */
@@ -197,9 +197,9 @@
   min-width: 0;
   max-width: 100%;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   padding: 3px var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-panel-raised);
   border: 1px solid color-mix(in oklch, var(--positive) 22%, var(--hairline));
   color: var(--text-secondary);
@@ -242,7 +242,7 @@
    문장 둘레의 간격은 여기서 주지 않는다 — 구간이 이미 gap과 구간 사이 여백으로 같은 호흡을
    주므로, 한 번 더 주면 두 겹으로 쌓여 집계 줄과 다음 문장 사이가 빈 줄 하나로 읽힌다. */
 .agent-chat .agent-chat-ledger-note.markdown-body {
-  --font-size-body: 12.5px;
+  --font-size-body: var(--t-md);
   overflow-wrap: anywhere;
 }
 
@@ -268,7 +268,7 @@
   gap: var(--space-2);
   padding: 2px var(--space-1);
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
 }
@@ -302,7 +302,7 @@
 .agent-chat-tally-fold > summary:focus-visible {
   outline: 2px solid var(--aurora);
   outline-offset: 2px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 /* 어포던스는 오직 이 꺾쇠가 진다. 이전에는 9px에 --hairline-strong이라, 쉬는 상태에서 눌리는
@@ -310,7 +310,7 @@
    차이는 이 글리프 하나뿐). 크기와 잉크를 한 단씩 올려 쉬는 상태에서도 읽히게 하고, hover는
    그 위 한 단으로 남긴다 — brass는 위치·포커스 채널이라 "눌린다"를 질 수 없다. */
 .agent-chat-tally-chev {
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1;
   align-self: center;
   color: var(--text-tertiary);
@@ -338,12 +338,12 @@
   gap: var(--space-2);
   min-width: 0;
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   padding: 5px var(--space-3);
   background: var(--surface-panel-raised);
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 /* 진행 중인 스텝 하나만 aurora를 진다 — 상태 채널이므로 완료된 줄은 중립으로 돌아간다. */
@@ -397,7 +397,7 @@
 /* Theater 밖 좌표 — 표시형으로 접히면 안쪽과 구별되지 않으므로 표식이 대신 말한다. */
 .agent-chat-step-outside {
   flex: none;
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.06em;
   padding: 0 6px;
   border-radius: var(--radius-pill);
@@ -412,7 +412,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.04em;
   padding: 1px 7px;
   border-radius: var(--radius-pill);
@@ -466,7 +466,7 @@
   align-items: center;
   gap: 6px;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--aurora);
@@ -491,7 +491,7 @@
 .agent-chat-ask-counter {
   margin-left: auto;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.08em;
   color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
@@ -499,7 +499,7 @@
 
 .agent-chat-ask-text {
   margin: 0 0 var(--space-3);
-  font-size: 14.5px;
+  font-size: var(--t-base);
   line-height: 1.55;
   font-weight: var(--weight-medium);
   color: var(--text-primary);
@@ -517,7 +517,7 @@
   gap: 2px;
   text-align: left;
   padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--hairline);
   background: var(--surface-panel);
   color: var(--text-secondary);
@@ -547,7 +547,7 @@
 /* 라벨은 사용자가 고르면 그대로 답이 되는 문자열이라 서버가 자르지 않는다 — 길면 여기서
    접는다. 자르는 쪽을 택하면 보이는 것과 보내는 것이 갈라진다. */
 .agent-chat-ask-option-label {
-  font-size: 13.5px;
+  font-size: var(--t-base);
   font-weight: var(--weight-medium);
   color: var(--text-primary);
   line-height: 1.45;
@@ -556,7 +556,7 @@
 }
 
 .agent-chat-ask-option-desc {
-  font-size: 12.5px;
+  font-size: var(--t-md);
   line-height: 1.5;
   color: var(--text-tertiary);
 }
@@ -573,9 +573,9 @@
   flex: 1 1 auto;
   min-width: 0;
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--t-md);
   padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px dashed var(--hairline-strong);
   background: var(--surface-panel);
   color: var(--text-primary);
@@ -597,10 +597,10 @@
 }
 
 .agent-chat-ask-send {
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   padding: 7px var(--space-4);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--brass);
   background: var(--brass);
   color: var(--text-on-brass);
@@ -624,10 +624,10 @@
 
 .agent-chat-ask-mini {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.05em;
   padding: 5px var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--hairline);
   background: transparent;
   color: var(--text-tertiary);
@@ -645,12 +645,12 @@
 .agent-chat-ask-hint {
   margin-left: auto;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
 }
 
 .agent-chat-ask-error {
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--coral-ink);
 }
 
@@ -659,7 +659,7 @@
   max-height: 260px;
   overflow-y: auto;
   padding: var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--hairline);
   background: var(--surface-panel);
 }
@@ -676,12 +676,12 @@
   gap: var(--space-2);
   min-width: 0;
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
   padding: 5px var(--space-3);
   background: var(--surface-panel-raised);
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 .agent-chat-ask-settled-mark { flex: none; color: var(--positive); }
@@ -712,7 +712,7 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
   font-variant-numeric: tabular-nums;
   color: var(--text-tertiary);
@@ -724,7 +724,7 @@
 .agent-chat-fold > summary:focus-visible {
   outline: 2px solid var(--aurora);
   outline-offset: 3px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 .agent-chat-fold > summary::-webkit-details-marker { display: none; }
@@ -745,7 +745,7 @@
   font-size: 9px;
   line-height: 1;
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   transition: transform var(--duration-fast), border-color var(--duration-fast);
 }
 
@@ -768,7 +768,7 @@
   gap: var(--space-2);
   margin-bottom: var(--space-2);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--text-tertiary);
@@ -836,7 +836,7 @@
   z-index: 3;
   margin: 0;
   max-width: 60%;
-  font-size: 12px;
+  font-size: var(--t-sm);
   line-height: 1.4;
   text-align: right;
   color: var(--brass-ink);
@@ -884,7 +884,7 @@
   border: 1px solid var(--hairline-strong);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
   transition: border-color var(--duration-fast), color var(--duration-fast);
 }
@@ -927,10 +927,10 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
   padding: 5px var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-panel-raised);
   border: 1px solid color-mix(in oklch, var(--aurora) 45%, var(--hairline-strong));
   color: var(--aurora-ink);
@@ -1012,10 +1012,10 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
   padding: 5px var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--ink-mid);
   border: 1px solid var(--hairline-strong);
   color: var(--text-secondary);
@@ -1057,18 +1057,18 @@
 .agent-chat-inter-card h4 {
   margin: 0 0 var(--space-2);
   color: var(--text-primary);
-  font-size: 15px;
+  font-size: var(--t-lg);
   font-weight: var(--weight-bold);
 }
 
 .agent-chat-inter-card p {
   margin: 0 0 var(--space-2);
-  font-size: 13px;
+  font-size: var(--t-md);
   color: var(--text-secondary);
 }
 
 .agent-chat-inter-fine {
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--text-tertiary);
 }
 
@@ -1076,7 +1076,7 @@
   display: flex;
   align-items: baseline;
   gap: var(--space-2);
-  font-size: 12px;
+  font-size: var(--t-sm);
   color: var(--coral-ink);
 }
 
@@ -1094,10 +1094,10 @@
 }
 
 .agent-chat-inter-button {
-  font-size: 13px;
+  font-size: var(--t-md);
   font-weight: var(--weight-medium);
   padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--hairline-strong);
   color: var(--text-secondary);
 }
@@ -1125,10 +1125,10 @@
   bottom: var(--space-6);
   z-index: 2;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   letter-spacing: 0.06em;
   padding: 5px var(--space-3);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--hairline-strong);
   background: color-mix(in oklch, var(--surface-panel-raised) 80%, transparent);
   color: var(--text-tertiary);
@@ -1253,7 +1253,7 @@
   padding: var(--space-2) var(--space-3);
   background: var(--surface-panel-raised);
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
   transition: border-color var(--duration-fast);
@@ -1275,7 +1275,7 @@
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
-  font-size: 11.5px;
+  font-size: var(--t-sm);
 }
 
 .agent-chat-job-mark { flex: none; width: 9px; text-align: center; color: var(--text-tertiary); }
@@ -1295,7 +1295,7 @@
 .agent-chat-job-outcome {
   margin-left: auto;
   flex: none;
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.04em;
   padding: 1px 7px;
   border-radius: var(--radius-pill);
@@ -1325,7 +1325,7 @@
   align-items: center;
   flex-wrap: wrap;
   gap: var(--space-2);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
   padding-left: 17px;
@@ -1373,7 +1373,7 @@
   max-width: min(var(--agent-chat-measure), calc(100% - 2 * (var(--space-3) + 40px + var(--space-2) + 72px)));
   padding: 6px var(--space-3);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-secondary);
   border: 1px solid color-mix(in oklch, var(--aurora) 30%, var(--hairline));
   border-radius: var(--radius-pill);
@@ -1472,7 +1472,7 @@
   border: none;
   border-bottom: 1px solid var(--hairline);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
   text-align: left;
   transition: color var(--duration-fast);
@@ -1483,19 +1483,19 @@
 .agent-chat-work-cap:focus-visible {
   outline: 2px solid var(--aurora);
   outline-offset: 2px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
 }
 
 .agent-chat-work-cap-chev {
   margin-left: auto;
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1;
   color: var(--text-tertiary);
 }
 
 .agent-chat-work-sec {
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-tertiary);
@@ -1506,7 +1506,7 @@
 
 .agent-chat-work-empty {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   line-height: 1.6;
   color: var(--text-tertiary);
   padding: var(--space-2) 0;
@@ -1528,7 +1528,7 @@
   border-radius: var(--radius-pill);
   padding: 2px 9px;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.08em;
   color: var(--text-tertiary);
   transition: color var(--duration-fast), border-color var(--duration-fast);
@@ -1545,7 +1545,7 @@
 }
 
 .agent-chat-detail-title {
-  font-size: 12.5px;
+  font-size: var(--t-md);
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1555,7 +1555,7 @@
 
 .agent-chat-detail-meta {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.04em;
   color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
@@ -1579,7 +1579,7 @@
 .agent-chat-detail-note {
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
 }
 
@@ -1589,7 +1589,7 @@
   gap: var(--space-2);
   margin-top: var(--space-2);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--text-tertiary);
@@ -1609,7 +1609,7 @@
 .agent-chat-detail-loading,
 .agent-chat-detail-cut {
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   color: var(--text-tertiary);
 }
 
@@ -1627,10 +1627,10 @@
   overflow: auto;
   padding: var(--space-2);
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   background: var(--surface-panel);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
   line-height: 1.55;
   color: var(--text-secondary);
   white-space: pre;
@@ -1641,7 +1641,7 @@
 
 .agent-chat-stage {
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   overflow: hidden;
 }
 
@@ -1652,7 +1652,7 @@
   padding: 5px var(--space-3);
   background: var(--surface-panel-raised);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--t-xs);
   color: var(--text-primary);
 }
 
@@ -1670,7 +1670,7 @@
 .agent-chat-stage-rows {
   overflow-x: auto;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--t-xs);
 }
 
 .agent-chat-stage-row {
@@ -1688,7 +1688,7 @@
 
 .agent-chat-stage-row.is-head {
   border-top: 0;
-  font-size: 9px;
+  font-size: var(--t-2xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-tertiary);

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
@@ -36,12 +36,12 @@
   overflow: hidden;
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-sm);
   font-weight: var(--weight-medium);
   white-space: nowrap;
   background: var(--surface-glass-strong);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;


### PR DESCRIPTION
## Summary

색은 3채널 차터와 계약 테스트로 이미 잠겨 있었지만 **치수·활자는 잠겨 있지 않았습니다.** 활자 크기에는 토큰이 아예 없었고(raw 32종·반픽셀 151회), 라운드는 이름 6개가 값 3개를 가리켰습니다. 그래서 표면마다 자기 스케일을 발명해, 같은 역할이 화면마다 다른 크기로 섰습니다.

실측(격리 인스턴스 1680×1010, 4테마)으로 확인한 것:

- 같은 Rail 슬롯인데 본문 활자가 패널마다 갈림 — repository 10.5px / quota 11.5px / skills·ledger 12px / file-explorer 13px
- Command Band 한 줄 안 컨트롤 높이 7종 — 로컬 칩은 고정 높이가 없어 내용이 정한 28.6px, 브레드크럼 21px
- 라운드 토큰 소비처 — `sm` 179회 · `md` 116 · `xs` 83 · `lg` 42 · `xl` 25, raw `999px` 58회

### 변경

- **활자 사다리 7단 신설**(`--t-2xs`~`--t-xl`) — 실측 주력값에서 유도, 710개 선언 이관
- **라운드 어휘 3개로 축소**(xs/md/pill) — 316 사이트 회수, 중복 토큰 `sm`·`lg`·`xl` 퇴역
- **Rail 활자 계약** — 슬롯 공유 패널이 본문 `--t-sm`을 공유, 조밀 목록만 한 단 아래
- **밴드 높이 스냅** — 고정 높이가 없던 컨트롤 3건을 24px 단으로
- **신택스 채널 분리** — file-explorer의 `.syn-*`가 신호색 대신 `--syntax-*`(정체성 8톤 파생)를 소비
- **스크림 토큰화** — codex reading scrim의 유채색 리터럴을 `--ink-abyss` 믹스로
- **계약 게이트 3종 추가** — raw font-size(`font` 단축 표기 포함), 퇴역 라운드 이름, 유채색 리터럴

예외는 계약 테스트에 명시했습니다: 도형을 재는 글리프 크기와 치수가 박힌 상자 20건(선택자 목록), 24px 이상 디스플레이 크기.

## Test Plan

- [x] `build` — 통과
- [x] `instrument-design-contract` — 68 통과 (게이트 3종 추가, 프로브 주입으로 실제로 무는 것 확인)
- [x] 플러그인 자체 러너 — repository 390 · terminal 866 · file-explorer 139 · quota 34 · ledger 107 · scuttlebutt 139 · skills 89
- [x] 콘솔 CSS 계약 테스트 10개 파일 251 통과
- [x] 헤디드 4테마 검증 — 밴드 컨트롤 24px 단일 단(before 7종), Rail 본문 12px 공유, file-explorer 트리 13→12px, 신택스 토큰이 4테마에서 각 채도 봉투로 재조율
- [ ] `tsc --noEmit` — `tests/fleet-cli/doctor.test.ts(56,5)` 실패는 **선존**입니다(canary와 byte-identical, 이 PR 변경 파일 아님)

리베이스 중 canary가 새로 들여온 `quota.css`의 `11.5px`를 게이트가 즉시 잡아 두 번째 커밋으로 이관했습니다.