### PR TITLE
fix(fleet-console): move Chat Mode journals onto ticketed WebSockets

### DIFF
--- a/.changelog.d/chat-sse-starvation.md
+++ b/.changelog.d/chat-sse-starvation.md
@@ -1,0 +1,8 @@
+---
+branch: chat-sse-starvation
+---
+
+### fleet-console
+#### Fixed
+- Keep Console APIs reachable when several Chat Mode panels are open by moving each chat journal off HTTP/1.1 EventSource onto the same ticketed WebSocket path the terminal already uses.
+  ko: 채팅 뷰를 여러 개 열어도 콘솔 API가 멈추지 않도록, 채팅 저널을 HTTP/1.1 EventSource에서 터미널과 같은 티켓 WebSocket으로 옮겼습니다.

--- a/runtime/fleet-console/tests/api-catalog.test.ts
+++ b/runtime/fleet-console/tests/api-catalog.test.ts
@@ -86,7 +86,7 @@ GET|/plugins/terminal/agent/agent-cli/diagnostics|http
 GET|/plugins/terminal/agent/agent-cli/state|http
 GET|/plugins/terminal/agent/events|sse
 GET|/plugins/terminal/agent/sessions/:sessionId/chat-job|http
-GET|/plugins/terminal/agent/sessions/:sessionId/chat-stream|sse
+GET|/plugins/terminal/agent/sessions/:sessionId/chat-stream|http
 GET|/plugins/terminal/agent/sessions|http
 GET|/plugins/terminal/agent/state|http
 GET|/plugins/terminal/analysis/:operationId/ready|http

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.test.tsx
@@ -4,31 +4,44 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useAgentChatStream, type AgentChatViewState } from "./chat-store.js";
+import { useAgentChatStream, type AgentChatViewState, type ChatWebSocketLike } from "./chat-store.js";
 
