### PR TITLE
fix(changelog): keep the Chat composer removal bullet ASCII

### DIFF
--- a/.changelog.d/chat-composer-panel.md
+++ b/.changelog.d/chat-composer-panel.md
@@ -11,5 +11,5 @@ branch: chat-composer-panel
 
 #### Removed
 
-- The floating reply bubble that opened Quick Launch from a chat panel is retired, along with the caption coordinate badge and the "via Quick Launch" dispatch tag — the in-panel composer replaces that path, and Quick Launch mentions keep working as a separate route.
+- The floating reply bubble that opened Quick Launch from a chat panel is retired, along with the caption coordinate badge and the "via Quick Launch" dispatch tag: the in-panel composer replaces that path, and Quick Launch mentions keep working as a separate route.
   ko: 채팅 패널에서 Quick Launch를 열던 말풍선 버튼과 캡션 좌표 배지, "Quick Launch로 전달" 표기가 퇴역했습니다. 인패널 컴포저가 그 경로를 대체하며, Quick Launch 멘션 전달은 별도 경로로 그대로 동작합니다.


### PR DESCRIPTION
## Summary
- `.changelog.d/chat-composer-panel.md`의 영어 불릿에 em dash(U+2014)가 남아 있어, 프래그먼트 검증기의 "bullet summary must be English ASCII text" 규칙에 걸립니다. canary 단독으로도 실패하므로 지금 canary 기준의 모든 PR이 `validate` red입니다.
- 해당 한 글자를 콜론으로 바꿉니다. 문구는 그 외 바이트 동일하며 한국어 줄은 손대지 않았습니다.

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty` — OK (7 entries)

Changelog-Amend: chat-composer-panel.md