### PR TITLE
feat(fleet-console): fold status groups into one shelf caption

### DIFF
--- a/.changelog.d/status-shelf-caption.md
+++ b/.changelog.d/status-shelf-caption.md
@@ -1,0 +1,8 @@
+---
+branch: status-shelf-caption
+---
+
+### fleet-console
+#### Changed
+- Fold every status group in the left sidebar and War Room into one shelf caption that keeps the signal stripe and count, drops the tinted wash, and keeps restore verbs on Minimized and Ended only.
+  ko: 좌측 사이드바와 War Room의 상태 그룹을 선반 캡션 한 줄로 합치고, 신호 스트라이프와 개수는 유지하되 틴트 워시는 거두며 복원 동사는 최소화·종료됨에만 남깁니다.

--- a/runtime/fleet-console/core/client/src/feature-tour-catalog.ts
+++ b/runtime/fleet-console/core/client/src/feature-tour-catalog.ts
@@ -114,7 +114,7 @@ export const FEATURE_TOURS: readonly FeatureTour[] = [
         bodyKey: "featureTour.warRoomSidebar.step1Body",
       },
       {
-        anchor: ".triage-side-bar:not(.is-closed) .triage-side-bar-caption",
+        anchor: ".triage-side-bar:not(.is-closed) .triage-side-bar-minimized-shelf .side-bar-status-header",
         titleKey: "featureTour.warRoomSidebar.step2Title",
         bodyKey: "featureTour.warRoomSidebar.step2Body",
       },

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -106,10 +106,10 @@ export const canvasEn = {
   "canvas.groupMenu.confirmUngroupAria": "Confirm: remove all members and delete group",
 
   // ── sidebar ─────────────────────────────────────────────────────────────
-  "sidebar.status.awaiting": "AWAITING",
-  "sidebar.status.running": "RUNNING",
-  "sidebar.status.idle": "IDLE",
-  "sidebar.status.ended": "ENDED",
+  "sidebar.status.awaiting": "Awaiting",
+  "sidebar.status.running": "Running",
+  "sidebar.status.idle": "Idle",
+  "sidebar.status.ended": "Ended · select to start again",
   "sidebar.status.expandSection": "Expand section {label}",
   "sidebar.status.collapseSection": "Collapse section {label}",
   "sidebar.status.expand": "Expand",
@@ -318,7 +318,7 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "sidebar.status.awaiting": "대기",
   "sidebar.status.running": "실행 중",
   "sidebar.status.idle": "유휴",
-  "sidebar.status.ended": "종료됨",
+  "sidebar.status.ended": "종료됨 · 선택하여 다시 시작",
   "sidebar.status.expandSection": "{label} 섹션 펼치기",
   "sidebar.status.collapseSection": "{label} 섹션 접기",
   "sidebar.status.expand": "펼치기",

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -242,20 +242,18 @@ export function StatusSectionSlot({
         empty ? "side-bar-status-section--empty" : "",
       ].filter(Boolean).join(" ")}
     >
-      <div className={`side-bar-status-header side-bar-status-header--${section.status}`}>
-        <button
-          type="button"
-          className="side-bar-status-header__toggle"
-          onClick={() => toggleSideBarStatusSectionCollapsed(theaterId, section.status, empty || defaultCollapsed)}
-          aria-expanded={!collapsed}
-          aria-label={collapsed ? t("sidebar.status.expandSection", { label: section.label }) : t("sidebar.status.collapseSection", { label: section.label })}
-          title={collapsed ? t("sidebar.status.expand") : t("sidebar.status.collapse")}
-        >
-          <StatusSectionCollapseArrow collapsed={collapsed} />
-        </button>
+      <button
+        type="button"
+        className={`side-bar-status-header side-bar-status-header--${section.status} side-bar-status-header__toggle`}
+        onClick={() => toggleSideBarStatusSectionCollapsed(theaterId, section.status, empty || defaultCollapsed)}
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? t("sidebar.status.expandSection", { label: section.label }) : t("sidebar.status.collapseSection", { label: section.label })}
+        title={collapsed ? t("sidebar.status.expand") : t("sidebar.status.collapse")}
+      >
+        <StatusSectionCollapseArrow collapsed={collapsed} />
         <span className="side-bar-status-header__label">{section.label}</span>
         <span className="side-bar-status-header__count">{section.entries.length}</span>
