### PR TITLE
feat(fleet-console): full standby list + bulk Tactical resume

### DIFF
--- a/.changelog.d/reentry-standby-list.md
+++ b/.changelog.d/reentry-standby-list.md
@@ -1,0 +1,11 @@
+---
+branch: reentry-standby-list
+---
+
+### fleet-console
+#### Added
+- The empty canvas now offers "Open all in Tactical", resuming every standing-by operation into the auto-arranged grid in one click; beyond eight operations the button arms first so a misclick cannot spawn a pile of shells.
+  ko: 빈 캔버스에 "모두 Tactical로 열기"가 생겨, 꺼둔 Operation 전부를 자동 정렬 그리드로 한 번에 재개합니다. 8개를 넘으면 버튼이 한 번 더 물어 실수로 셸을 한꺼번에 띄우지 않습니다.
+#### Changed
+- The empty canvas standby list shows every standing-by operation with its last-activity time instead of only the two most recent, scrolling past four; the Korean copy now labels them as kept off so it no longer collides with the War Room waiting label.
+  ko: 빈 캔버스 대기 목록이 최근 2건 대신 꺼둔 Operation 전부를 최근 활동 시각과 함께 보여주며, 4개를 넘으면 스크롤됩니다. 한국어 표기는 "꺼둔"으로 바뀌어 War Room의 "대기"와 더 이상 충돌하지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -45,6 +45,8 @@ interface OperationsCanvasProps {
   readonly onRefreshCatalog?: () => void;
   readonly onClose: (operationId: string) => void;
   readonly onFocus: (operationId: string) => void;
+  /** 빈 캔버스의 일괄 열기 — 대기 목록에 보인 순서(updatedAt 내림차순) 그대로 id를 넘긴다. */
+  readonly onOpenAll: (operationIds: readonly string[]) => void;
   readonly onRename: (operationId: string, title: string) => void;
   readonly onOpenOperationMenu?: (operationId: string, anchor: DOMRect, returnFocus?: HTMLElement | null) => void;
   /** 그 Operation의 패널이 focus layer 뒤로 숨었다 — 그 패널이 주인인 메뉴가 열려 있으면 거둔다. */
@@ -97,6 +99,7 @@ export function OperationsCanvas({
   onRefreshCatalog,
   onClose,
   onFocus,
+  onOpenAll,
   onRename,
   onOpenOperationMenu,
   onDismissOperationMenu,
@@ -1089,6 +1092,7 @@ export function OperationsCanvas({
           operations={theaterOperations}
           canLaunch={canLaunch}
           onOpenOperation={onFocus}
+          onOpenAll={onOpenAll}
           onNewOperation={requestOperationLaunchMenu}
         />
       ) : null}

--- a/runtime/fleet-console/core/client/src/canvas/operations-canvas-empty-state.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operations-canvas-empty-state.tsx
@@ -41,6 +41,17 @@ export function OperationsCanvasEmptyState({
     if (openAllArmTimerRef.current !== null) window.clearTimeout(openAllArmTimerRef.current);
   }, []);
 
+  // 목록 정체성(Theater·대기 집합)이 바뀌면 암을 해제한다 — 확인은 그것을 본 집합에만 유효하다.
+  // 컴포넌트는 Theater 전환에도 언마운트되지 않으므로 useState가 다음 목록으로 새어 나갈 수 있다.
+  const standbySetKey = (activeTheaterId ?? "") + "|" + operations.map((operation) => operation.id).sort().join(",");
+  useEffect(() => {
+    if (openAllArmTimerRef.current !== null) {
+      window.clearTimeout(openAllArmTimerRef.current);
+      openAllArmTimerRef.current = null;
+    }
+    setOpenAllArmed(false);
+  }, [standbySetKey]);
+
   if (!activeTheaterId) {
     return (
       <div className="operations-canvas-empty" data-canvas-blocker>

--- a/runtime/fleet-console/core/client/src/canvas/operations-canvas-empty-state.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operations-canvas-empty-state.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useRef, useState } from "react";
 import type { OperationNode } from "../types.js";
-import { useT } from "../i18n/index.js";
+import { formatRelativeTime, useConsoleLocale, useT } from "../i18n/index.js";
 
 interface OperationsCanvasEmptyStateProps {
   readonly activeTheaterId: string | null;
@@ -7,8 +8,16 @@ interface OperationsCanvasEmptyStateProps {
   readonly operations: readonly OperationNode[];
   readonly canLaunch: boolean;
   readonly onOpenOperation: (operationId: string) => void;
+  readonly onOpenAll: (operationIds: readonly string[]) => void;
   readonly onNewOperation: () => void;
 }
+
+/** 이 수를 넘는 일괄 열기는 PTY 동시 스폰 비용이 커 한 번 더 확인한다. */
+const OPEN_ALL_CONFIRM_THRESHOLD = 8;
+/** 사이드바 칩 닫기와 같은 암(arm) 문법 — 같은 지속시간을 쓴다(CLOSE_ARM_DURATION_MS와 동일). */
+const OPEN_ALL_ARM_DURATION_MS = 1500;
+/** 이 수까지는 목록이 스크롤 없이 전부 보인다. 넘으면 캡이 걸리고 다음 행이 살짝 보여 스크롤을 암시한다. */
+const STANDBY_LIST_UNCAPPED = 4;
 
 export function hasVisibleCanvasContent(operations: readonly OperationNode[], minimizedOperationIds: ReadonlySet<string>): boolean {
   return operations.some((operation) => !minimizedOperationIds.has(operation.id));
@@ -20,9 +29,17 @@ export function OperationsCanvasEmptyState({
   operations,
   canLaunch,
   onOpenOperation,
+  onOpenAll,
   onNewOperation,
 }: OperationsCanvasEmptyStateProps) {
   const t = useT();
+  const locale = useConsoleLocale();
+  const [openAllArmed, setOpenAllArmed] = useState(false);
+  const openAllArmTimerRef = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (openAllArmTimerRef.current !== null) window.clearTimeout(openAllArmTimerRef.current);
+  }, []);
 
   if (!activeTheaterId) {
     return (
@@ -33,10 +50,27 @@ export function OperationsCanvasEmptyState({
     );
   }
 
+  // 전부 나열한다 — 예전에는 최근 2건으로 잘라 카운트와 도달 가능 집합이 어긋났다.
   const standbyOperations = [...operations]
-    .sort((left, right) => right.ts.updatedAt - left.ts.updatedAt)
-    .slice(0, 2);
+    .sort((left, right) => right.ts.updatedAt - left.ts.updatedAt);
   const operationCount = operations.length;
+
+  const handleOpenAll = () => {
+    if (openAllArmTimerRef.current !== null) {
+      window.clearTimeout(openAllArmTimerRef.current);
+      openAllArmTimerRef.current = null;
+    }
+    if (operationCount > OPEN_ALL_CONFIRM_THRESHOLD && !openAllArmed) {
+      setOpenAllArmed(true);
+      openAllArmTimerRef.current = window.setTimeout(() => {
+        openAllArmTimerRef.current = null;
+        setOpenAllArmed(false);
+      }, OPEN_ALL_ARM_DURATION_MS);
+      return;
+    }
+    setOpenAllArmed(false);
+    onOpenAll(standbyOperations.map((operation) => operation.id));
+  };
 
   return (
     <div className="operations-canvas-empty" data-canvas-blocker>
@@ -45,7 +79,11 @@ export function OperationsCanvasEmptyState({
           <p className="operations-canvas-empty-ghost">
             {t(operationCount === 1 ? "canvas.empty.standingBy_one" : "canvas.empty.standingBy_other", { count: operationCount })}
           </p>
-          <div className="operations-canvas-empty-standby">
+          <div
+            className={operationCount > STANDBY_LIST_UNCAPPED
+              ? "operations-canvas-empty-standby operations-canvas-empty-standby--scroll"
+              : "operations-canvas-empty-standby"}
+          >
             {standbyOperations.map((operation) => (
               <button
                 key={operation.id}
@@ -55,7 +93,10 @@ export function OperationsCanvasEmptyState({
                 onClick={() => onOpenOperation(operation.id)}
               >
                 <span className="operations-canvas-empty-standby-title">{operation.title}</span>
-                <span className="operations-canvas-empty-standby-open" aria-hidden="true">{t("canvas.empty.open")}</span>
+                <span className="operations-canvas-empty-standby-meta" aria-hidden="true">
+                  <span className="operations-canvas-empty-standby-time">{formatRelativeTime(operation.ts.updatedAt, locale)}</span>
+                  <span className="operations-canvas-empty-standby-open">{t("canvas.empty.open")}</span>
+                </span>
               </button>
             ))}
           </div>
@@ -63,15 +104,31 @@ export function OperationsCanvasEmptyState({
       ) : (
         <p className="operations-canvas-empty-headline">{t("canvas.empty.headline")}</p>
       )}
-      <button
-        type="button"
-        className="operations-canvas-empty-new"
-        aria-label={t("canvas.empty.newOperationAria", { theater: theaterLabel })}
-        disabled={!canLaunch}
-        onClick={onNewOperation}
-      >
-        {t("canvas.empty.newOperation")}
-      </button>
+      <div className="operations-canvas-empty-actions">
+        <button
+          type="button"
+          className="operations-canvas-empty-new"
+          aria-label={t("canvas.empty.newOperationAria", { theater: theaterLabel })}
+          disabled={!canLaunch}
+          onClick={onNewOperation}
+        >
+          {t("canvas.empty.newOperation")}
+        </button>
+        {operationCount >= 2 ? (
+          <button
+            type="button"
+            className={openAllArmed
+              ? "operations-canvas-empty-open-all is-armed"
+              : "operations-canvas-empty-open-all"}
+            aria-label={openAllArmed
+              ? t("canvas.empty.openAllArmedAria", { count: operationCount })
+              : t("canvas.empty.openAllAria", { count: operationCount })}
+            onClick={handleOpenAll}
+          >
+            {openAllArmed ? t("canvas.empty.openAllArmed", { count: operationCount }) : t("canvas.empty.openAll")}
+          </button>
+        ) : null}
+      </div>
       <p className="operations-canvas-empty-hints">
         <kbd>⌘K</kbd> {t("canvas.empty.hintSearch")} <span aria-hidden="true">·</span> <kbd>Alt+F</kbd> {t("canvas.empty.hintFormation")} <span aria-hidden="true">·</span> <kbd>Alt+S</kbd> {t("canvas.empty.hintStatusBoard")} <span aria-hidden="true">·</span> <kbd>Alt+T</kbd> {t("canvas.empty.hintTriage")}
       </p>

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -5,6 +5,10 @@ export const canvasEn = {
   "canvas.empty.standingBy_other": "{count} operations standing by",
   "canvas.empty.openOperation": "Open operation {title}",
   "canvas.empty.open": "OPEN",
+  "canvas.empty.openAll": "Open all in Tactical",
+  "canvas.empty.openAllAria": "Open all {count} operations in Tactical",
+  "canvas.empty.openAllArmed": "Open {count}?",
+  "canvas.empty.openAllArmedAria": "Confirm opening {count} operations",
   "canvas.empty.headline": "Launch your first operation",
   "canvas.empty.newOperationAria": "New Operation in {theater}",
   "canvas.empty.newOperation": "+ New Operation",
@@ -208,10 +212,16 @@ export const canvasEn = {
 
 export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "canvas.empty.noTheater": "사이드바에서 Theater를 추가해 Operation을 시작하세요.",
-  "canvas.empty.standingBy_one": "대기 중인 Operation {count}개",
-  "canvas.empty.standingBy_other": "대기 중인 Operation {count}개",
+  // standby(꺼둠)는 War Room의 대기(awaiting)와 다른 상태다 — 같은 "대기"로 쓰면 빈 캔버스 "대기 6"과
+  // War Room "대기 0"이 같은 세션에서 모순된다.
+  "canvas.empty.standingBy_one": "꺼둔 Operation {count}개",
+  "canvas.empty.standingBy_other": "꺼둔 Operation {count}개",
   "canvas.empty.openOperation": "Operation {title} 열기",
   "canvas.empty.open": "열기",
+  "canvas.empty.openAll": "모두 Tactical로 열기",
+  "canvas.empty.openAllAria": "{count}개 Operation을 모두 Tactical로 열기",
+  "canvas.empty.openAllArmed": "{count}개를 열까요?",
+  "canvas.empty.openAllArmedAria": "{count}개 Operation 열기 확인",
   "canvas.empty.headline": "첫 Operation을 시작하세요",
   "canvas.empty.newOperationAria": "{theater}에서 새 Operation",
   "canvas.empty.newOperation": "+ 새 Operation",

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -445,6 +445,16 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
     void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => focusMapOperation(operationId));
   }, [focusMapOperation, registry.operationKinds]);
 
+  // 빈 캔버스의 일괄 열기 — 대기 전원을 복원하고 Tactical로 정렬해 스택 대신 그리드에 착지시킨다.
+  // 목록 순서(updatedAt 내림차순)의 첫 항목을 활성으로 둔다. 비행 연출은 N개분이라 생략하고
+  // formation 진입 전이가 그 역할을 대신한다.
+  const handleOpenAll = useCallback((operationIds: readonly string[]) => {
+    if (operationIds.length === 0) return;
+    for (const operationId of operationIds) restoreOperation(operationId);
+    setActiveOperation(operationIds[0] ?? null);
+    if (!getFormationView()) toggleFormationView();
+  }, []);
+
   const handleMinimize = useCallback((operationId: string) => {
     if (stateRef.current.activeOperationId === operationId) setActiveOperation(null);
     playMinimizeFlight(operationId);
@@ -758,6 +768,7 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
           onRefreshCatalog={refreshCatalog}
           onClose={handleClose}
           onFocus={handleFocus}
+          onOpenAll={handleOpenAll}
           onRename={handleRename}
           onOpenOperationMenu={openOperationMenu}
           onDismissOperationMenu={dismissOperationMenu}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6641,8 +6641,17 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-2);
 }
 
+/* 4행 + 5행의 윗자락(182px)까지만 보여 스크롤 가능을 암시한다 — 전부 나열하되 캔버스를 잠식하지 않는 캡. */
+.operations-canvas-empty-standby--scroll {
+  max-height: 182px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  padding-right: 2px;
+}
+
 .operations-canvas-empty-standby-chip,
-.operations-canvas-empty-new {
+.operations-canvas-empty-new,
+.operations-canvas-empty-open-all {
   pointer-events: auto;
   cursor: pointer;
 }
@@ -6669,13 +6678,33 @@ body[data-side-bar-animating="true"] .canvas-operation {
   white-space: nowrap;
 }
 
-.operations-canvas-empty-standby-open {
+.operations-canvas-empty-standby-meta {
   flex: none;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.operations-canvas-empty-standby-time {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.02em;
+}
+
+.operations-canvas-empty-standby-open {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
+}
+
+.operations-canvas-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
 }
 
 .operations-canvas-empty-new {
@@ -6688,6 +6717,22 @@ body[data-side-bar-animating="true"] .canvas-operation {
   font: var(--weight-bold) var(--t-xs)/1.2 var(--font-mono);
 }
 
+.operations-canvas-empty-open-all {
+  padding: 8px var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font: var(--weight-bold) var(--t-xs)/1.2 var(--font-mono);
+}
+
+/* 일괄 열기의 확인(arm)은 파괴가 아니라 비용 경고라 coral이 아니라 warn 채널을 쓴다(remote-rotate.is-armed와 같은 문법). */
+.operations-canvas-empty-open-all.is-armed {
+  border-color: color-mix(in oklch, var(--warn) 55%, transparent);
+  background: var(--warn-glow);
+  color: var(--warn-ink);
+}
+
 .operations-canvas-empty-standby-chip:hover,
 .operations-canvas-empty-new:hover:not(:disabled) {
   border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));
@@ -6695,8 +6740,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
   color: var(--brass-bright);
 }
 
+.operations-canvas-empty-open-all:hover:not(.is-armed) {
+  border-color: var(--surface-rim-strong);
+  color: var(--text-primary);
+}
+
 .operations-canvas-empty-standby-chip:focus-visible,
-.operations-canvas-empty-new:focus-visible {
+.operations-canvas-empty-new:focus-visible,
+.operations-canvas-empty-open-all:focus-visible {
   outline: 2px solid color-mix(in oklch, var(--brass) 58%, transparent);
   outline-offset: 2px;
 }

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -622,6 +622,7 @@ function renderOperationsCanvas(
     onLaunchAtGeometry: () => {},
     onClose: () => {},
     onFocus: () => {},
+    onOpenAll: () => {},
     onRename: () => {},
     onOpenOperationMenu: () => {},
     onDismissOperationMenu: () => {},

--- a/runtime/fleet-console/tests/operations-canvas-empty-state.test.tsx
+++ b/runtime/fleet-console/tests/operations-canvas-empty-state.test.tsx
@@ -56,7 +56,7 @@ describe("Operations Canvas empty state", () => {
     expect(onNewOperation).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the two most recently updated standby Operations and opens the selected one", () => {
+  it("shows every standby Operation in recency order and opens the selected one", () => {
     const onOpenOperation = vi.fn();
     renderEmptyState({
       activeTheaterId: "theater-a",
@@ -70,15 +70,88 @@ describe("Operations Canvas empty state", () => {
 
     expect(container?.querySelector(".operations-canvas-empty-ghost")?.textContent).toBe("3 operations standing by");
     const chips = Array.from(container?.querySelectorAll<HTMLButtonElement>(".operations-canvas-empty-standby-chip") ?? []);
-    expect(chips).toHaveLength(2);
+    expect(chips).toHaveLength(3);
     expect(chips.map((chip) => chip.getAttribute("aria-label"))).toEqual([
       "Open operation Newest watch",
       "Open operation Middle watch",
+      "Open operation Old watch",
     ]);
-    expect(chips.map((chip) => chip.querySelector(".operations-canvas-empty-standby-open")?.textContent)).toEqual(["OPEN", "OPEN"]);
+    expect(chips.map((chip) => chip.querySelector(".operations-canvas-empty-standby-open")?.textContent)).toEqual(["OPEN", "OPEN", "OPEN"]);
 
     act(() => chips[1]?.click());
     expect(onOpenOperation).toHaveBeenCalledWith("middle");
+  });
+
+  it("renders a relative last-activity time on each standby chip", () => {
+    renderEmptyState({
+      activeTheaterId: "theater-a",
+      operations: [operation("recent", "Recent watch", Date.now() - 12 * 60_000)],
+    });
+
+    const time = container?.querySelector(".operations-canvas-empty-standby-time");
+    expect(time?.textContent).toBe("12 minutes ago");
+  });
+
+  it("caps the standby list with the scroll modifier beyond four Operations", () => {
+    const five = [1, 2, 3, 4, 5].map((index) => operation(`op-${index}`, `Watch ${index}`, index));
+    const four = five.slice(0, 4);
+
+    renderEmptyState({ activeTheaterId: "theater-a", operations: five });
+    expect(container?.querySelector(".operations-canvas-empty-standby--scroll")).not.toBeNull();
+
+    renderEmptyState({ activeTheaterId: "theater-a", operations: four });
+    expect(container?.querySelector(".operations-canvas-empty-standby--scroll")).toBeNull();
+  });
+
+  it("opens all standby Operations at once without arming at or under the confirm threshold", () => {
+    const onOpenAll = vi.fn();
+    renderEmptyState({
+      activeTheaterId: "theater-a",
+      operations: [
+        operation("old", "Old watch", 10),
+        operation("newest", "Newest watch", 30),
+        operation("middle", "Middle watch", 20),
+      ],
+      onOpenAll,
+    });
+
+    const openAll = container?.querySelector<HTMLButtonElement>(".operations-canvas-empty-open-all");
+    expect(openAll?.textContent).toBe("Open all in Tactical");
+    act(() => openAll?.click());
+    expect(onOpenAll).toHaveBeenCalledWith(["newest", "middle", "old"]);
+  });
+
+  it("hides the bulk action for a single standby Operation", () => {
+    renderEmptyState({
+      activeTheaterId: "theater-a",
+      operations: [operation("solo", "Solo", 1)],
+    });
+
+    expect(container?.querySelector(".operations-canvas-empty-open-all")).toBeNull();
+  });
+
+  it("arms the bulk action beyond the confirm threshold and fires on the second click", () => {
+    vi.useFakeTimers();
+    try {
+      const onOpenAll = vi.fn();
+      const nine = Array.from({ length: 9 }, (_, index) => operation(`op-${index}`, `Watch ${index}`, index));
+      renderEmptyState({ activeTheaterId: "theater-a", operations: nine, onOpenAll });
+
+      const openAll = container?.querySelector<HTMLButtonElement>(".operations-canvas-empty-open-all");
+      act(() => openAll?.click());
+      expect(onOpenAll).not.toHaveBeenCalled();
+      expect(container?.querySelector(".operations-canvas-empty-open-all.is-armed")?.textContent).toBe("Open 9?");
+
+      act(() => { vi.advanceTimersByTime(1600); });
+      expect(container?.querySelector(".operations-canvas-empty-open-all.is-armed")).toBeNull();
+
+      act(() => openAll?.click());
+      act(() => openAll?.click());
+      expect(onOpenAll).toHaveBeenCalledTimes(1);
+      expect(onOpenAll.mock.calls[0]?.[0]).toHaveLength(9);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("uses the singular standby copy for one Operation", () => {
@@ -95,11 +168,13 @@ function renderEmptyState({
   activeTheaterId,
   operations,
   onOpenOperation = vi.fn(),
+  onOpenAll = vi.fn(),
   onNewOperation = vi.fn(),
 }: {
   readonly activeTheaterId: string | null;
   readonly operations: readonly OperationNode[];
   readonly onOpenOperation?: (operationId: string) => void;
+  readonly onOpenAll?: (operationIds: readonly string[]) => void;
   readonly onNewOperation?: () => void;
 }): void {
   act(() => root?.render(createElement(OperationsCanvasEmptyState, {
@@ -108,6 +183,7 @@ function renderEmptyState({
     operations,
     canLaunch: true,
     onOpenOperation,
+    onOpenAll,
     onNewOperation,
   })));
 }

--- a/runtime/fleet-console/tests/operations-canvas-empty-state.test.tsx
+++ b/runtime/fleet-console/tests/operations-canvas-empty-state.test.tsx
@@ -154,6 +154,27 @@ describe("Operations Canvas empty state", () => {
     }
   });
 
+  it("drops the armed state when the standby set changes underneath it", () => {
+    vi.useFakeTimers();
+    try {
+      const onOpenAll = vi.fn();
+      const nine = Array.from({ length: 9 }, (_, index) => operation(`op-${index}`, `Watch ${index}`, index));
+      renderEmptyState({ activeTheaterId: "theater-a", operations: nine, onOpenAll });
+
+      act(() => container?.querySelector<HTMLButtonElement>(".operations-canvas-empty-open-all")?.click());
+      expect(container?.querySelector(".operations-canvas-empty-open-all.is-armed")).not.toBeNull();
+
+      const otherNine = Array.from({ length: 9 }, (_, index) => operation(`other-${index}`, `Other ${index}`, index));
+      renderEmptyState({ activeTheaterId: "theater-b", operations: otherNine, onOpenAll });
+      expect(container?.querySelector(".operations-canvas-empty-open-all.is-armed")).toBeNull();
+
+      act(() => container?.querySelector<HTMLButtonElement>(".operations-canvas-empty-open-all")?.click());
+      expect(onOpenAll).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses the singular standby copy for one Operation", () => {
     renderEmptyState({
       activeTheaterId: "theater-a",

--- a/runtime/fleet-console/tests/triage-stage-companion.test.ts
+++ b/runtime/fleet-console/tests/triage-stage-companion.test.ts
@@ -179,6 +179,7 @@ function renderCanvas() {
     onLaunchAtGeometry: () => {},
     onClose: () => {},
     onFocus: () => {},
+    onOpenAll: () => {},
     onRename: () => {},
   })));
 }


### PR DESCRIPTION
## Summary
- 재진입 빈 캔버스의 대기 목록이 최근 2걧만 보여주던 것을(slice(0, 2)) 전체 목록으로 바꾸고, 각 행에 최근 활동 상대 시각을 붙였습니다. 4개를 넘으면 스크롤 캡이 걸립니다.
- "모두 Tactical로 열기" 일괄 재개를 추가했습니다 — 꺼둔 Operation 전원을 복원해 자동 정렬 그리드에 착지시킵니다. 8개 초과 시 버튼이 먼저 암(arm) 상태가 되어(1.5초 자동 해제) 실수로 PTY를 한꺼번에 띄우는 것을 막습니다.
- ko 카피 분리: 빈 상태의 standby는 "꺼둔 Operation"으로 바꿔 War Room의 "대기"(awaiting)와의 충돌을 없앴습니다(측정된 모순: 부팅 직후 "대기 중 6개" → War Room "대기 0").

제안서(측정 + 목업): product-proposal 스윕(2026-08-17)에서 실측 확정 — 6개 대기 중 2개만 도달 가능(`operations-canvas-empty-state.tsx:38`), 사용자 승인 옵션 A.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` 통과
- [x] `vitest run tests/operations-canvas-empty-state.test.tsx` 10/10 (전체 목록·시각·스크롤 캡·임계 이하 즉시 실행·임계 초과 암/자동해제/확인)
- [x] `vitest run tests/triage-stage-companion.test.ts tests/canvas-minimap-formation.test.ts tests/instrument-design-contract.test.ts` 87/87
- [x] `pnpm --filter @dotobokuri/fleet-console build` 통과
- [x] e2e(격리 인스턴스, 6→9 dormant op 시드): 전체 목록+상대 시각 렌더, 스크롤 캡, ko "꺼둔 Operation N개", 6개 즉시 일괄 오픈→Tactical, 9개 암("9개를 열까요?")→확인→9패널 Tactical 그리드 착지 확인