### PR TITLE
fix(core-ai-gateway): salvage a Grok tool call orphaned by a missing terminal frame

### DIFF
--- a/.changelog.d/xai-loop-optimization.md
+++ b/.changelog.d/xai-loop-optimization.md
@@ -1,0 +1,8 @@
+---
+branch: xai-loop-optimization
+---
+
+### fleet-console
+#### Fixed
+- Keep a Grok turn whose tool call arrived complete but whose stream stopped before its closing frame, instead of ending the turn with a mid-response server error.
+  ko: 도구 호출은 온전히 도착했는데 스트림이 마지막 프레임 전에 멈춘 Grok 턴을 응답 중단 오류로 끝내지 않고 살립니다.

--- a/packages/core-ai-gateway/src/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/xai/responses/adapter.ts
@@ -478,7 +478,12 @@ interface PendingXaiFunctionCall {
   readonly added: Extract<CanonicalResponseEvent, { type: "response.output_item.added" }>;
   readonly deadlineAt: number;
   argumentsDone?: Extract<CanonicalResponseEvent, { type: "response.function_call_arguments.done" }>;
+  /** Fragments absorbed from the wire. Never forwarded — the salvage below is their only reader. */
+  argumentsBuffer: string;
 }
+
+/** The deadline elapsed with calls still pending; the caller decides whether they can be salvaged. */
+const XAI_ASSEMBLY_DEADLINE = Symbol("xai-assembly-deadline");
 
 async function* assembleXaiFunctionCalls(
   source: AsyncIterable<CanonicalResponseEvent>,
@@ -487,22 +492,41 @@ async function* assembleXaiFunctionCalls(
 ): AsyncGenerator<CanonicalResponseEvent> {
   const iterator = source[Symbol.asyncIterator]();
   const pending = new Map<string, PendingXaiFunctionCall>();
+  let snapshot: CanonicalResponseSnapshot | undefined;
   let completedNormally = false;
   try {
     while (true) {
       const deadlineAt = earliestXaiFunctionCallDeadline(pending);
       const result = deadlineAt === undefined
         ? await iterator.next()
-        : await nextXaiEventBeforeDeadline(iterator, deadlineAt, controller, timeoutMs);
+        : await nextXaiEventBeforeDeadline(iterator, deadlineAt);
+      if (result === XAI_ASSEMBLY_DEADLINE) {
+        yield* salvageXaiPendingCalls(
+          pending,
+          snapshot,
+          `function call assembly exceeded ${timeoutMs}ms`,
+          controller,
+        );
+        completedNormally = true;
+        return;
+      }
       if (result.done) {
         if (pending.size > 0) {
-          throw incompleteXaiFunctionCall("stream ended before function call output_item.done");
+          yield* salvageXaiPendingCalls(
+            pending,
+            snapshot,
+            "stream ended before function call output_item.done",
+            controller,
+          );
         }
         completedNormally = true;
         return;
       }
 
       const event = result.value;
+      if (event.type === "response.created") {
+        snapshot = event.response;
+      }
       if (event.type === "response.completed" && pending.size > 0) {
         throw incompleteXaiFunctionCall("response.completed arrived before function call output_item.done");
       }
@@ -514,7 +538,18 @@ async function* assembleXaiFunctionCalls(
           // earliest active deadline, so a later parallel call is never shortened by
           // an earlier call's age.
           deadlineAt: Date.now() + timeoutMs,
+          argumentsBuffer: "",
         });
+        continue;
+      }
+      if (event.type === "response.function_call_arguments.delta") {
+        // Absorbed, never forwarded: a partial fragment cannot be reassembled safely by the
+        // client, and only the salvage below reads the buffer. A fragment for a call this
+        // stream never opened is dropped exactly as before.
+        const call = pending.get(xaiFunctionCallKey(event.output_index, event.item_id));
+        if (call !== undefined) {
+          call.argumentsBuffer += event.delta;
+        }
         continue;
       }
       if (event.type === "response.function_call_arguments.done") {
@@ -569,17 +604,74 @@ function earliestXaiFunctionCallDeadline(
   return earliest;
 }
 
+/**
+ * Grok CLI has been measured delivering a function call's complete argument object in a single
+ * `arguments.delta` and then never sending `arguments.done` or `output_item.done` — the stream
+ * simply stops. Failing the whole turn there discards a tool call the model demonstrably
+ * finished writing, so a pending call whose absorbed buffer parses as a complete JSON object is
+ * closed out and the turn is sealed. Anything short of that is still the protocol error it was:
+ * a truncated fragment cannot be told apart from a call the model was still writing.
+ */
+async function* salvageXaiPendingCalls(
+  pending: Map<string, PendingXaiFunctionCall>,
+  snapshot: CanonicalResponseSnapshot | undefined,
+  reason: string,
+  controller: AbortController,
+): AsyncGenerator<CanonicalResponseEvent> {
+  const salvageable = [...pending.values()].every(
+    (call) => completeXaiArguments(call) !== undefined,
+  );
+  if (snapshot === undefined || !salvageable) {
+    const error = incompleteXaiFunctionCall(reason);
+    controller.abort(error);
+    throw error;
+  }
+
+  wireLog("xai-responses.function_call.salvaged", {
+    reason,
+    calls: pending.size,
+  });
+  // The upstream read is parked on a stream that stopped writing. Releasing it here is what
+  // lets this attempt unwind at all — the failure path aborts for the same reason.
+  controller.abort(incompleteXaiFunctionCall(reason));
+
+  for (const [key, call] of pending) {
+    const args = completeXaiArguments(call) ?? "";
+    const item = { ...call.added.item, arguments: args } as typeof call.added.item;
+    yield call.added;
+    yield {
+      type: "response.function_call_arguments.done",
+      item_id: call.added.item.id,
+      output_index: call.added.output_index,
+      arguments: args,
+    };
+    yield { type: "response.output_item.done", output_index: call.added.output_index, item };
+    pending.delete(key);
+  }
+  // The client-facing encoder requires a terminal frame, and usage is genuinely unknown here.
+  yield { type: "response.completed", response: { ...snapshot, usage: null } };
+}
+
+/** The absorbed buffer, or the streamed `.done` payload, only when it is a complete JSON object. */
+function completeXaiArguments(call: PendingXaiFunctionCall): string | undefined {
+  const candidate = call.argumentsDone?.arguments ?? call.argumentsBuffer;
+  if (candidate.length === 0) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    return undefined;
+  }
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) ? candidate : undefined;
+}
+
 async function nextXaiEventBeforeDeadline(
   iterator: AsyncIterator<CanonicalResponseEvent>,
   deadlineAt: number,
-  controller: AbortController,
-  timeoutMs: number,
-): Promise<IteratorResult<CanonicalResponseEvent>> {
+): Promise<IteratorResult<CanonicalResponseEvent> | typeof XAI_ASSEMBLY_DEADLINE> {
   const remainingMs = deadlineAt - Date.now();
   if (remainingMs <= 0) {
-    const error = incompleteXaiFunctionCall(`function call assembly exceeded ${timeoutMs}ms`);
-    controller.abort(error);
-    throw error;
+    return XAI_ASSEMBLY_DEADLINE;
   }
 
   let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -591,11 +683,9 @@ async function nextXaiEventBeforeDeadline(
   try {
     return await Promise.race([
       next,
-      new Promise<never>((_, reject) => {
+      new Promise<typeof XAI_ASSEMBLY_DEADLINE>((resolve) => {
         timeout = setTimeout(() => {
-          const error = incompleteXaiFunctionCall(`function call assembly exceeded ${timeoutMs}ms`);
-          controller.abort(error);
-          reject(error);
+          resolve(XAI_ASSEMBLY_DEADLINE);
         }, remainingMs);
       }),
     ]);
@@ -696,11 +786,17 @@ function canonicalEvent(value: unknown): CanonicalResponseEvent | undefined {
         item
       };
     }
-    // Hold argument fragments until the Grok CLI proxy's partial-JSON behavior is observed.
-    // The `.done` event carries the complete argument object, which downstream treats as the
-    // remainder when nothing was streamed ahead of it.
+    // Fragments still never reach the client — the assembler absorbs them and the `.done`
+    // event carries the complete argument object. They are decoded rather than discarded
+    // because this proxy has been measured ending a stream with the whole argument object
+    // delivered as fragments and no terminal frame; the buffer is that turn's only copy.
     case "response.function_call_arguments.delta":
-      return undefined;
+      return {
+        type: value.type,
+        item_id: string(value.item_id, "item_id"),
+        output_index: number(value.output_index, "output_index"),
+        delta: string(value.delta, "delta"),
+      };
     case "response.function_call_arguments.done":
       return {
         type: value.type,

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -147,6 +147,10 @@ function argumentsDone(id: string, outputIndex = 0, value = "{}"): CanonicalResp
   return { type: "response.function_call_arguments.done", item_id: id, output_index: outputIndex, arguments: value };
 }
 
+function argumentsDelta(id: string, outputIndex = 0, delta = "{}"): CanonicalResponseEvent {
+  return { type: "response.function_call_arguments.delta", item_id: id, output_index: outputIndex, delta };
+}
+
 async function flushXaiStream(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -621,6 +625,169 @@ describe("Grok Responses function-call assembly", () => {
     expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: 0 })).toThrow("functionCallTimeoutMs must be a positive integer");
     expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: -1 })).toThrow("functionCallTimeoutMs must be a positive integer");
     expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: 1.5 })).toThrow("functionCallTimeoutMs must be a positive integer");
