### PR TITLE
fix(fleet-desktop): keep Windows window controls aligned across DPI and zoom

### DIFF
--- a/.changelog.d/fix-desktop-wco-dpi-overlay.md
+++ b/.changelog.d/fix-desktop-wco-dpi-overlay.md
@@ -1,0 +1,8 @@
+---
+branch: fix-desktop-wco-dpi-overlay
+---
+
+### fleet-desktop
+#### Fixed
+- Keep the Windows window control buttons sized and aligned with the top band when the window moves between monitors with different display scales and when the zoom level changes.
+  ko: Windows에서 디스플레이 배율이 다른 모니터로 창을 옮기거나 화면 배율(줌)을 바꿔도 창 제어 버튼이 상단 밴드에 맞는 크기와 위치로 표시됩니다.

--- a/runtime/fleet-desktop/src/main.ts
+++ b/runtime/fleet-desktop/src/main.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, dialog, Menu, Notification, session, shell, Tray, WebContentsView } from "electron";
+import { app, BrowserWindow, dialog, Menu, Notification, screen, session, shell, Tray, WebContentsView } from "electron";
 
 import { createDesktopLifecycle } from "./app-lifecycle.js";
 import { showBootFailureAndExit } from "./boot-failure.js";
@@ -32,7 +32,8 @@ import { resolveRuntimePaths } from "./runtime/runtime-paths.js";
 import { SidecarSupervisor, type SidecarRuntime } from "./sidecar-supervisor.js";
 import { configureTray, createDesktopTray, shouldConfigureTray } from "./tray.js";
 import { createNoopUpdateController, createUpdateController, resolveActiveWindow, showWindowsHiddenUpdateDialog } from "./update-controller.js";
-import { applyWindowPolicy, confinePickerNavigation, createSecureWindow } from "./window-policy.js";
+import { createTitleBarOverlayRefresher, type TitleBarOverlayRefresher } from "./title-bar-overlay-refresh.js";
+import { applyWindowPolicy, confinePickerNavigation, createSecureWindow, INITIAL_WINDOWS_TITLE_BAR_OVERLAY } from "./window-policy.js";
 import { createZoomState } from "./zoom-state.js";
 
 type RuntimeProgress = (state: RuntimeEntryState, detail?: string, progress?: number) => Promise<void>;
@@ -118,12 +119,14 @@ async function boot(): Promise<void> {
     const url = typeof input === "string" ? input : input.href;
     return isRemoteConsoleOrigin(new URL(url).origin) ? consoleSession.fetch(url, init) : globalThis.fetch(url, init);
   };
+  let overlayRefresher: TitleBarOverlayRefresher | null = null;
   const themeSynchronizer = process.platform === "win32"
     ? createDesktopThemeSynchronizer({
       fetch: consoleFetch,
       applyTheme: (snapshot) => {
         if (!window || window.isDestroyed()) return;
-        window.setTitleBarOverlay(snapshot.titleBarOverlay);
+        // 리프레셔가 현재 모니터 배율 보정을 소유한다 — 창이 아직 없으면 적용할 곳도 없다.
+        overlayRefresher?.applyOverlay(snapshot.titleBarOverlay);
       },
     })
     : null;
