### PR TITLE
ci: keep patch files under patches/ tracked

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -27,3 +27,9 @@ jobs:
       # Node 22 run locally, where --test rejects a directory. A suite added later is picked up on its own.
       - name: Run repository script tests
         run: node --test scripts/*.test.mjs
+
+      # This gate reads the repository's own git state, so it has to run against the checkout and not
+      # only against fixtures. An ignore rule arrives in a pull request, and Workspace Verify only runs
+      # on canary pushes, so this job is the one that catches it in time. It needs no install either.
+      - name: Check patch files stay tracked
+        run: node scripts/check-patches-tracked.mjs

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:core-boundary": "node scripts/check-core-boundary.mjs",
     "check:core-unified-agent-absent": "node scripts/check-core-unified-agent-absent.mjs",
     "check:localized-attributes": "node scripts/check-localized-attributes.mjs",
+    "check:patches-tracked": "node scripts/check-patches-tracked.mjs",
     "cli": "node scripts/run-isolated.mjs cli",
     "console": "node scripts/run-isolated.mjs console",
     "desktop": "node scripts/run-isolated.mjs desktop",

--- a/scripts/check-patches-tracked.mjs
+++ b/scripts/check-patches-tracked.mjs
@@ -1,0 +1,87 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * patches/ 아래 파일은 저장소가 언제나 추적한다.
+ *
+ * 패치는 생성물처럼 보이지만 다시 만들 수 없다 — pnpm이 patchedDependencies로 이 경로를 직접
+ * 가리키므로, 파일이 빠진 클론은 install에서 서고 무시 규칙에 걸린 클론은 패치 없이 조용히
+ * 빌드된다. 두 번째가 더 나쁘다: 파일을 가진 사람만 고쳐진 의존성을 쓰고, 나머지는 같은
+ * 커밋에서 다른 바이너리를 얻는다.
+ *
+ * 그래서 파일 상태만 보지 않는다. `*.patch`는 흔한 gitignore 항목이라 실수로 들어오기 쉽고,
+ * 그때 이미 추적 중인 파일은 계속 추적되어 아무도 눈치채지 못한 채 다음 패치부터 사라진다.
+ * 존재하지 않는 탐침 경로로 "새 패치가 무시될 규칙이 있는가"를 함께 묻는 이유다.
+ */
+const PATCHES_DIR = "patches";
+// 실재하지 않는 경로들이다. 무시 규칙에만 질의한다. 깊이를 둘 다 묻는 이유는 부정 패턴이
+// 한 깊이만 되살리기 때문이다 — `*.patch` 뒤의 `!patches/*.patch`는 최상위만 구제하고
+// 하위 디렉터리의 패치는 계속 무시한다. 최상위만 물으면 그 규칙이 통과한다.
+const PROBE_PATHS = [
+  `${PATCHES_DIR}/__ignore-probe__.patch`,
+  `${PATCHES_DIR}/__ignore-probe__/__ignore-probe__.patch`,
+];
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.dirname(scriptDir);
+
+export function findPatchTrackingViolations(root = repoRoot) {
+  if (!isGitWorkTree(root)) return [];
+  const violations = [];
+  if (PROBE_PATHS.some((probe) => isIgnored(root, probe))) {
+    violations.push(`${PATCHES_DIR}/: an ignore rule would hide patch files`);
+  }
+  for (const rel of listPatchFiles(root)) {
+    if (isIgnored(root, rel)) violations.push(`${rel}: ignored`);
+    else if (!isTracked(root, rel)) violations.push(`${rel}: untracked`);
+  }
+  return violations;
+}
+
+// 패치가 아직 하나도 없는 저장소도 정상이다. 그 상태에서도 무시 규칙 검사는 남는다.
+function listPatchFiles(root) {
+  const base = path.join(root, PATCHES_DIR);
+  let stat;
+  try { stat = statSync(base); } catch { return []; }
+  if (!stat.isDirectory()) return [];
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(child);
+      else files.push(path.relative(root, child).split(path.sep).join("/"));
+    }
+  };
+  walk(base);
+  return files.sort();
+}
+
+function git(root, args) {
+  return spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+}
+
+function isGitWorkTree(root) {
+  return git(root, ["rev-parse", "--is-inside-work-tree"]).stdout?.trim() === "true";
+}
+
+// --no-index: 이미 추적 중이라는 이유로 규칙을 못 본 척하지 않는다. 추적 여부는 따로 묻는다.
+function isIgnored(root, rel) {
+  return git(root, ["check-ignore", "--quiet", "--no-index", "--", rel]).status === 0;
+}
+
+function isTracked(root, rel) {
+  return git(root, ["ls-files", "--error-unmatch", "--", rel]).status === 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const violations = findPatchTrackingViolations();
+  if (violations.length > 0) {
+    console.error(`files under ${PATCHES_DIR}/ must stay tracked. These do not:`);
+    for (const violation of violations) console.error(`- ${violation}`);
+    console.error(`Drop the ignore rule, or commit the file — pnpm resolves patchedDependencies from ${PATCHES_DIR}/.`);
+    process.exit(1);
+  }
+  console.log(`[check-patches-tracked] no violations — ${PATCHES_DIR}/`);
+}