-      </div>
+      </button>
       {!collapsed ? (
         <ol className="side-bar-group-chips" aria-label={t("sidebar.status.sectionOperations", { label: section.label })}>
           {empty ? <li className="side-bar-status-empty-hint">{t("sidebar.status.noOperations")}</li> : children}
@@ -276,20 +274,17 @@ function StatusRecoveryShelves({
   readonly dormantSection: StatusSection;
   readonly renderEntry: (entry: SideBarEntry, index: number, recovery: "minimized" | "ended") => ReactNode;
 }) {
-  const t = useT();
   return (
     <li className="side-bar-status-recovery-shelves">
       <section className="triage-side-bar-minimized-shelf side-bar-status-recovery-shelf" onContextMenu={(event) => event.preventDefault()}>
-        <p className="triage-side-bar-caption">{t("sidebar.status.minimizedShelf")}</p>
-        <ol className="triage-side-bar-minimized-list" aria-label={t("sidebar.status.minimizedShelf")}>
+        <ol className="triage-side-bar-minimized-list" aria-label={minimizedSection.label}>
           <StatusSectionSlot theaterId={theaterId} section={minimizedSection}>
             {minimizedSection.entries.map((entry, index) => renderEntry(entry, index, "minimized"))}
           </StatusSectionSlot>
         </ol>
       </section>
       <footer className="triage-side-bar-dormant-shelf side-bar-status-recovery-shelf" onContextMenu={(event) => event.preventDefault()}>
-        <p className="triage-side-bar-caption">{t("sidebar.status.dormantShelf")}</p>
-        <ol className="triage-side-bar-dormant-list" aria-label={t("sidebar.status.dormantShelf")}>
+        <ol className="triage-side-bar-dormant-list" aria-label={dormantSection.label}>
           <StatusSectionSlot theaterId={theaterId} section={dormantSection}>
             {dormantSection.entries.map((entry, index) => renderEntry(entry, index, "ended"))}
           </StatusSectionSlot>
@@ -1271,12 +1266,12 @@ export function groupTheaterStatusEntries(
     living: sections.filter((section) => section.status !== "ended"),
     minimized: {
       status: "minimized",
-      label: t("triageSidebar.minimized"),
+      label: t("sidebar.status.minimizedShelf"),
       entries: minimizedEntries,
     },
     dormant: {
       status: "ended",
-      label: t("sidebar.status.ended"),
+      label: t("sidebar.status.dormantShelf"),
       entries: dormantEntries,
     },
   };

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -144,13 +144,16 @@ export function TriageSideBar({
   const minimizedEntries = entries.filter((entry) => minimizedIds.has(entry.operation.id) && !isDormantEntry(entry));
   const minimizedSection: StatusSection = {
     status: "minimized",
-    label: t("triageSidebar.minimized"),
+    label: t("triageSidebar.minimizedShelf"),
     entries: minimizedEntries,
   };
   const shelvedIds = new Set(minimizedEntries.map((entry) => entry.operation.id));
   const sections = resolveTriageSideBarSections(entries.filter((entry) => !shelvedIds.has(entry.operation.id)), queue, t);
   const livingSections = sections.filter((section) => section.status !== "ended");
-  const dormantSection = sections.find((section) => section.status === "ended");
+  const endedSection = sections.find((section) => section.status === "ended");
+  const dormantSection = endedSection
+    ? { ...endedSection, label: t("triageSidebar.dormantShelf") }
+    : undefined;
   const renderChip = (entry: SideBarEntry, index: number, shelf: "none" | "ended" | "minimized" = "none") => {
     const dormant = shelf === "ended";
     const accentKey = getTheaterCanvasSnapshot(entry.operation.theaterId).operationAccent[entry.operation.id]
@@ -217,8 +220,7 @@ export function TriageSideBar({
           잠든 것보다 손에 가깝다. 휴면처럼 0건이어도 자리를 지킨다: 되찾을 곳이 상황에 따라 나타났다
           사라지면 어디를 봐야 하는지가 매번 달라진다. */}
       <section className="triage-side-bar-minimized-shelf" onContextMenu={(event) => event.preventDefault()}>
-        <p className="triage-side-bar-caption">{t("triageSidebar.minimizedShelf")}</p>
-        <ol className="triage-side-bar-minimized-list" aria-label={t("triageSidebar.minimizedShelf")}>
+        <ol className="triage-side-bar-minimized-list" aria-label={minimizedSection.label}>
           <StatusSectionSlot theaterId={TRIAGE_SIDE_BAR_SECTION_KEY} section={minimizedSection}>
             {minimizedEntries.map((entry, index) => renderChip(entry, index, "minimized"))}
           </StatusSectionSlot>
@@ -229,8 +231,7 @@ export function TriageSideBar({
           아무것도 열지 않는다. menuEnabled=false는 핸들러를 떼기만 하므로 선반이 직접 막는다. */}
       {dormantSection ? (
         <footer className="triage-side-bar-dormant-shelf" onContextMenu={(event) => event.preventDefault()}>
-          <p className="triage-side-bar-caption">{t("triageSidebar.dormantShelf")}</p>
-          <ol className="triage-side-bar-dormant-list" aria-label={t("triageSidebar.dormantShelf")}>
+          <ol className="triage-side-bar-dormant-list" aria-label={dormantSection.label}>
             <StatusSectionSlot
               theaterId={TRIAGE_SIDE_BAR_SECTION_KEY}
               section={dormantSection}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4684,8 +4684,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 /* 선별 처리 전용 사이드바 — Map 사이드바(.operations-side-bar)의 표면·접힘 문법을 그대로
-   상속한다. 세 living 섹션은 스크롤 큐를 소유하고, 휴면만 separator 아래의 접힌 선반과 중립
-   캡션을 갖는다: 휴면 수량은 보이되 큐·덱·지도 문법에는 합류시키지 않는다. */
+   상속한다. 세 living 섹션은 스크롤 큐를 소유하고, 휴면은 separator 아래 선반에만 선다:
+   휴면 수량은 보이되 큐·덱·지도 문법에는 합류시키지 않는다. 칸 이름은 StatusSectionSlot
+   한 줄이 말하므로 바깥 캡션은 두지 않는다. */
 .triage-side-bar-sections {
   padding-top: var(--space-1);
 }
@@ -4696,15 +4697,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: var(--space-1) 0;
 }
 
-.triage-side-bar-caption {
-  margin: 0;
-  padding: var(--space-1) var(--space-3);
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--t-2xs);
-  font-weight: var(--weight-medium);
-  letter-spacing: 0.08em;
-}
+/* STATUS 캡션 줄 — 예전 바깥 <p> 문법을 슬롯 헤더가 흡수했다. 클래스 이름은 투어·계약이
+   복구 전용으로 읽지 않도록 슬롯에만 남긴다. */
 
 .triage-side-bar-dormant-list {
   list-style: none;
@@ -5378,8 +5372,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 /* ── Group Section Layout ──────────────────────────────────────────────────────── */
 
-/* STATUS 축의 3px border는 identity가 아니라 OperationActivity 신호 채널이다.
-   색 정본은 위 OperationActivity 축이며 --status-color는 기존 소비자를 위한 별칭이다. */
+/* STATUS 축의 3px stripe는 identity가 아니라 OperationActivity 신호 채널이다.
+   색 정본은 위 OperationActivity 축이며 --status-color는 기존 소비자를 위한 별칭이다.
+   스트라이프는 섹션 봉투가 아니라 캡션 줄에만 선다 — 봉투에 두면 열이 다시 색 그룹이 된다. */
 .side-bar-status-section {
   --status-color: var(--activity-color);
   list-style: none;
@@ -5387,20 +5382,21 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex-direction: column;
   margin-left: var(--space-1);
   margin-bottom: 6px;
-  border-left: 3px solid var(--status-color);
 }
 
 .side-bar-status-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 7px;
+  width: 100%;
   padding: 7px 12px 7px 8px;
-  background: color-mix(in oklch, var(--status-color) 8%, transparent);
+  background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: var(--t-xs);
-  font-weight: var(--weight-bold);
-  letter-spacing: 0.12em;
+  font-size: var(--t-2xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.08em;
+  text-align: left;
 }
 
 .side-bar-status-section--empty .side-bar-status-header {
@@ -5408,29 +5404,31 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .side-bar-status-header__toggle {
-  display: grid;
-  place-items: center;
-  flex: none;
-  width: 16px;
-  height: 16px;
-  padding: 0;
-  background: transparent;
-  border: none;
   cursor: pointer;
-  color: var(--text-tertiary);
-  border-radius: var(--radius-xs);
+  border: none;
+  border-left: 3px solid var(--status-color);
+  border-radius: 0;
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
 .side-bar-status-header__toggle:hover,
 .side-bar-status-header__toggle:focus-visible {
   color: var(--text-secondary);
-  outline: none;
+  outline: 1px solid color-mix(in oklch, var(--brass) 55%, transparent);
+  outline-offset: -1px;
+}
+
+.side-bar-status-header__label {
+  flex: 1;
+  min-width: 0;
+  text-wrap: balance;
 }
 
 .side-bar-status-header__arrow {
   width: 12px;
   height: 12px;
+  flex: none;
+  margin-top: 2px;
   transition: transform var(--duration-fast) var(--ease-spring);
 }
 

--- a/runtime/fleet-console/tests/feature-tour.test.ts
+++ b/runtime/fleet-console/tests/feature-tour.test.ts
@@ -272,7 +272,7 @@ describe("feature tour", () => {
   it("holds the sidebar walkthrough back until an item is actually waiting", () => {
     document.body.innerHTML = [
       '<aside class="triage-side-bar is-expanded">',
-      '<div class="triage-side-bar-caption"></div>',
+      '<section class="triage-side-bar-minimized-shelf"><button class="side-bar-status-header"></button></section>',
       '<li class="side-bar-status-section side-bar-status-section--awaiting side-bar-status-section--empty"></li>',
       "</aside>",
     ].join("");
@@ -285,7 +285,7 @@ describe("feature tour", () => {
     // 않으면 사용자가 본 적 없는 안내가 재생되고 시청 기록에 남는다.
     document.body.innerHTML = [
       '<aside class="triage-side-bar is-closed">',
-      '<div class="triage-side-bar-caption"></div>',
+      '<section class="triage-side-bar-minimized-shelf"><button class="side-bar-status-header"></button></section>',
       '<li class="side-bar-status-section side-bar-status-section--awaiting">',
       '<button class="side-bar-chip"></button>',
       "</li></aside>",
@@ -301,7 +301,7 @@ describe("feature tour", () => {
   it("defers the sidebar walkthrough while the visit that just played another tour continues", () => {
     document.body.innerHTML = [
       '<aside class="triage-side-bar is-expanded">',
-      '<div class="triage-side-bar-caption"></div>',
+      '<section class="triage-side-bar-minimized-shelf"><button class="side-bar-status-header"></button></section>',
       '<li class="side-bar-status-section side-bar-status-section--awaiting">',
       '<button class="side-bar-chip"></button>',
       "</li></aside>",

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1159,7 +1159,8 @@ describe("Instrument core design contract", () => {
     const sidebar = source("sidebar/triage-side-bar.tsx");
     const components = source("styles/components.css");
     const shelf = components.match(/\.triage-side-bar-dormant-shelf \{[^}]*\}/)?.[0] ?? "";
-    const caption = components.match(/\.triage-side-bar-caption \{[^}]*\}/)?.[0] ?? "";
+    const caption = components.match(/\.side-bar-status-header \{[^}]*\}/)?.[0] ?? "";
+    const captionToggle = components.match(/\.side-bar-status-header__toggle \{[^}]*\}/)?.[0] ?? "";
 
     expect(sidebar).toContain('const livingSections = sections.filter((section) => section.status !== "ended")');
     expect(sidebar).toContain('className="operations-side-bar-chips triage-side-bar-sections"');
@@ -1175,6 +1176,8 @@ describe("Instrument core design contract", () => {
     expect(shelf).not.toMatch(/var\(--(?:brass|aurora|warn|coral|positive)/);
     expect(caption).toMatch(/color: var\(--text-(?:primary|secondary|tertiary|on-brass)\)/);
     expect(caption).toMatch(/font-weight: var\(--weight-(?:regular|medium|bold)\)/);
+    expect(caption).toContain("background: transparent;");
+    expect(captionToggle).toContain("border-left: 3px solid var(--status-color);");
   });
 
   it("collapses sidebar chip actions out of layout until hover or focus-within", () => {
@@ -1234,6 +1237,8 @@ describe("Instrument core design contract", () => {
     expect(sidebar).toContain("groupTheaterStatusEntries(");
     expect(sidebar).toContain("minimizedIds.has(entry.operation.id) && !dormantIds.has(entry.operation.id)");
     expect(sidebar).toContain("<StatusRecoveryShelves");
+    expect(sidebar).not.toContain("triage-side-bar-caption");
+    expect(components).not.toContain(".triage-side-bar-caption");
     expect(components).toContain(".side-bar-status-section--minimized {");
     expect(sidebar).toContain("trackOperationActivityTransitions({");
     expect(sidebar).toContain("const landedIds = consumeStatusLandings();");
@@ -1276,6 +1281,8 @@ describe("Instrument core design contract", () => {
     expect(components).toMatch(/\.canvas-triage-map-dot\.is-background \{[^}]*background:\s*none;[^}]*border-color:\s*var\(--activity-color\)/);
     expect(components).toContain("--status-color: var(--activity-color);");
     expect(components).toContain("border-left: 3px solid var(--status-color);");
+    expect(components).not.toMatch(/\.side-bar-status-section \{[^}]*border-left:\s*3px solid var\(--status-color\)/);
+    expect(components).toMatch(/\.side-bar-status-header__toggle \{[^}]*border-left:\s*3px solid var\(--status-color\)/);
     expect(components).not.toContain(".side-bar-status-section--background");
     expect(sidebar).not.toContain("side-bar-status-header__dot");
     expect(components).not.toContain(".side-bar-status-header__dot");

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -353,10 +353,10 @@ describe("groupOperationsByStatus", () => {
     const sections = groupOperationsByStatus(entries);
 
     expect(sections.map((section) => [section.status, section.label])).toEqual([
-      ["awaiting", "AWAITING"],
-      ["running", "RUNNING"],
-      ["idle", "IDLE"],
-      ["ended", "ENDED"],
+      ["awaiting", "Awaiting"],
+      ["running", "Running"],
+      ["idle", "Idle"],
+      ["ended", "Ended · select to start again"],
     ]);
     expect(sections[2]?.entries.map((entry) => entry.operation.id)).toEqual(["idle-missing", "idle-explicit"]);
   });

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -83,11 +83,11 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(toggle.getAttribute("aria-pressed")).toBe("true");
     expect(toggle.querySelector(".side-bar-status-axis-live-tick")).toBeNull();
     expect(Array.from(container?.querySelectorAll(".side-bar-status-header__label") ?? []).map((node) => node.textContent)).toEqual([
-      "AWAITING",
-      "RUNNING",
-      "IDLE",
-      "Minimized",
-      "ENDED",
+      "Awaiting",
+      "Running",
+      "Idle",
+      "Minimized · select to restore",
+      "Ended · select to start again",
     ]);
     expect(container?.querySelector(".side-bar-group-header")).toBeNull();
     expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').style.getPropertyValue("--user-accent")).toBe("var(--id-rose)");
@@ -126,21 +126,21 @@ describe("OperationsSideBar STATUS axis", () => {
 
     const awaiting = required<HTMLElement>(".side-bar-status-section--awaiting");
     expect(awaiting.className).toContain("side-bar-status-section--empty");
-    const awaitingToggle = required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section AWAITING"]');
+    const awaitingToggle = required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section Awaiting"]');
     expect(awaitingToggle.getAttribute("aria-expanded")).toBe("false");
     expect(awaiting.querySelector(".side-bar-status-empty-hint")).toBeNull();
 
     act(() => awaitingToggle.click());
 
-    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING"]').title).toBe("Collapse");
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section Awaiting"]').title).toBe("Collapse");
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
 
-    const runningToggle = required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]');
+    const runningToggle = required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section Running"]');
     expect(runningToggle.getAttribute("aria-expanded")).toBe("true");
     act(() => runningToggle.click());
-    expect(required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section RUNNING"]').title).toBe("Expand");
+    expect(required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section Running"]').title).toBe("Expand");
     expect(container?.querySelector('[data-side-bar-chip-id="only"]')).toBeNull();
-    act(() => required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section RUNNING"]').click());
+    act(() => required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section Running"]').click());
     expect(container?.querySelector('[data-side-bar-chip-id="only"]')).not.toBeNull();
   });
 
@@ -232,19 +232,19 @@ describe("OperationsSideBar STATUS axis", () => {
     setSideBarStatusAxis(true);
     renderSideBar([]);
 
-    act(() => required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section AWAITING"]').click());
+    act(() => required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section Awaiting"]').click());
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
 
     act(() => setConsoleState({ operationRuntime: { arriving: { lifecycle: "live", activity: "awaiting" } } }));
     rerenderSideBar([makeOperation("arriving", null)]);
 
-    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING"]').getAttribute("aria-expanded")).toBe("true");
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section Awaiting"]').getAttribute("aria-expanded")).toBe("true");
     expect(container?.querySelector('[data-side-bar-chip-id="arriving"]')).not.toBeNull();
 
     act(() => setConsoleState({ operationRuntime: {} }));
     rerenderSideBar([]);
 
-    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING"]').getAttribute("aria-expanded")).toBe("true");
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section Awaiting"]').getAttribute("aria-expanded")).toBe("true");
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
   });
 
@@ -259,16 +259,16 @@ describe("OperationsSideBar STATUS axis", () => {
 
     const alpha = required<HTMLElement>(`[data-theater-id="${THEATER.id}"]`);
     const bravo = required<HTMLElement>(`[data-theater-id="${THEATER_B.id}"]`);
-    act(() => alpha.querySelector<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]')?.click());
+    act(() => alpha.querySelector<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section Running"]')?.click());
 
     expect(alpha.querySelector('[data-side-bar-chip-id="alpha-running"]')).toBeNull();
     expect(bravo.querySelector('[data-side-bar-chip-id="bravo-running"]')).not.toBeNull();
-    expect(bravo.querySelector('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]')).not.toBeNull();
+    expect(bravo.querySelector('.side-bar-status-section--running [aria-label="Collapse section Running"]')).not.toBeNull();
 
-    act(() => bravo.querySelector<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]')?.click());
+    act(() => bravo.querySelector<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section Running"]')?.click());
 
-    expect(alpha.querySelector('.side-bar-status-section--running [aria-label="Expand section RUNNING"]')).not.toBeNull();
-    expect(bravo.querySelector('.side-bar-status-section--running [aria-label="Expand section RUNNING"]')).not.toBeNull();
+    expect(alpha.querySelector('.side-bar-status-section--running [aria-label="Expand section Running"]')).not.toBeNull();
+    expect(bravo.querySelector('.side-bar-status-section--running [aria-label="Expand section Running"]')).not.toBeNull();
   });
 
   it("suppresses group pills but keeps the status mark and marks an idle arrival unseen in inactive Theater preview chips", () => {
@@ -340,7 +340,7 @@ describe("OperationsSideBar STATUS axis", () => {
     act(() => setConsoleState({ operationRuntime: { moving: { lifecycle: "live", activity: "awaiting" } } }));
 
     expect(required<HTMLElement>('[data-side-bar-chip-id="moving"]').className).toContain("side-bar-chip--status-landed");
-    expect(required<HTMLElement>(".side-bar-status-header__label").textContent).toBe("AWAITING");
+    expect(required<HTMLElement>(".side-bar-status-header__label").textContent).toBe("Awaiting");
   });
 
   it("puts the most recently transitioned Operation first and keeps untouched Operations in operationOrder", () => {


### PR DESCRIPTION
## Summary
- Fold every STATUS group in the Map sidebar and War Room into one shelf caption row (name + count + collapse).
- Keep the 3px signal stripe on that row and drop the 8% tinted wash so the column is no longer a colored group block.
- Speak restore/restart verbs only on Minimized and Ended. Living buckets stay names: Awaiting / Running / Idle.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run` on status-axis, group, design-contract, feature-tour, triage-store (287 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Isolated console: restore moves a chip from Minimized to Idle; re-minimize moves it back; War Room uses `Minimized · select to restore to the deck` with no outer caption stack