@@ -197,10 +200,19 @@ async function boot(): Promise<void> {
         const createdWindow = createSecureWindow(BrowserWindow, { iconPath: desktopResources.iconPath, platform: process.platform });
         window = createdWindow;
         fullscreenSynchronizer = createDesktopFullscreenSynchronizer(createdWindow, { fetch: consoleFetch });
+        overlayRefresher = process.platform === "win32"
+          ? createTitleBarOverlayRefresher(createdWindow, {
+            screen,
+            initialOverlay: INITIAL_WINDOWS_TITLE_BAR_OVERLAY,
+            getZoomFactor: () => createdWindow.webContents.getZoomFactor(),
+          })
+          : null;
         createdWindow.once("closed", () => {
           themeSynchronizer?.stop();
           fullscreenSynchronizer?.stop();
           fullscreenSynchronizer = null;
+          overlayRefresher?.stop();
+          overlayRefresher = null;
           picker.close();
         });
         controls.attachWindow(createdWindow);
@@ -209,7 +221,17 @@ async function boot(): Promise<void> {
         bridge.attach(createdWindow.webContents);
         // 창이 어디로 옮겨 가든 덮개는 따라가지 않는다 — 새 콘솔 위에 남은 옛 목록은 거짓말이다.
         createdWindow.webContents.on("did-navigate", () => picker.close());
-        createdWindow.webContents.on("zoom-changed", (_event, zoomDirection) => controls.zoomChanged(createdWindow.webContents, zoomDirection));
+        createdWindow.webContents.on("zoom-changed", (_event, zoomDirection) => {
+          controls.zoomChanged(createdWindow.webContents, zoomDirection);
+          overlayRefresher?.refresh();
+        });
+        // 시작 시 복원되는 줌은 이벤트를 내지 않는다 — 로드가 끝난 자리에서 보정 높이를 재확인한다.
+        createdWindow.webContents.on("did-finish-load", () => overlayRefresher?.refresh());
+        // 스냅·최대화 전환(Win+Shift+화살표 등)은 moved 없이 모니터를 건널 수 있다 — 게이트가
+        // no-op이므로 상태 전환마다 배율 정합을 재확인해도 비용이 없다.
+        createdWindow.on("maximize", () => overlayRefresher?.refresh());
+        createdWindow.on("unmaximize", () => overlayRefresher?.refresh());
+        createdWindow.on("restore", () => overlayRefresher?.refresh());
         refreshNativeUpdateActions?.();
         await createdWindow.loadFile(desktopResources.entryPagePath);
         return createdWindow;
@@ -246,9 +268,9 @@ async function boot(): Promise<void> {
     show: () => { void lifecycle.show(); },
     quit: () => { void lifecycle.quit(); },
     diagnostics: () => { void shell.openPath(path.join(app.getPath("userData"), "logs")); },
-    zoomIn: () => controls.zoomIn(),
-    zoomOut: () => controls.zoomOut(),
-    actualSize: () => controls.actualSize(),
+    zoomIn: () => { controls.zoomIn(); overlayRefresher?.refresh(); },
+    zoomOut: () => { controls.zoomOut(); overlayRefresher?.refresh(); },
+    actualSize: () => { controls.actualSize(); overlayRefresher?.refresh(); },
     reloadConsole: () => controls.reloadConsole(),
     consoleReady: () => controls.consoleReady(),
     updates,

--- a/runtime/fleet-desktop/src/title-bar-overlay-refresh.ts
+++ b/runtime/fleet-desktop/src/title-bar-overlay-refresh.ts
@@ -1,0 +1,141 @@
+import type { BrowserWindow, Display, Rectangle } from "electron";
+
+/**
+ * Windows WCO 캡션 버튼(최소화/최대화/닫기)의 배치는 창 생성 시점에 시스템(주 모니터)
+ * 배율로 굳고, 배율이 다른 모니터로 이동해도 Electron이 스스로 재배치하지 않는다
+ * (electron/electron#36200·#36791 계열). 다행히 `setTitleBarOverlay`는 값이 같아도 항상
+ * `InvalidateCaptionButtons()`로 재배치를 강제하고, 그 재배치는 현재 모니터 배율을 올바르게
+ * 쓴다 — 그래서 창이 배율이 다른 모니터에 놓일 때마다 오버레이를 다시 적용하는 것으로
+ * 스테일 배치를 치유한다.
+ *
+ * 높이는 페이지 줌을 따라간다: Command Band(CSS 44px)는 줌에 비례해 커지고 작아지지만
+ * 네이티브 오버레이 DIP 높이는 줌과 무관하므로, `round(height × 줌)`을 적용해야 어느
+ * 줌에서든 스트립이 밴드의 실제 크기와 정합한다. 줌 1에서는 원값 그대로다.
+ */
+
+export interface OverlayRefreshWindow extends Pick<BrowserWindow, "isDestroyed" | "getBounds" | "setTitleBarOverlay"> {
+  on(event: "moved", listener: () => void): this;
+  removeListener(event: "moved", listener: () => void): this;
+}
+
+type DisplayMetricsListener = (event: unknown, display: Display, changedMetrics: string[]) => void;
+
+export interface OverlayRefreshScreen {
+  getDisplayMatching(rect: Rectangle): Display;
+  on(event: "display-metrics-changed", listener: DisplayMetricsListener): this;
+  removeListener(event: "display-metrics-changed", listener: DisplayMetricsListener): this;
+}
+
+export interface DesktopTitleBarOverlay {
+  readonly color: string;
+  readonly symbolColor: string;
+  readonly height: number;
+}
+
+export interface TitleBarOverlayRefresher {
+  /** 오버레이 스냅샷을 교체해 즉시 적용한다(테마 변경). */
+  applyOverlay(overlay: DesktopTitleBarOverlay): void;
+  /** 배율·줌이 바뀌었을 수 있는 신호 — 적용 높이나 모니터 배율이 실제로 달라졌을 때만 재적용한다. */
+  refresh(): void;
+  stop(): void;
+}
+
+export interface TitleBarOverlayRefresherDeps {
+  readonly screen: OverlayRefreshScreen;
+  readonly initialOverlay: DesktopTitleBarOverlay;
+  readonly getZoomFactor?: () => number;
+  readonly refreshDelayMs?: number;
+  readonly setTimeout?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimeout?: (timer: ReturnType<typeof setTimeout>) => void;
+}
+
+// 배율 전환 직후의 재적용은 무시될 수 있어 한 박자 늦춘다(electron/electron#36791의 실측 지연).
+// 드래그 중 연속되는 moved 이벤트의 디바운스 간격도 겸한다.
+export const OVERLAY_REFRESH_DELAY_MS = 100;
+
+export function zoomedOverlayHeight(height: number, zoomFactor: number): number {
+  if (!(zoomFactor > 0)) return height;
+  return Math.max(1, Math.round(height * zoomFactor));
+}
+
+export function createTitleBarOverlayRefresher(
+  window: OverlayRefreshWindow,
+  deps: TitleBarOverlayRefresherDeps,
+): TitleBarOverlayRefresher {
+  const schedule = deps.setTimeout ?? globalThis.setTimeout;
+  const cancelSchedule = deps.clearTimeout ?? globalThis.clearTimeout;
+  const refreshDelayMs = deps.refreshDelayMs ?? OVERLAY_REFRESH_DELAY_MS;
+  let stopped = false;
+  let pending: ReturnType<typeof setTimeout> | null = null;
+  let overlay: DesktopTitleBarOverlay = deps.initialOverlay;
+  let appliedHeight: number | null = null;
+  let appliedScaleFactor: number | null = null;
+
+  const measure = (): { height: number; currentScaleFactor: number } => {
+    const currentScaleFactor = deps.screen.getDisplayMatching(window.getBounds()).scaleFactor;
+    const zoomFactor = deps.getZoomFactor?.() ?? 1;
+    return { height: zoomedOverlayHeight(overlay.height, zoomFactor), currentScaleFactor };
+  };
+
+  // 같은 높이라도 모니터 배율이 달라졌으면 스테일 배치다 — 재적용만이 현재 배율로 되돌린다.
+  const upToDate = (measured: { height: number; currentScaleFactor: number }): boolean =>
+    measured.height === appliedHeight && measured.currentScaleFactor === appliedScaleFactor;
+
+  const apply = (): void => {
+    if (stopped || window.isDestroyed()) return;
+    const { height, currentScaleFactor } = measure();
+    window.setTitleBarOverlay({ color: overlay.color, symbolColor: overlay.symbolColor, height });
+    appliedHeight = height;
+    appliedScaleFactor = currentScaleFactor;
+  };
+
+  const cancelPending = (): void => {
+    if (pending !== null) cancelSchedule(pending);
+    pending = null;
+  };
+
+  const scheduleRefresh = (): void => {
+    cancelPending();
+    pending = schedule(() => {
+      pending = null;
+      if (stopped || window.isDestroyed()) return;
+      if (upToDate(measure())) return;
+      apply();
+    }, refreshDelayMs);
+  };
+
+  const maybeRefresh = (): void => {
+    if (stopped || window.isDestroyed()) return;
+    if (upToDate(measure()) && pending === null) return;
+    scheduleRefresh();
+  };
+
+  const onDisplayMetricsChanged: DisplayMetricsListener = (_event, _display, changedMetrics) => {
+    if (!changedMetrics.includes("scaleFactor")) return;
+    maybeRefresh();
+  };
+
+  window.on("moved", maybeRefresh);
+  deps.screen.on("display-metrics-changed", onDisplayMetricsChanged);
+  // 생성자 옵션의 오버레이는 시스템 배율 배치로 시작한다 — 창이 주 모니터 밖에서 열렸어도
+  // 첫 적용이 곧바로 현재 모니터 배율로 바로잡도록 여기서 한 번 적용한다.
+  apply();
+
+  return {
+    applyOverlay(next: DesktopTitleBarOverlay): void {
+      overlay = next;
+      cancelPending();
+      apply();
+    },
+    refresh(): void {
+      maybeRefresh();
+    },
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      cancelPending();
+      window.removeListener("moved", maybeRefresh);
+      deps.screen.removeListener("display-metrics-changed", onDisplayMetricsChanged);
+    },
+  };
+}

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -24,7 +24,7 @@ export interface WindowPolicy {
 export const DESKTOP_WINDOW_TITLE = "Fleet Console";
 
 const CANVAS_FAR_BACKGROUND_COLOR = "#010204";
-const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#03080e", symbolColor: "#989fa6", height: 43 } as const;
+export const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#03080e", symbolColor: "#989fa6", height: 43 } as const;
 
 export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, options: SecureWindowOptions): BrowserWindow {
   const windowOptions: BrowserWindowConstructorOptions = {

--- a/runtime/fleet-desktop/tests/title-bar-overlay-refresh.test.ts
+++ b/runtime/fleet-desktop/tests/title-bar-overlay-refresh.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTitleBarOverlayRefresher, OVERLAY_REFRESH_DELAY_MS, zoomedOverlayHeight, type DesktopTitleBarOverlay, type OverlayRefreshScreen, type OverlayRefreshWindow } from "../src/title-bar-overlay-refresh.js";
+
+const INITIAL: DesktopTitleBarOverlay = { color: "#03080e", symbolColor: "#989fa6", height: 43 };
+
+interface Harness {
+  readonly setTitleBarOverlay: ReturnType<typeof vi.fn>;
+  readonly refresher: ReturnType<typeof createTitleBarOverlayRefresher>;
+  setScaleFactor(scaleFactor: number): void;
+  setZoomFactor(zoomFactor: number): void;
+  destroyWindow(): void;
+  fireMoved(): void;
+  fireDisplayMetricsChanged(changedMetrics: string[]): void;
+  runPending(): void;
+  pendingCount(): number;
+  readonly windowListeners: Map<string, () => void>;
+  readonly screenListeners: Map<string, Parameters<OverlayRefreshScreen["on"]>[1]>;
+}
+
+function createHarness(scaleFactorInitial = 1.5): Harness {
+  let scaleFactor = scaleFactorInitial;
+  let zoomFactor = 1;
+  let destroyed = false;
+  const windowListeners = new Map<string, () => void>();
+  const screenListeners = new Map<string, Parameters<OverlayRefreshScreen["on"]>[1]>();
+  const scheduled: { callback: () => void; delay: number; cancelled: boolean }[] = [];
+  const setTitleBarOverlay = vi.fn();
+
+  const window: OverlayRefreshWindow = {
+    isDestroyed: () => destroyed,
+    getBounds: () => ({ x: 0, y: 0, width: 900, height: 560 }),
+    setTitleBarOverlay,
+    on(event, listener) { windowListeners.set(event, listener); return window; },
+    removeListener(event, listener) {
+      if (windowListeners.get(event) === listener) windowListeners.delete(event);
+      return window;
+    },
+  };
+  const display = (factor: number) => ({ scaleFactor: factor } as ReturnType<OverlayRefreshScreen["getDisplayMatching"]>);
+  const screen: OverlayRefreshScreen = {
+    getDisplayMatching: () => display(scaleFactor),
+    on(event, listener) { screenListeners.set(event, listener); return screen; },
+    removeListener(event, listener) {
+      if (screenListeners.get(event) === listener) screenListeners.delete(event);
+      return screen;
+    },
+  };
+  const refresher = createTitleBarOverlayRefresher(window, {
+    screen,
+    initialOverlay: INITIAL,
+    getZoomFactor: () => zoomFactor,
+    setTimeout: (callback, delay) => {
+      const entry = { callback, delay, cancelled: false };
+      scheduled.push(entry);
+      return scheduled.length as never;
+    },
+    clearTimeout: (timer) => {
+      const entry = scheduled[(timer as unknown as number) - 1];
+      if (entry) entry.cancelled = true;
+    },
+  });
+
+  return {
+    setTitleBarOverlay,
+    refresher,
+    setScaleFactor: (next) => { scaleFactor = next; },
+    setZoomFactor: (next) => { zoomFactor = next; },
+    destroyWindow: () => { destroyed = true; },
+    fireMoved: () => windowListeners.get("moved")?.(),
+    fireDisplayMetricsChanged: (changedMetrics) => screenListeners.get("display-metrics-changed")?.({}, display(scaleFactor), changedMetrics),
+    runPending: () => {
+      for (const entry of scheduled.splice(0)) {
+        if (entry.cancelled) continue;
+        expect(entry.delay).toBe(OVERLAY_REFRESH_DELAY_MS);
+        entry.callback();
+      }
+    },
+    pendingCount: () => scheduled.filter((entry) => !entry.cancelled).length,
+    windowListeners,
+    screenListeners,
+  };
+}
+
+describe("zoomedOverlayHeight", () => {
+  it("follows the page zoom because the CSS band grows with zoom while the native overlay does not", () => {
+    expect(zoomedOverlayHeight(43, 1)).toBe(43);
+    expect(zoomedOverlayHeight(43, 1.25)).toBe(54);
+    expect(zoomedOverlayHeight(43, 5 / 6)).toBe(36);
+    expect(zoomedOverlayHeight(43, 0.5)).toBe(22);
+  });
+
+  it("passes the height through on unusable zoom factors and never returns less than one", () => {
+    expect(zoomedOverlayHeight(43, 0)).toBe(43);
+    expect(zoomedOverlayHeight(43, Number.NaN)).toBe(43);
+    expect(zoomedOverlayHeight(1, 0.1)).toBe(1);
+  });
+});
+
+describe("title bar overlay refresher", () => {
+  it("applies the overlay immediately on creation so a window born off the primary display gets a current-scale layout", () => {
+    const harness = createHarness(1);
+
+    expect(harness.setTitleBarOverlay).toHaveBeenCalledExactlyOnceWith({ ...INITIAL });
+  });
+
+  it("applies theme snapshots through applyOverlay with the zoomed height", () => {
+    const harness = createHarness(1);
+    harness.setZoomFactor(5 / 6);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.refresher.applyOverlay({ color: "#101215", symbolColor: "#bfc1c3", height: 43 });
+
+    expect(harness.setTitleBarOverlay).toHaveBeenCalledExactlyOnceWith({ color: "#101215", symbolColor: "#bfc1c3", height: 36 });
+  });
+
+  it("reapplies the same height after the window lands on a display with a different scale factor, because the stale layout must be redone at the current scale", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.setScaleFactor(1);
+    harness.fireMoved();
+    expect(harness.setTitleBarOverlay).not.toHaveBeenCalled();
+    harness.runPending();
+
+    expect(harness.setTitleBarOverlay).toHaveBeenCalledExactlyOnceWith({ ...INITIAL });
+  });
+
+  it("does not schedule anything for moves within the same display scale", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.fireMoved();
+
+    expect(harness.pendingCount()).toBe(0);
+    harness.runPending();
+    expect(harness.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("coalesces a burst of moved events into a single delayed reapply", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.setScaleFactor(1);
+    harness.fireMoved();
+    harness.fireMoved();
+    harness.fireMoved();
+    expect(harness.pendingCount()).toBe(1);
+    harness.runPending();
+
+    expect(harness.setTitleBarOverlay).toHaveBeenCalledOnce();
+  });
+
+  it("reapplies when the current display's scale factor changes in place", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.setScaleFactor(1.25);
+    harness.fireDisplayMetricsChanged(["scaleFactor"]);
+    harness.runPending();
+
+    expect(harness.setTitleBarOverlay).toHaveBeenCalledExactlyOnceWith({ ...INITIAL });
+  });
+
+  it("ignores display metric changes that do not touch the scale factor", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.setScaleFactor(1);
+    harness.fireDisplayMetricsChanged(["workArea", "bounds"]);
+
+    expect(harness.pendingCount()).toBe(0);
+    expect(harness.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("reapplies with the new zoomed height after a zoom change is signalled through refresh", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.setZoomFactor(1.25);
+    harness.refresher.refresh();
+    harness.runPending();
+
+    expect(harness.setTitleBarOverlay).toHaveBeenCalledExactlyOnceWith({ ...INITIAL, height: 54 });
+  });
+
+  it("treats refresh as a no-op while the applied height and display scale are unchanged", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.refresher.refresh();
+
+    expect(harness.pendingCount()).toBe(0);
+    expect(harness.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("skips the reapply when the display scale returns to the applied value before the delay elapses", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.setScaleFactor(1);
+    harness.fireMoved();
+    harness.setScaleFactor(1.5);
+    harness.runPending();
+
+    expect(harness.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("does not reapply on a destroyed window", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.setScaleFactor(1);
+    harness.fireMoved();
+    harness.destroyWindow();
+    harness.runPending();
+
+    expect(harness.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("stop removes both listeners and cancels the pending reapply", () => {
+    const harness = createHarness(1.5);
+    harness.setTitleBarOverlay.mockClear();
+
+    harness.setScaleFactor(1);
+    harness.fireMoved();
+    expect(harness.pendingCount()).toBe(1);
+    harness.refresher.stop();
+
+    expect(harness.pendingCount()).toBe(0);
+    expect(harness.windowListeners.size).toBe(0);
+    expect(harness.screenListeners.size).toBe(0);
+    harness.runPending();
+    expect(harness.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Windows WCO 캡션 버튼(최소화/최대화/닫기)이 창 생성 시점의 시스템(주 모니터) 배율로 배치가 굳은 채 재계산되지 않아, 배율이 다른 모니터에서 Command Band를 넘치거나 어긋나던 문제를 수정합니다 (electron/electron#36200 계열 — `setTitleBarOverlay` 재호출이 캡션을 현재 모니터 배율로 강제 재배치한다는 점을 이용).
- 새 `title-bar-overlay-refresh` 모듈이 모니터 배율 변화(모니터 간 이동, 제자리 배율 변경, 스냅/최대화 전환)마다 오버레이를 재적용하고, 높이를 `round(43 × 페이지 줌)`으로 계산해 줌 상태에서도 네이티브 버튼 스트립이 CSS 밴드와 정합하도록 합니다. 주 모니터·줌 100% 환경에서는 기존 동작과 동일합니다.
- Windows(win32) 전용 배선이며 macOS/Linux 경로는 변경되지 않습니다. 테마 스냅샷 적용은 리프레셔로 위임됩니다.

## Type of Change
- [x] fix — bug fix

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-desktop test` — 297 passed (신규 리프레셔 테스트 13개 포함)
- [x] `pnpm --filter @dotobokuri/fleet-desktop build`
- [x] 실기기 검증 — Windows 11, 150%(주 4K) + 100%(보조 FHD) 듀얼 모니터, 언사인드 패키징 빌드: 모니터 간 드래그/스냅/줌 변경 후 진단 로그로 WCO 영역과 밴드가 44 vs 44 CSS px로 정합함을 수치 확인