### PR TITLE
feat(fleet-console): drop the status mark from status group headers

### DIFF
--- a/.changelog.d/status-group-header-icon.md
+++ b/.changelog.d/status-group-header-icon.md
@@ -1,0 +1,8 @@
+---
+branch: status-group-header-icon
+---
+
+### fleet-console
+#### Changed
+- Drop the rounded status mark from Sort by status and War Room group headers. Each panel already shows that mark.
+  ko: 상태별 정렬과 War Room 그룹 헤더에서 둥근 상태 마크를 뺍니다. 각 패널이 이미 그 마크를 보여 줍니다.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -250,7 +250,6 @@ export function StatusSectionSlot({
         >
           <StatusSectionCollapseArrow collapsed={collapsed} />
         </button>
-        <span className="side-bar-status-header__dot" aria-hidden="true" />
         <span className="side-bar-status-header__label">{section.label}</span>
         {unseenCount > 0 ? <span className="side-bar-status-header__unseen">{unseenCount}</span> : null}
         <span className="side-bar-status-header__count">{section.entries.length}</span>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5410,35 +5410,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
   transform: rotate(-90deg);
 }
 
-/* 섹션 머리글 마크도 활동 축이다 — 행의 마크와 같은 둥근 네모를 쓴다(원형 폐지). */
-.side-bar-status-header__dot {
-  display: block;
-  flex: none;
-  width: 7px;
-  height: 7px;
-  border-radius: 2px;
-  background: var(--status-color);
-}
-
-.side-bar-status-section--background .side-bar-status-header__dot {
-  background: none;
-  border: 1.5px solid var(--activity-color);
-  box-sizing: border-box;
-}
-
-.side-bar-status-section--empty .side-bar-status-header__dot {
-  opacity: 0.4;
-}
-
-.side-bar-status-header--awaiting .side-bar-status-header__dot {
-  animation: aurora-pulse 1.8s infinite;
-}
-
-/* 빈 섹션은 주의 신호를 낼 상태가 없으므로 awaiting pulse도 끈다 — count 0에서
-   맥동하는 dot은 "대기 입력이 있다"는 거짓 신호가 된다(명시도 우위로 pulse 규칙을 덮는다). */
-.side-bar-status-section--empty .side-bar-status-header--awaiting .side-bar-status-header__dot {
-  animation: none;
-}
+/* 상태 그룹 헤더는 라벨·카운트·왼쪽 스트라이프로 버킷을 말한다. 둥근 네모 마크는
+   칩과 패널이 이미 그리므로 머리글에 반복하지 않는다. */
 
 .side-bar-status-header__count {
   flex: none;
@@ -5618,8 +5591,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
     transition: none;
   }
 
-  .side-bar-status-axis-live-tick,
-  .side-bar-status-header--awaiting .side-bar-status-header__dot {
+  .side-bar-status-axis-live-tick {
     animation: none;
   }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1250,8 +1250,9 @@ describe("Instrument core design contract", () => {
     expect(sideBarStore).not.toContain("STORAGE_KEY_STATUS");
     expect(sideBarStore).not.toContain("fleet-console.operations.status");
 
-    // Doctrine: status-section border/dot/count are signal-owned, while the chip group mark
+    // Doctrine: status-section border/count are signal-owned, while the chip group mark
     // consumes only resolveAccentColor identity values and never repaints the status beacon.
+    // The group header does not repeat the rounded activity mark; chips and panels already do.
     expect(sidebar).toContain("groupMarkByGroupId.get(entry.operation.groupId)");
     expect(components).toContain(".tenant-beacon.is-awaiting,\n.canvas-triage-map-dot.is-awaiting,\n.side-bar-status-section--awaiting {");
     expect(components).toMatch(/\.tenant-beacon\.is-idle,\s*\.canvas-triage-map-dot\.is-idle,\s*\.side-bar-status-section--idle\s*\{[^}]*--activity-color:\s*var\(--positive\)/);
@@ -1265,7 +1266,8 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("--status-color: var(--activity-color);");
     expect(components).toContain("border-left: 3px solid var(--status-color);");
     expect(components).toMatch(/\.side-bar-status-section--background \{[^}]*border-left-style:\s*dashed/);
-    expect(components).toMatch(/\.side-bar-status-section--background \.side-bar-status-header__dot \{[^}]*background:\s*none;[^}]*border:\s*1\.5px solid var\(--activity-color\)/);
+    expect(sidebar).not.toContain("side-bar-status-header__dot");
+    expect(components).not.toContain(".side-bar-status-header__dot");
     expect(components).toContain("background: var(--group-mark);");
     expect(components).toMatch(/\.side-bar-chip-unseen \{[^}]*background:\s*var\(--positive\)/);
     expect(components).toMatch(/\.side-bar-chip--unseen \{[^}]*border-color:\s*color-mix\(in oklch, var\(--positive\)/);
@@ -1273,8 +1275,7 @@ describe("Instrument core design contract", () => {
     expect(components).toMatch(/\.canvas-operation\.is-unseen \{[^}]*--caption-rail:\s*var\(--positive\)/);
     expect(components).not.toContain(".canvas-operation.is-unseen.is-active {");
     expect(components).toMatch(/\.side-bar-status-header__unseen::before \{[^}]*background:\s*var\(--positive\)/);
-    expect(components).toContain(".side-bar-status-axis-live-tick,");
-    expect(components).toContain(".side-bar-status-header--awaiting .side-bar-status-header__dot {");
+    expect(components).toContain(".side-bar-status-axis-live-tick {");
   });
 
   it("pins the selectable Right Rail panel behavior contract", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -102,8 +102,10 @@ describe("OperationsSideBar STATUS axis", () => {
       .toBe("Focus operation awaiting in group Alpha crew");
     expect(container?.querySelector('[data-side-bar-chip-id="awaiting"] .side-bar-chip-group-mark')).toBeNull();
     // 상태 마크는 축과 무관하게 이름 왼쪽에 선다 — STATUS 축에서도 행이 자기 상태를 말한다.
+    // 그룹 헤더는 그 마크를 반복하지 않는다. 버킷은 라벨·카운트·왼쪽 스트라이프로 읽는다.
     expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"] .side-bar-chip-status').className)
       .toContain("tenant-beacon is-awaiting");
+    expect(container?.querySelector(".side-bar-status-header__dot")).toBeNull();
     expect(container?.querySelector('[data-side-bar-chip-id="idle"] .side-bar-chip-group-pill')).toBeNull();
     expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').dataset.reorderEnabled).toBe("false");
   });


### PR DESCRIPTION
## Summary
- Sort by status와 War Room 상태 그룹 헤더에서 둥근 네모 활동 마크를 뺍니다. 두 표면이 같은 `StatusSectionSlot`을 탑니다.
- 버킷은 라벨·카운트·왼쪽 3px 스트라이프로 읽습니다. 칩·패널·커맨드 밴드·캡션 마크는 그대로입니다.
- 사용자 요청: 패널이 이미 상태를 보여 주므로 그룹 헤더 마크는 중복이다 (방향 B).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/operations-side-bar-status-axis.test.tsx tests/instrument-design-contract.test.ts tests/triage-store.test.ts tests/operations-side-bar-chip-status.test.ts` (197 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Isolated Console: Sort by status 헤더 점 0, 칩 `tenant-beacon` 유지
- [x] Isolated Console: War Room 좌측 열 헤더 점 0, 칩 마크 유지
- [ ] Codex review

## Notes for Reviewers
- `.side-bar-group-header__dot` (사용자 그룹 정체성)는 건드리지 않았습니다.