### PR TITLE
feat(fleet-console): close the War Room card ring and answer hover at once

### DIFF
--- a/.changelog.d/warroom-card-signal.md
+++ b/.changelog.d/warroom-card-signal.md
@@ -1,0 +1,12 @@
+---
+branch: warroom-card-signal
+---
+
+### fleet-console
+#### Changed
+- Answer the pointer the moment it reaches a War Room card: the card you are aiming at now takes a brass hairline and a warmed caption right away, instead of staying silent for the four-tenths of a second before the preview opens. The enlarged preview then lifts clear of the cards it covers, and a card reached by keyboard shows the same mark as one reached by pointer.
+  ko: War Room 카드에 포인터가 닿는 순간 덱이 대답합니다. 겨눈 카드가 곧바로 놋쇠 실선과 밝아진 캡션을 얻어, 미리보기가 열리기까지의 0.4초를 잠자코 보내지 않습니다. 열린 미리보기는 자기가 덮은 카드들 위로 떠오르고, 키보드로 닿은 카드도 포인터로 닿은 카드와 같은 표시를 받습니다.
+
+#### Fixed
+- Close the state ring around a War Room card. A card waiting for review, arriving, or landing back on the deck drew its coloured outline down both sides and along the bottom but never across the top, so the caption sat outside the ring; the outline now encloses the whole card, including with reduced motion turned on. The magnified panel in the map view also gets its intended brass edge back instead of a green one that read as a completion signal.
+  ko: War Room 카드의 상태 링을 닫습니다. 검토를 기다리거나 도착하거나 덱으로 돌아온 카드는 색 아웃라인을 좌우와 아래로만 그리고 윗변은 그리지 않아 캡션이 링 밖에 남아 있었습니다. 이제 아웃라인이 카드 전체를 감싸며, 모션 최소화를 켠 상태에서도 같습니다. 지도 보기에서 확대된 패널의 테두리도 완료 신호처럼 보이던 초록 대신 본래의 놋쇠 색을 되찾습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3500,9 +3500,13 @@
 }
 
 /* 지도 Quick-Look로 끌어올린 칸의 패널 — 판 위에 떠 있다는 사실만 테두리·그림자로 말한다.
-   자리와 크기는 칸이 지고(is-map-quicklook), 여기서는 그 위에 얹는 강조만 소유한다. */
+   자리와 크기는 칸이 지고(is-map-quicklook), 여기서는 그 위에 얹는 강조만 소유한다.
+   믹스는 oklab이다 — 캡션 포커스 워시와 같은 이유다(.canvas-operation.is-active 옆 주석 참조).
+   oklch는 hue를 극좌표 짧은 호로 보간해 brass(78)와 rim(245)의 60% 믹스가 실측 hue 144.8(Instrument)
+   ·144.2(Maritime)·354(Carbon)에 착지했다 — 위치 채널이 신호 채널 positive(160·152) 옆에 앉거나
+   아예 마젠타로 넘어간다. 네 테마 중 Whites만 우연히 brass에 남았다. */
 .canvas-triage-deck-cell.is-map-quicklook > .canvas-triage-deck-mount > .canvas-operation {
-  border-color: color-mix(in oklch, var(--brass) 60%, var(--surface-rim));
+  border-color: color-mix(in oklab, var(--brass) 60%, var(--surface-rim));
   box-shadow: var(--shadow-floating), 0 0 0 1px var(--brass-glow);
 }
 
@@ -3585,12 +3589,48 @@
   display: grid;
   min-width: 0;
   min-height: 0;
-  transition: transform var(--duration-slow) var(--ease-glide);
+  /* 칸 자신은 배경도 보더도 없지만, 아래 hover 링이 패널의 10px 라운드를 따라가려면
+     그 링을 그리는 상자에도 같은 반경이 있어야 한다. overflow는 visible 그대로다. */
+  border-radius: var(--radius-md);
+  transition:
+    transform var(--duration-slow) var(--ease-glide),
+    box-shadow var(--duration-base) var(--ease-glide);
 }
 
