### PR TITLE
fix(fleet-console): keep the Quick Launch ultracode ring cruising

### DIFF
--- a/.changelog.d/ql-ultracode-rim-cruise.md
+++ b/.changelog.d/ql-ultracode-rim-cruise.md
@@ -1,0 +1,8 @@
+---
+branch: ql-ultracode-rim-cruise
+---
+
+### fleet-console
+#### Fixed
+- The apex outline on Quick Launch keeps circling for as long as `ultracode` stays in the prompt. It used to freeze into a single arc the moment the ignition finished.
+  ko: Quick Launch 프롬프트에 `ultracode`가 남아 있는 동안 apex 외곽선이 계속 돕니다. 이전에는 점화가 끝나는 순간 호 하나로 굳어 있었습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -11998,7 +11998,13 @@ body[data-codex-reading="true"] .operations-side-bar {
   }
 }
 
+/* 순항은 시작점을 스스로 말해야 한다. `to`만 두면 시작 각도를 **밑에 깔린 값**에서 빌리는데,
+   그 자리에는 앞 순번 점화가 `both`로 앞으로 채워 둔 끝값 360deg가 앉아 있다 — 그러면 순항은
+   360deg에서 360deg로 돌아 재생만 되고 링은 정지한다(실측: 4.0s 동안 360deg 고정, 그동안
+   animation은 running이었다). 360deg와 0deg는 conic에서 같은 자리라 점화→순항 인계는 이음매가
+   없다. 뒤에 어떤 전이가 더 붙어도 이 키프레임은 자기 시작점을 잃지 않는다. */
 @keyframes quick-launch-ultracode-rim {
+  from { --quick-launch-rim-angle: 0deg; }
   to { --quick-launch-rim-angle: 360deg; }
 }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2450,7 +2450,13 @@ describe("Effort track interaction grammar", () => {
     expect(components).toContain("@property --quick-launch-rim-spread");
     expect(components).toContain("@keyframes quick-launch-ultracode-ignite");
     expect(components).toContain("@keyframes quick-launch-ultracode-bead");
-    expect(components).toMatch(/@keyframes quick-launch-ultracode-rim \{\s*to \{ --quick-launch-rim-angle: 360deg; \}\s*\}/);
+    // 순항 키프레임은 시작 각도를 스스로 적어야 한다. `to`만 두면 시작점을 밑에 깔린 값에서
+    // 빌리는데, 앞 순번 점화가 `both`로 채워 둔 끝값 360deg가 거기 앉아 있어 순항이 360deg에서
+    // 360deg로 돌았다 — 재생은 running인 채 링만 정지했다. 조성만 고정하던 이 계약이 그 정지를
+    // 초록으로 통과시켰으므로, 여기서는 시작점 자체를 고정한다.
+    expect(components).toMatch(
+      /@keyframes quick-launch-ultracode-rim \{\s*from \{ --quick-launch-rim-angle: 0deg; \}\s*to \{ --quick-launch-rim-angle: 360deg; \}\s*\}/,
+    );
     // 점화가 끝난 뒤에야 순항에 올라탄다 — 완성된 호가 갑자기 붙으면 이질감이 난다.
     expect(components).toMatch(/quick-launch-ultracode-ignite 900ms[\s\S]*quick-launch-ultracode-rim 2\.8s linear 900ms infinite/);
     // 무한 애니메이션은 규약의 예외이므로 근거가 규칙 옆에 남아 있어야 한다.


### PR DESCRIPTION
## Summary
- 프롬프트에 `ultracode`가 남아 있는 동안 Quick Launch 카드의 apex 링이 계속 돌게 복구했습니다. 순항 키프레임이 `to`만 선언해 시작 각도를 **밑에 깔린 값**(앞 순번 점화가 `fill: both`로 앞으로 채운 끝값 `360deg`)에서 빌리는 바람에, 순항이 `360deg → 360deg`로 돌아 재생만 되고 링은 정지해 있었습니다.
- `from { --quick-launch-rim-angle: 0deg; }`를 선언해 순항이 자기 양 끝을 스스로 갖게 했습니다. conic에서 `360deg`와 `0deg`는 같은 자리라 점화→순항 인계는 이음매가 없습니다.
- 디자인 계약 테스트가 애니메이션 **조성**만 문자열로 고정하고 있어 링이 멈춘 채로 초록이었습니다. 시작 각도 자체를 고정하도록 바꿨습니다.

## Test Plan
- [x] `vitest run tests/instrument-design-contract.test.ts` — 68 passed
- [x] 역검증: `from` 줄을 제거하면 같은 테스트가 실패(게이트가 실제로 문다)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과, 산출 CSS에 `0%{--quick-launch-rim-angle: 0deg}` 포함
- [x] 격리 콘솔 실측(headless 실브라우저): 무장 후 각도가 4.2s 동안 연속 회전(338.6° → 32.1° 랩), 속도 ≈ 360°/2.82s, spread는 108deg 유지
- [x] 점화→순항 경계 실측: t=895ms 360.0° → t=928ms 4.3°, 델타가 순항 속도와 일치(점프·정지 없음)