### PR TITLE
fix(fleet-console): keep nested subagent frames off chat host

### DIFF
--- a/.changelog.d/chat-subagent-main-leak.md
+++ b/.changelog.d/chat-subagent-main-leak.md
@@ -1,0 +1,8 @@
+---
+branch: chat-subagent-main-leak
+---
+
+### fleet-console
+#### Fixed
+- Keep nested subagent frames off the Chat Mode host transcript so their tools and reports stay on the job surface.
+  ko: 채팅 모드 호스트 원장에서 중첩 서브에이전트 프레임을 빼, 도구와 보고가 작업 면에만 남게 합니다.

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-events.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-events.ts
@@ -342,6 +342,14 @@ export function chatEventsFromSdkMessage(message: {
   readonly type: string;
   readonly [key: string]: unknown;
 }, options: ChatEventMapOptions = {}): readonly AgentChatStreamEvent[] {
+  // 중첩 서브에이전트 프레임. SDK는 기본값에서도 서브에이전트의 tool_use/tool_result를
+  // parent_tool_use_id와 함께 부모 스트림에 흘린다(forwardSubagentText는 텍스트·thinking까지
+  // 연다). 재생 경로가 isSidechain을 버리듯이, 라이브도 그 프레임을 메인 원장에 세우지 않는다 —
+  // 세우면 서브에이전트가 읽은 파일·쓴 글이 호스트 Answer·원장에 한 번 더 선다. 잡 원장
+  // (task_started 등)은 system 축이라 이 문에 닿지 않는다.
+  if (typeof message.parent_tool_use_id === "string" && message.parent_tool_use_id.length > 0) {
+    return [];
+  }
   if (message.type === "stream_event") {
     // 모양은 fleet-analyst가 실측으로 고정한 것과 동일하다. text_delta와 tool_use 블록의
     // 시작만 취한다 — thinking_delta는 공개 출력 금지 불변식에 따라 버리고, input_json_delta는

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-events.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-events.test.ts
@@ -164,6 +164,44 @@ describe("chat sdk message mapping", () => {
     })).toEqual([{ kind: "text", text: "hi" }]);
   });
 
+  /**
+   * 서브에이전트 프레임은 메인 원장이 아니다. SDK는 parent_tool_use_id를 달고 부모 스트림에
+   * 흘리므로, 여기서 거르지 않으면 서브에이전트가 읽은 파일과 쓴 글이 호스트 턴에 한 번 더 선다.
+   * 재생이 isSidechain을 버리는 것과 같은 문이다. 빈 문자열·null은 호스트 프레임이다.
+   */
+  it("keeps nested subagent frames off the host transcript", () => {
+    expect(chatEventsFromSdkMessage({
+      type: "assistant",
+      parent_tool_use_id: "task-1",
+      message: { content: [{ type: "text", text: "subagent report" }] },
+    })).toEqual([]);
+    expect(chatEventsFromSdkMessage({
+      type: "assistant",
+      parent_tool_use_id: "task-1",
+      message: { content: [{ type: "tool_use", id: "s1", name: "Read", input: { file_path: "src/a.ts" } }] },
+    })).toEqual([]);
+    expect(chatEventsFromSdkMessage({
+      type: "user",
+      parent_tool_use_id: "task-1",
+      message: { content: [{ type: "tool_result", tool_use_id: "s1", content: "file body" }] },
+    })).toEqual([]);
+    expect(chatEventsFromSdkMessage({
+      type: "stream_event",
+      parent_tool_use_id: "task-1",
+      event: { type: "content_block_delta", delta: { type: "text_delta", text: "nested" } },
+    })).toEqual([]);
+    expect(chatEventsFromSdkMessage({
+      type: "assistant",
+      parent_tool_use_id: null,
+      message: { content: [{ type: "text", text: "host" }] },
+    })).toEqual([{ kind: "text", text: "host" }]);
+    expect(chatEventsFromSdkMessage({
+      type: "assistant",
+      parent_tool_use_id: "",
+      message: { content: [{ type: "text", text: "host" }] },
+    })).toEqual([{ kind: "text", text: "host" }]);
+  });
+
   it("maps a result into turn-end with duration", () => {
     expect(chatEventsFromSdkMessage({ type: "result", subtype: "success", is_error: false, duration_ms: 1200 }))
       .toEqual([{ kind: "turn-end", ok: true, durationMs: 1200 }]);

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -780,6 +780,43 @@ describe("AgentChatRegistry — background follow-up turns", () => {
     await registry.disposeAll();
   });
 
+  it("does not open a turn for nested subagent frames that arrive after the turn closed", async () => {
+    // 서브에이전트 도구·텍스트는 부모 스트림에 parent_tool_use_id를 달고 온다. 턴이 닫힌 뒤에
+    // 그것이 오면 opensChatTurn이 새 턴을 열고, 서브에이전트 보고가 메인 Answer처럼 선다.
+    const transcriptPath = writeTranscript("sid-follow-nested", []);
+    const { factory } = createFakeSdkFactory([
+      {
+        messages: [
+          { type: "result", subtype: "success", is_error: false, duration_ms: 10, result: "launched" },
+          {
+            type: "assistant",
+            parent_tool_use_id: "task-1",
+            message: { role: "assistant", content: [{ type: "text", text: "the subagent finished" }] },
+          },
+          {
+            type: "assistant",
+            parent_tool_use_id: "task-1",
+            message: { role: "assistant", content: [{ type: "tool_use", id: "s1", name: "Read", input: { file_path: "src/a.ts" } }] },
+          },
+        ],
+      },
+    ]);
+    const registry = new AgentChatRegistry(factory);
+    const session = await registry.ensure("op-follow-nested", () => seedFor(transcriptPath));
+    const events: AgentChatJournalEvent[] = [];
+    session.subscribe((entry) => events.push(entry));
+
+    session.send("go");
+    await drainTurn(registry, "op-follow-nested");
+
+    const live = kinds(events).slice(kinds(events).indexOf("dispatch"));
+    expect(live).toEqual(["dispatch", "turn-start", "turn-end"]);
+    expect(events.map((entry) => entry.event)).not.toContainEqual(
+      expect.objectContaining({ kind: "text", text: "the subagent finished" }),
+    );
+    await registry.disposeAll();
+  });
+
   it("does not open a turn for background pulses that arrive after the turn closed", async () => {
     // 맥박은 턴이 닫힌 뒤에도 계속 흐르는 것이 정상이다 — 그것으로 턴을 열면 빈 턴이 선다.
     const transcriptPath = writeTranscript("sid-follow-4", []);


### PR DESCRIPTION
## Summary
- Chat Mode의 라이브 SDK 스트림은 서브에이전트 프레임을 `isSidechain`이 아니라 `parent_tool_use_id`로 표시합니다. 재생 경로만 사이드체인을 버리고 라이브 매퍼는 그대로 받아, 서브에이전트가 읽은 파일·쓴 글이 호스트 원장과 Answer에 한 번 더 섰습니다.
- `chatEventsFromSdkMessage`가 비지 않은 `parent_tool_use_id` 프레임을 버립니다. 잡 원장(`task_started`/`task_notification`)은 `system` 축이라 작업 면에 남습니다.
- 호스트 응답과 서브에이전트 보고가 갈라지는 계약을 단위 테스트와 격리 콘솔의 cursor-auto 실측으로 확인했습니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` (883 passed)
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal build`
- [x] Isolated Console + `cursor--auto` Chat Mode: host Answer showed only `HOST_TOKEN_9c2b`; job report showed only `SUBAGENT_TOKEN_7f3a`