### PR TITLE
feat(fleet-console): give each panel state its own caption rail motion

### DIFF
--- a/.changelog.d/panel-state-motion.md
+++ b/.changelog.d/panel-state-motion.md
@@ -1,0 +1,8 @@
+---
+branch: panel-state-motion
+---
+
+### fleet-console
+#### Changed
+- Give each panel state its own motion on the caption rail: background work now flows in one direction, a panel awaiting your answer pulses with a widening glow, and a finished but unopened panel breathes slowly instead of sitting still. Panels in the same state now pulse in step with each other, an awaiting panel never dims below a working one, and with reduced motion turned on background work stays a dashed rail so it never reads as a running turn.
+  ko: 패널 상태마다 캡션 레일의 운동을 따로 줍니다. 백그라운드 작업은 한 방향으로 흐르고, 답을 기다리는 패널은 번짐이 함께 열리는 맥동으로 부르며, 끝났지만 아직 열지 않은 패널은 멈춰 있는 대신 느리게 숨 쉽니다. 같은 상태의 패널들은 이제 한 박자로 맥동하고, 답을 기다리는 패널이 작업 중인 패널보다 어두워지는 구간도 없습니다. 모션 최소화를 켜면 백그라운드 작업은 점선 레일로 남아 진행 중인 턴과 섞이지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -74,6 +74,8 @@ const CLOSE_ARM_DURATION_MS = 1500;
 const DRAG_THRESHOLD_PX = 3;
 // 캡션 상태 레일의 도착 플래시 길이 — CSS의 var(--duration-slow)와 한 값이다.
 const ARRIVAL_FLASH_DURATION_MS = 360;
+// 위상을 한 박자로 묶는 레일 애니메이션 — components.css의 상태 레일 선언과 한 벌이다.
+const PHASE_LOCKED_RAIL_ANIMATIONS = new Set(["caption-rail-flow", "caption-rail-call", "caption-rail-tide"]);
 
 export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, deckTile = false, glanceHud, accentKey = null, groupName = null, groupColor = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onOpenMenu, onRenderHiddenDismissMenu, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
   const t = useT();
@@ -140,6 +142,20 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
       setArrivalFlash(false);
     }, ARRIVAL_FLASH_DURATION_MS);
   }, [unseen]);
+
+  // 같은 상태의 레일은 한 박자로 뛴다 — CSS 애니메이션의 위상은 그 요소가 상태에 들어간 시각에
+  // 묶인다. 패널마다 진입 시각이 다르면 같은 순간의 밝기가 갈려(실측: 0.45 대 0.78) 화면이
+  // 제각각 깜빡이는 반딧불이가 된다. 상태가 바뀔 때 레일 애니메이션의 시작을 문서 타임라인
+  // 원점으로 옮겨 위상을 하나로 맞춘다. turn의 트래블과 도착 플래시는 제외한다 — 앞의 것은
+  // 진행 위치를 말하는 왕복이고, 뒤의 것은 상태가 아니라 전이라 겹쳐 뛰면 안 된다.
+  useEffect(() => {
+    const frame = operationRef.current;
+    if (!frame || typeof frame.getAnimations !== "function") return;
+    for (const animation of frame.getAnimations({ subtree: true })) {
+      if (!PHASE_LOCKED_RAIL_ANIMATIONS.has((animation as CSSAnimation).animationName)) continue;
+      animation.startTime = 0;
+    }
+  }, [status, unseen]);
 
   useEffect(() => {
     if (rename.renaming || !restoreIdentityFocusRef.current) return;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5764,18 +5764,42 @@ body[data-side-bar-animating="true"] .canvas-operation {
   animation: caption-rail-travel 3.8s ease-in-out infinite;
 }
 
-/* background는 턴이 끝나고 작업만 남은 상태 — 같은 warn을 낮은 광량의 정적 레일로 낮춘다. */
+/* background는 턴이 끝나고 작업만 남은 상태 — 사람을 부르지 않는 일이 혼자 굴러간다.
+   turn의 왕복과 성격이 겹치지 않도록 한 방향으로만 흐르고, 되감기는 순간이 보이지 않게
+   타일 한 주기(160px)를 정확히 민다. 이동량은 픽셀이어야 한다: background-position의
+   퍼센트는 (영역 폭 − 이미지 폭) 기준이라 타일 주기와 맞아떨어지지 않아 한 바퀴 끝에서 튄다.
+   마루 0.55는 옛 균일 레일(0.45)보다 밝고 unseen 하한(0.58) 아래다 — 흐름의 골이 어두워지는
+   만큼 마루가 밝지 않으면 "살아 있다"가 오히려 약해진다. */
 .canvas-operation.is-running--background > .canvas-operation-titlebar::after {
-  opacity: 0.45;
+  opacity: 0.55;
+  background: repeating-linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--warn) 22%, transparent) 0px,
+    var(--warn) 64px,
+    var(--warn) 96px,
+    color-mix(in oklab, var(--warn) 22%, transparent) 160px
+  );
+  background-size: 160px 100%;
+  animation: caption-rail-flow 6.5s linear infinite;
 }
 
