### PR TITLE
feat(fleet-console): fold leftover work into Running

### DIFF
--- a/.changelog.d/merge-background-into-running.md
+++ b/.changelog.d/merge-background-into-running.md
@@ -1,0 +1,8 @@
+---
+branch: merge-background-into-running
+---
+
+### fleet-console
+#### Changed
+- The left sidebar no longer keeps a separate Background group. Operations still doing leftover work now sit in Running, and only their row mark still says they are in the background.
+  ko: 왼쪽 사이드바에서 백그라운드 그룹을 없앱니다. 남은 작업을 도는 Operation은 실행 중 칸에 앉고, 백그라운드라는 사실은 행 마크만 말합니다.

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -108,7 +108,6 @@ export const canvasEn = {
   // ── sidebar ─────────────────────────────────────────────────────────────
   "sidebar.status.awaiting": "AWAITING",
   "sidebar.status.running": "RUNNING",
-  "sidebar.status.background": "BACKGROUND",
   "sidebar.status.idle": "IDLE",
   "sidebar.status.ended": "ENDED",
   "sidebar.status.expandSection": "Expand section {label}",
@@ -318,7 +317,6 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
 
   "sidebar.status.awaiting": "대기",
   "sidebar.status.running": "실행 중",
-  "sidebar.status.background": "백그라운드",
   "sidebar.status.idle": "유휴",
   "sidebar.status.ended": "종료됨",
   "sidebar.status.expandSection": "{label} 섹션 펼치기",

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -46,6 +46,7 @@ let pendingStatusLandingIds = new Set<string>();
 // 앞의 다섯은 Operation의 활동 상태다. "minimized"는 활동이 아니라 사용자가 고른 표시 상태이며,
 // 그래서 buildStatusSectionOrder의 상태 축에는 들어가지 않는다 — 활동 축을 순회하는 곳은 이 값을
 // 만들지 않고, War Room의 최소화 선반만 같은 섹션 문법(접힘 키·카운트·빈 힌트)을 빌려 쓴다.
+// background 활동은 실행 중 칸에 합류한다. 칸 키는 running이고, 행 마크는 그대로 background다.
 export type SideBarStatus = "awaiting" | "running" | "background" | "idle" | "ended" | "minimized";
 
 export function useSideBarState(): SideBarState {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -209,10 +209,15 @@ function buildStatusSectionOrder(t: Translate<CoreMessageKey>): readonly Omit<St
   return [
     { status: "awaiting", label: t("sidebar.status.awaiting") },
     { status: "running", label: t("sidebar.status.running") },
-    { status: "background", label: t("sidebar.status.background") },
     { status: "idle", label: t("sidebar.status.idle") },
     { status: "ended", label: t("sidebar.status.ended") },
   ];
+}
+
+// 사이드바 STATUS 칸은 활동을 네 칸으로만 읽는다. background는 실행 중과 같은 칸에 앉히되,
+// 행 마크는 그대로 background다 — 칸 키로 활동을 덮으면 헤더와 비콘이 다른 상태를 말한다.
+export function statusSectionBucket(status: OperationActivityVisual | SideBarStatus): SideBarStatus {
+  return status === "background" ? "running" : status;
 }
 
 export function StatusSectionSlot({
@@ -507,11 +512,11 @@ export function OperationsSideBar({
     }
     // 상태축에서는 그룹 접힘이 배치에 영향을 주지 않는다 — 여기서 펼치면 사용자의 그룹축 설정만 조용히 바뀐다.
     if (statusAxis) {
-      const status = resolveOperationDisplayActivity({
+      const status = statusSectionBucket(resolveOperationDisplayActivity({
         activity: resolveOperationActivity(operation, operationRuntime),
         operationId: operation.id,
         idleArrivalIds,
-      });
+      }));
       if (getSideBarStatusSectionCollapsed(operation.theaterId, status, false)) {
         toggleSideBarStatusSectionCollapsed(operation.theaterId, status, false);
       }
@@ -1289,7 +1294,8 @@ export function groupOperationsByStatus(
     // 섹션 승격은 이 함수 하나가 소유한다 — 도착한 행을 AWAITING 칸에 세워 놓치지 않게 하는 것은
     // 배치의 결정이고, 그 행을 무슨 색으로 그릴지는 마크 축(entry.mark)의 결정이다. 둘을 한 값으로
     // 합치면 색이 칸을 따라가 "사람을 기다리는 중"과 "안 본 채 끝난 것"이 같은 파랑이 된다.
-    // 칸을 정한 값을 엔트리의 status에도 실어 보낸다: 섹션 헤더와 행이 같은 분류를 들고 있어야 한다.
+    // background는 실행 중 칸에 앉히되 status는 승격된 활동(background)을 유지한다. 칸 키로
+    // 덮으면 마크가 없는 입력에서 행이 채운 running으로 그려진다.
     // 미해소(undefined) 엔트리의 idle 폭백은 직접 구성된 입력에 대한 방어 계약이다.
     entries: entries
       .flatMap((entry) => {
@@ -1298,7 +1304,7 @@ export function groupOperationsByStatus(
           operationId: entry.operation.id,
           idleArrivalIds,
         });
-        if (display !== status) return [];
+        if (statusSectionBucket(display) !== status) return [];
         return [entry.status === display ? entry : { ...entry, status: display }];
       })
       .sort((left, right) => {

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -26,7 +26,7 @@ const TRIAGE_SIDE_BAR_SECTION_KEY = "__triage__";
 const EMPTY_MINIMIZED: ReadonlySet<string> = new Set();
 
 // 전역 선별 목록도 Map 사이드바의 표현 문법(상태 섹션 헤더 + 칩)을 그대로 쓴다 — 모드가 바뀌어도
-// 왼쪽 열의 읽는 법이 바뀌지 않아야 한다. 네 living 섹션은 큐 문법을 공유하되, 휴면은 큐에 합류하지
+// 왼쪽 열의 읽는 법이 바뀌지 않아야 한다. 세 living 섹션은 큐 문법을 공유하되, 휴면은 큐에 합류하지
 // 않고 하단 선반에만 머문다. 대기 섹션은 전역 큐의 처리 순서를 따른다.
 export function resolveTriageSideBarSections(
   entries: readonly SideBarEntry[],
@@ -136,7 +136,7 @@ export function TriageSideBar({
     operationRuntime,
   }));
   // 최소화한 Operation은 상태 축에서 내려와 전용 선반으로 모인다 — 최소화는 활동 상태가 아니라
-  // 표시 선택이므로 대기·실행 중·백그라운드·유휴 중 어디에도 새 칸을 만들지 않는다.
+  // 표시 선택이므로 대기·실행 중·유휴 중 어디에도 새 칸을 만들지 않는다.
   // 휴면은 그대로 휴면 선반이 가져간다: 재개 대기는 사용자가 고른 상태가 아니라 세션의 상태다.
   const minimizedIds = new Set(getTheaterMinimizedIds(theaters.map((theater) => theater.id)));
   const isDormantEntry = (entry: SideBarEntry): boolean =>
@@ -203,7 +203,7 @@ export function TriageSideBar({
       aria-label={t("triageSidebar.aria")}
       onContextMenu={openLaunchMenuAtCursor}
     >
-      {/* 상태 섹션은 비어 있어도 항상 선다 — 대기·실행 중·백그라운드·유휴는 War Room이 읽는
+      {/* 상태 섹션은 비어 있어도 항상 선다 — 대기·실행 중·유휴는 War Room이 읽는
           축 자체라, 건수가 0이라고 축이 사라지면 좌측 열의 읽는 법이 상황에 따라 달라진다.
           "없음"은 빈 섹션의 자체 힌트가 말한다(전역 empty 문구는 이 계약으로 퇴역했다). */}
       <ol className="operations-side-bar-chips triage-side-bar-sections" aria-label={t("triageSidebar.aria")}>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2575,8 +2575,7 @@
 }
 
 .tenant-beacon.is-background,
-.canvas-triage-map-dot.is-background,
-.side-bar-status-section--background {
+.canvas-triage-map-dot.is-background {
   --activity-color: var(--warn);
   --activity-glow: var(--warn-glow);
 }
@@ -4685,7 +4684,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 /* 선별 처리 전용 사이드바 — Map 사이드바(.operations-side-bar)의 표면·접힘 문법을 그대로
-   상속한다. 네 living 섹션은 스크롤 큐를 소유하고, 휴면만 separator 아래의 접힌 선반과 중립
+   상속한다. 세 living 섹션은 스크롤 큐를 소유하고, 휴면만 separator 아래의 접힌 선반과 중립
    캡션을 갖는다: 휴면 수량은 보이되 큐·덱·지도 문법에는 합류시키지 않는다. */
 .triage-side-bar-sections {
   padding-top: var(--space-1);
@@ -5389,12 +5388,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
   margin-left: var(--space-1);
   margin-bottom: 6px;
   border-left: 3px solid var(--status-color);
-}
-
-/* background는 running과 같은 warn 축을 쓰되, 중공 beacon의 기하를 세로선에도 옮겨
-   채운 running과 혼동되지 않게 한다. */
-.side-bar-status-section--background {
-  border-left-style: dashed;
 }
 
 .side-bar-status-header {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1269,14 +1269,14 @@ describe("Instrument core design contract", () => {
     expect(components).toMatch(/\.tenant-beacon\.is-idle,\s*\.tenant-beacon\.is-unseen,\s*\.canvas-triage-map-dot\.is-idle,\s*\.canvas-triage-map-dot\.is-unseen,\s*\.side-bar-status-section--idle\s*\{[^}]*--activity-color:\s*var\(--positive\)/);
     expect(components).toContain(".tenant-beacon.is-ended,\n.canvas-triage-map-dot.is-ended,\n.side-bar-status-section--ended {");
     expect(components).toContain("--activity-color: var(--ink-fog);");
-    expect(components).toMatch(/\.tenant-beacon\.is-background,\s*\.canvas-triage-map-dot\.is-background,\s*\.side-bar-status-section--background\s*\{[^}]*--activity-color:\s*var\(--warn\)/);
+    expect(components).toMatch(/\.tenant-beacon\.is-background,\s*\.canvas-triage-map-dot\.is-background\s*\{[^}]*--activity-color:\s*var\(--warn\)/);
     expect(components).toMatch(/\.canvas-triage-map-dot \{[^}]*background:\s*var\(--activity-color\)/);
     // War Room 덱은 자기 상태 축을 갖지 않는다 — 칸에 선 것이 패널이라 캡션 비콘이 이 선언을 그대로 받는다.
     expect(components).not.toContain(".canvas-triage-deck-card");
     expect(components).toMatch(/\.canvas-triage-map-dot\.is-background \{[^}]*background:\s*none;[^}]*border-color:\s*var\(--activity-color\)/);
     expect(components).toContain("--status-color: var(--activity-color);");
     expect(components).toContain("border-left: 3px solid var(--status-color);");
-    expect(components).toMatch(/\.side-bar-status-section--background \{[^}]*border-left-style:\s*dashed/);
+    expect(components).not.toContain(".side-bar-status-section--background");
     expect(sidebar).not.toContain("side-bar-status-header__dot");
     expect(components).not.toContain(".side-bar-status-header__dot");
     expect(components).toContain("background: var(--group-mark);");

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -332,7 +332,7 @@ describe("groupOperationsByStatus", () => {
 
     const sections = groupOperationsByStatus(entries);
     expect(sections[0]?.entries.map((entry) => entry.operation.id)).toEqual(["awaiting", "arrived"]);
-    expect(sections[3]?.entries.map((entry) => entry.operation.id)).toEqual(["idle"]);
+    expect(sections[2]?.entries.map((entry) => entry.operation.id)).toEqual(["idle"]);
     expect(sections.flatMap((section) => section.entries)).toHaveLength(entries.length);
 
     const operations = entries.map((entry) => entry.operation);
@@ -355,11 +355,21 @@ describe("groupOperationsByStatus", () => {
     expect(sections.map((section) => [section.status, section.label])).toEqual([
       ["awaiting", "AWAITING"],
       ["running", "RUNNING"],
-      ["background", "BACKGROUND"],
       ["idle", "IDLE"],
       ["ended", "ENDED"],
     ]);
-    expect(sections[3]?.entries.map((entry) => entry.operation.id)).toEqual(["idle-missing", "idle-explicit"]);
+    expect(sections[2]?.entries.map((entry) => entry.operation.id)).toEqual(["idle-missing", "idle-explicit"]);
+  });
+
+  it("places background activity in the running section without rewriting the row activity", () => {
+    const sections = groupOperationsByStatus([
+      makeEntry("running", null, "running"),
+      makeEntry("background", null, "background"),
+    ]);
+
+    expect(sections.map((section) => section.status)).toEqual(["awaiting", "running", "idle", "ended"]);
+    expect(sections.find((section) => section.status === "running")?.entries.map((entry) => [entry.operation.id, entry.status]))
+      .toEqual([["running", "running"], ["background", "background"]]);
   });
 
   it("preserves the incoming sortOperationsByOrder sequence inside each status section", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -85,7 +85,6 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(Array.from(container?.querySelectorAll(".side-bar-status-header__label") ?? []).map((node) => node.textContent)).toEqual([
       "AWAITING",
       "RUNNING",
-      "BACKGROUND",
       "IDLE",
       "Minimized",
       "ENDED",
@@ -110,14 +109,14 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').dataset.reorderEnabled).toBe("false");
   });
 
-  it("pins four live sections plus both recovery shelves, defaults empty sections collapsed, and toggles empty and occupied sections independently", () => {
+  it("pins three live sections plus both recovery shelves, defaults empty sections collapsed, and toggles empty and occupied sections independently", () => {
     setConsoleState({ operationRuntime: { only: { lifecycle: "live", activity: "running" } } });
     setSideBarStatusAxis(true);
     renderSideBar([makeOperation("only", null)]);
 
     const sections = Array.from(container?.querySelectorAll<HTMLElement>(".side-bar-status-section") ?? []);
-    expect(sections).toHaveLength(6);
-    expect(sections.map((section) => section.querySelector(".side-bar-status-header__count")?.textContent)).toEqual(["0", "1", "0", "0", "0", "0"]);
+    expect(sections).toHaveLength(5);
+    expect(sections.map((section) => section.querySelector(".side-bar-status-header__count")?.textContent)).toEqual(["0", "1", "0", "0", "0"]);
     const recoveryShelves = Array.from(container?.querySelectorAll<HTMLElement>(".side-bar-status-recovery-shelf") ?? []);
     expect(recoveryShelves).toHaveLength(2);
     expect(recoveryShelves.map((shelf) => shelf.className)).toEqual([
@@ -143,6 +142,26 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(container?.querySelector('[data-side-bar-chip-id="only"]')).toBeNull();
     act(() => required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section RUNNING"]').click());
     expect(container?.querySelector('[data-side-bar-chip-id="only"]')).not.toBeNull();
+  });
+
+  it("keeps a background Operation in RUNNING with its hollow beacon", () => {
+    setConsoleState({
+      operationRuntime: {
+        turn: { lifecycle: "live", activity: "running" },
+        leftover: { lifecycle: "live", activity: "background" },
+      },
+    });
+    setSideBarStatusAxis(true);
+    renderSideBar([makeOperation("turn", null), makeOperation("leftover", null)]);
+
+    expect(container?.querySelector(".side-bar-status-section--background")).toBeNull();
+    expect(required<HTMLElement>('[data-side-bar-chip-id="turn"]').closest(".side-bar-status-section--running")).not.toBeNull();
+    expect(required<HTMLElement>('[data-side-bar-chip-id="leftover"]').closest(".side-bar-status-section--running")).not.toBeNull();
+    expect(required<HTMLElement>('[data-side-bar-chip-id="leftover"] .side-bar-chip-status').className)
+      .toContain("tenant-beacon is-background");
+    expect(required<HTMLElement>('[data-side-bar-chip-id="turn"] .side-bar-chip-status').className)
+      .toContain("tenant-beacon is-turn-running");
+    expect(required<HTMLElement>(".side-bar-status-section--running .side-bar-status-header__count").textContent).toBe("2");
   });
 
   it("reveals an idle arrival from the AWAITING section for a palette action", () => {

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -963,7 +963,7 @@ describe("triage store", () => {
 
     const sections = resolveTriageSideBarSections(entries, queue);
 
-    expect(sections.map((section) => section.status)).toEqual(["awaiting", "running", "background", "idle", "ended"]);
+    expect(sections.map((section) => section.status)).toEqual(["awaiting", "running", "idle", "ended"]);
     const byStatus = new Map(sections.map((section) => [section.status, section.entries.map((entry) => entry.operation.id)]));
     expect(byStatus.get("awaiting")).toEqual(["beta-waiting", "alpha-waiting"]);
     expect(byStatus.get("running")).toEqual(["alpha-running"]);


### PR DESCRIPTION
## Summary
- 왼쪽 사이드바 STATUS 축에서 별도의 백그라운드 그룹을 없앱니다. War Room과 Cruise/Tactical이 같은 `groupOperationsByStatus`를 쓰므로 양쪽이 같이 바뀝니다.
- 남은 작업을 도는 Operation은 실행 중 칸에 앉고, 백그라운드라는 사실은 행 마크만 말합니다. 활동 어휘와 모바일 목록의 Background 섹션은 그대로 둡니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/operations-side-bar-group.test.ts tests/operations-side-bar-status-axis.test.tsx tests/operations-side-bar-inactive-theater.test.tsx tests/triage-store.test.ts tests/instrument-design-contract.test.ts tests/i18n.test.ts` — 265 passed
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p tsconfig.json` — pass
- [x] 격리 콘솔에서 STATUS 축 칸이 `대기 / 실행 중 / 유휴 / 종료됨`이고 백그라운드 헤더가 없는 것을 확인