### PR TITLE
feat(fleet-console): tell an unopened arrival apart from a real wait

### DIFF
--- a/.changelog.d/sidebar-unseen-mark.md
+++ b/.changelog.d/sidebar-unseen-mark.md
@@ -1,0 +1,8 @@
+---
+branch: sidebar-unseen-mark
+---
+
+### fleet-console
+#### Changed
+- The activity mark now separates an operation that is waiting for you from one that finished without being opened. Waiting keeps the cyan calling pulse; a finished, unacknowledged operation carries the green of a finished run and says so with a slow blink instead. Both still gather at the top of the status list, so nothing moves out of sight to gain the distinction.
+  ko: 활동 마크가 답을 기다리는 Operation과 열지 않은 채 끝난 Operation을 갈라서 말합니다. 기다리는 쪽은 부르는 청록 맥동을 그대로 쓰고, 끝났지만 확인하지 않은 쪽은 끝난 일의 초록에 느린 점등을 얹습니다. 둘 다 상태 목록 위쪽에 그대로 모이므로, 구별을 얻자고 눈에서 멀어지는 항목은 없습니다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -4,7 +4,7 @@ import type { OperationActivityVisual } from "../operation-activity.js";
 
 import { useT } from "../i18n/index.js";
 import { getIdleArrivalIds } from "../operation-idle-arrival.js";
-import { operationActivityVisual, resolveOperationActivity, resolveOperationDisplayActivity } from "../operation-activity.js";
+import { operationActivityVisual, operationMarkVisual, resolveOperationActivity, resolveOperationDisplayActivity, resolveOperationMarkVisual } from "../operation-activity.js";
 import { useOperationStatusDetails } from "../operation-status-detail-store.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import type { OperationGeometry, OperationNode } from "../types.js";