+  });
+
+  it("never forwards argument fragments on a normally terminated call", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+      xaiFrame(responseCreated()),
+      xaiFrame(functionCallAdded("call-1")),
+      xaiFrame(argumentsDelta("call-1", 0, '{"path":')),
+      xaiFrame(argumentsDelta("call-1", 0, '"a.ts"}')),
+      xaiFrame(functionCallDone("call-1", 0, '{"path":"a.ts"}')),
+      xaiFrame(responseCompleted()),
+    ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    const events = await collectXaiEvents(response.events);
+    expect(eventTypes(events)).toEqual([
+      "response.created",
+      "response.output_item.added",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "response.function_call_arguments.done",
+      arguments: '{"path":"a.ts"}',
+    }));
+  });
+
+  it("salvages a complete argument object when the stream ends without a terminal frame", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+      xaiFrame(responseCreated()),
+      xaiFrame(functionCallAdded("call-1")),
+      xaiFrame(argumentsDelta("call-1", 0, '{"path":"a.ts"')),
+      xaiFrame(argumentsDelta("call-1", 0, "}")),
+    ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    const events = await collectXaiEvents(response.events);
+    expect(eventTypes(events)).toEqual([
+      "response.created",
+      "response.output_item.added",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "response.output_item.done",
+      item: expect.objectContaining({ id: "call-1", name: "Read", arguments: '{"path":"a.ts"}' }),
+    }));
+  });
+
+  it("salvages a stalled call at the assembly deadline and seals the turn", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, functionCallTimeoutMs: 20 }).stream(functionCallRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      controlled.push(xaiFrame(responseCreated()));
+      controlled.push(xaiFrame(functionCallAdded("call-1")));
+      controlled.push(xaiFrame(argumentsDelta("call-1", 0, '{"path":"a.ts"}')));
+      await flushXaiStream();
+      await vi.advanceTimersByTimeAsync(20);
+      expect(eventTypes(await events)).toEqual([
+        "response.created",
+        "response.output_item.added",
+        "response.function_call_arguments.done",
+        "response.output_item.done",
+        "response.completed",
+      ]);
+      expect(controlled.wasCancelled()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still fails a stalled call whose absorbed fragments are truncated", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, functionCallTimeoutMs: 20 }).stream(functionCallRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      const eventsExpectation = expect(events).rejects.toThrow("assembly exceeded 20ms");
+      controlled.push(xaiFrame(responseCreated()));
+      controlled.push(xaiFrame(functionCallAdded("call-1")));
+      controlled.push(xaiFrame(argumentsDelta("call-1", 0, '{"path":"a.ts"')));
+      await flushXaiStream();
+      await vi.advanceTimersByTimeAsync(20);
+      await eventsExpectation;
+      expect(controlled.wasCancelled()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops a fragment for a call this stream never opened", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+      xaiFrame(responseCreated()),
+      xaiFrame(argumentsDelta("ghost", 3, '{"path":"a.ts"}')),
+      xaiFrame(responseCompleted()),
+    ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    expect(eventTypes(await collectXaiEvents(response.events))).toEqual([
+      "response.created",
+      "response.completed",
+    ]);
+  });
+
+  it("does not salvage a complete JSON scalar or array", async () => {
+    for (const fragment of ['"a.ts"', '["a.ts"]']) {
+      const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+        xaiFrame(responseCreated()),
+        xaiFrame(functionCallAdded("call-1")),
+        xaiFrame(argumentsDelta("call-1", 0, fragment)),
+      ));
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      await expect(collectXaiEvents(response.events)).rejects.toThrow("stream ended before");
+    }
+  });
+
+  it("hands the salvaged call to the Anthropic encoder as a complete tool_use turn", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+      xaiFrame(responseCreated()),
+      xaiFrame(textDelta("Extending the CLI.")),
+      xaiFrame(functionCallAdded("call-1", 1)),
+      xaiFrame(argumentsDelta("call-1", 1, '{"path":"a.ts"}')),
+    ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    const frames = parseEncodedSse(await collectEncodedBody(encodeAnthropicSse(response.events)));
+    expect(frames.map((frame) => frame.event)).toContain("message_stop");
+    expect(frames.at(-2)?.data).toMatchObject({ delta: { stop_reason: "tool_use" } });
+    const toolStart = frames.find((frame) => (frame.data as { content_block?: { type?: string } }).content_block?.type === "tool_use");
+    expect(toolStart?.data).toMatchObject({ content_block: { type: "tool_use", id: "call-1", name: "Read" } });
+    expect(JSON.stringify(frames)).toContain('a.ts');
+  });
+
+  it("records only payload-light fields when a call is salvaged", async () => {
+    const wire = wireLogFixture("fleet-xai-salvage-");
+    try {
+      const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+        xaiFrame(responseCreated()),
+        xaiFrame(functionCallAdded("call-1")),
+        xaiFrame(argumentsDelta("call-1", 0, '{"path":"secret-marker.ts"}')),
+      ));
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      await collectXaiEvents(response.events);
+      const salvaged = wire.read().filter((entry) => entry.event === "xai-responses.function_call.salvaged");
+      expect(salvaged).toHaveLength(1);
+      expect(salvaged[0]?.payload).toEqual({
+        reason: "stream ended before function call output_item.done",
+        calls: 1,
+      });
+      expect(JSON.stringify(salvaged)).not.toContain("secret-marker");
+    } finally {
+      wire.cleanup();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Grok CLI Responses 프록시가 함수 호출의 완전한 인자 객체를 `arguments.delta` 하나로 보낸 뒤 `arguments.done`/`output_item.done`을 끝내 보내지 않는 경우가 실측됐습니다(함수 호출 38건 중 1건). 어댑터는 델타를 버리고 30초 조립 데드라인에서 턴 전체를 실패시켜, 모델이 이미 다 써낸 7KB `Write` 호출이 통째로 사라지고 사용자에게는 `API Error: Server error mid-response`가 표시됐습니다.
- 이제 인자 델타를 pending 호출별 버퍼로 **흡수**합니다. 클라이언트로는 여전히 한 조각도 전달하지 않습니다.
- 조립이 pending 상태로 끝날 때(데드라인 또는 EOF), 버퍼가 **완전한 JSON 객체로 파싱되는 경우에만** `arguments.done` + `output_item.done` + `response.completed`를 합성해 턴을 봉인합니다. 잘린 버퍼·스칼라/배열·`response.created` 미수신은 종전과 동일한 프로토콜 오류입니다. `xai-responses.function_call.salvaged`(reason·건수만) 진단을 남깁니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 738 passed (xAI 53 -> 61)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck` / `build` — 통과
- [x] `e2e:provider-loop --model claude-gateway--xai--grok-4.6 --operations 3 --trials 5` — 변경 전후 불변량 동일(요청 4/트라이얼, 도구 호출 3, 오류 0), 클라이언트로 전달된 인자 조각 0(수신 15)
- [x] 실제 Console Operation 장기작업 — 동일 업스트림 결함이 재현됐고 77.59초에 6837자 `Write` 호출을 복원, 0.12초 뒤 다음 요청이 나가며 루프 지속. 변경 전 동일 작업은 같은 지점에서 중단됐습니다.
- 알려진 한계: 살린 턴은 업스트림이 종결 전 프레임에 usage를 싣지 않아 `usage: null`로 봉인되며, 해당 턴 동안 컨텍스트 미터가 0%로 표시되고 다음 턴에 복구됩니다.