+/* 포인터가 겨눈 칸 — 위치(brass)는 칸이 지고 상태(신호색)는 패널이 진다. 이 분담은 취향이 아니라
+   캐스케이드가 정한다: is-fresh·is-arriving·is-landed가 패널의 border-color와 box-shadow를
+   키프레임으로 물고 있어, 같은 두 속성에 얹은 author-normal 선언은 애니메이션 오리진에 진다.
+   실측(맥동 카드에 hover brass를 얹어 계산): 나온 값은 brass가 아니라 aurora였고 그림자도
+   맥동 글로우였다 — 신호가 가장 급한 카드에서만 hover가 사라지는 조용한 실패다.
+   그래서 위치 마크는 패널이 건드리지 않는 표면, 곧 칸의 box-shadow가 소유한다.
+   확대 중(is-quicklook)과 밀도 변형 중(is-morphing)은 각자 자기 그림자·z-index를 이미
+   소유하므로 제외한다 — 넣으면 확대 칸이 이 규칙의 스택으로 떨어진다.
+   키보드는 같은 마크를 같은 순간에 받는다. 기존 .canvas-triage-deck-pick:focus-visible 링은
+   그대로 남긴다: 그 링은 본문 안쪽을, 이 링은 캡션까지 포함한 칸 전체를 말한다.
+   지도 모드에서는 카드 컨테이너가 visibility:hidden + pointer-events:none이라 :hover가 서지 않는다. */
+.canvas-triage-deck-cell:hover:not(.is-quicklook):not(.is-morphing),
+.canvas-triage-deck-cell:has(> .canvas-triage-deck-pick:focus-visible):not(.is-quicklook):not(.is-morphing) {
+  /* 이웃 카드의 16px 맥동 글로우가 10px 간격을 건너와 이 1px 링을 씻지 않게 한 칸 올린다. */
+  z-index: 6;
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent);
+}
+
+/* 겨눈 카드의 캡션은 포커스 패널과 같은 워시를 입는다 — 새 값이 아니라
+   .canvas-operation.is-active > .canvas-operation-titlebar와 같은 한 값이다. */
+.canvas-triage-deck-cell:hover .canvas-operation.is-deck-tile > .canvas-operation-titlebar,
+.canvas-triage-deck-cell:has(> .canvas-triage-deck-pick:focus-visible) .canvas-operation.is-deck-tile > .canvas-operation-titlebar {
+  background: color-mix(in oklab, var(--brass) 10%, var(--surface-panel));
+  /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
+  background-clip: padding-box;
+}
+
+/* 확대는 드웰 400ms가 열리고 나서의 읽기 단계다 — 지도 Quick-Look과 같은 "떠 있음" 문법을 입어
+   덮고 있는 이웃과 갈린다. --shadow-floating(0 32px 60px -28px)은 원래 크기 칸에 주면 10px 간격을
+   넘어 이웃 rim을 덮으므로 확대된 칸에만 준다. */
 .canvas-triage-deck-cell.is-quicklook {
   transform: scale(var(--triage-quicklook-scale, 1.95));
   z-index: 9;
+  box-shadow: var(--shadow-floating), 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent);
 }
 
 /* 지도 모드의 Quick-Look — 은닉된 밴드 안의 칸을 판 위로 끌어올려 점 옆에 세운다. 좌표는
@@ -4346,6 +4386,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
      행처럼 열에도 최소값 0을 명시해야 성립한다. */
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
+  /* 이 두 줄만으로는 윗변이 서지 않는다 — 파일 뒤쪽 캡션 이음새 규칙이 같은 (0,2,0)으로 뒤에 와서
+     이긴다. 실제로 윗변을 되찾는 것은 그 규칙 바로 뒤의
+     `.canvas-operation.is-deck-tile:has(> .canvas-operation-titlebar)` 예외다. 여기 남는 두 줄은
+     "타일은 네 변을 진다"는 이 블록의 의도 표명이고, 예외가 지워지면 함께 지워져야 한다. */
   border-top-width: 1px;
   border-top-style: solid;
   border-radius: var(--radius-md);