-/* awaiting은 사람을 기다리는 유일한 상태 — 호출 신호로 맥동한다. */
+/* awaiting은 사람을 기다리는 유일한 상태 — 호출 신호로 맥동한다. 밝기만이 아니라 글로우가
+   함께 열렸다 닫혀 "부른다"가 형태로도 읽힌다. 하한은 background 마루(0.55) 위에 둔다:
+   옛 맥동은 하한이 0.34라 주기의 절반가량 부르는 신호가 아무도 부르지 않는 신호보다
+   어두웠다(위계 역전). */
 .canvas-operation.is-running--awaiting > .canvas-operation-titlebar::after {
-  animation: caption-rail-pulse 2s var(--ease-glide) infinite;
+  animation: caption-rail-call 2.4s var(--ease-glide) infinite;
 }
 
-/* 미확인 완료는 도착 순간 1회 플래시로 시선을 부르고 그 뒤 상시 레일로 남는다 —
-   상시 aura(22px glow)를 순간 운동으로 교환한 자리다.
+/* 미확인 완료는 이미 끝난 일이라 급하지 않다 — 부름(2.4s)보다 느린 잔광으로 남는다.
+   하한 0.58은 awaiting 하한(0.62) 아래, background 마루(0.55) 위다. 세 상태의 밝기 위계는
+   awaiting > unseen > background 순으로 어느 순간에도 뒤집히지 않는다. */
+.canvas-operation.is-unseen > .canvas-operation-titlebar::after {
+  animation: caption-rail-tide 4.4s var(--ease-glide) infinite;
+}
+
+/* 도착 순간의 1회 플래시는 그 위에 따로 선다 — 상시 aura(22px glow)를 순간 운동으로
+   교환한 자리이며, 플래시가 끝나면 위의 상시 잔광이 이어받는다.
    플래시를 is-unseen이 아니라 별도의 일시 클래스에 건다: is-unseen은 확인 전까지 계속 참이라
    Theater를 오가며 프레임이 리마운트될 때마다 애니메이션이 다시 돈다. 도착은 상태의 전이이지
    상태의 존재가 아니다. */
@@ -5801,13 +5825,40 @@ body[data-side-bar-animating="true"] .canvas-operation {
   }
 }
 
-@keyframes caption-rail-pulse {
+/* 흐름의 이동량은 타일 한 주기와 같다 — 마지막 프레임이 첫 프레임과 같은 그림이라
+   되감기는 이음매가 없다. 퍼센트로 적으면 이 등식이 깨진다. */
+@keyframes caption-rail-flow {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: -160px 0;
+  }
+}
+
+/* 부름과 잔광은 시작·끝을 완전 점등으로 못박는다 — reduced-motion이 반복을 1회로 자르거나
+   애니메이션이 멈춘 자리에서도 레일이 꺼진 채 남지 않아야 한다(비콘 마크와 같은 규약). */
+@keyframes caption-rail-call {
   0%,
   100% {
     opacity: 1;
+    box-shadow: 0 0 11px 1px var(--aurora-glow);
   }
   50% {
-    opacity: 0.34;
+    opacity: 0.62;
+    box-shadow: 0 0 0 0 var(--aurora-glow);
+  }
+}
+
+@keyframes caption-rail-tide {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 9px 1px var(--positive-glow);
+  }
+  50% {
+    opacity: 0.58;
+    box-shadow: 0 0 0 0 var(--positive-glow);
   }
 }
 
