### PR TITLE
fix(fleet-console): keep QL ULTRACODE as chat session opt-in

### DIFF
--- a/.changelog.d/chat-ultracode-session-optin.md
+++ b/.changelog.d/chat-ultracode-session-optin.md
@@ -1,0 +1,8 @@
+---
+branch: chat-ultracode-session-optin
+---
+
+### fleet-console
+#### Fixed
+- Starting Chat Mode from Quick Launch with the ULTRACODE track now keeps standing dynamic-workflow orchestration (`xhigh` plus the session ultracode setting) instead of collapsing that choice to max intensity.
+  ko: 퀵런치 강도 트랙에서 ULTRACODE를 고른 채 채팅으로 태어나면, 그 선택을 max 강도로 접지 않고 xhigh와 세션 ultracode 설정으로 다이나믹 워크플로우를 유지합니다.

--- a/packages/core-agent/src/claude/contracts.ts
+++ b/packages/core-agent/src/claude/contracts.ts
@@ -191,6 +191,13 @@ export interface ClaudeGatewaySdkOptions {
    */
   readonly skillOverrides?: Readonly<Record<string, "on" | "name-only" | "user-invocable-only" | "off">>;
   /**
+   * 세션 설정 `ultracode`. CLI의 `--effort ultracode`가 켜는 것과 같은 자리 — `xhigh` 강도와
+   * standing dynamic-workflow orchestration. `Options.effort` 단이 아니라 settings 플래그다.
+   *
+   * `true`만 연다. `false`를 실으면 사용자·프로젝트 설정의 켠 값을 flag 소스가 덮어 끈다.
+   */
+  readonly ultracode?: true;
+  /**
    * 자식의 `CLAUDE_CONFIG_DIR` 정책. 생략하면 격리다.
    *
    * 정책을 불리언이나 경로 하나로 숨기지 않는 이유: 격리 홈과 공유 홈은 캐시 소유권과 트랜스크립트

--- a/packages/core-agent/src/claude/sdk.ts
+++ b/packages/core-agent/src/claude/sdk.ts
@@ -101,9 +101,8 @@ export async function createClaudeGatewaySdk(
             ? { plugins: options.plugins.map((plugin) => ({ type: "local" as const, path: plugin.path, skipMcpDiscovery: true })) }
             : {}),
           // `--settings`와 같은 자리다. flag 소스로 병합되므로 사용자·프로젝트 설정을 대체하지 않는다.
-          ...(options.skillOverrides && Object.keys(options.skillOverrides).length > 0
-            ? { settings: { skillOverrides: { ...options.skillOverrides } } }
-            : {}),
+          // skillOverrides와 ultracode만 연다 — settings 전체를 열면 호출자가 쓰지 않은 지시가 들어온다.
+          ...vendorFlagSettings(options),
           ...(turn.effort === undefined ? {} : { effort: turn.effort }),
           ...(turn.cwd === undefined ? {} : { cwd: turn.cwd }),
           ...(turn.resume === undefined ? {} : { resume: turn.resume }),
@@ -269,6 +268,19 @@ function vendorCanUseTool(
       return { behavior: "deny", message: error instanceof Error ? error.message : String(error) };
     }
   };
+}
+
+/**
+ * 호출자가 고른 flag 설정만 모은다. 빈 객체는 키 자체를 생략한다 — `{}`를 넘기면 vendor가
+ * 빈 설정으로 병합해 호출자가 쓰지 않은 기본값을 심을 수 있다.
+ */
+function vendorFlagSettings(options: ClaudeGatewaySdkOptions): { readonly settings: Record<string, unknown> } | Record<string, never> {
+  const settings: Record<string, unknown> = {};
+  if (options.skillOverrides && Object.keys(options.skillOverrides).length > 0) {
+    settings.skillOverrides = { ...options.skillOverrides };
+  }
+  if (options.ultracode === true) settings.ultracode = true;
+  return Object.keys(settings).length > 0 ? { settings } : {};
 }
 
 /** 호출자가 고른 모드를 vendor가 아는 모양으로 옮긴다. 텍스트는 이 패키지가 만들지 않는다. */

--- a/packages/core-agent/tests/claude-sdk.test.ts
+++ b/packages/core-agent/tests/claude-sdk.test.ts
@@ -168,6 +168,28 @@ describe("turn assembly", () => {
     await sdk.dispose();
   });
 
+  it("merges ultracode into flag settings without opening the rest of settings", async () => {
+    const sdk = await createClaudeGatewaySdk({
+      baseUrl: BASE_URL,
+      models: [LUNA],
+      ultracode: true,
+      skillOverrides: { Explore: "off" },
+    });
+    await drain(await sdk.startTurn({ prompt: "hi", model: LUNA, effort: "xhigh" }));
+    const options = runVendorQuery.mock.calls[0]?.[0].options as Record<string, unknown>;
+    expect(options.effort).toBe("xhigh");
+    expect(options.settings).toEqual({ ultracode: true, skillOverrides: { Explore: "off" } });
+    await sdk.dispose();
+  });
+
+  it("omits settings entirely when neither ultracode nor skillOverrides is set", async () => {
+    const sdk = await createClaudeGatewaySdk({ baseUrl: BASE_URL, models: [LUNA] });
+    await drain(await sdk.startTurn({ prompt: "hi", model: LUNA }));
+    const options = runVendorQuery.mock.calls[0]?.[0].options as Record<string, unknown>;
+    expect(options).not.toHaveProperty("settings");
+    await sdk.dispose();
+  });
+
   it("omits an unset optional instead of forwarding undefined", async () => {
     const sdk = await createClaudeGatewaySdk({ baseUrl: BASE_URL, models: [LUNA] });
     await drain(await sdk.startTurn({ prompt: "hi", model: LUNA }));

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-launch-effort.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-launch-effort.ts
@@ -1,0 +1,23 @@
+import type { ClaudeGatewayEffort } from "@dotobokuri/core-agent/claude";
+
+const WIRE_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+/**
+ * 퀵런치 트랙의 launch sentinel을 Chat Mode SDK 시드로 옮긴다.
+ *
+ * `ultra`는 wire effort가 아니다. CLI의 `--effort ultracode`와 같이 `xhigh` 강도에
+ * 세션 설정 `ultracode`(standing dynamic-workflow orchestration)를 얹는다. SDK
+ * `Options.effort`에는 `ultracode`가 없고, `max`로 접으면 오케스트레이션이 빠진다.
+ */
+export type ChatLaunchEffortResolution = {
+  readonly effort: ClaudeGatewayEffort;
+  readonly ultracode?: true;
+};
+
+export function resolveChatLaunchEffort(value: string): ChatLaunchEffortResolution | undefined {
+  if (value.length === 0) return undefined;
+  if (value === "ultra") return { effort: "xhigh", ultracode: true };
+  return (WIRE_EFFORTS as readonly string[]).includes(value)
+    ? { effort: value as ClaudeGatewayEffort }
+    : undefined;
+}

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -54,6 +54,11 @@ export interface AgentChatSessionSeed {
   readonly baseUrl: string;
   readonly model: string;
   readonly effort?: ClaudeGatewayEffort;
+  /**
+   * 세션 설정 `ultracode`. 퀵런치 트랙의 ULTRACODE가 채팅으로 태어날 때 CLI `--effort ultracode`와
+   * 같은 자리로 옮긴다. `effort`와 별개다 — SDK는 강도를 `xhigh`로 받고, 오케스트레이션은 이 플래그가 켠다.
+   */
+  readonly ultracode?: true;
   readonly cwd: string;
   /**
    * 사용자의 실제 Claude 홈(`CLAUDE_CONFIG_DIR` 또는 `~/.claude`). 터미널로 띄운 CLI가 쓰는
@@ -776,6 +781,7 @@ class AgentChatSession {
           settingSources: ["user", "project", "local"],
           allowAmbientMcpServers: true,
           ...(this.seed.skillOverrides ? { skillOverrides: this.seed.skillOverrides } : {}),
+          ...(this.seed.ultracode ? { ultracode: true } : {}),
           // 플러그인이 실은 훅은 세션 식별자로 자기 축을 찾는다. 이 자식에게는 그 식별자가
           // 없어야 한다 — 상속된 값이 남으면 남의 세션 축에 보고한다.
           env: chatChildEnv(process.env),

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -32,11 +32,11 @@ import { createConsoleObservabilityStore } from "./agent-api/observability-store
 import { writeAgentSessionEvents } from "./agent-api/observability-routes.js";
 import { createOscAgentActivityTracker, type OscAgentActivityTracker } from "./agent-api/osc-agent-activity.js";
 import { readAnalysisProviderSession, readProviderSession, type AnalysisProviderSession } from "./agent-api/provider-session.js";
+import { resolveChatLaunchEffort } from "./agent-api/chat-launch-effort.js";
 import { AgentChatRegistry, type AgentChatSessionOrigin, type AgentChatSessionSeed, type CreateChatSdk } from "./agent-api/chat-session.js";
 import { attachAgentChatSocket } from "./agent-api/chat-ws.js";
 import { resolveAnalysisGatewayBaseUrl } from "./agent-api/analysis-types.js";
 import { resolveTranscriptPath } from "./agent-api/transcript-path.js";
-import type { ClaudeGatewayEffort } from "@dotobokuri/core-agent/claude";
 import type { AgentProviderSession, AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
 import { startIdleAgentDormantSweeper } from "./agent-idle-dormant-sweeper.js";
 type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown; readonly model?: unknown; readonly effort?: unknown; readonly prompt?: unknown; readonly attachmentIds?: unknown; readonly viewMode?: unknown };
@@ -1308,7 +1308,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     if (!cwd) return { ok: false, status: 404, error: "theater_not_found" };
     // resume core와 같은 좌표 정책: launchModel이 없던 구세대 Operation은 native Opus 1M로 계속된다.
     const model = readPayloadString(node.payload, "launchModel") || "opus[1m]";
-    const effort = chatEffortFromLaunchEffort(readPayloadString(node.payload, "launchEffort"));
+    const launchEffort = resolveChatLaunchEffort(readPayloadString(node.payload, "launchEffort"));
     // Chat Mode는 표면만 다른 같은 Operation이다 — 터미널에서 열었을 때 CLI가 받는 것과 같은
     // doctrine, 같은 Fleet 도구를 받아야 한다. 프롬프트 모드도 PTY 경로와 같은 전역 설정을 읽는다.
     const claudeConfigDir = resolveClaudeConfigDir();
@@ -1339,7 +1339,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       seed: {
         baseUrl: gatewayBaseUrl,
         model,
-        ...(effort ? { effort } : {}),
+        ...(launchEffort ? { effort: launchEffort.effort } : {}),
         cwd,
         claudeConfigDir,
         origin: sessionOrigin,
@@ -1366,6 +1366,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         // 터미널이 `--settings`로 강제하는 것과 같은 값이다. 없으면 같은 프롬프트가 표면에
         // 따라 다른 내장 스킬을 깨운다.
         ...(chatSkillOverrides ? { skillOverrides: chatSkillOverrides } : {}),
+        ...(launchEffort?.ultracode ? { ultracode: true } : {}),
         // 터미널 런치와 같은 자리에 같은 옵션으로 렌더한다 — 두 표면이 한 플러그인을 공유한다.
         resolveFleetPluginRoots: () => renderFleetPluginRootsForChat({
           cwd,
@@ -1750,15 +1751,6 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     ctx.host.http.writeJson(res, 401, { error: "Unauthorized" });
     return true;
   }
-}
-
-// launch factory의 ultra는 wire effort가 아니라 하네스 능력이다 — SDK 턴에는 max로 옮긴다.
-function chatEffortFromLaunchEffort(value: string): ClaudeGatewayEffort | undefined {
-  if (value.length === 0) return undefined;
-  if (value === "ultra") return "max";
-  return (["low", "medium", "high", "xhigh", "max"] as readonly string[]).includes(value)
-    ? value as ClaudeGatewayEffort
-    : undefined;
 }
 
 function isOperationDeletedEventPayload(value: unknown): value is { readonly operationId: string; readonly pluginId: string } {

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -62,9 +62,9 @@ function createFakeSdkFactory(turns: FakeTurn[]) {
     };
   });
   const dispose = vi.fn(async () => {});
-  const factory = vi.fn(async ({ models }: { readonly baseUrl: string; readonly models: readonly string[] }) => ({
+  const factory = vi.fn(async (options: { readonly baseUrl: string; readonly models: readonly string[]; readonly ultracode?: true }) => ({
     configDir,
-    models,
+    models: options.models,
     startTurn,
     dispose,
   }));
@@ -363,6 +363,28 @@ describe("AgentChatRegistry", () => {
       // 글자 단위 스트리밍의 전제 — text_delta는 부분 메시지에만 실린다.
       includePartialMessages: true,
     }));
+    await registry.disposeAll();
+  });
+
+  it("forwards session ultracode into the SDK factory, not as a turn effort rung", async () => {
+    const transcriptPath = writeTranscript("sid-ultra", [
+      { type: "user", message: { role: "user", content: "first order" } },
+    ]);
+    const { factory, startTurn } = createFakeSdkFactory([
+      { messages: [{ type: "result", subtype: "success", is_error: false, duration_ms: 10 }] },
+    ]);
+    const registry = new AgentChatRegistry(factory);
+    const session = await registry.ensure("op-ultra", () => ({
+      ...seedFor(transcriptPath),
+      effort: "xhigh",
+      ultracode: true,
+    }));
+    session.send("continue");
+    await drainTurn(registry, "op-ultra");
+
+    expect(factory).toHaveBeenCalledWith(expect.objectContaining({ ultracode: true }));
+    expect(startTurn).toHaveBeenCalledWith(expect.objectContaining({ effort: "xhigh" }));
+    expect(startTurn.mock.calls[0]?.[0]).not.toHaveProperty("ultracode");
     await registry.disposeAll();
   });
 

--- a/runtime/fleet-plugins/terminal/tests/chat-launch-effort.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/chat-launch-effort.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveChatLaunchEffort } from "../server/agent-api/chat-launch-effort.js";
+
+describe("resolveChatLaunchEffort", () => {
+  it("maps the ultra launch sentinel to xhigh plus session ultracode", () => {
+    expect(resolveChatLaunchEffort("ultra")).toEqual({ effort: "xhigh", ultracode: true });
+  });
+
+  it("does not collapse ultra onto max — max is intensity without orchestration", () => {
+    expect(resolveChatLaunchEffort("ultra")).not.toEqual({ effort: "max" });
+    expect(resolveChatLaunchEffort("max")).toEqual({ effort: "max" });
+  });
+
+  it("forwards everyday rungs unchanged", () => {
+    expect(resolveChatLaunchEffort("low")).toEqual({ effort: "low" });
+    expect(resolveChatLaunchEffort("medium")).toEqual({ effort: "medium" });
+    expect(resolveChatLaunchEffort("high")).toEqual({ effort: "high" });
+    expect(resolveChatLaunchEffort("xhigh")).toEqual({ effort: "xhigh" });
+  });
+
+  it("drops empty and unknown values", () => {
+    expect(resolveChatLaunchEffort("")).toBeUndefined();
+    expect(resolveChatLaunchEffort("ultracode")).toBeUndefined();
+    expect(resolveChatLaunchEffort("minimal")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- 퀵런치 강도 트랙에서 ULTRACODE를 고른 채 채팅으로 태어나면, 그 선택을 SDK `effort: max`로 접지 않습니다.
- Claude Agent SDK에는 `effort: ultracode`가 없습니다. CLI `--effort ultracode`와 같이 `xhigh` 강도에 세션 설정 `ultracode`(standing dynamic-workflow orchestration)를 얹습니다.
- 프롬프트 속 `ultracode` 단어의 턴 옵트인(human origin 스탬프)은 이 PR 범위가 아닙니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-agent exec vitest run tests/claude-sdk.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run tests/chat-launch-effort.test.ts tests/agent-chat-session.test.ts`
- [x] `pnpm --filter @dotobokuri/core-agent typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [ ] 퀵런치에서 ULTRACODE를 고르고 채팅으로 발사한 뒤, 세션이 다이나믹 워크플로우를 세션 옵트인으로 켜는지 확인