@@ -5716,6 +5760,18 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .canvas-operation:has(> .canvas-operation-titlebar) {
   border-top-width: 0;
   border-top-style: none;
+}
+
+/* 덱 타일만 그 면제에서 빠진다 — 카드뷰 캡션은 흐름 안으로 들어오며 자기 보더를 내려놓으므로
+   (.canvas-operation.is-deck-tile > .canvas-operation-titlebar { border: 0 }) 윗변을 이을 주체가
+   패널밖에 없다. is-deck-tile 블록이 이미 border-top 1px을 적어 두었지만 그 선택자는 위 이음새
+   규칙과 같은 (0,2,0)이고 이음새 규칙이 뒤라서 이겼다 — 실측 borderTopWidth "0px". 결과는 상태
+   맥동(is-fresh·is-arriving·is-landed)과 reduced-motion 폴백이 좌·하·우만 칠하는 열린 U였다.
+   :has()로 (0,3,0)을 만들어 이 규칙만 되찾는다. 위 이음새 규칙은 떠 있는 캡션(Cruise·Tactical·
+   companion)의 계약이므로 건드리지 않는다. */
+.canvas-operation.is-deck-tile:has(> .canvas-operation-titlebar) {
+  border-top-width: 1px;
+  border-top-style: solid;
 }
 
 /* 포커스 = 캡션 워시 + 이름 티어. 선(윗변 라인·캡션 아웃라인)은 쓰지 않는다 — 상태 레일과

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2918,7 +2918,7 @@ describe("War Room deck panel grammar", () => {
     expect(tile).toContain("width: auto;");
     expect(tile).toContain("height: auto;");
     // 캡션은 창 밖(-32px)에 설 수 없다 — 위 행의 칸을 덮는다. 덱에서만 흐름 안으로 들어온다.
-    const tileCaption = components.match(/\.canvas-operation\.is-deck-tile > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
+    const tileCaption = components.match(/^\.canvas-operation\.is-deck-tile > \.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
     expect(tileCaption).toContain("position: relative;");
   });
 
@@ -2938,6 +2938,58 @@ describe("War Room deck panel grammar", () => {
     // 전이 소유가 칸이므로 reduced-motion도 칸을 끊는다.
     const reducedMotion = components.slice(components.indexOf("@media (prefers-reduced-motion: reduce)"));
     expect(reducedMotion).toMatch(/\.canvas-triage-deck-cell \{\s*transition: none;\s*\}/);
+    // 확대는 지도 Quick-Look과 같은 "떠 있음"을 입는다 — 확대된 칸만이 --shadow-floating을 진다.
+    // 원래 크기 칸에 주면 0 32px 60px -28px가 10px 간격을 넘어 이웃 카드의 rim을 덮는다.
+    expect(cell).toContain("box-shadow: var(--shadow-floating), 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent);");
+  });
+
+  it("closes the deck tile's state ring across its caption", () => {
+    // 카드뷰 캡션은 흐름 안으로 들어오며 자기 보더를 내려놓으므로 윗변을 이을 주체가 패널뿐이다.
+    // is-deck-tile 블록의 border-top 1px은 캡션 이음새 규칙과 같은 (0,2,0)이고 이음새가 뒤라서
+    // 졌다 — 상태 맥동이 좌·하·우만 칠하는 열린 U가 된다. :has()로 (0,3,0)을 만든 예외가
+    // 실제로 이기는 규칙이므로, 이 예외가 사라지면 U가 되돌아온다.
+    const tileSeamExemption = components.match(/\.canvas-operation\.is-deck-tile:has\(> \.canvas-operation-titlebar\) \{[^}]*\}/)?.[0] ?? "";
+    expect(tileSeamExemption).toContain("border-top-width: 1px;");
+    expect(tileSeamExemption).toContain("border-top-style: solid;");
+    // 예외는 반드시 이음새 규칙 뒤에 온다 — 앞에 두면 같은 승부를 다시 진다.
+    expect(components.indexOf(tileSeamExemption))
+      .toBeGreaterThan(components.indexOf(".canvas-operation:has(> .canvas-operation-titlebar) {"));
+    // 떠 있는 캡션(Cruise·Tactical·companion)의 계약은 그대로다.
+    const tileCaption = components.match(/^\.canvas-operation\.is-deck-tile > \.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
+    expect(tileCaption).toContain("border: 0;");
+  });
+
+  it("puts the deck card's hover mark on the cell, never on the pulsing panel", () => {
+    // is-fresh·is-arriving·is-landed가 패널의 border-color와 box-shadow를 키프레임으로 물고 있어,
+    // 같은 두 속성에 얹은 hover 선언은 애니메이션 오리진에 진다 — 신호가 가장 급한 카드에서만
+    // 위치 마크가 사라지는 조용한 실패다. 그래서 위치는 칸의 box-shadow가 소유한다.
+    const hover = components.match(/\.canvas-triage-deck-cell:hover:not\(\.is-quicklook\):not\(\.is-morphing\),\n\.canvas-triage-deck-cell:has\(> \.canvas-triage-deck-pick:focus-visible\):not\(\.is-quicklook\):not\(\.is-morphing\) \{[^}]*\}/)?.[0] ?? "";
+    expect(hover).toContain("box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent);");
+    expect(hover).toContain("z-index: 6;");
+    // 확대·변형 중인 칸은 자기 그림자와 z-index를 이미 소유한다 — 제외하지 않으면 확대 칸이 떨어진다.
+    expect(hover).not.toContain("--shadow-floating");
+    // 위치 마크는 패널의 맥동 속성을 절대 건드리지 않는다.
+    expect(components).not.toContain(".canvas-triage-deck-cell:hover > .canvas-triage-deck-mount > .canvas-operation {");
+    // 링이 패널의 10px 라운드를 따라가려면 그 링을 그리는 칸에도 같은 반경이 있어야 한다.
+    const cellBase = components.match(/\n\.canvas-triage-deck-cell \{[^}]*\}/)?.[0] ?? "";
+    expect(cellBase).toContain("border-radius: var(--radius-md);");
+    // 포인터와 키보드가 같은 마크를 받는다. 본문 안쪽 링(pick:focus-visible)은 그대로 남는다.
+    expect(components).toContain(".canvas-triage-deck-pick:focus-visible {");
+    // 겨눈 카드의 캡션 워시는 포커스 패널과 같은 한 값이다 — 새 값을 만들지 않는다.
+    const wash = components.match(/\.canvas-triage-deck-cell:hover \.canvas-operation\.is-deck-tile > \.canvas-operation-titlebar,\n[^{]*\{[^}]*\}/)?.[0] ?? "";
+    expect(wash).toContain("background: color-mix(in oklab, var(--brass) 10%, var(--surface-panel));");
+    expect(wash).toContain("background-clip: padding-box;");
+  });
+
+  it("mixes the map quick-look border in oklab so brass stays on the location channel", () => {
+    // oklch는 hue를 극좌표 짧은 호로 보간한다. brass(78)와 surface-rim(245)의 60% 믹스는
+    // 실측 hue 144.8(Instrument)·144.2(Maritime)·354(Carbon)에 착지해, 위치 채널이 신호 채널
+    // positive(160·152) 옆에 앉거나 마젠타로 넘어갔다. 같은 함정을 캡션 포커스 워시가 이미
+    // oklab으로 옮겨 해결했다. War Room 안에서는 지도 점 hover(raw brass)·카드 hover와
+    // 같은 색이어야 하므로 이 자리도 oklab이다.
+    const mapQuicklook = components.match(/\.canvas-triage-deck-cell\.is-map-quicklook > \.canvas-triage-deck-mount > \.canvas-operation \{[^}]*\}/)?.[0] ?? "";
+    expect(mapQuicklook).toContain("border-color: color-mix(in oklab, var(--brass) 60%, var(--surface-rim));");
+    expect(mapQuicklook).not.toContain("in oklch");
   });
 
   it("keeps the deck tile's live body out of reach of both pointer and keyboard", () => {


### PR DESCRIPTION
## Summary

War Room 카드뷰의 두 신고를 실측으로 확정하고 P1로 닫습니다.

- **상태 링이 캡션을 지나지 않던 원인은 특이도 동점**이었습니다. `.canvas-operation.is-deck-tile`(components.css:4335)이 `border-top: 1px solid`를 이미 선언하지만, 뒤쪽 캡션 이음새 규칙 `.canvas-operation:has(> .canvas-operation-titlebar)`가 **같은 (0,2,0)** 으로 뒤에 와서 이겼습니다(실측 `borderTopWidth: "0px"`). 이음새 규칙 바로 뒤에 `(0,3,0)` 예외를 두어 타일만 윗변을 되찾습니다 — 떠 있는 캡션(Cruise·Tactical·companion)의 계약은 그대로입니다.
- **hover는 401ms 동안 아무 말도 하지 않았습니다.** 덱에서 카드용 `:hover` 규칙은 0건이었고(있는 1건은 지도 점의 것), 첫 pointermove→`is-quicklook` 사이 DOM 변이도 0건이었습니다. 위치 마크를 **칸(cell)** 이 지도록 해 포인터가 닿는 순간 brass 헤어라인과 캡션 워시가 섭니다.
- 위치 마크를 패널에 얹지 않은 이유는 취향이 아니라 캐스케이드입니다. 맥동 카드에 `:hover { border-color: brass; box-shadow: floating }`을 실제로 얹어 재니 계산값이 **aurora**·맥동 글로우였습니다(애니메이션 오리진 > author-normal) — 신호가 가장 급한 카드에서만 hover가 사라지는 조용한 실패입니다.
- 확대된 칸만 `--shadow-floating`을 입어 이웃 위로 떠오릅니다. 원래 크기 칸에 주면 `0 32px 60px -28px`가 10px 간격을 넘어 이웃 rim을 덮습니다.
- 같은 패스에서 지도 Quick-Look 테두리를 `in oklab`으로 정정합니다. `in oklch` 짧은 호 보간이 brass를 instrument 144.8 / maritime 144.2 / carbon 354로 보내 `--positive`(160·152) 옆에 앉혔습니다.

제안 아티팩트(실측·11안·채점): https://claude.ai/code/artifact/37210e83-6d36-4692-873f-b863a1fc30f4

## Test Plan

- [x] `vitest run` — `instrument-design-contract` 외 10개 파일, 309 passed (새 계약 4건 포함: 링 닫힘·예외 배치 순서·hover 마크 소유자·지도 oklab)
- [x] `pnpm --filter @dotobokuri/fleet-console build` / `tsc --noEmit` 클린
- [x] 헤디드 실측(격리 콘솔 :61239, 번들 `index-v0ndYHZA.js`): 타일 `borderTopWidth 1px`·`borderTopStyle solid`
- [x] 맥동 중인 카드 hover — 칸 그림자에 `oklch(0.8 0.085 78 / 0.42) 0 0 0 1px` 생존, 패널은 aurora 유지(두 채널 공존)
- [x] 포인터 도착 즉시 마크 시작(드웰 전), 키보드 Tab → `pick:focus-visible`에서 동일 마크
- [x] reduced-motion: 맥동 정지 + `border-color: aurora`가 **네 변 모두**, hover 마크는 전이 없이 즉시
- [x] 4테마 스윕 — hover 링 hue = brass(78/75/62/82), 지도 테두리 hue = brass(80/75/62/82, 이전 144.8/144.2/354/87)
- [x] 좁은 뷰포트(900×700)·밀도 1.0/1.6× — 칸 밖으로 나간 자식 0, 그리드 스크롤 오버플로 0, 페이지 에러 0

> 참고: 리뷰 시점에 canary가 3커밋 전진해 `instrument-design-contract.test.ts`가 겹쳐, canary(`f2dec7a81`) 기준으로 리베이스한 뒤 `--force-with-lease`로 다시 올렸습니다(`06d22307c` → `527e19184`, 충돌 0). 리베이스한 tip에서 typecheck·build·309 테스트·`compile-changelog-fragments --check`(11 entries OK) 전부 통과했습니다.