@@ -6230,9 +6281,19 @@ body[data-side-bar-animating="true"] .canvas-operation {
      즉시 정착한 레일로 대체한다. 상태 자체는 계속 읽혀야 하므로 레일을 끄지는 않는다. */
   .canvas-operation.is-running--turn > .canvas-operation-titlebar::after,
   .canvas-operation.is-running--awaiting > .canvas-operation-titlebar::after,
+  .canvas-operation.is-unseen > .canvas-operation-titlebar::after,
   .canvas-operation.is-unseen-arriving > .canvas-operation-titlebar::after {
     animation: none;
     background: var(--caption-rail);
+    box-shadow: none;
+  }
+
+  /* background만은 색면으로 단락할 수 없다 — 운동을 걷으면 turn과 같은 warn 균일선이 되어
+     두 상태가 한 그림으로 겹친다. 흐름 대신 점선을 켜 형상으로 가른다. aurora·positive는
+     색이 이미 갈라 주므로 균일 색면으로 충분하다. */
+  .canvas-operation.is-running--background > .canvas-operation-titlebar::after {
+    animation: none;
+    background: repeating-linear-gradient(90deg, var(--warn) 0 7px, transparent 7px 13px);
     box-shadow: none;
   }
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2350,6 +2350,54 @@ describe("Instrument core design contract", () => {
     expect(rail).toContain("width: 44px");
   });
 
+  it("pins the caption status rail motion grammar — one motion per state, hierarchy, phase lock", () => {
+    const components = source("styles/components.css");
+    const operationFrame = source("canvas/operation-frame.tsx");
+    // 상태마다 운동의 종류가 다르다. 왕복(travel)은 turn 하나만 소유한다 — 진행 위치가 옮겨
+    // 간다는 사실을 말하는 형태라, 옮겨 갈 지점이 없는 나머지 상태가 빌리면 뜻이 갈라진다.
+    expect(components).toContain("animation: caption-rail-travel 3.8s ease-in-out infinite;");
+    expect(components).toContain("animation: caption-rail-flow 6.5s linear infinite;");
+    expect(components).toContain("animation: caption-rail-call 2.4s var(--ease-glide) infinite;");
+    expect(components).toContain("animation: caption-rail-tide 4.4s var(--ease-glide) infinite;");
+    expect(components).toContain("@keyframes caption-rail-flow");
+    expect(components).toContain("@keyframes caption-rail-call");
+    expect(components).toContain("@keyframes caption-rail-tide");
+    // background·unseen이 운동 없이 색만 다른 정지선으로 되돌아가지 않도록 사용처를 고정한다.
+    const backgroundRail = components.match(/\.canvas-operation\.is-running--background > \.canvas-operation-titlebar::after \{[^}]*\}/)?.[0] ?? "";
+    expect(backgroundRail).toContain("animation: caption-rail-flow");
+    expect(components).toMatch(/\.canvas-operation\.is-unseen > \.canvas-operation-titlebar::after \{\s*animation: caption-rail-tide/);
+    // 흐름의 이동량은 타일 한 주기와 같아야 한다 — background-position의 퍼센트는
+    // (영역 폭 − 이미지 폭) 기준이라 타일 주기와 어긋나고, 한 바퀴 끝에서 그림이 튄다.
+    expect(backgroundRail).toContain("background-size: 160px 100%;");
+    expect(components).toMatch(/@keyframes caption-rail-flow \{\s*from \{\s*background-position: 0 0;\s*\}\s*to \{\s*background-position: -160px 0;/);
+    expect(components).not.toMatch(/@keyframes caption-rail-flow \{[^}]*background-position: -\d+% 0/);
+    // 밝기 위계는 어느 순간에도 뒤집히지 않는다 — awaiting 하한 > unseen 하한 > background 마루.
+    // 옛 맥동은 하한 0.34로 background 상시값(0.45)보다 어두워지는 구간이 있었다.
+    expect(backgroundRail).toContain("opacity: 0.55;");
+    expect(components).toMatch(/@keyframes caption-rail-call \{[^@]*50% \{\s*opacity: 0\.62;/);
+    expect(components).toMatch(/@keyframes caption-rail-tide \{[^@]*50% \{\s*opacity: 0\.58;/);
+    expect(components).not.toContain("@keyframes caption-rail-pulse");
+    // 시작·끝은 완전 점등이다 — reduced-motion이 반복을 1회로 잘라도 레일이 꺼진 채 남지 않는다.
+    expect(components).toMatch(/@keyframes caption-rail-call \{\s*0%,\s*100% \{\s*opacity: 1;/);
+    expect(components).toMatch(/@keyframes caption-rail-tide \{\s*0%,\s*100% \{\s*opacity: 1;/);
+    // reduced-motion: 색이 갈라 주는 상태는 색면으로 단락하고, turn과 색을 공유하는
+    // background만 점선으로 형상을 남긴다 — 균일 warn 선 둘이 겹치면 두 상태가 한 그림이 된다.
+    // 슬라이스 기준을 캡션 폴백 블록 자체로 잡는다 — 파일 앞쪽 @media부터 자르면 미디어 밖의
+    // 일반 상태 규칙이 먼저 매치되어 폴백이 비어 있어도 통과한다.
+    const captionReducedMotion = components.slice(
+      components.indexOf("  .canvas-operation.is-running--turn > .canvas-operation-titlebar::after,"),
+    );
+    expect(captionReducedMotion).toContain("  .canvas-operation.is-unseen > .canvas-operation-titlebar::after,");
+    const reducedBackgroundRail = captionReducedMotion.match(/ {2}\.canvas-operation\.is-running--background > \.canvas-operation-titlebar::after \{[^}]*\}/)?.[0] ?? "";
+    expect(reducedBackgroundRail).toContain("animation: none;");
+    expect(reducedBackgroundRail).toContain("repeating-linear-gradient(90deg, var(--warn) 0 7px, transparent 7px 13px)");
+    // 위상은 문서 타임라인 원점에 묶는다 — 상태 진입 시각이 다르면 같은 상태의 패널들이
+    // 제각각 깜빡인다. 도착 플래시(전이)와 turn 트래블은 이 잠금에 들어가지 않는다.
+    expect(operationFrame).toContain('const PHASE_LOCKED_RAIL_ANIMATIONS = new Set(["caption-rail-flow", "caption-rail-call", "caption-rail-tide"]);');
+    expect(operationFrame).toContain("animation.startTime = 0;");
+    expect(operationFrame).toMatch(/PHASE_LOCKED_RAIL_ANIMATIONS\.has\(\(animation as CSSAnimation\)\.animationName\)/);
+  });
+
   it("forbids native product selects in Console core, SDK, and built-in plugins", () => {
     const hits = findRawProductSelects();
     expect(hits, hits.map((hit) => `${hit.file}:${hit.line} ${hit.snippet}`).join("\n")).toEqual([]);


### PR DESCRIPTION
## Summary
- 백그라운드·대기·미확인 세 상태가 색만 다른 정지 레일을 공유하던 것을, 상태의 성격에 맞는 서로 다른 운동으로 가릅니다: 백그라운드는 한 방향 흐름(6.5s), 대기는 번짐이 함께 열리는 부름(2.4s), 미확인은 느린 잔광(4.4s). 왕복 트래블은 진행 지점이 옮겨 가는 실행 중 하나만 계속 소유합니다.
- 밝기 위계를 수치로 못박습니다(대기 0.62 > 미확인 0.58 > 백그라운드 마루 0.55). 옛 대기 맥동은 하한이 0.34라 주기의 절반가량 백그라운드 상시값(0.45)보다 어두웠습니다 — 부르는 신호가 아무도 부르지 않는 신호보다 약해지는 구간이 사라집니다.
- 레일 위상을 문서 타임라인에 묶습니다. CSS 애니메이션 위상은 요소가 상태에 들어간 시각을 따르므로, 진입 시각이 다른 패널들이 제각각 깜빡였습니다(같은 순간 0.45 대 0.78 실측).
- 흐름은 타일 한 주기(160px)를 픽셀로 정확히 밀어 되감기는 이음매가 없습니다. `background-position`의 퍼센트는 (영역 폭 − 이미지 폭) 기준이라 타일 주기와 어긋나 한 바퀴 끝에서 튑니다.
- 모션 최소화에서는 색이 갈라 주는 상태(대기·미확인)만 균일 색면으로 단락하고, 실행 중과 warn을 공유하는 백그라운드는 점선 레일을 켜 형상으로 가릅니다.

## Test Plan
- [x] `pnpm typecheck` (전체 워크스페이스) — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `vitest run tests/instrument-design-contract.test.ts` — 70/70 통과(레일 운동 문법 계약 신규 1건 포함)
- [x] `vitest run` operation-frame-body-activation · operation-frame-identity · mobile-settings-drilldown · triage-store — 195/195 통과
- [x] `pnpm check:core-boundary`, `pnpm check:localized-attributes` — 위반 없음
- [x] 격리 콘솔 실측(Operation 4건 시드, Tactical): 네 상태 레일의 `animationName`/주기/불투명도/글로우를 계산값으로 확인하고 확대 캡처로 대조
- [x] `set media dark reduced-motion` 에뮬레이션: 실행 중·대기·미확인은 균일 색면, 백그라운드는 점선 유지 확인
- [x] 흐름 루프 이음매: 요소 애니메이션의 `currentTime` 0 / 3250 / 6500ms 프레임 해시가 0 = 6500(동일) · 3250(상이)
- [ ] 실제 런타임 상태 전이(에이전트 CLI가 보고하는 background/awaiting) 재현은 미실행 — 상태 클래스를 주입해 표현을 측정했고, 위상 잠금은 `startTime = 0` 적용 전후의 밝기 일치로 확인