@@ -1374,8 +1374,9 @@ function renderTriageMapDots(
   return band.mapMarkers?.map((marker) => {
     const operation = band.operations.find((candidate) => candidate.id === marker.operationId);
     if (!operation) return null;
-    // 카드·지도·사이드바가 같은 display-state resolver를 써서 유휴 도착을 모두 대기로 읽는다.
-    const visual = operationActivityVisual(resolveOperationDisplayActivity({
+    // 점·사이드바 칩·커맨드 밴드가 같은 마크 축을 써서 도착을 "unseen"(초록 느린 점등)으로 읽는다.
+    // 선별 축(대기 밴드 정렬·무대 승격)은 그대로 표시 활동을 쓴다 — 색과 배치는 다른 질문이다.
+    const visual = operationMarkVisual(resolveOperationMarkVisual({
       activity: resolveOperationActivity(operation, operationRuntime),
       operationId: operation.id,
       idleArrivalIds: getIdleArrivalIds(),

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -13,7 +13,7 @@ import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
 import { ViewModeToggle } from "./view-mode-toggle.js";
 import { OperationStatusIcon } from "./operation-status-icon.js";
 import { useConsoleState } from "../hooks/use-store.js";
-import { resolveOperationActivity, resolveOperationDisplayActivity } from "../operation-activity.js";
+import { resolveOperationActivity, resolveOperationMarkVisual } from "../operation-activity.js";
 import { getIdleArrivalIds, subscribeIdleArrival } from "../operation-idle-arrival.js";
 import { setRailChromeExpanded, toggleRailChrome, useRailChromeExpanded } from "../rail/rail-store.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
@@ -130,11 +130,13 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const activeLaunchModel = typeof activeOperation?.payload.launchModel === "string" ? activeOperation.payload.launchModel : null;
   // 사이드바 칩과 같은 규율: 이름 왼쪽 슬롯은 활동 상태가 가져간다. 무엇으로 띄웠는지가 아니라
   // 지금 무엇을 하고 있는지가 먼저 읽혀야 한다. 모델 이름은 스위처 메뉴 메타로만 남긴다.
-  // 도착 승격까지 사이드바·덱과 같은 표시 활동으로 읽는다 — War Room이 도착 항목을 무대에 올릴 때는
-  // 확인 처리를 미루므로(acknowledged: false), raw 활동만 보면 목록은 대기라는 그 패널을 밴드만 유휴라 부른다.
+  // 마크는 사이드바 칩·지도 점과 같은 마크 축을 읽는다 — 미확인 도착은 AWAITING이 아니라 "unseen"
+  // 이므로 초록 느린 점등으로 그려진다. raw 활동만 보면 목록은 도착이라는 그 패널을 밴드만 유휴라
+  // 부르고(War Room 무대 승격은 acknowledged: false라 도착 표식이 살아남는다), 표시 활동을 그대로
+  // 쓰면 이번엔 안 본 채 끝난 것이 사람을 기다리는 중과 같은 파랑으로 서 버린다.
   const activeOperationStatusMark = activeOperation
     ? <OperationStatusIcon
-        status={resolveOperationDisplayActivity({
+        status={resolveOperationMarkVisual({
           activity: resolveOperationActivity(activeOperation, state.operationRuntime),
           operationId: activeOperation.id,
           idleArrivalIds,

--- a/runtime/fleet-console/core/client/src/components/operation-status-icon.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-status-icon.tsx
@@ -1,28 +1,29 @@
-import { operationActivityLabel, operationActivityVisual, type OperationActivityVisual } from "../operation-activity.js";
+import { operationMarkLabel, operationMarkVisual, type OperationMarkVisual } from "../operation-activity.js";
 
 /**
  * Operation 활동 상태를 그리는 단일 조형. 사이드바 칩·War Room·커맨드 밴드·모바일 목록이
  * 같은 마크를 쓴다 — 표면마다 다른 조형을 두면 같은 사실이 표면 수만큼의 이야기로 갈라진다.
  * 조형은 둥근 네모 하나뿐이다(원형 폐지). 상태는 채움·중공·발광·맥동으로만 갈린다.
  */
-export function operationStatusIconClass(status: OperationActivityVisual | undefined): string {
-  const visual = operationActivityVisual(status);
+export function operationStatusIconClass(status: OperationMarkVisual | undefined): string {
+  const visual = operationMarkVisual(status);
   if (visual === "running") return "tenant-beacon is-turn-running";
   if (visual === "background") return "tenant-beacon is-background";
   if (visual === "awaiting") return "tenant-beacon is-awaiting";
+  if (visual === "unseen") return "tenant-beacon is-unseen";
   if (visual === "ended") return "tenant-beacon is-ended";
   return "tenant-beacon is-idle";
 }
 
 interface OperationStatusIconProps {
-  readonly status: OperationActivityVisual | undefined;
+  readonly status: OperationMarkVisual | undefined;
   /** 마크를 감싼 요소가 이미 상태를 접근성 이름으로 말하는 자리 — 중복 낭독을 막는다. */
   readonly decorative?: boolean;
   readonly className?: string;
 }
 
 export function OperationStatusIcon({ status, decorative = false, className }: OperationStatusIconProps) {
-  const label = operationActivityLabel(status);
+  const label = operationMarkLabel(status);
   const classes = [operationStatusIconClass(status), className].filter(Boolean).join(" ");
   if (decorative) return <span className={classes} aria-hidden="true" title={label} />;
   return <span className={classes} role="img" aria-label={label} title={label} />;

--- a/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
@@ -331,6 +331,9 @@ export const pagesEn = {
   "activity.awaiting": "Awaiting input",
   "activity.ended": "Ended",
   "activity.idle": "Idle",
+  // War Room은 무대에 올린 패널의 확인 처리를 미루므로(acknowledged: false), 눈앞에 열려 있는
+  // 패널도 이 마크를 단다 — "아직 열지 않음"은 그 자리에서 거짓이 된다. 확인 여부로만 말한다.
+  "activity.unseen": "Finished, unacknowledged",
 
   // codex — cowork
   "codex.cowork.requestFailed": "Cowork request failed.",
@@ -816,6 +819,7 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "activity.awaiting": "대기",
   "activity.ended": "종료됨",
   "activity.idle": "유휴",
+  "activity.unseen": "종료됨 — 확인 전",
 
   "codex.cowork.requestFailed": "Cowork 요청에 실패했습니다.",
   "codex.cowork.draftChangesAria": "초안 변경",

--- a/runtime/fleet-console/core/client/src/operation-activity.ts
+++ b/runtime/fleet-console/core/client/src/operation-activity.ts
@@ -72,6 +72,28 @@ export function resolveOperationDisplayActivity({
   return activity === "idle" && idleArrivalIds.has(operationId) ? "awaiting" : activity;
 }
 
+// 마크 축 — 상태 마크가 그리는 값. 섹션·선별 축(resolveOperationDisplayActivity)과 갈라진다:
+// 그쪽은 미확인 도착을 AWAITING 칸에 세워 사용자가 놓치지 않게 하고, 이쪽은 그것을 자기 값으로
+// 남겨 색이 사실을 바꾸지 않게 한다. 사람을 기다리는 중(aurora)과 이미 끝났는데 안 본 것(positive)은
+// 다른 일이고, 한 색으로 뭉치면 화면은 둘을 구별해 주지 못한다.
+export type OperationMarkVisual = OperationActivityVisual | "unseen";
+
+export function resolveOperationMarkVisual({
+  activity,
+  operationId,
+  idleArrivalIds,
+}: {
+  readonly activity: OperationActivityVisual;
+  readonly operationId: string;
+  readonly idleArrivalIds: ReadonlySet<string>;
+}): OperationMarkVisual {
+  return activity === "idle" && idleArrivalIds.has(operationId) ? "unseen" : activity;
+}
+
+export function operationMarkVisual(mark: OperationMarkVisual | undefined): OperationMarkVisual {
+  return mark === "unseen" ? "unseen" : operationActivityVisual(mark);
+}
+
 export function operationActivityVisual(status: OperationActivityVisual | undefined): OperationActivityVisual {
   if (status === "running") return "running";
   if (status === "background") return "background";
@@ -87,6 +109,11 @@ function resolveActiveLocale() {
       ? navigator.language.toLowerCase()
       : "";
   return resolveConsoleLanguage(preference, navigatorLanguage);
+}
+
+export function operationMarkLabel(mark: OperationMarkVisual | undefined): string {
+  if (mark === "unseen") return getT(resolveActiveLocale())("activity.unseen");
+  return operationActivityLabel(mark);
 }
 
 export function operationActivityLabel(status: OperationActivityVisual | undefined): string {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, type CSSProperties, type PointerEvent as ReactPointe
 
 import { OperationStatusIcon } from "../components/operation-status-icon.js";
 import { useT } from "../i18n/index.js";
-import { type OperationActivityVisual } from "../operation-activity.js";
+import { type OperationActivityVisual, type OperationMarkVisual } from "../operation-activity.js";
 import { useInlineRename } from "../use-inline-rename.js";
 import type { OperationNode } from "../types.js";
 import {
@@ -16,7 +16,16 @@ export interface SideBarEntry {
   readonly active: boolean;
   readonly minimized: boolean;
   readonly notificationCount: number;
+  /**
+   * 활동 — 섹션 분류의 입력. groupOperationsByStatus가 이 값에서 칸을 정하며(미확인 도착은 거기서
+   * AWAITING으로 승격된다), 승격은 그 함수 하나만 소유한다.
+   */
   readonly status?: OperationActivityVisual;
+  /**
+   * 마크 축 — 마크가 그리는 값. 섹션 축과 갈라지는 유일한 값이 "unseen"이다: 칸은 AWAITING이되
+   * 색은 초록(느린 점등)이라, 진짜 대기와 안 본 채 끝난 것이 한 화면에서 구별된다.
+   */
+  readonly mark?: OperationMarkVisual;
   /**
    * 플러그인이 준 실행 표면 표식(예: "CHAT"). 호스트는 뜻을 모른 채 글자만 그린다 —
    * 색은 활동을 말하는 자리이므로 모드는 신호 채널을 빌리지 않는다.
@@ -92,7 +101,9 @@ export function OperationsSideBarChip({
   const t = useT();
   const chipRef = useRef<HTMLLIElement | null>(null);
   const suppressClickRef = useRef(false);
-  const { operation, active, minimized, status, surface } = entry;
+  const { operation, active, minimized, status, mark, surface } = entry;
+  // 마크 축이 없는 엔트리(직접 구성한 입력)는 섹션 축을 그대로 그린다 — 두 축은 "unseen"에서만 갈린다.
+  const markVisual = mark ?? status;
   const title = displayTitle(operation);
   // 전역 선별 목록에서 같은 제목이 여러 Theater에 있을 수 있다 — pill은 장식(aria-hidden)이므로
   // 소속 Theater를 접근성 이름에 함께 싣는다. 기존 aria 키의 groupContext 슬롯을 재사용한다.
@@ -226,7 +237,7 @@ export function OperationsSideBarChip({
           띄웠는지가 아니라 지금 무엇을 하고 있는지다. 칩 자체가 상태를 접근성 이름으로
           말하지 않으므로 마크가 그 이름을 진다. */}
       <span className="side-bar-chip-beacon-button">
-        <OperationStatusIcon status={status} className="side-bar-chip-status" />
+        <OperationStatusIcon status={markVisual} className="side-bar-chip-status" />
       </span>
       {rename.renaming ? (
         <input

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -17,7 +17,7 @@ import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
 import { getTheaterCanvasSnapshot, setOperationOrder, toggleGroupCollapsed, toggleTheaterGroupCollapsed, useCanvasState, useCollapsedGroups } from "../canvas/canvas-store.js";
 import { consumeOperationLaunchMenu, consumeSideBarAddTheater, consumeSideBarTheaterLaunch, sortOperationsByOrder } from "../store.js";
-import { operationRuntimeSurface, resolveOperationActivity, resolveOperationDisplayActivity } from "../operation-activity.js";
+import { operationRuntimeSurface, resolveOperationActivity, resolveOperationDisplayActivity, resolveOperationMarkVisual } from "../operation-activity.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderTheaterIds, reorderWithinSegment, theaterDropIndexFromPoint, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { useContextMenuKeyboard } from "./context-menu-keyboard.js";
 import {
@@ -390,20 +390,21 @@ export function OperationsSideBar({
   const activeGroups = groups.filter((group) => group.theaterId === activeTheaterId);
   const minimizedSet = new Set(minimized);
   const collapsedGroupSet = new Set(collapsedGroups);
-  // 엔트리는 처음부터 표시 활동을 싣는다 — 미확인 도착으로 AWAITING에 오른 Operation이 축마다
-  // 다른 상태를 말하지 않도록, 그룹축·상태축·복구 선반이 같은 값을 받는다.
-  const allEntries: SideBarEntry[] = sortOperationsByOrder(activeOperations, canvas.operationOrder).map((operation) => ({
-    operation,
-    active: activeOperationId === operation.id,
-    minimized: minimizedSet.has(operation.id),
-    notificationCount: operationNotifications[operation.id] ? 1 : 0,
-    status: resolveOperationDisplayActivity({
-      activity: resolveOperationActivity(operation, operationRuntime),
-      operationId: operation.id,
-      idleArrivalIds,
-    }),
-    ...(operationRuntimeSurface(operationRuntime[operation.id]) ? { surface: operationRuntimeSurface(operationRuntime[operation.id])! } : {}),
-  }));
+  // 엔트리는 raw 활동과 마크 축을 싣는다. 섹션 승격은 groupOperationsByStatus가 혼자 소유한다 —
+  // 여기서 미리 승격해 두면 그 함수가 같은 계산을 다시 해 값이 겹치고, 겹친 값은 어느 표면에도
+  // 드러나지 않아 틀려도 아무 테스트가 죽지 않는다. 그리는 값은 언제나 mark다.
+  const allEntries: SideBarEntry[] = sortOperationsByOrder(activeOperations, canvas.operationOrder).map((operation) => {
+    const activity = resolveOperationActivity(operation, operationRuntime);
+    return {
+      operation,
+      active: activeOperationId === operation.id,
+      minimized: minimizedSet.has(operation.id),
+      notificationCount: operationNotifications[operation.id] ? 1 : 0,
+      status: activity,
+      mark: resolveOperationMarkVisual({ activity, operationId: operation.id, idleArrivalIds }),
+      ...(operationRuntimeSurface(operationRuntime[operation.id]) ? { surface: operationRuntimeSurface(operationRuntime[operation.id])! } : {}),
+    };
+  });
   const groupedSections = groupOperations(allEntries, activeGroups, canvas.operationOrder);
   const { living: statusSections, minimized: minimizedSection, dormant: dormantSection } = groupTheaterStatusEntries(
     allEntries,
@@ -1285,10 +1286,11 @@ export function groupOperationsByStatus(
   return buildStatusSectionOrder(t).map(({ status, label }) => ({
     status,
     label,
-    // 사이드바 엔트리는 생성 시점에 이미 표시 활동으로 해소되므로 여기서의 승격은 멱등이다.
-    // 그래도 남겨 둔다 — 이 함수는 raw 활동으로 직접 구성된 입력도 받으며, 칸을 정한 표시 활동을
-    // 엔트리에도 실어 보내야 섹션과 행의 마크가 같은 화면에서 다른 상태를 말하지 않는다.
-    // 미해소(undefined) 엔트리의 idle 폭백은 그 직접 구성 입력에 대한 방어 계약이다.
+    // 섹션 승격은 이 함수 하나가 소유한다 — 도착한 행을 AWAITING 칸에 세워 놓치지 않게 하는 것은
+    // 배치의 결정이고, 그 행을 무슨 색으로 그릴지는 마크 축(entry.mark)의 결정이다. 둘을 한 값으로
+    // 합치면 색이 칸을 따라가 "사람을 기다리는 중"과 "안 본 채 끝난 것"이 같은 파랑이 된다.
+    // 칸을 정한 값을 엔트리의 status에도 실어 보낸다: 섹션 헤더와 행이 같은 분류를 들고 있어야 한다.
+    // 미해소(undefined) 엔트리의 idle 폭백은 직접 구성된 입력에 대한 방어 계약이다.
     entries: entries
       .flatMap((entry) => {
         const display = resolveOperationDisplayActivity({
@@ -1348,18 +1350,18 @@ export function buildTheaterEntries({
   return sortOperationsByOrder(
     operations.filter((operation) => operation.theaterId === theaterId),
     operationOrder,
-  ).map((operation) => ({
-    operation,
-    active: activeOperationId === operation.id,
-    minimized: minimizedSet.has(operation.id),
-    notificationCount: operationNotifications[operation.id] ? 1 : 0,
-    status: resolveOperationDisplayActivity({
-      activity: resolveOperationActivity(operation, operationRuntime),
-      operationId: operation.id,
-      idleArrivalIds,
-    }),
-    ...(operationRuntimeSurface(operationRuntime[operation.id]) ? { surface: operationRuntimeSurface(operationRuntime[operation.id])! } : {}),
-  }));
+  ).map((operation) => {
+    const activity = resolveOperationActivity(operation, operationRuntime);
+    return {
+      operation,
+      active: activeOperationId === operation.id,
+      minimized: minimizedSet.has(operation.id),
+      notificationCount: operationNotifications[operation.id] ? 1 : 0,
+      status: activity,
+      mark: resolveOperationMarkVisual({ activity, operationId: operation.id, idleArrivalIds }),
+      ...(operationRuntimeSurface(operationRuntime[operation.id]) ? { surface: operationRuntimeSurface(operationRuntime[operation.id])! } : {}),
+    };
+  });
 }
 
 function TheaterSectionHeader({

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2549,8 +2549,13 @@
   --activity-glow: var(--warn-glow);
 }
 
+/* 미확인 완료는 유휴와 같은 초록을 쓴다 — 이미 끝난 일이라는 사실이 색을 정하고, 아직 열지
+   않았다는 것은 색이 아니라 느린 점등이 말한다. 상태 섹션에는 자기 칸이 없다(승격되어 AWAITING
+   칸에 선다): 색과 칸이 갈리는 자리이며, 놓치지 않게 위로 모으는 쪽을 택한 결과다. */
 .tenant-beacon.is-idle,
+.tenant-beacon.is-unseen,
 .canvas-triage-map-dot.is-idle,
+.canvas-triage-map-dot.is-unseen,
 .side-bar-status-section--idle {
   --activity-color: var(--positive);
   --activity-glow: var(--positive-glow);
@@ -2634,6 +2639,33 @@
 .tenant-beacon.is-idle {
   background: var(--activity-color);
   box-shadow: 0 0 9px var(--activity-glow);
+}
+
+/* unseen — 끝났지만 아직 열지 않음. 색은 유휴와 같은 그린이고, 느린 점등만이 미확인을 말한다.
+   주기는 awaiting 맥동(1.8s)의 두 배라 "부르는 중"과 "안 본 채 끝난 것"이 한눈에 갈린다.
+   키프레임의 0%/100%는 완전 점등이다 — reduced-motion이 1회로 잘라도 켜진 채 남는다. */
+.tenant-beacon.is-unseen {
+  background: var(--activity-color);
+  /* 정지 상태를 키프레임의 0%와 같게 못박는다 — 애니메이션은 fill-mode: none이라 reduced-motion이
+     1회로 자르고 나면 요소 자기 스타일로 되돌아온다. 글로우를 키프레임에만 두면 그 자리에서
+     마크가 유휴(9px 글로우)보다도 약한 평평한 사각으로 남는다. */
+  box-shadow: 0 0 10px 1px var(--activity-glow);
+  animation: beacon-unseen-blink 3.6s var(--ease-glide) infinite;
+}
+
+/* 활동 축의 --activity-glow를 읽으므로 theme.css가 아니라 이 파일에 산다 — 토큰이 선언되는
+   스코프 밖에 키프레임을 두면 커스텀 속성 계약 게이트가 미정의 참조로 잡는다.
+   시작·끝을 모두 완전 점등으로 못박는다: reduced-motion이 1회로 잘라도 켜진 채 남아야 한다. */
+@keyframes beacon-unseen-blink {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 10px 1px var(--activity-glow);
+  }
+  50% {
+    opacity: 0.38;
+    box-shadow: 0 0 0 0 var(--activity-glow);
+  }
 }
 
 .status-dot--lg {
@@ -3323,6 +3355,28 @@
 
 /* deferred는 사용자가 이미 본 항목이다 — fresh-card와 같은 제외로 다시 흔들지 않는다. */
 .canvas-triage-map-dot.is-awaiting.is-deferred::after {
+  animation: none;
+  opacity: 0.6;
+}
+
+/* 지도의 미확인 — 점 자체의 animation은 지도 모드의 유영(triage-map-drift)이 소유하므로,
+   느린 점등은 ::after 후광이 진다. 비콘과 같은 키프레임을 써서 두 표면의 박자를 맞춘다. */
+.canvas-triage-map-dot.is-unseen {
+  box-shadow: 0 0 11px var(--activity-glow);
+  opacity: 1;
+}
+
+.canvas-triage-map-dot.is-unseen::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: 4px;
+  box-shadow: 0 0 12px 2px var(--activity-glow);
+  animation: beacon-unseen-blink 3.6s var(--ease-glide) infinite;
+}
+
+/* deferred는 사용자가 이미 본 항목이다 — awaiting 링과 같은 제외로 다시 흔들지 않는다. */
+.canvas-triage-map-dot.is-unseen.is-deferred::after {
   animation: none;
   opacity: 0.6;
 }

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -81,9 +81,11 @@ describe("Command Band switcher disclosure", () => {
     const styles = readFileSync(resolve(process.cwd(), "core/client/src/styles/layout.css"), "utf8");
 
     // 이름 왼쪽 슬롯은 활동 상태가 소유한다 — 공급자 글리프는 이 표면에서 물러났다.
-    // 사이드바·덱과 같은 표시 활동을 읽어야 한다: raw 활동만 보면 War Room이 무대에 올린 도착 항목을
-    // 목록은 대기라 하고 밴드만 유휴라 부른다(무대 승격이 acknowledged: false로 확인을 미루기 때문).
-    expect(source).toContain("resolveOperationDisplayActivity({");
+    // 사이드바 칩·지도 점과 같은 마크 축을 읽어야 한다: raw 활동만 보면 War Room이 무대에 올린 도착
+    // 항목을 목록은 도착이라 하고 밴드만 유휴라 부르고(무대 승격이 acknowledged: false로 확인을
+    // 미룬다), 섹션 축을 그대로 쓰면 안 본 채 끝난 것이 진짜 대기와 같은 파랑으로 서 버린다.
+    expect(source).toContain("resolveOperationMarkVisual({");
+    expect(source).not.toContain("resolveOperationDisplayActivity");
     expect(source).toContain("activity: resolveOperationActivity(activeOperation, state.operationRuntime),");
     expect(source).toContain("idleArrivalIds,");
     expect(source).toContain("{activeOperationStatusMark}");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1223,6 +1223,10 @@ describe("Instrument core design contract", () => {
     const idleArrival = source("operation-idle-arrival.ts");
     const chip = source("sidebar/operations-side-bar-chip.tsx");
     const components = source("styles/components.css");
+    const theme = source("styles/theme.css");
+    const activity = source("operation-activity.ts");
+    const commandBand = source("components/command-band.tsx");
+    const watchDeck = source("canvas/triage-watch-deck.tsx");
 
     expect(operations).toContain('event.code === "KeyS" && !event.shiftKey');
     expect(operations).toContain("toggleSideBarStatusAxis();");
@@ -1243,9 +1247,8 @@ describe("Instrument core design contract", () => {
     expect(chip).not.toContain("idleUnseen");
     expect(sidebar).not.toContain("idleUnseen");
     expect(sidebar).not.toContain("side-bar-status-header__unseen");
-    // 사이드바 엔트리는 생성 시점부터 표시 활동을 싣는다 — 그룹축·복구 선반이 raw idle을 그리면
-    // 도착한 Operation이 축마다 다른 상태를 말한다.
-    expect(sidebar).toContain("status: resolveOperationDisplayActivity({");
+    // 그룹축·복구 선반이 raw idle을 그리면 도착한 Operation이 축마다 다른 상태를 말한다 — 그래서
+    // 모든 사이드바 표면이 마크 축을 읽는다(아래 마크/섹션 계약이 그 배선을 고정한다).
     expect(sideBarStore).toContain("let statusAxis = false;");
     expect(sideBarStore).toContain("let statusTransitionTicks = new Map<string, number>();");
     expect(idleArrival).toContain("let idleArrivalIds = new Set<string>();");
@@ -1262,7 +1265,8 @@ describe("Instrument core design contract", () => {
     // The group header does not repeat the rounded activity mark; chips and panels already do.
     expect(sidebar).toContain("groupMarkByGroupId.get(entry.operation.groupId)");
     expect(components).toContain(".tenant-beacon.is-awaiting,\n.canvas-triage-map-dot.is-awaiting,\n.side-bar-status-section--awaiting {");
-    expect(components).toMatch(/\.tenant-beacon\.is-idle,\s*\.canvas-triage-map-dot\.is-idle,\s*\.side-bar-status-section--idle\s*\{[^}]*--activity-color:\s*var\(--positive\)/);
+    // 미확인 완료는 유휴와 같은 --positive를 받는다 — 색은 "끝난 일"을 말하고, 미확인은 모션이 말한다.
+    expect(components).toMatch(/\.tenant-beacon\.is-idle,\s*\.tenant-beacon\.is-unseen,\s*\.canvas-triage-map-dot\.is-idle,\s*\.canvas-triage-map-dot\.is-unseen,\s*\.side-bar-status-section--idle\s*\{[^}]*--activity-color:\s*var\(--positive\)/);
     expect(components).toContain(".tenant-beacon.is-ended,\n.canvas-triage-map-dot.is-ended,\n.side-bar-status-section--ended {");
     expect(components).toContain("--activity-color: var(--ink-fog);");
     expect(components).toMatch(/\.tenant-beacon\.is-background,\s*\.canvas-triage-map-dot\.is-background,\s*\.side-bar-status-section--background\s*\{[^}]*--activity-color:\s*var\(--warn\)/);
@@ -1276,10 +1280,32 @@ describe("Instrument core design contract", () => {
     expect(sidebar).not.toContain("side-bar-status-header__dot");
     expect(components).not.toContain(".side-bar-status-header__dot");
     expect(components).toContain("background: var(--group-mark);");
-    // 사이드바에는 미확인 도착 전용 표면이 없다 — 상태 마크(aurora AWAITING)가 그 사실을 혼자 나른다.
+    // 사이드바에는 미확인 도착 전용 표면이 없다 — 상태 마크가 그 사실을 혼자 나른다.
     expect(components).not.toContain(".side-bar-chip-unseen");
     expect(components).not.toContain(".side-bar-chip--unseen");
     expect(components).not.toContain(".side-bar-status-header__unseen");
+    // 마크 축은 진짜 대기(aurora 1.8s 호출 맥동)와 미확인 완료(positive 3.6s 느린 점등)를 갈라 그린다.
+    // 두 사실이 한 색이면 화면은 "사람을 기다리는 중"과 "안 본 채 끝난 것"을 구별해 주지 못한다.
+    expect(components).toMatch(/\.tenant-beacon\.is-unseen \{[^}]*background:\s*var\(--activity-color\);[^}]*box-shadow:\s*0 0 10px 1px var\(--activity-glow\);\s*animation:\s*beacon-unseen-blink 3\.6s/);
+    expect(components).toMatch(/\.tenant-beacon\.is-awaiting \{[^}]*animation:\s*aurora-pulse 1\.8s/);
+    // 키프레임은 --activity-glow가 사는 이 파일에 있어야 하고, 0%/100%가 완전 점등이어야 한다 —
+    // reduced-motion이 iteration-count를 1로 자를 때 꺼진 채 남으면 신호가 사라진다.
+    expect(components).toMatch(/@keyframes beacon-unseen-blink \{\s*0%,\s*100% \{\s*opacity: 1;/);
+    expect(theme).not.toContain("@keyframes beacon-unseen-blink");
+    // 지도 점은 유영 애니메이션이 점 자체를 소유하므로 느린 점등을 ::after 후광에 싣는다.
+    expect(components).toMatch(/\.canvas-triage-map-dot\.is-unseen::after \{[^}]*animation:\s*beacon-unseen-blink 3\.6s/);
+    expect(components).toMatch(/\.canvas-triage-map-dot\.is-unseen\.is-deferred::after \{[^}]*animation:\s*none/);
+    // 마크 축과 섹션 축은 갈라진 채로 각자의 자리에 실린다 — 하나로 합치면 색이 칸을 따라간다.
+    expect(activity).toContain('return activity === "idle" && idleArrivalIds.has(operationId) ? "unseen" : activity;');
+    expect(activity).toContain('return activity === "idle" && idleArrivalIds.has(operationId) ? "awaiting" : activity;');
+    // 생성 지점은 raw 활동과 마크만 싣는다 — 섹션 승격을 여기서도 해 두면 groupOperationsByStatus가
+    // 같은 계산을 다시 해 값이 겹치고, 겹친 값은 어느 표면에도 드러나지 않아 틀려도 아무 테스트가 죽지 않는다.
+    expect(sidebar).toContain("mark: resolveOperationMarkVisual({ activity, operationId: operation.id, idleArrivalIds }),");
+    expect(sidebar).toContain("      status: activity,");
+    expect(sidebar).not.toContain("status: resolveOperationDisplayActivity({");
+    expect(chip).toContain("const markVisual = mark ?? status;");
+    expect(commandBand).toContain("status={resolveOperationMarkVisual({");
+    expect(watchDeck).toContain("const visual = operationMarkVisual(resolveOperationMarkVisual({");
     // 미확인 완료는 패널 아웃라인이 아니라 캡션 아랫변 레일이 나른다 — 상시 aura는 사라졌다.
     expect(components).toMatch(/\.canvas-operation\.is-unseen \{[^}]*--caption-rail:\s*var\(--positive\)/);
     expect(components).not.toContain(".canvas-operation.is-unseen.is-active {");

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -162,18 +162,37 @@ describe("OperationsSideBar STATUS axis", () => {
 
   // 도착으로 AWAITING에 오른 행은 그 승격을 마크로도 말해야 한다 — 섹션은 대기라고 하는데
   // 마크만 유휴로 남으면 같은 행이 한 화면에서 두 상태를 말한다.
-  it("marks an idle arrival promoted into AWAITING as awaiting, not idle", () => {
+  it("stands an idle arrival in AWAITING but marks it unseen, not awaiting", () => {
     const operation = makeOperation("arrived", null);
     setConsoleState({ operationRuntime: { arrived: { lifecycle: "live", activity: "idle" } } });
     markIdleArrival(operation.id);
     setSideBarStatusAxis(true);
     renderSideBar([operation]);
 
+    // 두 축이 갈라지는 유일한 자리 — 칸은 AWAITING(놓치지 않게 위로), 마크는 unseen(안 본 채 끝난 것).
     const chip = required<HTMLElement>('.side-bar-status-section--awaiting [data-side-bar-chip-id="arrived"]');
     const mark = required<HTMLElement>('.side-bar-status-section--awaiting [data-side-bar-chip-id="arrived"] .side-bar-chip-status');
     expect(chip).not.toBeNull();
-    expect(mark.className).toContain("is-awaiting");
-    expect(mark.getAttribute("aria-label")).toBe("Awaiting input");
+    expect(mark.className).toContain("is-unseen");
+    expect(mark.className).not.toContain("is-awaiting");
+    expect(mark.getAttribute("aria-label")).toBe("Finished, unacknowledged");
+  });
+
+  it("marks a genuine awaiting Operation as awaiting even while an arrival shares its section", () => {
+    const genuine = { ...makeOperation("genuine", null), title: "genuine" };
+    const arrived = { ...makeOperation("arrived", null), title: "arrived" };
+    setConsoleState({ operationRuntime: {
+      genuine: { lifecycle: "live", activity: "awaiting" },
+      arrived: { lifecycle: "live", activity: "idle" },
+    } });
+    markIdleArrival("arrived");
+    setSideBarStatusAxis(true);
+    renderSideBar([genuine, arrived]);
+
+    const section = required<HTMLElement>(".side-bar-status-section--awaiting");
+    expect(section.querySelectorAll("[data-side-bar-chip-id]").length).toBe(2);
+    expect(required<HTMLElement>('[data-side-bar-chip-id="genuine"] .side-bar-chip-status').className).toContain("tenant-beacon is-awaiting");
+    expect(required<HTMLElement>('[data-side-bar-chip-id="arrived"] .side-bar-chip-status').className).toContain("tenant-beacon is-unseen");
   });
 
   it("continues to reveal an ordinary idle Operation from the IDLE section", () => {
@@ -233,7 +252,7 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(bravo.querySelector('.side-bar-status-section--running [aria-label="Expand section RUNNING"]')).not.toBeNull();
   });
 
-  it("suppresses group pills but keeps the status mark and promotes an idle arrival to AWAITING in inactive Theater preview chips", () => {
+  it("suppresses group pills but keeps the status mark and marks an idle arrival unseen in inactive Theater preview chips", () => {
     setConsoleState({ operationRuntime: { preview: { lifecycle: "live", activity: "running" } } });
     setSideBarStatusAxis(true);
     renderSideBar([makeOperation("preview", "group-a")], [GROUP_A], vi.fn(), "theater-other");
@@ -246,17 +265,17 @@ describe("OperationsSideBar STATUS axis", () => {
 
     act(() => setConsoleState({ operationRuntime: { preview: { lifecycle: "live", activity: "idle" } } }));
 
-    // 미확인 도착은 별도 표식이 아니라 표시 활동의 AWAITING이다 — peek 칩도 마크 하나로만 말한다.
+    // 미확인 도착은 별도 표식이 아니라 마크 축의 "unseen"이다 — peek 칩도 마크 하나로만 말한다.
     const arrived = required<HTMLElement>('[data-side-bar-chip-id="preview"]');
-    expect(arrived.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-awaiting");
+    expect(arrived.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-unseen");
     expect(arrived.querySelector(".side-bar-chip-unseen")).toBeNull();
 
-    // STATUS를 끄면 peek는 groupOperations만 거친다 — 이 경로엔 재작성이 없으므로 이 단언만이
-    // buildTheaterEntries의 승격을 고정한다. STATUS 켠 채로 두면 섹션 재작성에 가려 통과해버린다.
+    // STATUS를 끄면 peek는 groupOperations만 거친다 — 섹션 재작성이 없으므로, 이 단언만이
+    // buildTheaterEntries가 마크 축을 싣는 것을 고정한다(칸이 없으니 마크 외엔 관측할 것이 없다).
     act(() => setSideBarStatusAxis(false));
     const grouped = required<HTMLElement>('[data-side-bar-chip-id="preview"]');
     expect(grouped.closest(".side-bar-status-section--awaiting")).toBeNull();
-    expect(grouped.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-awaiting");
+    expect(grouped.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-unseen");
   });
 
   it("keeps keyboard reordering disabled in STATUS and unchanged in GROUP", () => {
@@ -384,14 +403,14 @@ describe("OperationsSideBar STATUS axis", () => {
       (chip) => chip.dataset.sideBarChipId,
     )).toEqual(["recorded"]);
     const recordedChip = required<HTMLElement>('[data-side-bar-chip-id="recorded"]');
-    expect(recordedChip.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-awaiting");
+    expect(recordedChip.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-unseen");
     expect(recordedChip.className).not.toContain("side-bar-chip--status-landed");
     expect(recordedChip.querySelector(".side-bar-chip-unseen")).toBeNull();
     expect(container?.querySelector(".side-bar-status-header__unseen")).toBeNull();
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-header__count").textContent).toBe("1");
   });
 
-  it("promotes an idle arrival to AWAITING while STATUS is off, omits focused transitions, and clears on focus", () => {
+  it("marks an idle arrival unseen while STATUS is off, omits focused transitions, and clears on focus", () => {
     const operations = [makeOperation("unseen", null), makeOperation("focused", null)];
     setConsoleState({ operationRuntime: { unseen: { lifecycle: "live", activity: "running" }, focused: { lifecycle: "live", activity: "running" } } });
     renderSideBar(operations, [], vi.fn(), THEATER.id, [THEATER], "focused");
@@ -399,14 +418,14 @@ describe("OperationsSideBar STATUS axis", () => {
     act(() => setConsoleState({ operationRuntime: { unseen: { lifecycle: "live", activity: "idle" }, focused: { lifecycle: "live", activity: "idle" } } }));
     // GROUP 축(STATUS off)도 표시 활동을 읽는다 — 예전에는 여기서만 raw idle을 그려, 우측 미확인 점이
     // 유일한 대기 신호였고 같은 사실이 초록 마크와 초록 점으로 두 번 그려졌다.
-    expect(required<HTMLElement>('[data-side-bar-chip-id="unseen"] .side-bar-chip-status').className).toContain("tenant-beacon is-awaiting");
+    expect(required<HTMLElement>('[data-side-bar-chip-id="unseen"] .side-bar-chip-status').className).toContain("tenant-beacon is-unseen");
     expect(required<HTMLElement>('[data-side-bar-chip-id="focused"] .side-bar-chip-status').className).toContain("tenant-beacon is-idle");
     expect(container?.querySelector(".side-bar-chip-unseen")).toBeNull();
 
     act(() => setSideBarStatusAxis(true));
 
     const unseenChip = required<HTMLElement>('[data-side-bar-chip-id="unseen"]');
-    expect(unseenChip.querySelector(".side-bar-chip-status")?.getAttribute("aria-label")).toBe("Awaiting input");
+    expect(unseenChip.querySelector(".side-bar-chip-status")?.getAttribute("aria-label")).toBe("Finished, unacknowledged");
     // 접근성 이름에는 더 이상 미확인 접미가 붙지 않는다 — 상태는 마크의 이름이 진다.
     expect(unseenChip.getAttribute("aria-label")).toBe("Focus operation unseen");
     expect(unseenChip.closest(".side-bar-status-section--awaiting")).not.toBeNull();
@@ -419,7 +438,7 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(getIdleArrivalIds().has("unseen")).toBe(false);
   });
 
-  it("drops the AWAITING promotion on exit and grants it again on a later idle episode", () => {
+  it("drops the unseen mark on exit and grants it again on a later idle episode", () => {
     const operations = [makeOperation("repeat", null)];
     setConsoleState({ operationRuntime: { repeat: { lifecycle: "live", activity: "running" } } });
     setSideBarStatusAxis(true);
@@ -427,13 +446,13 @@ describe("OperationsSideBar STATUS axis", () => {
     const mark = () => required<HTMLElement>('[data-side-bar-chip-id="repeat"] .side-bar-chip-status').className;
 
     act(() => setConsoleState({ operationRuntime: { repeat: { lifecycle: "live", activity: "idle" } } }));
-    expect(mark()).toContain("tenant-beacon is-awaiting");
+    expect(mark()).toContain("tenant-beacon is-unseen");
 
     act(() => setConsoleState({ operationRuntime: { repeat: { lifecycle: "live", activity: "running" } } }));
     expect(mark()).toContain("tenant-beacon is-turn-running");
 
     act(() => setConsoleState({ operationRuntime: { repeat: { lifecycle: "live", activity: "idle" } } }));
-    expect(mark()).toContain("tenant-beacon is-awaiting");
+    expect(mark()).toContain("tenant-beacon is-unseen");
   });
 
   it("does not mark an Operation that is already idle on page load", () => {
@@ -480,7 +499,7 @@ describe("OperationsSideBar STATUS axis", () => {
     const minimizedChip = required<HTMLElement>('[data-side-bar-chip-id="minimized-unseen"]');
     const dormantChip = required<HTMLElement>('[data-side-bar-chip-id="dormant-unseen"]');
     // 최소화 선반도 표시 활동을 읽는다 — 예전에는 raw idle 마크 옆에 미확인 점이 따로 붙었다.
-    expect(minimizedChip.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-awaiting");
+    expect(minimizedChip.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-unseen");
     expect(minimizedChip.className).toContain("side-bar-chip--status-landed");
     expect(dormantChip.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-ended");
     expect(dormantChip.className).not.toContain("side-bar-chip--status-landed");
@@ -555,7 +574,7 @@ describe("OperationsSideBar STATUS axis", () => {
 
     const transitionedChip = required<HTMLElement>('[data-side-bar-chip-id="restored"]');
     expect(getStatusTransitionTick("restored")).toBeGreaterThan(runningTick ?? 0);
-    expect(transitionedChip.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-awaiting");
+    expect(transitionedChip.querySelector(".side-bar-chip-status")?.className).toContain("tenant-beacon is-unseen");
     expect(transitionedChip.className).toContain("side-bar-chip--status-landed");
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-header__count").textContent).toBe("1");
   });

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -2232,7 +2232,7 @@ describe("triage fleet map markers", () => {
     expect(Number.parseFloat(calm["--triage-drift-mult"]!)).toBeGreaterThan(Number.parseFloat(active["--triage-drift-mult"]!));
   });
 
-  it("classifies an idle arrival as an awaiting marker, matching the queue vocabulary", () => {
+  it("classifies an idle arrival as an unseen marker, distinct from a genuine awaiting one", () => {
     const container = document.createElement("div");
     document.body.append(container);
     triagePlateRoot = createRoot(container);
@@ -2253,10 +2253,12 @@ describe("triage fleet map markers", () => {
       setTriageDeckMapModeLive(true);
     });
 
-    // 사이드바·큐가 대기로 세는 유휴 도착은 지도에서도 aurora 대기 마커여야 한다 —
-    // 회색 유휴 점이면 같은 상태가 표면마다 다르게 읽힌다.
+    // 유휴 도착은 지도에서도 사이드바 칩·커맨드 밴드와 같은 마크 축을 쓴다 — 진짜 대기(aurora)와
+    // 구별되는 미확인 마커(초록 느린 점등)여야 한다. 큐가 그것을 대기로 세는 것은 배치 축의 일이고,
+    // 색이 그 배치를 따라가면 두 사실이 한 색으로 뭉친다.
     const dot = container.querySelector<HTMLElement>('[data-triage-map-dot="arrival-map"]');
-    expect(dot?.classList.contains("is-awaiting")).toBe(true);
+    expect(dot?.classList.contains("is-unseen")).toBe(true);
+    expect(dot?.classList.contains("is-awaiting")).toBe(false);
     expect(dot?.classList.contains("is-idle")).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- 활동 마크가 서로 다른 두 사실을 한 색으로 말하고 있었습니다. 열지 않은 채 끝난 Operation은 `resolveOperationDisplayActivity`가 AWAITING으로 승격해, 진짜로 운영자 입력을 기다리는 Operation과 같은 aurora로 그려졌습니다(PR#794의 결과). 어느 쪽이 답을 요구하는지 화면이 말해 주지 못합니다.
- **승격이 아니라 축을 가릅니다.** 배치는 그대로입니다 — 미확인 도착은 여전히 AWAITING 섹션에 서고, War Room 대기열·무대 승격·라이브 틱·함대 알림에 그대로 오릅니다(재가된 결정: 놓치지 않게 위로 모은다). 바뀌는 것은 마크뿐입니다: 도착은 끝난 일의 초록을 유지하고, 미확인은 **3.6s 느린 점등**(대기 호출 맥동 1.8s의 절반 박자)이 말합니다.
- 새 마크 축(`OperationMarkVisual` / `resolveOperationMarkVisual`)을 사이드바 칩 · 커맨드 밴드 · War Room 지도 점이 읽습니다. 인패널 캡션 띠는 이미 aurora/positive로 둘을 갈라 그리고 있어 손대지 않았습니다. War Room 덱 칸의 `is-${visual}`은 스타일이 없고 밴드 배치 축이라 그대로 둡니다.
- 곁들여: 섹션 승격을 `groupOperationsByStatus` 하나에게 돌려줬습니다. 생성 지점에서 한 번 더 승격해 두면 그 값이 어느 표면에도 드러나지 않아 틀려도 아무 테스트가 죽지 않습니다(적대 검증이 정확히 이 구멍을 짚었습니다).

## Test Plan

- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — 통과
- [x] `pnpm exec vitest run` — 182 files / **2266 tests** 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK: 6 entries
- [x] 격리 Console 실측(headless) — 진짜 대기 · 미확인 도착 · 순수 유휴 **세 상태를 한 화면에** 세워 계산 스타일로 확인:
  - 진짜 대기 `tenant-beacon is-awaiting` · `bg oklch(0.77 0.085 200)` · `aurora-pulse/1.8s` · `대기`
  - 미확인 도착 `tenant-beacon is-unseen` · `bg oklch(0.76 0.11 160)` · `beacon-unseen-blink/3.6s` · `종료됨 — 확인 전` · 섹션은 `--awaiting`(배치 유지)
  - 순수 유휴 `tenant-beacon is-idle` · 같은 초록 · `animation: none`
  - 커맨드 밴드 `tenant-beacon is-awaiting … aurora-pulse`
  - Cruise 그룹축 · Sort by status · War Room 사이드바 모두 동일 어휘. 브라우저 오류 0 · 미처리 거부 0
- [x] 적대 검증 4렌즈 + 교차 계보 반박 — 생존 1건(생성 지점 승격이 관측 불가) 수정, reduced-motion 정지 상태 결함과 무대 라벨 모순 2건 추가 수정
- [ ] War Room **지도 점**은 헤드리스에서 Map 토글이 무대 뒤로 접혀 열리지 않아 스크린샷 미실시 — `triage-store.test.ts`가 덱을 map 모드로 렌더해 `is-unseen`을 단언하는 것으로 대신합니다