--- a/scripts/check-patches-tracked.test.mjs
+++ b/scripts/check-patches-tracked.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { findPatchTrackingViolations } from "./check-patches-tracked.mjs";
+
+// 이 게이트가 읽는 것은 파일 내용이 아니라 git의 판정이므로 픽스처도 진짜 저장소여야 한다.
+// 개발자 전역 설정(core.excludesFile 등)이 결과를 흔들지 않도록 끊고 만든다.
+const GIT_ENV = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
+
+function fixture(files, { track = [] } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "patches-gate-"));
+  execFileSync("git", ["init", "--quiet"], { cwd: root, env: GIT_ENV, stdio: "pipe" });
+  // 설정을 끊어도 git은 core.excludesFile의 기본값(~/.config/git/ignore)을 계속 읽는다.
+  // 거기에 `*.patch`를 둔 개발자의 기계에서 이 스위트가 빨개지지 않도록 명시적으로 덮는다.
+  execFileSync("git", ["config", "core.excludesFile", "/dev/null"], { cwd: root, env: GIT_ENV, stdio: "pipe" });
+  for (const [rel, body] of Object.entries(files)) {
+    const target = path.join(root, rel);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, body);
+  }
+  if (track.length > 0) execFileSync("git", ["add", "-f", "--", ...track], { cwd: root, env: GIT_ENV, stdio: "pipe" });
+  return root;
+}
+
+test("passes when the patch file is tracked", () => {
+  const root = fixture({ "patches/expo@1.0.0.patch": "diff --git a/a b/a\n" }, { track: ["patches/expo@1.0.0.patch"] });
+  assert.deepEqual(findPatchTrackingViolations(root), []);
+});
+
+test("reports a patch file nobody committed", () => {
+  const root = fixture({ "patches/expo@1.0.0.patch": "diff --git a/a b/a\n" });
+  assert.deepEqual(findPatchTrackingViolations(root), ["patches/expo@1.0.0.patch: untracked"]);
+});
+
+// 규칙만 들어오고 파일은 아직 멀쩡한 상태가 이 게이트의 존재 이유다 — 다음 패치부터 사라진다.
+test("reports an ignore rule that would hide patch files, with no patch present", () => {
+  const root = fixture({ ".gitignore": "*.patch\n" });
+  assert.deepEqual(findPatchTrackingViolations(root), ["patches/: an ignore rule would hide patch files"]);
+});
+
+// 부정 패턴은 한 깊이만 되살린다. 최상위만 물으면 이 규칙이 통과하고, 다음 하위 패치가 사라진다.
+test("reports a negation that rescues only the top level", () => {
+  const root = fixture({ ".gitignore": "*.patch\n!patches/*.patch\n" });
+  assert.deepEqual(findPatchTrackingViolations(root), ["patches/: an ignore rule would hide patch files"]);
+});
+
+test("reports a tracked patch file that a later ignore rule matches", () => {
+  const root = fixture(
+    { ".gitignore": "*.patch\n", "patches/expo@1.0.0.patch": "diff --git a/a b/a\n" },
+    { track: ["patches/expo@1.0.0.patch"] },
+  );
+  assert.deepEqual(findPatchTrackingViolations(root), [
+    "patches/: an ignore rule would hide patch files",
+    "patches/expo@1.0.0.patch: ignored",
+  ]);
+});
+
+test("covers every file under the directory, not only .patch", () => {
+  const root = fixture({ "patches/README.md": "why these exist\n" });
+  assert.deepEqual(findPatchTrackingViolations(root), ["patches/README.md: untracked"]);
+});
+
+test("passes when the repository carries no patches directory", () => {
+  const root = fixture({ "package.json": "{}\n" }, { track: ["package.json"] });
+  assert.deepEqual(findPatchTrackingViolations(root), []);
+});
+
+test("says nothing outside a git work tree", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "patches-gate-plain-"));
+  mkdirSync(path.join(root, "patches"), { recursive: true });
+  writeFileSync(path.join(root, "patches", "expo@1.0.0.patch"), "diff --git a/a b/a\n");
+  assert.deepEqual(findPatchTrackingViolations(root), []);
+});


