### PR TITLE
feat(ai-gateway): add Codex context variants

### DIFF
--- a/.changelog.d/add-sol-luna-1m-gateway.md
+++ b/.changelog.d/add-sol-luna-1m-gateway.md
@@ -1,0 +1,13 @@
+---
+branch: add-sol-luna-1m-gateway
+---
+
+### fleet-cli
+#### Changed
+- Codex Sol, Luna, and Terra (including Fast) now advertise a 1M context window, with explicit 512K variants selectable in the gateway picker.
+  ko: Codex Sol, Luna, Terra(Fast 포함)는 1M 컨텍스트로 표시되고, 명시적 512K 변형도 게이트웨이 선택기에서 고를 수 있습니다.
+
+### fleet-console
+#### Changed
+- Codex Sol, Luna, and Terra (including Fast) now advertise a 1M context window, with explicit 512K variants selectable in the gateway picker.
+  ko: Codex Sol, Luna, Terra(Fast 포함)는 1M 컨텍스트로 표시되고, 명시적 512K 변형도 게이트웨이 선택기에서 고를 수 있습니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -5,13 +5,13 @@
     "codex": {
       "name": "Codex",
       "defaultModel": "gpt-5.6-sol",
-      "source": "codex app-server model/list (codex-cli 0.147.0, observed 2026-08-11) for model/effort/service-tier; Fleet catalog effort ladders are capped at max because harness launch capabilities are not model rungs; contextWindow=272000 is codex debug models context_window/max_context_window (codex-cli 0.146.0, observed 2026-08-02)",
+      "source": "codex app-server model/list (codex-cli 0.147.0, observed 2026-08-11) for model/effort/service-tier; Fleet catalog effort ladders are capped at max because harness launch capabilities are not model rungs; 2026-08-17 production Codex live observation: gpt-5.6-sol/luna/terra accepted 520,012 input tokens (HTTP 200) and gpt-5.6-terra accepted 900,012 input tokens (HTTP 200); official OpenAI model cards (observed 2026-08-17) list Sol/Luna/Terra native context 1,050,000 — unsuffixed and Fast ids advertise the explicit Claude [1m] coordinate (1,000,000); explicit *-512k ids advertise 524288",
       "models": [
         {
           "modelId": "gpt-5.6-sol",
           "name": "GPT-5.6-Sol",
           "capabilityClass": "flagship",
-          "contextWindow": 272000,
+          "contextWindow": 1000000,
           "effort": {
             "supported": true,
             "levels": [
@@ -33,7 +33,7 @@
           "capabilityClass": "flagship",
           "providerModelId": "gpt-5.6-sol",
           "serviceTier": "priority",
-          "contextWindow": 272000,
+          "contextWindow": 1000000,
           "effort": {
             "supported": true,
             "levels": [
@@ -53,7 +53,7 @@
           "modelId": "gpt-5.6-terra",
           "name": "GPT-5.6-Terra",
           "capabilityClass": "standard",
-          "contextWindow": 272000,
+          "contextWindow": 1000000,
           "effort": {
             "supported": true,
             "levels": [
@@ -75,7 +75,7 @@
           "capabilityClass": "standard",
           "providerModelId": "gpt-5.6-terra",
           "serviceTier": "priority",
-          "contextWindow": 272000,
+          "contextWindow": 1000000,
           "effort": {
             "supported": true,
             "levels": [
@@ -95,7 +95,7 @@
           "modelId": "gpt-5.6-luna",
           "name": "GPT-5.6-Luna",
           "capabilityClass": "light",
-          "contextWindow": 272000,
+          "contextWindow": 1000000,
           "effort": {
             "supported": true,
             "levels": [
@@ -117,7 +117,7 @@
           "capabilityClass": "light",
           "providerModelId": "gpt-5.6-luna",
           "serviceTier": "priority",
-          "contextWindow": 272000,
+          "contextWindow": 1000000,
           "effort": {
             "supported": true,
             "levels": [
@@ -132,6 +132,135 @@
             "gpt-5.6-luna-fast"
           ],
           "benchmarkKey": "gpt-5.6-luna"
+        },
+        {
+          "modelId": "gpt-5.6-sol-512k",
+          "name": "GPT-5.6-Sol-512K",
+          "capabilityClass": "flagship",
+          "providerModelId": "gpt-5.6-sol",
+          "contextWindow": 524288,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-5.6-sol-512k"
+          ],
+          "benchmarkKey": "gpt-5.6-sol"
+        },
+        {
+          "modelId": "gpt-5.6-sol-512k-fast",
+          "name": "GPT-5.6-Sol-512K-Fast",
+          "capabilityClass": "flagship",
+          "providerModelId": "gpt-5.6-sol",
+          "serviceTier": "priority",
+          "contextWindow": 524288,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-5.6-sol-512k-fast"
+          ],
+          "benchmarkKey": "gpt-5.6-sol"
+        },
+        {
+          "modelId": "gpt-5.6-luna-512k",
+          "name": "GPT-5.6-Luna-512K",
+          "capabilityClass": "light",
+          "providerModelId": "gpt-5.6-luna",
+          "contextWindow": 524288,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-5.6-luna-512k"
+          ],
+          "benchmarkKey": "gpt-5.6-luna"
+        },
+        {
+          "modelId": "gpt-5.6-luna-512k-fast",
+          "name": "GPT-5.6-Luna-512K-Fast",
+          "capabilityClass": "light",
+          "providerModelId": "gpt-5.6-luna",
+          "serviceTier": "priority",
+          "contextWindow": 524288,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-5.6-luna-512k-fast"
+          ],
+          "benchmarkKey": "gpt-5.6-luna"
+        },
+        {
+          "modelId": "gpt-5.6-terra-512k",
+          "name": "GPT-5.6-Terra-512K",
+          "capabilityClass": "standard",
+          "providerModelId": "gpt-5.6-terra",
+          "contextWindow": 524288,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-5.6-terra-512k"
+          ],
+          "benchmarkKey": "gpt-5.6-terra"
+        },
+        {
+          "modelId": "gpt-5.6-terra-512k-fast",
+          "name": "GPT-5.6-Terra-512K-Fast",
+          "capabilityClass": "standard",
+          "providerModelId": "gpt-5.6-terra",
+          "serviceTier": "priority",
+          "contextWindow": 524288,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-5.6-terra-512k-fast"
+          ],
+          "benchmarkKey": "gpt-5.6-terra"
         }
       ]
     },

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -175,7 +175,7 @@ describe("upstream credential", () => {
 
     expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       apiKey: SUBSCRIPTION_TOKEN,
-      contextWindow: 272_000,
+      contextWindow: 1_000_000,
       model: "gpt-5.6-sol",
       serviceTier: "priority",
       reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
@@ -255,7 +255,7 @@ describe("upstream credential", () => {
 
     expect(res.status).toBe(200);
     expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
-      contextWindow: 272_000,
+      contextWindow: 1_000_000,
     }));
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -514,7 +514,9 @@ describe("model context window", () => {
   it.each([
     // The guard and Claude-coordinate projection both take the model's real window.
     // Marker choice only selects Claude's 200k or 1M coordinate.
-    ["claude-gateway--codex--gpt-5.6-sol", 272_000],
+    ["claude-gateway--codex--gpt-5.6-sol", 1_000_000],
+    ["claude-gateway--codex--gpt-5.6-terra", 1_000_000],
+    ["claude-gateway--codex--gpt-5.6-sol-512k", 524_288],
     ["claude-gateway--cursor--grok-4.5-fast", 256_000],
     ["claude-gateway--cursor--composer-2.5", 200_000],
   ])("passes %s's real window to both context contracts", async (model, expected) => {
@@ -543,9 +545,9 @@ describe("model context window", () => {
     await router.handle(ctx({
       res,
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--codex--gpt-5.6-sol",
-      // 4 chars/token puts this at ~500_000 tokens against a 272_000 window.
-      messages: [{ role: "user", content: "x".repeat(2_000_000) }],
+      model: "claude-gateway--codex--gpt-5.6-terra-512k",
+      // 4 chars/token puts this at ~750_000 tokens against the 512K Terra variant.
+      messages: [{ role: "user", content: "x".repeat(3_000_000) }],
     }));
 
     expect(res.status).toBe(413);
@@ -553,7 +555,7 @@ describe("model context window", () => {
       type: "error",
       error: {
         type: "invalid_request_error",
-        message: expect.stringMatching(/^Prompt is too long: \d+ tokens > 272000 maximum context window$/),
+        message: expect.stringMatching(/^Prompt is too long: \d+ tokens > 524288 maximum context window$/),
       },
     });
     // The guard runs inside the gateway, so upstream was still spared the turn.
@@ -569,10 +571,10 @@ describe("oversized skill payloads", () => {
     "- claude-api: Reference for the Claude API / Anthropic SDK.",
     "TRIGGER — read BEFORE opening the target file.",
   ].join("\n");
-  // 4 chars/token puts this at 100_000 tokens, past the 27_200 one skill may take
-  // from a 272_000-token window.
+  // 4 chars/token puts this at 150_000 tokens, past the 104_857 one skill may take
+  // from a 524_288-token window.
   const BODY = "Base directory for this skill: /tmp/bundled-skills/2.1.222/abc/claude-api\n\n"
-    + "x".repeat(400_000);
+    + "x".repeat(600_000);
 
   function sentText(request: AnthropicMessagesRequest | undefined, index: number): string {
     const content = request?.messages[index]?.content;
@@ -590,7 +592,7 @@ describe("oversized skill payloads", () => {
     await router.handle(ctx({
       res: response(),
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--codex--gpt-5.6-sol",
+      model: "claude-gateway--codex--gpt-5.6-terra-512k",
       messages: [listingTurn, { role: "user", content: [{ type: "text", text: BODY }] }],
     }));
 
@@ -605,7 +607,7 @@ describe("oversized skill payloads", () => {
     await router.handle(ctx({
       res: response(),
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--codex--gpt-5.6-sol",
+      model: "claude-gateway--codex--gpt-5.6-terra-512k",
       messages: [listingTurn],
     }));
 
@@ -1789,7 +1791,7 @@ describe("route surface", () => {
       }));
 
       expect(JSON.parse(settingsResponse.body).data).toEqual([
-        expect.objectContaining({ id: "claude-gateway--codex--gpt-5.6-sol" }),
+        expect.objectContaining({ id: "claude-gateway--codex--gpt-5.6-sol[1m]" }),
       ]);
       expect(withoutReaderSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
         model: "gpt-5.6-sol",
@@ -1824,8 +1826,22 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(31);
-    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
+    expect(list.data).toHaveLength(37);
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-luna[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-luna-fast[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-terra[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-terra-fast[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-512k");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-512k-fast");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-luna-512k");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-luna-512k-fast");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-terra-512k");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-terra-512k-fast");
+    expect(ids).not.toContain("claude-gateway--codex--gpt-5.6-sol-512k[512k]");
+    expect(ids).not.toContain("claude-gateway--codex--gpt-5.6-terra");
+    expect(ids).not.toContain("claude-gateway--codex--gpt-5.6-terra-fast");
     expect(ids).toContain("claude-gateway--cursor--auto");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5-fast");
@@ -1842,7 +1858,6 @@ describe("route surface", () => {
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
     expect(ids).toContain("claude-gateway--opencode--minimax-m3[1m]");
-    expect(ids.some((id) => id.includes("--codex--") && id.endsWith("[1m]"))).toBe(false);
     expect(list.data).toContainEqual(expect.objectContaining({
       id: "claude-gateway--cursor--grok-4.5",
       display_name: "Cursor-Grok-4.5",
@@ -1905,8 +1920,8 @@ describe("route surface", () => {
     expect(res.status).toBe(200);
     const list = JSON.parse(res.body) as { data: Array<{ id: string }> };
     expect(list.data.map((entry) => entry.id)).toEqual([
-      "claude-gateway--codex--gpt-5.6-sol-fast",
-      "claude-gateway--codex--gpt-5.6-luna-fast",
+      "claude-gateway--codex--gpt-5.6-sol-fast[1m]",
+      "claude-gateway--codex--gpt-5.6-luna-fast[1m]",
       "claude-gateway--cursor--grok-4.5-fast",
       "claude-gateway--kimi--k3[1m]",
     ]);

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -845,12 +845,29 @@ describe("model catalog", () => {
   });
 
   it("contains only the approved provider families", () => {
-    expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(6);
+    expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(12);
     expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(11);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(11);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
-    expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.contextWindow === 272_000)).toBe(true);
+    expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => model.id.includes("512k")).every((model) => model.contextWindow === 524_288)).toBe(true);
+    expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => !model.id.includes("512k")).every((model) => model.contextWindow === 1_000_000)).toBe(true);
+    expect(CODEX_SUBSCRIPTION_MODELS.map((model) => model.id.replace(/^codex--/, ""))).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-sol-fast",
+      "gpt-5.6-terra",
+      "gpt-5.6-terra-fast",
+      "gpt-5.6-luna",
+      "gpt-5.6-luna-fast",
+      "gpt-5.6-sol-512k",
+      "gpt-5.6-sol-512k-fast",
+      "gpt-5.6-luna-512k",
+      "gpt-5.6-luna-512k-fast",
+      "gpt-5.6-terra-512k",
+      "gpt-5.6-terra-512k-fast",
+    ]);
+    expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => model.id.endsWith("-fast")).every((model) => model.serviceTier === "priority")).toBe(true);
+    expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => !model.id.endsWith("-fast")).every((model) => model.serviceTier === undefined)).toBe(true);
     expect(CURSOR_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual([
       "default",
       "composer-2.5",
@@ -1053,12 +1070,55 @@ describe("model catalog", () => {
     );
     // Claude Code는 claude로 시작하지 않는 id를 discovery 결과에서 버린다.
     expect(list.data.every((entry) => entry.id.startsWith("claude"))).toBe(true);
-    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol")).toMatchObject({
-      display_name: "Codex-GPT-5.6-Sol",
-      max_input_tokens: 272_000,
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol[1m]")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Sol (1M Context)",
+      max_input_tokens: 1_000_000,
     });
-    expect(list.data.some((entry) => entry.id.includes("--codex--") && entry.id.endsWith("[1m]")))
-      .toBe(false);
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol-fast[1m]")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Sol-Fast (1M Context)",
+      max_input_tokens: 1_000_000,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-luna[1m]")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Luna (1M Context)",
+      max_input_tokens: 1_000_000,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-luna-fast[1m]")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Luna-Fast (1M Context)",
+      max_input_tokens: 1_000_000,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-terra[1m]")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Terra (1M Context)",
+      max_input_tokens: 1_000_000,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-terra-fast[1m]")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Terra-Fast (1M Context)",
+      max_input_tokens: 1_000_000,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol-512k")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Sol-512K",
+      max_input_tokens: 524_288,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol-512k-fast")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Sol-512K-Fast",
+      max_input_tokens: 524_288,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-luna-512k")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Luna-512K",
+      max_input_tokens: 524_288,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-luna-512k-fast")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Luna-512K-Fast",
+      max_input_tokens: 524_288,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-terra-512k")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Terra-512K",
+      max_input_tokens: 524_288,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-terra-512k-fast")).toMatchObject({
+      display_name: "Codex-GPT-5.6-Terra-512K-Fast",
+      max_input_tokens: 524_288,
+    });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol-512k[512k]")).toBeUndefined();
     expect(list.data.find((entry) => entry.id.endsWith("cursor--grok-4.5"))).toMatchObject({
       display_name: "Cursor-Grok-4.5",
       max_input_tokens: 256_000,
@@ -1133,8 +1193,8 @@ describe("model catalog", () => {
 
   it("advertises the official Anthropic effort capability per gateway model", () => {
     const entries = new Map(buildAnthropicModelList().data.map((entry) => [entry.id, entry]));
-    const sol = entries.get("claude-gateway--codex--gpt-5.6-sol");
-    const luna = entries.get("claude-gateway--codex--gpt-5.6-luna");
+    const sol = entries.get("claude-gateway--codex--gpt-5.6-sol[1m]");
+    const luna = entries.get("claude-gateway--codex--gpt-5.6-luna[1m]");
     const kimi = entries.get("claude-gateway--kimi--k3[1m]");
     const cursor = entries.get("claude-gateway--cursor--auto");
     const cursorGrok = entries.get("claude-gateway--cursor--grok-4.5");
@@ -1204,16 +1264,38 @@ describe("model catalog", () => {
       model: model?.upstreamId,
       serviceTier: model?.serviceTier,
     })).toMatchObject({ model: "gpt-5.6-sol", service_tier: "priority" });
+    const sol512k = findGatewayModel("claude-gateway--codex--gpt-5.6-sol-512k");
+    const sol512kFast = findGatewayModel("claude-gateway--codex--gpt-5.6-sol-512k-fast");
+    expect(sol512k).toMatchObject({ upstreamId: "gpt-5.6-sol" });
+    expect(sol512k).not.toHaveProperty("serviceTier");
+    expect(sol512kFast).toMatchObject({ upstreamId: "gpt-5.6-sol", serviceTier: "priority" });
+    expect(translateAnthropicRequest(baseRequest(), {
+      model: sol512kFast?.upstreamId,
+      serviceTier: sol512kFast?.serviceTier,
+    })).toMatchObject({ model: "gpt-5.6-sol", service_tier: "priority" });
   });
 
   it("accepts truthful marked ids and current unmarked aliases", () => {
     const model = findGatewayModel("claude-gateway--kimi--k3[1m]");
     expect(model).toMatchObject({ id: "kimi--k3", upstreamId: "k3" });
+    expect(findGatewayModel("claude-gateway--codex--gpt-5.6-luna[1m]")).toMatchObject({
+      id: "codex--gpt-5.6-luna",
+      upstreamId: "gpt-5.6-luna",
+    });
     expect(findGatewayModel("claude-gateway--codex--gpt-5.6-luna")).toMatchObject({
       id: "codex--gpt-5.6-luna",
       upstreamId: "gpt-5.6-luna",
     });
-    expect(findGatewayModel("claude-gateway--codex--gpt-5.6-luna[1m]")).toBeUndefined();
+    expect(findGatewayModel("claude-gateway--codex--gpt-5.6-terra[1m]")).toMatchObject({
+      id: "codex--gpt-5.6-terra",
+      upstreamId: "gpt-5.6-terra",
+    });
+    expect(findGatewayModel("claude-gateway--codex--gpt-5.6-sol-512k")).toMatchObject({
+      id: "codex--gpt-5.6-sol-512k",
+      upstreamId: "gpt-5.6-sol",
+    });
+    expect(findGatewayModel("claude-gateway--codex--gpt-5.6-sol-512k[512k]")).toBeUndefined();
+    expect(findGatewayModel("claude-gateway--codex--gpt-5.6-sol-512k[1m]")).toBeUndefined();
     expect(findGatewayModel("claude-gateway--kimi--k3")).toMatchObject({ id: "kimi--k3" });
     expect(findGatewayModel("claude-gateway--cursor--grok-4.5")).toMatchObject({
       id: "cursor--grok-4.5",
@@ -1267,9 +1349,16 @@ describe("Claude context coordinate", () => {
   } as GatewayModel);
 
   it("marks only a model whose real window reaches one million", () => {
-    const codex = CODEX_SUBSCRIPTION_MODELS[0]!;
-    expect(codex.contextWindow).toBe(272_000);
-    expect(toClaudeGatewayModelId(codex).endsWith("[1m]")).toBe(false);
+    const sol = CODEX_SUBSCRIPTION_MODELS.find((entry) => entry.id === "codex--gpt-5.6-sol")!;
+    const terra = CODEX_SUBSCRIPTION_MODELS.find((entry) => entry.id === "codex--gpt-5.6-terra")!;
+    const sol512k = CODEX_SUBSCRIPTION_MODELS.find((entry) => entry.id === "codex--gpt-5.6-sol-512k")!;
+    expect(sol.contextWindow).toBe(1_000_000);
+    expect(terra.contextWindow).toBe(1_000_000);
+    expect(sol512k.contextWindow).toBe(524_288);
+    expect(toClaudeGatewayModelId(sol).endsWith("[1m]")).toBe(true);
+    expect(toClaudeGatewayModelId(terra).endsWith("[1m]")).toBe(true);
+    expect(toClaudeGatewayModelId(sol512k).endsWith("[1m]")).toBe(false);
+    expect(toClaudeGatewayModelId(sol512k)).toBe("claude-gateway--codex--gpt-5.6-sol-512k");
     expect(toClaudeGatewayModelId(model({ contextWindow: 1_000_000 })).endsWith("[1m]")).toBe(true);
   });
 

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -640,8 +640,9 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(31);
-    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
+    expect(cache.models).toHaveLength(37);
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-512k-fast");
     expect(ids).toContain("claude-gateway--cursor--auto");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5");
     expect(ids).toContain("claude-gateway--cursor--grok-4.5");
@@ -656,7 +657,6 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-luna[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
-    expect(ids.some((id) => id.includes("--codex--") && id.endsWith("[1m]"))).toBe(false);
     expect(cache.models).toContainEqual(expect.objectContaining({
       id: "claude-gateway--cursor--grok-4.5",
       display_name: "Cursor-Grok-4.5",


### PR DESCRIPTION
## Summary
- expose Codex Sol, Luna, and Terra standard and Fast models with 1M context discovery IDs
- add explicit 512K catalog variants backed by the same upstream models and preserve priority-tier routing for Fast variants
- update gateway and Console discovery contracts for the expanded model catalog

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/launch.test.ts`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] live Codex probes for 512K input on Sol, Luna, and Terra and near-1M input on all three models
- [x] live provider-loop routing for all 12 standard/Fast context variants