-class FakeEventSource {
-  static instances: FakeEventSource[] = [];
+class FakeWebSocket implements ChatWebSocketLike {
+  static instances: FakeWebSocket[] = [];
   readonly url: string;
   readyState = 0;
   onopen: (() => void) | null = null;
+  onmessage: ((event: { readonly data: string | ArrayBuffer }) => void) | null = null;
+  onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
-  onmessage: ((message: MessageEvent<string>) => void) | null = null;
   closed = false;
+  sent: string[] = [];
 
   constructor(url: string) {
     this.url = url;
-    FakeEventSource.instances.push(this);
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
   }
 
   close(): void {
     this.closed = true;
-    this.readyState = 2;
+    this.readyState = 3;
+    this.onclose?.();
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.onopen?.();
   }
 }
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
 let latest: AgentChatViewState | null = null;
+const ticketFetches: Array<{ readonly url: string; readonly body: unknown }> = [];
 
 function Probe({ operationId, live }: { readonly operationId: string; readonly live: boolean }) {
   latest = useAgentChatStream(operationId, live);
@@ -45,9 +58,19 @@ function mount(operationId: string, live: boolean): void {
 }
 
 beforeEach(() => {
-  FakeEventSource.instances = [];
+  FakeWebSocket.instances = [];
+  ticketFetches.length = 0;
   latest = null;
-  vi.stubGlobal("EventSource", FakeEventSource);
+  vi.stubGlobal("WebSocket", FakeWebSocket);
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    ticketFetches.push({ url, body });
+    return {
+      ok: true,
+      json: async () => ({ ticket: `ticket-for-${body?.operationId ?? "unknown"}`, ttlMs: 10_000, role: "control" }),
+    } as Response;
+  });
 });
 
 afterEach(() => {
@@ -60,41 +83,53 @@ afterEach(() => {
 });
 
 describe("useAgentChatStream", () => {
-  it("opens one EventSource while the body is live", () => {
+  it("requests a chat ticket and opens one WebSocket while the body is live", async () => {
     mount("op-live", true);
-    expect(FakeEventSource.instances).toHaveLength(1);
-    expect(FakeEventSource.instances[0]?.url).toBe("/plugins/terminal/agent/sessions/op-live/chat-stream");
-    expect(FakeEventSource.instances[0]?.closed).toBe(false);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(ticketFetches).toHaveLength(1);
+    expect(ticketFetches[0]?.url).toBe("/plugins/terminal/agent/ticket");
+    expect(ticketFetches[0]?.body).toEqual({ operationId: "op-live", channel: "chat" });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0]?.url).toContain("/plugins/terminal/ws?ticket=ticket-for-op-live");
+    expect(FakeWebSocket.instances[0]?.closed).toBe(false);
     expect(latest?.connection).toBe("connecting");
   });
 
-  it("does not open an EventSource while the body is parked", () => {
+  it("does not open a WebSocket while the body is parked", () => {
     mount("op-parked", false);
-    expect(FakeEventSource.instances).toHaveLength(0);
+    expect(ticketFetches).toHaveLength(0);
+    expect(FakeWebSocket.instances).toHaveLength(0);
     expect(latest?.connection).toBe("idle");
   });
 
-  it("closes the EventSource when the body leaves the live surface", () => {
+  it("closes the WebSocket when the body leaves the live surface", async () => {
     mount("op-toggle", true);
-    const source = FakeEventSource.instances[0];
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const source = FakeWebSocket.instances[0];
     expect(source?.closed).toBe(false);
     act(() => {
       root!.render(createElement(Probe, { operationId: "op-toggle", live: false }));
     });
     expect(source?.closed).toBe(true);
-    expect(FakeEventSource.instances).toHaveLength(1);
-    // 화면 밖에서도 마지막 로그를 지키므로 lost로 뒤집지 않는다 — 다시 보이면 재접속이 저널을 되쓴다.
+    expect(FakeWebSocket.instances).toHaveLength(1);
     expect(latest?.connection).toBe("idle");
   });
 
-  it("opens a new EventSource when a parked body becomes live", () => {
+  it("opens a new WebSocket when a parked body becomes live", async () => {
     mount("op-return", false);
-    expect(FakeEventSource.instances).toHaveLength(0);
+    expect(FakeWebSocket.instances).toHaveLength(0);
     act(() => {
       root!.render(createElement(Probe, { operationId: "op-return", live: true }));
     });
-    expect(FakeEventSource.instances).toHaveLength(1);
-    expect(FakeEventSource.instances[0]?.url).toBe("/plugins/terminal/agent/sessions/op-return/chat-stream");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0]?.url).toContain("/plugins/terminal/ws?ticket=ticket-for-op-return");
     expect(latest?.connection).toBe("connecting");
   });
 });

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.test.tsx
@@ -132,4 +132,35 @@ describe("useAgentChatStream", () => {
     expect(FakeWebSocket.instances[0]?.url).toContain("/plugins/terminal/ws?ticket=ticket-for-op-return");
     expect(latest?.connection).toBe("connecting");
   });
+
+  it("resets the journal when a socket reconnects so replay does not duplicate turns", async () => {
+    mount("op-replay", true);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const first = FakeWebSocket.instances[0];
+    expect(first).toBeTruthy();
+    const replay = { seq: 1, event: { kind: "dispatch", text: "hello" } };
+    act(() => {
+      first!.open();
+      first!.onmessage?.({ data: JSON.stringify(replay) });
+    });
+    expect(latest?.turns).toHaveLength(1);
+    expect(latest?.turns[0]?.dispatch?.text).toBe("hello");
+
+    act(() => {
+      first!.close();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+    const second = FakeWebSocket.instances[1];
+    expect(second).toBeTruthy();
+    act(() => {
+      second!.open();
+      second!.onmessage?.({ data: JSON.stringify(replay) });
+    });
+    expect(latest?.turns).toHaveLength(1);
+    expect(latest?.connection).toBe("open");
+  });
 });

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
@@ -48,7 +48,13 @@ export function useAgentChatStream(operationId: string, live = true): AgentChatV
     setLog(initialAgentChatLogState);
     const session = createChatSocketSession({
       operationId,
-      onConnection: setConnection,
+      onConnection: (next) => {
+        // 서버는 접속마다 보유 저널을 처음부터 되쓴다. 채팅 출생은 replay-start를 남기지
+        // 않고, JOURNAL_CAP에 걸린 세션은 그 마커가 앞에서 잘린다. 열릴 때 비우지 않으면
+        // 재접속 리플레이가 남은 턴·잡·질문 카드 위에 겹친다(옛 EventSource onopen과 같은 자리).
+        if (next === "open") setLog(() => initialAgentChatLogState);
+        setConnection(next);
+      },
       onEvent: (raw) => {
         const entry = readChatJournalEvent(raw);
         if (!entry) return;

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
@@ -1,53 +1,238 @@
 import { React } from "@fleet-console/sdk/plugin/browser";
 
+import { TerminalTicketError, buildTerminalWsUrl } from "../../shared/terminal-connection.js";
 import { initialAgentChatLogState, readChatJournalEvent, reduceAgentChatLog, type AgentChatLogState } from "./chat-events.js";
 
 export type AgentChatConnection = "connecting" | "open" | "lost" | "idle";
 
-export interface AgentChatViewState extends AgentChatLogState {
-  readonly connection: AgentChatConnection;
+export interface AgentChatAnswerCommand {
+  readonly askId: string;
+  readonly answers?: readonly string[];
+  readonly approve?: boolean;
+  readonly message?: string;
 }
 
+export interface AgentChatViewState extends AgentChatLogState {
+  readonly connection: AgentChatConnection;
+  readonly stopTurn: () => Promise<void>;
+  readonly answerAsk: (body: AgentChatAnswerCommand) => Promise<void>;
+}
+
+const CHAT_TICKET_PATH = "/plugins/terminal/agent/ticket";
+const CHAT_WS_PATH = "/plugins/terminal/ws";
+const INITIAL_RECONNECT_DELAY_MS = 250;
+const MAX_RECONNECT_DELAY_MS = 5_000;
+const OPEN_READY_STATE = 1;
+const COMMAND_WAIT_MS = 8_000;
+
 /**
- * Operation 하나의 chat-stream 구독.
+ * Operation 하나의 채팅 소켓.
  *
- * 서버는 접속(재접속 포함)마다 저널 전체를 되쓴다 — 저널의 첫 이벤트는 언제나 replay-start라
- * reducer가 스스로 초기화하지만, 저널이 상한으로 앞이 잘린 재접속에서도 상태가 겹으로 쌓이지
- * 않도록 open 시점에 로그 상태를 초기화한다. EventSource의 자동 재접속을 그대로 쓴다.
- *
+ * PTY와 같은 수명이다: 티켓 POST → `/plugins/terminal/ws` upgrade → 저널 리플레이.
  * `live`가 false면 소켓을 열지 않는다. 본문 풀이 주차·최소화·숨김 본문을 살려 두므로,
- * 그때도 구독하면 화면 밖 패널마다 HTTP/1.1 슬롯을 하나씩 점유한다. 덱 타일은 본문이
+ * 그때도 구독하면 화면 밖 패널마다 소켓을 하나씩 점유한다. 덱 타일은 본문이
  * 그려지므로 live로 남긴다.
  */
 export function useAgentChatStream(operationId: string, live = true): AgentChatViewState {
   const [connection, setConnection] = React.useState<AgentChatConnection>(live ? "connecting" : "idle");
   const [log, setLog] = React.useState<AgentChatLogState>(initialAgentChatLogState);
+  const sessionRef = React.useRef<ChatSocketSession | null>(null);
 
   React.useEffect(() => {
     if (!live) {
       setConnection("idle");
+      sessionRef.current = null;
       return;
     }
     setConnection("connecting");
     setLog(initialAgentChatLogState);
-    const source = new EventSource(`/plugins/terminal/agent/sessions/${encodeURIComponent(operationId)}/chat-stream`);
-    source.onopen = () => {
-      setConnection("open");
-      setLog(initialAgentChatLogState);
-    };
-    source.onerror = () => {
-      // EventSource가 스스로 재시도한다. CLOSED로 굳었을 때만 상실로 읽는다.
-      setConnection(source.readyState === EventSource.CLOSED ? "lost" : "connecting");
-    };
-    source.onmessage = (message: MessageEvent<string>) => {
-      const entry = readChatJournalEvent(message.data);
-      if (!entry) return;
-      setLog((current) => reduceAgentChatLog(current, entry.event));
-    };
+    const session = createChatSocketSession({
+      operationId,
+      onConnection: setConnection,
+      onEvent: (raw) => {
+        const entry = readChatJournalEvent(raw);
+        if (!entry) return;
+        setLog((current) => reduceAgentChatLog(current, entry.event));
+      },
+    });
+    sessionRef.current = session;
+    session.start();
     return () => {
-      source.close();
+      session.dispose();
+      if (sessionRef.current === session) sessionRef.current = null;
     };
   }, [operationId, live]);
 
-  return React.useMemo(() => ({ ...log, connection }), [log, connection]);
+  const stopTurn = React.useCallback(async () => {
+    await sessionRef.current?.send({ type: "stop" });
+  }, []);
+  const answerAsk = React.useCallback(async (body: AgentChatAnswerCommand) => {
+    await sessionRef.current?.send({ type: "answer", ...body });
+  }, []);
+
+  return React.useMemo(() => ({ ...log, connection, stopTurn, answerAsk }), [log, connection, stopTurn, answerAsk]);
+}
+
+interface ChatSocketSession {
+  start(): void;
+  send(command: ChatOutboundCommand): Promise<void>;
+  dispose(): void;
+}
+
+type ChatOutboundCommand =
+  | { readonly type: "stop" }
+  | { readonly type: "answer"; readonly askId: string; readonly answers?: readonly string[]; readonly approve?: boolean; readonly message?: string };
+
+interface ChatSocketSessionOptions {
+  readonly operationId: string;
+  readonly onConnection: (connection: AgentChatConnection) => void;
+  readonly onEvent: (raw: string) => void;
+  readonly location?: Pick<Location, "host" | "protocol">;
+  readonly webSocketFactory?: (url: string) => ChatWebSocketLike;
+  readonly fetchImpl?: typeof fetch;
+}
+
+export interface ChatWebSocketLike {
+  readonly readyState: number;
+  readonly send: (data: string) => void;
+  readonly close: () => void;
+  onopen: (() => void) | null;
+  onmessage: ((event: { readonly data: string | ArrayBuffer }) => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+}
+
+export function createChatSocketSession(options: ChatSocketSessionOptions): ChatSocketSession {
+  const abort = new AbortController();
+  const fetchImpl = options.fetchImpl ?? fetch;
+  let reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+  let socket: ChatWebSocketLike | null = null;
+  let commandSeq = 0;
+  const pending = new Map<string, { readonly resolve: () => void; readonly reject: (error: Error) => void; readonly timer: ReturnType<typeof setTimeout> }>();
+
+  const rejectPending = (error: Error): void => {
+    for (const wait of pending.values()) {
+      clearTimeout(wait.timer);
+      wait.reject(error);
+    }
+    pending.clear();
+  };
+
+  const attach = async (url: string): Promise<void> => {
+    await new Promise<void>((resolve, reject) => {
+      const ws = (options.webSocketFactory ?? defaultChatWebSocketFactory)(url);
+      socket = ws;
+      let opened = false;
+      ws.onopen = () => {
+        opened = true;
+        options.onConnection("open");
+      };
+      ws.onmessage = (event) => {
+        if (typeof event.data !== "string") return;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(event.data);
+        } catch {
+          return;
+        }
+        if (parsed && typeof parsed === "object" && "type" in parsed) {
+          const frame = parsed as { readonly type?: unknown; readonly id?: unknown; readonly error?: unknown };
+          if ((frame.type === "ok" || frame.type === "nack") && typeof frame.id === "string") {
+            const wait = pending.get(frame.id);
+            if (!wait) return;
+            pending.delete(frame.id);
+            clearTimeout(wait.timer);
+            if (frame.type === "ok") wait.resolve();
+            else wait.reject(new Error(typeof frame.error === "string" ? frame.error : "chat_command_failed"));
+            return;
+          }
+        }
+        options.onEvent(event.data);
+      };
+      ws.onerror = () => {
+        if (!opened) reject(new Error("chat_socket_error"));
+      };
+      ws.onclose = () => {
+        if (socket === ws) socket = null;
+        rejectPending(new Error("chat_socket_closed"));
+        if (opened) resolve();
+        else reject(new Error("chat_socket_closed"));
+      };
+    });
+  };
+
+  const connectLoop = async (): Promise<void> => {
+    while (!abort.signal.aborted) {
+      options.onConnection("connecting");
+      try {
+        const ticket = await requestChatTicket(options.operationId, abort.signal, fetchImpl);
+        if (abort.signal.aborted) return;
+        await attach(buildTerminalWsUrl(ticket, options.location, CHAT_WS_PATH));
+        reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+      } catch {
+        if (abort.signal.aborted) return;
+        options.onConnection("lost");
+      }
+      if (abort.signal.aborted) return;
+      await delay(reconnectDelay, abort.signal);
+      reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
+    }
+  };
+
+  return {
+    start: () => {
+      void connectLoop();
+    },
+    send: (command) => {
+      const ws = socket;
+      if (!ws || ws.readyState !== OPEN_READY_STATE) return Promise.reject(new Error("chat_not_connected"));
+      const id = `c${++commandSeq}`;
+      return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error("chat_command_timeout"));
+        }, COMMAND_WAIT_MS);
+        pending.set(id, { resolve, reject, timer });
+        ws.send(JSON.stringify({ id, ...command }));
+      });
+    },
+    dispose: () => {
+      abort.abort();
+      rejectPending(new Error("chat_socket_closed"));
+      socket?.close();
+      socket = null;
+    },
+  };
+}
+
+async function requestChatTicket(operationId: string, signal: AbortSignal, fetchImpl: typeof fetch): Promise<string> {
+  const response = await fetchImpl(CHAT_TICKET_PATH, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ operationId, channel: "chat" }),
+    signal,
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null) as { readonly error?: unknown } | null;
+    throw new TerminalTicketError(typeof payload?.error === "string" ? payload.error : `http_${response.status}`, response.status);
+  }
+  const payload = await response.json() as { readonly ticket?: unknown };
+  if (typeof payload.ticket !== "string") throw new Error("Invalid chat ticket response");
+  return payload.ticket;
+}
+
+function defaultChatWebSocketFactory(url: string): ChatWebSocketLike {
+  return new WebSocket(url) as unknown as ChatWebSocketLike;
+}
+
+async function delay(ms: number, signal: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal.addEventListener("abort", finish);
+  });
 }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -2,9 +2,9 @@ import { React } from "@fleet-console/sdk/plugin/browser";
 import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
 
 import { getT } from "../../i18n/index.js";