### PR DESCRIPTION
`patches/` 아래 파일이 git 추적에서 빠지는 일을 CI에서 막는 저장소 게이트를 추가합니다.

## 왜

패치는 생성물처럼 보이지만 다시 만들 수 없습니다. pnpm이 `patchedDependencies`로 이 경로를 직접 가리키므로, 파일이 빠진 클론은 install에서 서고 무시 규칙에 걸린 클론은 패치 없이 조용히 빌드됩니다. 두 번째가 더 나쁩니다 — 파일을 가진 사람만 고쳐진 의존성을 쓰고, 나머지는 같은 커밋에서 다른 바이너리를 얻습니다.

`*.patch`는 흔한 gitignore 항목이고, 그런 규칙이 들어와도 **이미 추적 중인 파일은 계속 추적되므로** 아무도 눈치채지 못합니다. 다음 패치부터 사라집니다.

## 무엇을

- `scripts/check-patches-tracked.mjs` — `patches/` 아래 모든 파일이 추적되고 무시되지 않는지 확인하고, 아직 존재하지 않는 패치를 숨길 무시 규칙이 있는지 **탐침 경로**로 함께 묻습니다. 탐침은 두 깊이를 쓰는데, `*.patch` 뒤의 `!patches/*.patch` 같은 부정 패턴이 최상위만 구제하고 하위 디렉터리는 계속 무시하기 때문입니다.
- `scripts/check-patches-tracked.test.mjs` — 임시 git 저장소 픽스처 8건. 개발자의 `~/.config/git/ignore`가 결과를 흔들지 않도록 `core.excludesFile`을 명시적으로 끊습니다.
- `pnpm check:patches-tracked` 스크립트 키.
- `Scripts Tests` 워크플로에 게이트 실행 스텝. 이 잡은 PR에서 발화하고 설치가 필요 없습니다 — 무시 규칙은 PR로 들어오는데 `Workspace Verify`는 canary push에서만 돌기 때문입니다.

현재 canary에는 `patches/`가 없으므로 게이트는 조용히 통과하고, 첫 패치(#778)가 들어오는 순간부터 실효가 생깁니다.

## 검증

- `node --test scripts/*.test.mjs` 67/67 통과 (신규 8건 포함)
- 이 워크트리에서 게이트 exit 0, `patches/`가 실재하는 PR #778 워크트리에 대해서도 위반 0
- `.gitignore`에 `*.patch`를 실제로 넣고 돌려 exit 1과 위반 메시지를 확인한 뒤 되돌림
- `*.patch` + `!patches/*.patch`만 있고 파일은 없는 저장소에서 위반 검출 확인 (탐침 보강 전에는 통과했음)
- `XDG_CONFIG_HOME`에 `*.patch` 전역 무시를 주입한 상태에서도 스위트 8/8 통과
- `git diff --check` 클린

사용자가 인지하는 제품 변화가 아니라 changelog fragment는 넣지 않았습니다.