### PR TITLE
fix(fleet-console): place Cruise right-click panels at the click

### DIFF
--- a/.changelog.d/cruise-rightclick-panel-geometry.md
+++ b/.changelog.d/cruise-rightclick-panel-geometry.md
@@ -1,0 +1,8 @@
+---
+branch: cruise-rightclick-panel-geometry
+---
+
+### fleet-console
+#### Fixed
+- Place a panel created from a Cruise right-click at the click, instead of dropping it on the default cascade origin.
+  ko: Cruise에서 우클릭으로 만든 패널이 기본 계단 원점이 아니라 클릭한 자리에 놓입니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -582,11 +582,11 @@ export function liftTopZIndex(toAtLeast: number): void {
   topZIndex = Math.max(topZIndex, toAtLeast);
 }
 
-export function ensureDefaultGeometry(sessionId: string): OperationGeometry {
+export function ensureDefaultGeometry(sessionId: string, persisted?: OperationGeometry | null): OperationGeometry {
   const existing = state.operations[sessionId];
   if (existing) return existing;
   const index = Object.keys(state.operations).length;
-  let geometry: OperationGeometry = {
+  let geometry: OperationGeometry = persisted ?? {
     x: index * DEFAULT_OPERATION_OFFSET,
     y: index * DEFAULT_OPERATION_OFFSET,
     width: DEFAULT_OPERATION_WIDTH,
@@ -597,6 +597,7 @@ export function ensureDefaultGeometry(sessionId: string): OperationGeometry {
     const spot = resolveStationKeepingPosition(geometry, visibleObstacles(sessionId));
     geometry = { ...geometry, x: spot.x, y: spot.y };
   }
+  liftTopZIndex(geometry.zIndex);
   setState({ operations: { ...state.operations, [sessionId]: geometry } });
   return geometry;
 }

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -317,7 +317,7 @@ export function OperationSearch({
         // minimizeOperations는 geometry 맵에 없는 id를 버리므로, 페이지와 같이 현재 op의 기본
         // geometry를 먼저 심는다 — persisted canvas가 없는 신규 op도 최소화 대상이 된다.
         const theaterOperations = state.operations.filter((op) => op.theaterId === state.activeTheaterId);
-        for (const operation of theaterOperations) ensureDefaultGeometry(operation.id);
+        for (const operation of theaterOperations) ensureDefaultGeometry(operation.id, operation.geometry);
         minimizeOperations(theaterOperations.map((op) => op.id));
         break;
       }

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -12,7 +12,7 @@ import { isBlockingDialogOpen } from "../focus-guards.js";
 import { closeOperationCompletely } from "../operation-close.js";
 import { resumeOperationInPlace } from "../operation-resume.js";
 import { forgetTheaterCompletely, registerTheaterFromPath } from "../theater-crud.js";
-import { claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, consumePendingFitAllOperations, ensureDefaultGeometry, fitAllOperations, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getCompanionPanelVisibilityOverrides, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, resolveLaunchGeometry, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
+import { claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, consumePendingFitAllOperations, ensureDefaultGeometry, fitAllOperations, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getCompanionPanelVisibilityOverrides, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, resolveLaunchGeometry, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setTheaterOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
@@ -281,7 +281,7 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
       : null;
     if (resumeBootProtection !== null || viewMode.effective === "mobile") resumeBootProtectionRef.current = null;
     if (viewMode.effective === "mobile") return;
-    for (const operationId of operationOrder) ensureDefaultGeometry(operationId);
+    for (const operation of sortedTheaterOperations(state)) ensureDefaultGeometry(operation.id, operation.geometry);
     if (!state.operationsHydrated) return;
     pruneOperations(operationOrder);
     // 각 Theater를 세션 중 처음 열 때 한 번, 그 Theater의 부팅 시점 기존 패널을 최소화한다.
@@ -956,6 +956,9 @@ async function launchViaPlugin(
   }
   await fetchOperations(null).then(hydrateOperations).catch(() => {});
   if (!newOperationId) return;
+  // 플러그인 persist와 별개로 생성 좌표를 그 Theater 캔버스에 먼저 심는다. hydrate 뒤
+  // ensureDefaultGeometry가 cascade(index×40)로 덮는 창을 없애기 위함이다.
+  setTheaterOperationGeometry(theaterId, newOperationId, geometry);
   // 최대화 패널이 떠 있는 상태에서 새 Operation을 만들면 최대화를 유지하고 새 패널을 최대화 대상으로 승계한다.
   // focusOperation은 pendingOperationFocus 경로로 clearMaximizedOperationId를 부르므로(최대화 해제), 최대화 중에는 호출하지 않는다.
   // handleFocus(operations.tsx)·Alt+←/→ 순환과 동일 정책으로, 새 패널로 렌더 전용 포커스 레이어를 승계한다.

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -812,6 +812,23 @@ describe("station keeping", () => {
     expectAllVisibleClear();
   });
 
+  it("ensureDefaultGeometry seeds a persisted click rect instead of the cascade origin", () => {
+    const persisted = { x: 480, y: 240, width: 560, height: 360, zIndex: 7 };
+
+    ensureDefaultGeometry("op-click", persisted);
+
+    expect(getSnapshot().operations["op-click"]).toMatchObject(persisted);
+  });
+
+  it("ensureDefaultGeometry keeps the first write when a later persist arrives", () => {
+    const persisted = { x: 480, y: 240, width: 560, height: 360, zIndex: 7 };
+
+    ensureDefaultGeometry("op-click");
+    ensureDefaultGeometry("op-click", persisted);
+
+    expect(getSnapshot().operations["op-click"]).toMatchObject({ x: 0, y: 0, width: 640, height: 400 });
+  });
+
   it("restoreOperation settles a panel whose spot was taken while minimized", () => {
     setOperationGeometry("op-a", rect(0, 0));
     setStationKeeping(true);

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -8,7 +8,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, requestFitAllOperations, resetCanvasViewportSize, restoreOperation, setCanvasViewportSize, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, subscribe as subscribeCanvas, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, requestFitAllOperations, resetCanvasViewportSize, restoreOperation, setCanvasViewportSize, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setStationKeeping, setViewport, subscribe as subscribeCanvas, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
 import { BOOT_MINIMIZATION_STORAGE_KEY, resetBootMinimizationSession } from "../core/client/src/boot-minimization-session.js";
 import { CANVAS_MODE_STORAGE_KEY } from "../core/client/src/canvas/canvas-mode-session.js";
 import { armTriageSetAside, getTriageSetAsideArmedId, isTriageActive, resetTriageTheater, setTriageActive } from "../core/client/src/canvas/triage-store.js";
@@ -36,6 +36,7 @@ const canvasMocks = vi.hoisted(() => ({
   catalog: [] as readonly OperationCatalogPlugin[],
   onMount: null as null | (() => void | (() => void)),
   onLaunchAtGeometry: null as null | ((pluginId: string, kind: { readonly type: string; readonly title: string }, geometry: { readonly x: number; readonly y: number; readonly width: number; readonly height: number; readonly zIndex: number }) => void),
+  onLaunchKind: null as null | ((pluginId: string, kind: { readonly type: string; readonly title: string }, canvasPoint: { readonly x: number; readonly y: number }, theaterId?: string) => void),
   onRefreshCatalog: null as null | (() => void),
 }));
 const registryMocks = vi.hoisted(() => ({
@@ -70,13 +71,15 @@ vi.mock("../core/client/src/api.js", () => ({
 
 vi.mock("@fleet-console/sdk/operations/browser", () => ({ fetchOperationCatalog: vi.fn().mockResolvedValue([]) }));
 vi.mock("../core/client/src/canvas/canvas.js", () => ({
-  OperationsCanvas: ({ catalog, onLaunchAtGeometry, onRefreshCatalog }: {
+  OperationsCanvas: ({ catalog, onLaunchAtGeometry, onLaunchKind, onRefreshCatalog }: {
     readonly catalog: readonly OperationCatalogPlugin[];
     readonly onLaunchAtGeometry: NonNullable<typeof canvasMocks.onLaunchAtGeometry>;
+    readonly onLaunchKind: NonNullable<typeof canvasMocks.onLaunchKind>;
     readonly onRefreshCatalog: () => void;
   }) => {
     canvasMocks.catalog = catalog;
     canvasMocks.onLaunchAtGeometry = onLaunchAtGeometry;
+    canvasMocks.onLaunchKind = onLaunchKind;
     canvasMocks.onRefreshCatalog = onRefreshCatalog;
     useLayoutEffect(() => canvasMocks.onMount?.(), []);
     return null;
@@ -152,6 +155,7 @@ beforeEach(() => {
   resetBootMinimizationSession();
   window.history.replaceState({}, "", "/operations");
   loadForTheater("theater-a");
+  setStationKeeping(false);
   clearMaximizedOperationId();
   clearCompanionOperationId();
   clearFormationView();
@@ -174,6 +178,7 @@ beforeEach(() => {
   canvasMocks.catalog = [];
   canvasMocks.onMount = null;
   canvasMocks.onLaunchAtGeometry = null;
+  canvasMocks.onLaunchKind = null;
   canvasMocks.onRefreshCatalog = null;
   vi.mocked(fetchOperationCatalog).mockReset().mockResolvedValue([]);
   registryMocks.plugins = [];
@@ -1253,6 +1258,58 @@ describe("Operations boot minimization", () => {
     expect(getState().activeTheaterId).toBe("theater-b");
     expect(getTheaterCompanionOperationId("theater-a")).toBe("a1");
     expect(getCompanionOperationId()).toBeNull();
+  });
+
+  it("seeds the click geometry onto the canvas even when plugin launch omits it", async () => {
+    const launch = deferred<{ readonly id: string }>();
+    registryMocks.plugins = [{ id: "terminal", launch: vi.fn(() => launch.promise) }];
+    await bootApp([]);
+    const clickGeometry = { x: 480, y: 240, width: 560, height: 360, zIndex: 4 };
+    apiMocks.fetchOperations.mockResolvedValue([operation("launched")]);
+
+    await act(async () => {
+      canvasMocks.onLaunchAtGeometry?.("terminal", { type: "shell", title: "Shell" }, clickGeometry);
+      launch.resolve({ id: "launched" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getSnapshot().operations.launched).toMatchObject({
+      x: clickGeometry.x,
+      y: clickGeometry.y,
+      width: clickGeometry.width,
+      height: clickGeometry.height,
+    });
+  });
+
+  it("places a Cruise canvas-point launch at the click, not the cascade origin", async () => {
+    const launch = deferred<{ readonly id: string }>();
+    const launchFn = vi.fn(() => launch.promise);
+    registryMocks.plugins = [{ id: "terminal", launch: launchFn }];
+    await bootApp([]);
+    const canvasPoint = { x: 800, y: 400 };
+    const expected = { x: 520, y: 220, width: 560, height: 360 };
+    apiMocks.fetchOperations.mockResolvedValue([operation("launched")]);
+
+    await act(async () => {
+      canvasMocks.onLaunchKind?.("terminal", { type: "shell", title: "Shell" }, canvasPoint);
+      launch.resolve({ id: "launched" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(launchFn).toHaveBeenCalledWith(expect.objectContaining({
+      geometry: expect.objectContaining(expected),
+    }));
+    expect(getSnapshot().operations.launched).toMatchObject(expected);
+  });
+
+  it("seeds persisted Operation.geometry onto an empty canvas on hydrate", async () => {
+    const persisted = { x: 480, y: 240, width: 560, height: 360, zIndex: 7 };
+
+    await bootApp([{ ...operation("clicked"), geometry: persisted }]);
+
+    expect(getSnapshot().operations.clicked).toMatchObject(persisted);
   });
 
   it("minimizes a second Theater's existing panels on first in-session view, surfacing only the selected panel", async () => {

--- a/runtime/fleet-plugins/terminal/client/agent/api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/api.ts
@@ -1,4 +1,4 @@
-import type { OperationNode } from "@fleet-console/sdk/operations";
+import type { OperationGeometry, OperationNode } from "@fleet-console/sdk/operations";
 import { readAgentChatJobDetailPayload, type AgentChatJobDetail } from "./chat/chat-events.js";
 import type { AgentCliDiagnostics, AgentCliMetadata, AgentCliState, SessionInfo } from "./types.js";
 
@@ -93,6 +93,7 @@ export async function createAgentSession(
     readonly attachmentIds?: readonly string[];
     /** 생략은 터미널이다 — 기본이 곧 계약이라 이 키를 모르는 호출부도 같은 길을 탄다. */
     readonly viewMode?: "chat";
+    readonly geometry?: OperationGeometry;
   },
   signal?: AbortSignal,
 ): Promise<SessionInfo> {
@@ -105,7 +106,7 @@ export async function createAgentSession(
   const response = await fetch("/plugins/terminal/agent/sessions", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ theaterId, cliId, ...(model ? { model } : {}), ...(effort ? { effort } : {}), ...(prompt ? { prompt } : {}), ...(attachmentIds ? { attachmentIds } : {}), ...(viewMode ? { viewMode } : {}) }),
+    body: JSON.stringify({ theaterId, cliId, ...(model ? { model } : {}), ...(effort ? { effort } : {}), ...(prompt ? { prompt } : {}), ...(attachmentIds ? { attachmentIds } : {}), ...(viewMode ? { viewMode } : {}), ...(options?.geometry ? { geometry: options.geometry } : {}) }),
     signal,
   });
   // 거절 사유 코드를 그대로 실어 던진다 — Quick Launch가 초안을 되살리면서 무엇을 고쳐야 하는지

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -181,7 +181,7 @@ export const agentPlugin = definePlugin({
   // Quick Launch 이미지 첨부. 실패 표현은 컴포저가 거절 코드로 소유한다(messageOperation과 같은 계약).
   uploadLaunchAttachment: async (file) => uploadLaunchAttachment(file),
   discardLaunchAttachment: async (id) => discardLaunchAttachment(id),
-  launch: async ({ theaterId, kind, variant }) => {
+  launch: async ({ theaterId, kind, variant, geometry }) => {
     // 첨부 id는 variant 문자열 계약(Record<string,string>)에 CSV로 실려 온다 — id는 서버가 만든
     // UUID라 쉼표를 품지 않는다.
     const attachmentIds = variant?.attachments?.split(",").filter((id) => id.length > 0);
@@ -189,6 +189,7 @@ export const agentPlugin = definePlugin({
       model: variant?.model,
       effort: variant?.effort,
       prompt: variant?.prompt,
+      geometry,
       ...(attachmentIds?.length ? { attachmentIds } : {}),
       // 모르는 값은 실어 보내지 않는다 — 서버가 최종 판정자지만, 오타가 400으로 왕복하며
       // 초안을 잃게 하는 것보다 여기서 터미널로 접는 편이 낫다(기본이 곧 계약이다).

--- a/runtime/fleet-plugins/terminal/client/shell/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/shell/index.tsx
@@ -23,13 +23,14 @@ export const shellPlugin = definePlugin({
   closeOperation: async (operationId) => {
     await fetch(`/plugins/terminal/shell/sessions/${encodeURIComponent(operationId)}`, { method: "DELETE" });
   },
-  launch: async ({ theaterId, operations }) => {
+  launch: async ({ theaterId, operations, geometry }) => {
     const operation = await operations.create({
       theaterId,
       type: "shell",
       pluginId: "terminal",
       title: getT("en")("terminal.kind.shell"),
       payload: { theaterId },
+      geometry,
     });
     return { id: operation.id };
   },

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -7,7 +7,7 @@ import { buildDisabledSkillOverrides, buildGatewayModelsToolSpec, createDelayedP
 import type { AgentToolSpec } from "@dotobokuri/core-agent";
 import { ensureWorkspaceDirectory, withDirectoryLock, type GlobalOptionsService } from "@dotobokuri/core-infra";
 import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
-import type { OperationLaunchKind, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
+import type { OperationGeometry, OperationLaunchKind, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
 import { registerRouter } from "@fleet-console/sdk/plugin/node";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { readSocketRole, readTicketChannel } from "./shared/index.js";
@@ -39,7 +39,7 @@ import { resolveAnalysisGatewayBaseUrl } from "./agent-api/analysis-types.js";
 import { resolveTranscriptPath } from "./agent-api/transcript-path.js";
 import type { AgentProviderSession, AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
 import { startIdleAgentDormantSweeper } from "./agent-idle-dormant-sweeper.js";
-type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown; readonly model?: unknown; readonly effort?: unknown; readonly prompt?: unknown; readonly attachmentIds?: unknown; readonly viewMode?: unknown };
+type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown; readonly model?: unknown; readonly effort?: unknown; readonly prompt?: unknown; readonly attachmentIds?: unknown; readonly viewMode?: unknown; readonly geometry?: unknown };
 type HookTurnBody = { readonly phase?: unknown; readonly input?: unknown };
 type HookBackgroundBody = { readonly input?: unknown };
 type HookAttentionBody = { readonly input?: unknown; readonly reason?: unknown };
@@ -490,6 +490,8 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     }
     const launchOptions = readLaunchOptions(body, cliId, res);
     if (launchOptions === false) return true;
+    const geometry = readOptionalGeometry(body?.geometry, res);
+    if (geometry === false) return true;
     if (body?.prompt !== undefined && typeof body.prompt !== "string") {
       ctx.host.http.writeJson(res, 400, { error: "invalid_prompt" });
       return true;
@@ -539,6 +541,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         ...(composedPrompt ? { prompt: composedPrompt } : {}),
         ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
         ...(chatBorn ? { chatBorn: true as const } : {}),
+        ...(geometry ? { geometry } : {}),
       });
     } catch (error) {
       // createSession이 스스로 처리하지 못한 throw까지 예약을 되돌린다 — bind 후에는 no-op이라 안전.
@@ -555,6 +558,29 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       return false;
     }
     return value as readonly string[];
+  }
+
+  function readOptionalGeometry(value: unknown, res: Parameters<typeof handle>[0]["res"]): OperationGeometry | undefined | false {
+    if (value === undefined) return undefined;
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      ctx.host.http.writeJson(res, 400, { error: "invalid_geometry" });
+      return false;
+    }
+    const candidate = value as Record<string, unknown>;
+    const x = candidate.x;
+    const y = candidate.y;
+    const width = candidate.width;
+    const height = candidate.height;
+    const zIndex = candidate.zIndex;
+    if (typeof x !== "number" || !Number.isFinite(x)
+      || typeof y !== "number" || !Number.isFinite(y)
+      || typeof width !== "number" || !Number.isFinite(width)
+      || typeof height !== "number" || !Number.isFinite(height)
+      || typeof zIndex !== "number" || !Number.isFinite(zIndex)) {
+      ctx.host.http.writeJson(res, 400, { error: "invalid_geometry" });
+      return false;
+    }
+    return { x, y, width, height, zIndex };
   }
 
   function readLaunchOptions(
@@ -682,7 +708,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     theaterId: string,
     cliId: AgentCliId,
     res: Parameters<typeof handle>[0]["res"],
-    launchOptions: { readonly model?: string; readonly effort?: string; readonly prompt?: string; readonly attachmentIds?: readonly string[]; readonly chatBorn?: true } = {},
+    launchOptions: { readonly model?: string; readonly effort?: string; readonly prompt?: string; readonly attachmentIds?: readonly string[]; readonly chatBorn?: true; readonly geometry?: OperationGeometry } = {},
   ): Promise<void> {
     const meta = (await buildAgentCliLaunchMetadata()).find((entry) => entry.id === cliId);
     if (!meta || !meta.available || !meta.signedIn) {
@@ -725,6 +751,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         // "transcript 부재는 상실이 아니라 아직 첫 턴 전"이라는 뜻을 durable하게 남긴다.
         ...(launchOptions.chatBorn ? { [CHAT_MODE_PAYLOAD_KEY]: true, [CHAT_BORN_PAYLOAD_KEY]: true } : {}),
       },
+      ...(launchOptions.geometry ? { geometry: launchOptions.geometry } : {}),
       createdAt: session.createdAt,
     });
     if (launchOptions.chatBorn) {

--- a/runtime/fleet-plugins/terminal/tests/agent-launch-attachments.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-launch-attachments.test.ts
@@ -343,6 +343,25 @@ describe("agent attachment routes", () => {
     await harness.postSessions({ theaterId: "theater-1", cliId: "claude", prompt: "fix it", attachmentIds: [id] });
     expect(harness.responses.at(-1)).toEqual({ status: 400, body: { error: "attachment_not_found" } });
   });
+
+  it("stores launch geometry on the created Operation", async () => {
+    const harness = await createHarness();
+    const geometry = { x: 240, y: 160, width: 560, height: 360, zIndex: 4 };
+
+    await harness.postSessions({ theaterId: "theater-1", cliId: "claude", geometry });
+
+    expect(harness.responses.at(-1)?.status).toBe(200);
+    expect(harness.operations[0]?.geometry).toEqual(geometry);
+  });
+
+  it("rejects a launch whose geometry is not a complete rect", async () => {
+    const harness = await createHarness();
+
+    await harness.postSessions({ theaterId: "theater-1", cliId: "claude", geometry: { x: 10, y: 20 } });
+
+    expect(harness.responses.at(-1)).toEqual({ status: 400, body: { error: "invalid_geometry" } });
+    expect(harness.operations).toHaveLength(0);
+  });
 });
 
 async function createHarness(options: { readonly attachError?: Error } = {}) {

--- a/runtime/fleet-plugins/terminal/tests/client-launch-prompt.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/client-launch-prompt.test.ts
@@ -5,6 +5,7 @@ import type { LaunchContext } from "@fleet-console/sdk/plugin";
 import { assertSessionInfo, createAgentSession } from "../client/agent/api.js";
 import { agentPlugin } from "../client/agent/index.js";
 import { getAgentState, removeSession } from "../client/agent/store.js";
+import { shellPlugin } from "../client/shell/index.js";
 
 afterEach(() => {
   for (const sessionId of Object.keys(getAgentState().sessions)) {
@@ -31,6 +32,7 @@ describe("agent client launch prompt threading", () => {
       model: "kimi--k3",
       effort: "max",
       prompt: "ship the prompt",
+      geometry: LAUNCH_GEOMETRY,
     });
   });
 
@@ -45,6 +47,7 @@ describe("agent client launch prompt threading", () => {
       theaterId: "theater-1",
       cliId: "claude-gateway",
       model: "fable[1m]",
+      geometry: LAUNCH_GEOMETRY,
     });
   });
 
@@ -58,6 +61,7 @@ describe("agent client launch prompt threading", () => {
     expect(readCreateBody(fetch)).toEqual({
       theaterId: "theater-1",
       cliId: "claude-gateway",
+      geometry: LAUNCH_GEOMETRY,
     });
   });
 
@@ -89,6 +93,29 @@ describe("agent client launch prompt threading", () => {
   });
 });
 
+describe("shell client launch geometry", () => {
+  it("creates the shell Operation at the launch-context geometry", async () => {
+    const create = vi.fn(async (input: { readonly geometry?: unknown }) => ({ id: "shell-1", ...input }));
+    const launch = shellPlugin.launch;
+    if (!launch) throw new Error("Shell plugin launch must exist.");
+
+    await launch({
+      theaterId: "theater-1",
+      kind: { id: "shell", type: "shell", title: "Shell" },
+      geometry: LAUNCH_GEOMETRY,
+      operations: { create } as unknown as LaunchContext["operations"],
+    });
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      theaterId: "theater-1",
+      type: "shell",
+      geometry: LAUNCH_GEOMETRY,
+    }));
+  });
+});
+
+const LAUNCH_GEOMETRY = { x: 120, y: 80, width: 560, height: 360, zIndex: 3 } as const;
+
 function createLaunchContext(
   variant: Readonly<Record<string, string>>,
   kindId = "claude-gateway",
@@ -100,7 +127,7 @@ function createLaunchContext(
       type: "agent",
       title: "Agent",
     },
-    geometry: { x: 0, y: 0, width: 1, height: 1, zIndex: 1 },
+    geometry: LAUNCH_GEOMETRY,
     operations: {} as LaunchContext["operations"],
     variant,
   };


### PR DESCRIPTION
## Summary
- Cruise 우클릭으로 만든 패널이 기본 cascade 원점(`index×40`)이 아니라 클릭한 world 좌표에 놓입니다.
- 터미널 `plugin.launch`가 `LaunchContext.geometry`를 버려 Operation이 `geometry: null`로 저장되고, hydrate의 `ensureDefaultGeometry`가 existing-first로 cascade를 얼리던 경로를 끊었습니다.
- Shell/Agent 생성이 geometry를 Operation 노드에 쓰고, hydrate가 persist를 시드하며, `launchViaPlugin`이 같은 턴에 캔버스에도 심습니다. 사이드바/QL 중앙 생성과 War Room의 저장된 Theater viewport는 그대로입니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal test -- client-launch-prompt.test.ts agent-launch-attachments.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/canvas-store.test.ts tests/operations-boot-minimization.integration.test.ts`
- [ ] Cruise 빈 바다를 우클릭해 Shell/Agent를 만들고, 패널이 클릭 자리에 생기는지 확인
- [ ] 사이드바/Quick Launch 생성이 계속 뷰포트 중앙인지 확인