-import { AgentApiError, answerAgentChatAsk, readAgentChatJobDetail, stopAgentChatTurn } from "../api.js";
+import { AgentApiError, readAgentChatJobDetail } from "../api.js";
 import { StreamedMarkdown } from "../streamed-markdown.js";
-import { useAgentChatStream } from "./chat-store.js";
+import { useAgentChatStream, type AgentChatViewState } from "./chat-store.js";
 import {
   agentChatToolFamily,
   openAgentChatJobs,
@@ -217,14 +217,14 @@ export function AgentChatView({
   const handleStop = React.useCallback(async (): Promise<void> => {
     setStopping(true);
     try {
-      await stopAgentChatTurn(context.operationId);
+      await state.stopTurn();
     } catch {
       // 실패해도 따로 말하지 않는다. 이 버튼이 실패하는 경우는 사실상 "이미 끝났다" 하나이고,
       // 그 사실은 턴이 스스로 닫히면서 화면에 말한다 — 오류 줄을 더하면 같은 사건이 두 번 읽힌다.
     } finally {
       setStopping(false);
     }
-  }, [context.operationId]);
+  }, [state.stopTurn]);
 
   // 손잡이 드래그. 가로(오른쪽 컬럼)와 세로(아래 서랍)가 같은 상태를 쓰고 축만 다르다 —
   // 좁은 패널에서 컬럼이 서랍으로 접히는 것이 별개의 기능이 아니라 같은 면의 다른 방향이기 때문이다.
@@ -316,6 +316,7 @@ export function AgentChatView({
             streaming={index === state.turns.length - 1 && turn.state === "working"}
             jobsByToolUse={jobsByToolUse}
             onOpenJob={showJob}
+            onAnswer={state.answerAsk}
           />
         ))}
         {state.errorCode === "chat_turn_failed"
@@ -479,6 +480,7 @@ function ChatTurn({
   streaming,
   jobsByToolUse,
   onOpenJob,
+  onAnswer,
 }: {
   readonly operationId: string;
   readonly turn: AgentChatTurn;
@@ -487,6 +489,7 @@ function ChatTurn({
   readonly streaming: boolean;
   readonly jobsByToolUse: ReadonlyMap<string, AgentChatJob>;
   readonly onOpenJob: (id: string) => void;
+  readonly onAnswer: AgentChatViewState["answerAsk"];
 }) {
   const t = getT(language);
   const view = splitAgentChatTurn(turn);
@@ -531,6 +534,7 @@ function ChatTurn({
                   language={language}
                   jobsByToolUse={jobsByToolUse}
                   onOpenJob={onOpenJob}
+                  onAnswer={onAnswer}
                   working
                   pending={view.streamingText === null
                     && !view.ledger.some((item) => item.state === "running")
@@ -549,7 +553,7 @@ function ChatTurn({
                 language={language}
               >
                 <ChangeStrip changes={view.changes} language={language} />
-                <Ledger operationId={operationId} items={view.ledger} language={language} jobsByToolUse={jobsByToolUse} onOpenJob={onOpenJob} />
+                <Ledger operationId={operationId} items={view.ledger} language={language} jobsByToolUse={jobsByToolUse} onOpenJob={onOpenJob} onAnswer={onAnswer} />
               </WorkFold>
             ) : null}
             {/* 중지된 턴에서 흐르던 글도 여기 선다 — Answer가 아니므로 그 이름표를 달지 않고,
@@ -636,6 +640,7 @@ function Ledger({
   language,
   jobsByToolUse,
   onOpenJob,
+  onAnswer,
   working = false,
   pending = false,
 }: {
@@ -644,6 +649,7 @@ function Ledger({
   readonly language: "en" | "ko";
   readonly jobsByToolUse: ReadonlyMap<string, AgentChatJob>;
   readonly onOpenJob: (id: string) => void;
+  readonly onAnswer: AgentChatViewState["answerAsk"];
   /** 진행 중인 턴인가 — 마지막 구간을 열어 둘지, 전부 접을지를 가른다. */
   readonly working?: boolean;
   /** 원장 꼬리에 "아직 살아 있다" 한 줄을 세운다 — 도구도 글자도 없는 구간의 유일한 신호다. */
@@ -677,7 +683,7 @@ function Ledger({
           ) : null}
           <Tally groups={segment.groups} folded={segment.folded} language={language} jobsByToolUse={jobsByToolUse} onOpenJob={onOpenJob} />
           {segment.inline.map((item, at) => (item.type === "ask" && item.ask
-            ? <AskCard key={`ask-${item.ask.id}`} operationId={operationId} ask={item.ask} language={language} />
+            ? <AskCard key={`ask-${item.ask.id}`} ask={item.ask} language={language} onAnswer={onAnswer} />
             : step(item, `in-${at}`)))}
           {segment.running.map((item, at) => step(item, `run-${at}`))}
         </div>
@@ -768,13 +774,13 @@ function groupLabel(group: AgentChatStepGroup, t: ReturnType<typeof getT>): stri
  * "답하지 않기", 계획에는 "수정 요청". 후자는 되돌림이 아니라 되묻기라, 모델이 계획을 고쳐 다시 낸다.
  */
 function AskCard({
-  operationId,
   ask,
   language,
+  onAnswer,
 }: {
-  readonly operationId: string;
   readonly ask: AgentChatAsk;
   readonly language: "en" | "ko";
+  readonly onAnswer: AgentChatViewState["answerAsk"];
 }) {
   const t = getT(language);
   const [picks, setPicks] = React.useState<readonly (readonly string[])[]>(() => ask.questions.map(() => []));
@@ -785,11 +791,11 @@ function AskCard({
 
   if (ask.outcome !== undefined) return <AskSettled ask={ask} language={language} />;
 
-  const send = async (body: Parameters<typeof answerAgentChatAsk>[1]): Promise<void> => {
+  const send = async (body: Parameters<AgentChatViewState["answerAsk"]>[0]): Promise<void> => {
     setPending(true);
     setFailed(false);
     try {
-      await answerAgentChatAsk(operationId, body);
+      await onAnswer(body);
     } catch {
       // 카드는 자리에 남는다 — 실패로 카드를 걷으면 대기는 계속되는데 답할 방법이 사라진다.
       setFailed(true);

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
@@ -13,10 +13,15 @@ let logState: AgentChatLogState;
 
 const detailCalls: string[] = [];
 
-vi.mock("./chat-store.js", () => ({ useAgentChatStream: () => logState }));
+vi.mock("./chat-store.js", () => ({
+  useAgentChatStream: () => ({
+    ...logState,
+    connection: "open",
+    stopTurn: async () => {},
+    answerAsk: async () => {},
+  }),
+}));
 vi.mock("../api.js", () => ({
-  answerAgentChatAsk: async () => {},
-  stopAgentChatTurn: async () => {},
   readAgentChatJobDetail: async (_op: string, jobId: string) => {
     detailCalls.push(jobId);
     return null;

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-ws.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-ws.ts
@@ -1,0 +1,141 @@
+import type { TerminalSocket, TerminalSocketData } from "../shared/terminal-types.js";
+
+import type { AgentChatAnswerInput, AgentChatAnswerResult } from "./chat-session.js";
+import type { AgentChatJournalEvent } from "./chat-events.js";
+
+const MAX_CHAT_ANSWER_MESSAGE_CHARS = 2_000;
+const CHAT_UNAVAILABLE_CLOSE_CODE = 1013;
+
+export interface AgentChatSocketSession {
+  subscribe(listener: (entry: AgentChatJournalEvent) => void): () => void;
+  stopTurn(): boolean;
+  answer(id: string, input: AgentChatAnswerInput): AgentChatAnswerResult;
+}
+
+/**
+ * 채팅 티켓이 연 소켓 하나. 저널은 내려가고, 뷰의 중지·답만 올라온다.
+ * 새 턴을 넣는 message는 이 소켓에 없다 — Quick Launch HTTP가 그 자리다.
+ */
+export function attachAgentChatSocket(
+  socket: TerminalSocket,
+  start: () => Promise<AgentChatSocketSession | { readonly error: string }>,
+): void {
+  let closed = false;
+  let unsubscribe: (() => void) | null = null;
+  let session: AgentChatSocketSession | null = null;
+  socket.once("close", () => {
+    closed = true;
+    unsubscribe?.();
+    unsubscribe = null;
+    session = null;
+  });
+  socket.on("message", (data, isBinary) => {
+    if (closed || isBinary || !session) return;
+    const command = readChatSocketCommand(decodeSocketText(data));
+    if (!command) {
+      sendJson(socket, { type: "nack", error: "invalid_command", ...(commandId(data) ? { id: commandId(data) } : {}) });
+      return;
+    }
+    if (command.type === "stop") {
+      if (!session.stopTurn()) {
+        sendJson(socket, { type: "nack", id: command.id, error: "chat_idle" });
+        return;
+      }
+      sendJson(socket, { type: "ok", id: command.id });
+      return;
+    }
+    const result = session.answer(command.askId, {
+      ...(command.answers ? { answers: command.answers } : {}),
+      ...(command.approve === true ? { approve: true } : {}),
+      ...(command.message !== undefined ? { message: command.message.slice(0, MAX_CHAT_ANSWER_MESSAGE_CHARS) } : {}),
+    });
+    if (!result.ok) {
+      sendJson(socket, { type: "nack", id: command.id, error: result.error });
+      return;
+    }
+    sendJson(socket, { type: "ok", id: command.id });
+  });
+  void start().then((ready) => {
+    if (closed) return;
+    if ("error" in ready) {
+      sendJson(socket, { seq: 0, event: { kind: "error", code: ready.error } });
+      socket.close(CHAT_UNAVAILABLE_CLOSE_CODE, ready.error);
+      return;
+    }
+    session = ready;
+    unsubscribe = ready.subscribe((entry) => {
+      if (!closed) sendJson(socket, entry);
+    });
+  }).catch(() => {
+    if (closed) return;
+    sendJson(socket, { seq: 0, event: { kind: "error", code: "chat_unavailable" } });
+    socket.close(CHAT_UNAVAILABLE_CLOSE_CODE, "chat_unavailable");
+  });
+}
+
+function sendJson(socket: TerminalSocket, value: unknown): void {
+  if (socket.readyState !== 1) return;
+  socket.send(Buffer.from(JSON.stringify(value), "utf8"), { binary: false });
+}
+
+function decodeSocketText(data: TerminalSocketData): string {
+  if (Buffer.isBuffer(data)) return data.toString("utf8");
+  if (Array.isArray(data)) return Buffer.concat(data).toString("utf8");
+  return Buffer.from(data).toString("utf8");
+}
+
+function commandId(data: TerminalSocketData): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(decodeSocketText(data));
+    if (parsed && typeof parsed === "object" && typeof (parsed as { id?: unknown }).id === "string") {
+      return (parsed as { id: string }).id;
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+type ChatSocketCommand =
+  | { readonly type: "stop"; readonly id: string }
+  | {
+      readonly type: "answer";
+      readonly id: string;
+      readonly askId: string;
+      readonly answers?: readonly string[];
+      readonly approve?: boolean;
+      readonly message?: string;
+    };
+
+function readChatSocketCommand(raw: string): ChatSocketCommand | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const value = parsed as {
+    readonly type?: unknown;
+    readonly id?: unknown;
+    readonly askId?: unknown;
+    readonly answers?: unknown;
+    readonly approve?: unknown;
+    readonly message?: unknown;
+  };
+  if (typeof value.id !== "string" || value.id.length === 0) return null;
+  if (value.type === "stop") return { type: "stop", id: value.id };
+  if (value.type !== "answer" || typeof value.askId !== "string" || value.askId.length === 0) return null;
+  const answers = Array.isArray(value.answers)
+    ? value.answers.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+  if (Array.isArray(value.answers) && answers?.length !== value.answers.length) return null;
+  return {
+    type: "answer",
+    id: value.id,
+    askId: value.askId,
+    ...(answers ? { answers } : {}),
+    ...(value.approve === true ? { approve: true } : {}),
+    ...(typeof value.message === "string" ? { message: value.message } : {}),
+  };
+}

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -10,7 +10,7 @@ import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet
 import type { OperationLaunchKind, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
 import { registerRouter } from "@fleet-console/sdk/plugin/node";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
-import { readSocketRole } from "./shared/index.js";
+import { readSocketRole, readTicketChannel } from "./shared/index.js";
 import type { TerminalRuntime } from "./shared/index.js";
 
 import { createDefaultAgentCliDetector, validateAgentCliPathForSave, type AgentCliDetector } from "./agent-api/agent-cli-detect.js";
@@ -33,6 +33,7 @@ import { writeAgentSessionEvents } from "./agent-api/observability-routes.js";
 import { createOscAgentActivityTracker, type OscAgentActivityTracker } from "./agent-api/osc-agent-activity.js";
 import { readAnalysisProviderSession, readProviderSession, type AnalysisProviderSession } from "./agent-api/provider-session.js";
 import { AgentChatRegistry, type AgentChatSessionOrigin, type AgentChatSessionSeed, type CreateChatSdk } from "./agent-api/chat-session.js";
+import { attachAgentChatSocket } from "./agent-api/chat-ws.js";
 import { resolveAnalysisGatewayBaseUrl } from "./agent-api/analysis-types.js";
 import { resolveTranscriptPath } from "./agent-api/transcript-path.js";
 import type { ClaudeGatewayEffort } from "@dotobokuri/core-agent/claude";
@@ -122,7 +123,7 @@ export async function registerAgentRoutes(
     { method: "POST", path: "/sessions/:sessionId/message", summary: "Deliver a prompt to an Agent session.", category: "Terminal Plugin", gate: "origin-write", transport: "http" },
     { method: "POST", path: "/sessions/:sessionId/chat", summary: "Switch an Agent session to chat mode.", category: "Terminal Plugin", gate: "origin-write", transport: "http" },
     { method: "DELETE", path: "/sessions/:sessionId/chat", summary: "Leave chat mode for an Agent session.", category: "Terminal Plugin", gate: "origin-write", transport: "http" },
-    { method: "GET", path: "/sessions/:sessionId/chat-stream", summary: "Stream Agent chat events.", category: "Terminal Plugin", gate: "origin-write", transport: "sse" },
+    { method: "GET", path: "/sessions/:sessionId/chat-stream", summary: "Removed — Chat Mode observation uses the ticketed WebSocket.", category: "Terminal Plugin", gate: "origin-write", transport: "http" },
     { method: "POST", path: "/sessions/:sessionId/chat-answer", summary: "Answer a pending Agent chat question.", category: "Terminal Plugin", gate: "origin-write", transport: "http" },
     { method: "POST", path: "/sessions/:sessionId/chat-stop", summary: "Stop the in-flight Agent chat turn.", category: "Terminal Plugin", gate: "origin-write", transport: "http" },
     { method: "GET", path: "/sessions/:sessionId/chat-job", summary: "Read one Agent chat background job's detail.", category: "Terminal Plugin", gate: "origin-write", transport: "http" },
@@ -206,6 +207,27 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
   // __fleetAgentCliDetector와 같은 자리의 테스트 훅 — 실 SDK 스폰 없이 chat 경로를 고정한다.
   const testChatSdkFactory = (globalThis as { __fleetAgentChatSdkFactory?: CreateChatSdk }).__fleetAgentChatSdkFactory;
   const chatRegistry = testChatSdkFactory ? new AgentChatRegistry(testChatSdkFactory) : new AgentChatRegistry();
+  const unbindChatAttach = terminalRuntime.bindChatAttach((socket, context) => {
+    const sessionId = context.sessionId;
+    attachAgentChatSocket(socket, async () => {
+      const node = ctx.host.operations.get(sessionId);
+      if (!node || node.pluginId !== ctx.pluginId || node.type !== AGENT_OPERATION_TYPE) {
+        return { error: "session_not_found" };
+      }
+      if (node.payload[CHAT_MODE_PAYLOAD_KEY] !== true) return { error: "chat_not_active" };
+      const seed = await resolveChatSeed(node);
+      if (!seed.ok) return { error: seed.error };
+      if (ctx.host.operations.get(sessionId)?.payload[CHAT_MODE_PAYLOAD_KEY] !== true) {
+        return { error: "chat_not_active" };
+      }
+      try {
+        return await chatRegistry.ensure(sessionId, () => seed.seed);
+      } catch {
+        return { error: "chat_unavailable" };
+      }
+    });
+  });
+  ctx.host.lifecycle.registerCleanup(unbindChatAttach);
   const launchResolver = createAgentTerminalLaunchResolver({
     agentRuntime: runtime,
     ...(deps.aiGateway ? { aiGateway: deps.aiGateway } : {}),
@@ -347,7 +369,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         ctx.host.http.writeJson(res, 401, { error: "Unauthorized" });
         return true;
       }
-      const body = await ctx.host.http.readJsonBody<{ readonly operationId?: unknown; readonly colorScheme?: unknown; readonly role?: unknown }>(req);
+      const body = await ctx.host.http.readJsonBody<{ readonly operationId?: unknown; readonly colorScheme?: unknown; readonly role?: unknown; readonly channel?: unknown }>(req);
       if (typeof body?.operationId !== "string") {
         ctx.host.http.writeJson(res, 400, { error: "terminal_session_not_found" });
         return true;
@@ -355,6 +377,23 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       const operation = ctx.host.operations.get(body.operationId);
       if (!operation) {
         ctx.host.http.writeJson(res, 404, { error: "terminal_session_not_found" });
+        return true;
+      }
+      const channel = readTicketChannel(body?.channel);
+      if (channel === "chat") {
+        if (operation.payload[CHAT_MODE_PAYLOAD_KEY] !== true) {
+          ctx.host.http.writeJson(res, 409, { error: "chat_not_active" });
+          return true;
+        }
+        ctx.host.http.writeJson(res, 200, terminalRuntime.issueTicket({
+          cwd: readPayloadString(operation.payload, "cwd") ?? ctx.host.paths.resolveTheaterPath(operation.theaterId) ?? "",
+          sessionId: operation.id,
+          operationId: operation.id,
+          operationType: operation.type,
+          pluginId: operation.pluginId,
+          theaterId: operation.theaterId,
+          channel: "chat",
+        }));
         return true;
       }
       // dormant 세션은 ticket 발급을 거부한다 — stale 클라이언트가 PTY를 재생성하지 못하게 한다.
@@ -1232,54 +1271,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       ctx.host.http.writeJson(res, 409, { error: "chat_not_active" });
       return true;
     }
-    let closed = false;
-    let unsubscribe: (() => void) | null = null;
-    const write = (data: string) => {
-      if (!closed && !res.writableEnded && !res.destroyed) res.write(data);
-    };
-    res.writeHead(200, {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-store",
-      Connection: "keep-alive",
-      "Cross-Origin-Opener-Policy": "same-origin",
-      "Cross-Origin-Resource-Policy": "same-origin",
-      "Referrer-Policy": "no-referrer",
-      "X-Content-Type-Options": "nosniff",
-    });
-    // 헤더를 쓰는 것만으로는 소켓이 흐르지 않는다. 재생할 과거가 없는 세션 — 첫 턴 전에 표면을
-    // 바꾼 경우 — 은 그다음 프레임이 30초 뒤 keepalive라, 브라우저의 `onopen`이 그때까지 뜨지
-    // 않고 화면은 "연결하는 중"에 머문다. 이벤트를 만들지 않는 주석 한 줄을 즉시 흘려 연결
-    // 확립을 그 자리에서 알린다(과거가 있는 세션에서는 replay가 이 역할을 우연히 해 왔다).
-    write(": open\n\n");
-    const keepalive = setInterval(() => write(": keepalive\n\n"), 30_000);
-    req.on("close", () => {
-      closed = true;
-      clearInterval(keepalive);
-      unsubscribe?.();
-    });
-    void (async () => {
-      const seed = await resolveChatSeed(node);
-      if (!seed.ok) {
-        write(`data: ${JSON.stringify({ seq: 0, event: { kind: "error", code: seed.error } })}\n\n`);
-        res.end();
-        return;
-      }
-      // seed 해석의 await 동안 DELETE가 chat을 접었을 수 있다 — ensure와 같은 tick의 재검증이
-      // stale 스트림 요청의 새 세션 생성을 막는다(메시지 라우트와 같은 계약).
-      if (ctx.host.operations.get(sessionId)?.payload[CHAT_MODE_PAYLOAD_KEY] !== true) {
-        write(`data: ${JSON.stringify({ seq: 0, event: { kind: "error", code: "chat_not_active" } })}\n\n`);
-        res.end();
-        return;
-      }
-      try {
-        const chat = await chatRegistry.ensure(sessionId, () => seed.seed);
-        if (closed) return;
-        unsubscribe = chat.subscribe((entry) => write(`data: ${JSON.stringify(entry)}\n\n`));
-      } catch {
-        write(`data: ${JSON.stringify({ seq: 0, event: { kind: "error", code: "chat_unavailable" } })}\n\n`);
-        res.end();
-      }
-    })();
+    ctx.host.http.writeJson(res, 410, { error: "chat_stream_moved" });
     return true;
   }
 

--- a/runtime/fleet-plugins/terminal/server/shared/index.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/index.ts
@@ -7,10 +7,11 @@ export type {
   TerminalSocket,
   TerminalSocketData,
   TerminalTicket,
+  TerminalTicketChannel,
   TerminalTicketContext,
   TerminalTitleListener,
 } from "./terminal-types.js";
-export { createPluginTerminalTicketRegistry, readSocketRole } from "./tickets.js";
+export { createPluginTerminalTicketRegistry, readSocketRole, readTicketChannel } from "./tickets.js";
 export type { TerminalTicketRegistry, TerminalTicketRegistryDeps } from "./tickets.js";
 export { createTerminalRuntime } from "./runtime.js";
 export type { TerminalRuntime, TerminalLaunchResolver } from "./runtime.js";

--- a/runtime/fleet-plugins/terminal/server/shared/runtime.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/runtime.ts
@@ -5,7 +5,7 @@ import type { UpgradeHandler } from "@fleet-console/sdk/routing";
 import { createShellTerminalLaunchResolver, startTerminalShell, type TerminalLaunchResolver } from "./pty.js";
 import { createTerminalSessionManager } from "./session-manager.js";
 import { createPluginTerminalTicketRegistry } from "./tickets.js";
-import type { TerminalTicket, TerminalTicketContext, TerminalLaunchContext, TerminalLaunchSpec, TerminalTitleListener } from "./terminal-types.js";
+import type { TerminalTicket, TerminalTicketContext, TerminalLaunchContext, TerminalLaunchSpec, TerminalSocket, TerminalTitleListener } from "./terminal-types.js";
 import { createPluginTerminalUpgradeHandler } from "./ws.js";
 
 export interface TerminalRuntime {
@@ -25,6 +25,11 @@ export interface TerminalRuntime {
   onExit(callback: (operationId: string) => void | Promise<void>): () => void;
   onTitle(operationType: string, callback: TerminalTitleListener): () => void;
   registerLaunchResolver(operationType: string, resolver: TerminalLaunchResolver): () => void;
+  /**
+   * 채팅 티켓이 소켓을 연 뒤 저널을 붙일 자리. 플러그인 라우트가 등록한다.
+   * 등록 전 채팅 업그레이드는 소켓을 거절한다.
+   */
+  bindChatAttach(attach: (socket: TerminalSocket, context: TerminalTicketContext) => void): () => void;
   stop(): Promise<void>;
 }
 
@@ -34,6 +39,7 @@ const SHELL_OPERATION_TYPE = "shell";
 
 export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRuntime {
   const tickets = createPluginTerminalTicketRegistry();
+  let chatAttach: ((socket: TerminalSocket, context: TerminalTicketContext) => void) | null = null;
   const terminalExitListeners = new Set<(operationId: string) => void | Promise<void>>();
   const terminalTitleListeners = new Map<string, Set<TerminalTitleListener>>();
   const terminalLaunchResolvers = new Map<string, TerminalLaunchResolver>();
@@ -57,6 +63,13 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
     tickets,
     sessions,
     isAuthorized: ctx.host.security.isTerminalAuthorized,
+    attachChat: (socket, context) => {
+      if (!chatAttach) {
+        socket.close(1013, "chat_unavailable");
+        return;
+      }
+      chatAttach(socket, context);
+    },
   });
 
   return {
@@ -93,7 +106,14 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
         if (terminalLaunchResolvers.get(operationType) === resolver) terminalLaunchResolvers.delete(operationType);
       };
     },
+    bindChatAttach: (attach) => {
+      chatAttach = attach;
+      return () => {
+        if (chatAttach === attach) chatAttach = null;
+      };
+    },
     stop: async () => {
+      chatAttach = null;
       upgrade.close();
       await sessions.stop();
       terminalExitListeners.clear();

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -65,7 +65,16 @@ export interface TerminalTicketContext {
    * 보내지도 못한다.
    */
   readonly role?: TerminalSocketRole;
+  /**
+   * 이 티켓이 여는 관측 면. 생략하면 PTY다 — 지금까지 발급된 모든 티켓이 그것이었고,
+   * 기본값을 바꾸면 채팅 티켓이 살아 있는 PTY에 붙는다.
+   *
+   * `chat`은 저널 구독이다. PTY를 만들지도, canAttach를 묻지도 않는다.
+   */
+  readonly channel?: TerminalTicketChannel;
 }
+
+export type TerminalTicketChannel = "chat";
 
 export type TerminalSocketRole = "control" | "viewer";
 

--- a/runtime/fleet-plugins/terminal/server/shared/tickets.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/tickets.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 
-import type { TerminalSocketRole, TerminalTicket, TerminalTicketContext } from "./terminal-types.js";
+import type { TerminalSocketRole, TerminalTicket, TerminalTicketChannel, TerminalTicketContext } from "./terminal-types.js";
 
 /**
  * 티켓 요청이 밝힌 역할. `viewer`만 알아듣고 나머지는 전부 undefined로 떨어뜨린다 — 모르는
@@ -8,6 +8,14 @@ import type { TerminalSocketRole, TerminalTicket, TerminalTicketContext } from "
  */
 export function readSocketRole(value: unknown): TerminalSocketRole | undefined {
   return value === "viewer" ? "viewer" : undefined;
+}
+
+/**
+ * 티켓 요청이 밝힌 관측 면. `chat`만 알아듣고 나머지는 전부 undefined로 떨어뜨린다 —
+ * 모르는 값을 PTY로 승격시키면 오타 하나가 채팅 티켓을 터미널 attach에 실어 보낸다.
+ */
+export function readTicketChannel(value: unknown): TerminalTicketChannel | undefined {
+  return value === "chat" ? "chat" : undefined;
 }
 
 export interface TerminalTicketRegistryDeps {

--- a/runtime/fleet-plugins/terminal/server/shared/ws.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/ws.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import type { UpgradeHandler } from "@fleet-console/sdk/routing";
 
 import { resolveConsolePackageRequire } from "./console-require.js";
-import type { TerminalSessionManager, TerminalTicketContext } from "./terminal-types.js";
+import type { TerminalSessionManager, TerminalSocket, TerminalTicketContext } from "./terminal-types.js";
 
 export interface TerminalUpgradeHandlerDeps {
   readonly tickets: {
@@ -14,6 +14,11 @@ export interface TerminalUpgradeHandlerDeps {
   };
   readonly sessions: TerminalSessionManager;
   readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  /**
+   * 채팅 티켓이 소켓을 연 뒤 저널을 붙인다. 없으면 채팅 티켓은 업그레이드에서 거절된다 —
+   * PTY attach로 떨어뜨리면 휴면 Chat Mode가 터미널을 되살린다.
+   */
+  readonly attachChat?: (socket: TerminalSocket, context: TerminalTicketContext) => void;
 }
 
 export interface TerminalUpgradeHandler {
@@ -35,7 +40,23 @@ export function createPluginTerminalUpgradeHandler(deps: TerminalUpgradeHandlerD
       return true;
     }
     const context = deps.tickets.consume(url.searchParams.get("ticket"));
-    if (!context || !deps.sessions.canAttach(context.sessionId)) {
+    if (!context) {
+      socket.destroy();
+      return true;
+    }
+    if (context.channel === "chat") {
+      const attachChat = deps.attachChat;
+      if (!attachChat) {
+        socket.destroy();
+        return true;
+      }
+      const server = getWebSocketServer();
+      server.handleUpgrade(req, socket, head, (ws) => {
+        attachChat(ws, context);
+      });
+      return true;
+    }
+    if (!deps.sessions.canAttach(context.sessionId)) {
       socket.destroy();
       return true;
     }

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -253,6 +253,7 @@ async function createHarness(body: Record<string, unknown>) {
       };
     },
     registerLaunchResolver: () => () => {},
+    bindChatAttach: () => () => {},
     stop: async () => {},
   };
   const ctx = {

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-mode.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-mode.test.ts
@@ -9,8 +9,25 @@ import type { RouteHandler } from "@fleet-console/sdk/routing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { registerAgentRoutes } from "../server/agent.js";
-import type { TerminalRuntime } from "../server/shared/index.js";
+import type { TerminalRuntime, TerminalSocket } from "../server/shared/index.js";
 import { createPluginTerminalTicketRegistry } from "../server/shared/tickets.js";
+
+function createTestChatSocket(onSend: (raw: string) => void): TerminalSocket {
+  const closeListeners = new Set<() => void>();
+  return {
+    readyState: 1,
+    send(data: Buffer) {
+      onSend(data.toString("utf8"));
+    },
+    close() {
+      for (const listener of closeListeners) listener();
+    },
+    on() {},
+    once(event, listener) {
+      if (event === "close") closeListeners.add(listener);
+    },
+  };
+}
 
 type TestRequest = http.IncomingMessage & { __body?: Record<string, unknown> };
 
@@ -226,14 +243,30 @@ describe("agent chat mode routes", () => {
     }));
   });
 
-  it("streams the replayed journal over the chat stream", async () => {
+  it("issues a chat-channel ticket and refuses the retired SSE stream", async () => {
     const harness = await createHarness();
     const sessionId = await harness.createSession();
     harness.attachProviderSession(sessionId);
     await harness.post(sessionId, "chat");
 
-    const frames = await harness.openChatStream(sessionId);
+    await harness.postTicket(sessionId, { channel: "chat" });
+    const issued = harness.responses.at(-1);
+    expect(issued?.status).toBe(200);
+    const ticket = (issued?.body as { readonly ticket?: string }).ticket;
+    expect(typeof ticket).toBe("string");
+    expect(harness.tickets.consume(ticket!)).toMatchObject({ sessionId, channel: "chat" });
 
+    await harness.get(sessionId, "chat-stream");
+    expect(harness.responses.at(-1)).toEqual({ status: 410, body: { error: "chat_stream_moved" } });
+  });
+
+  it("replays the journal onto a chat ticket socket", async () => {
+    const harness = await createHarness();
+    const sessionId = await harness.createSession();
+    harness.attachProviderSession(sessionId);
+    await harness.post(sessionId, "chat");
+
+    const frames = await harness.openChatSocket(sessionId);
     const kinds = frames.map((frame) => frame.event.kind);
     expect(kinds[0]).toBe("replay-start");
     expect(kinds).toContain("dispatch");
@@ -324,6 +357,7 @@ async function createHarness(options: { readonly cliId?: string; readonly holdAt
   const liveSessions = new Set<string>();
   let route: RouteHandler | undefined;
   const tickets = createPluginTerminalTicketRegistry();
+  let chatAttach: Parameters<TerminalRuntime["bindChatAttach"]>[0] | null = null;
   const attach = vi.fn<TerminalRuntime["attach"]>(async () => {
     if (options.holdAttachAfterFirst && attach.mock.calls.length > 1) await options.holdAttachAfterFirst;
   });
@@ -350,6 +384,12 @@ async function createHarness(options: { readonly cliId?: string; readonly holdAt
     onExit: () => () => {},
     onTitle: () => () => {},
     registerLaunchResolver: () => () => {},
+    bindChatAttach: (attachChat) => {
+      chatAttach = attachChat;
+      return () => {
+        if (chatAttach === attachChat) chatAttach = null;
+      };
+    },
     stop: async () => {},
   };
   const ctx = {
@@ -492,35 +532,36 @@ async function createHarness(options: { readonly cliId?: string; readonly holdAt
     post: (sessionId: string, action: string, body?: Record<string, unknown>) => dispatch("POST", sessionId, action, body),
     del: (sessionId: string, action: string) => dispatch("DELETE", sessionId, action),
     get: (sessionId: string, action: string) => dispatch("GET", sessionId, action),
-    postTicket: async (sessionId: string): Promise<void> => {
+    tickets,
+    postTicket: async (sessionId: string, extra: Record<string, unknown> = {}): Promise<void> => {
       if (!route) throw new Error("Agent route was not registered");
       await route({
-        req: { method: "POST", url: "/plugins/terminal/agent/ticket", __body: { operationId: sessionId } } as unknown as TestRequest,
+        req: { method: "POST", url: "/plugins/terminal/agent/ticket", __body: { operationId: sessionId, ...extra } } as unknown as TestRequest,
         res: {} as http.ServerResponse,
         pathname: "/plugins/terminal/agent/ticket",
       });
     },
-    openChatStream: async (sessionId: string): Promise<Array<{ seq: number; event: { kind: string } }>> => {
-      const chunks: string[] = [];
-      const res = {
-        writableEnded: false,
-        destroyed: false,
-        writeHead: () => res,
-        write: (data: string) => {
-          chunks.push(data);
-          return true;
-        },
-        end: () => {},
-      } as unknown as http.ServerResponse;
-      await dispatch("GET", sessionId, "chat-stream", undefined, res);
-      await vi.waitFor(() => {
-        expect(chunks.join("")).toContain("replay-end");
+    openChatSocket: async (sessionId: string): Promise<Array<{ seq: number; event: { kind: string } }>> => {
+      if (!route) throw new Error("Agent route was not registered");
+      await route({
+        req: { method: "POST", url: "/plugins/terminal/agent/ticket", __body: { operationId: sessionId, channel: "chat" } } as unknown as TestRequest,
+        res: {} as http.ServerResponse,
+        pathname: "/plugins/terminal/agent/ticket",
       });
-      return chunks
-        .join("")
-        .split("\n\n")
-        .filter((frame) => frame.startsWith("data: "))
-        .map((frame) => JSON.parse(frame.slice("data: ".length)) as { seq: number; event: { kind: string } });
+      const ticket = (responses.at(-1)?.body as { readonly ticket?: string } | undefined)?.ticket;
+      if (!ticket) throw new Error("Chat ticket was not issued");
+      const context = tickets.consume(ticket);
+      if (!context || !chatAttach) throw new Error("Chat attach was not bound");
+      const frames: Array<{ seq: number; event: { kind: string } }> = [];
+      const socket = createTestChatSocket((raw) => {
+        const parsed = JSON.parse(raw) as { seq?: number; event?: { kind: string } };
+        if (typeof parsed.seq === "number" && parsed.event) frames.push({ seq: parsed.seq, event: parsed.event });
+      });
+      chatAttach(socket, context);
+      await vi.waitFor(() => {
+        expect(frames.some((frame) => frame.event.kind === "replay-end")).toBe(true);
+      });
+      return frames;
     },
     setLive: (sessionId: string) => { liveSessions.add(sessionId); },
     overrideCliId: (sessionId: string, value: string) => {

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -381,6 +381,7 @@ async function createHarness(options: {
     },
     onTitle: () => () => {},
     registerLaunchResolver: () => () => {},
+    bindChatAttach: () => () => {},
     stop: async () => {},
   };
   const ctx = {

--- a/runtime/fleet-plugins/terminal/tests/agent-launch-attachments.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-launch-attachments.test.ts
@@ -376,6 +376,7 @@ async function createHarness(options: { readonly attachError?: Error } = {}) {
     onExit: () => () => {},
     onTitle: () => () => {},
     registerLaunchResolver: () => () => {},
+    bindChatAttach: () => () => {},
     stop: async () => {},
   };
   const fleetDataDir = mkdtempSync(path.join(os.tmpdir(), "fleet-terminal-attachments-"));

--- a/runtime/fleet-plugins/terminal/tests/agent-message-delivery.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-message-delivery.test.ts
@@ -156,6 +156,7 @@ async function createHarness(options: { readonly resumeAttachError?: Error } = {
     onExit: () => () => {},
     onTitle: () => () => {},
     registerLaunchResolver: () => () => {},
+    bindChatAttach: () => () => {},
     stop: async () => {},
   };
   const ctx = {

--- a/runtime/fleet-plugins/terminal/tests/chat-ws-upgrade.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/chat-ws-upgrade.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPluginTerminalUpgradeHandler } from "../server/shared/ws.js";
+import type { TerminalTicketContext } from "../server/shared/terminal-types.js";
+
+function context(overrides: Partial<TerminalTicketContext> = {}): TerminalTicketContext {
+  return { cwd: "/tmp", sessionId: "op-1", ...overrides };
+}
+
+describe("terminal upgrade chat channel", () => {
+  it("destroys a chat upgrade when no chat attach is bound", () => {
+    const canAttach = vi.fn(() => false);
+    const handler = createPluginTerminalUpgradeHandler({
+      tickets: { consume: () => context({ channel: "chat" }) },
+      sessions: { canAttach, attach: vi.fn(), attachViewer: vi.fn() } as never,
+      isAuthorized: () => true,
+    });
+    const socket = { destroy: vi.fn() };
+    const handled = handler.handleUpgrade({
+      req: { url: "/plugins/terminal/ws?ticket=chat" } as never,
+      socket: socket as never,
+      head: Buffer.alloc(0),
+      pathname: "/plugins/terminal/ws",
+    });
+    expect(handled).toBe(true);
+    expect(canAttach).not.toHaveBeenCalled();
+    expect(socket.destroy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 채팅 뷰 저널을 HTTP/1.1 EventSource에서 터미널과 같은 일회용 티켓 WebSocket(`/plugins/terminal/ws`)으로 옮겼습니다. 떠 있는 채팅 패널마다 HTTP 슬롯을 점유하지 않아, 채팅 4개 이상에서도 콘솔 API가 살아 있습니다.
- 뷰 안의 중지·질문 답만 그 소켓으로 보내고, 새 턴은 기존 POST `/message`(Quick Launch)에 둡니다. 옛 `chat-stream`은 410 `chat_stream_moved`입니다.
- 채팅 티켓은 `channel:"chat"`일 때만 발급되고, 채팅 모드에서 PTY 티켓은 거절됩니다. 채팅↔터미널 왕복은 DELETE `/chat` + resume / POST `/chat` 경로를 그대로 탑니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] 터미널 플러그인 대상 vitest: chat-store / chat-work-surface / chat-ledger-note / agent-chat-mode / chat-ws-upgrade
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/api-catalog.test.ts`
- [x] 격리 콘솔 e2e: cursor-auto 채팅 턴 와이어+UI(`pong`), 4패널 HTTP 슬롯 생존(이전 실측)
- [x] 같은 패널 채팅→터미널→채팅 왕복: 저널 `pong` 재생, 소켓 1개 유지, 최소화 시 소켓 0, 복원 시 1, 재접속 폭주 없음