### PR TITLE
fix(fleet-console): stage panels that finish while focused in War Room

### DIFF
--- a/.changelog.d/warroom-stage-promotion.md
+++ b/.changelog.d/warroom-stage-promotion.md
@@ -1,0 +1,8 @@
+---
+branch: warroom-stage-promotion
+---
+
+### fleet-console
+#### Fixed
+- Promote a panel that finishes during War Room onto the stage even when it was already focused before you entered.
+  ko: War Room에 들어오기 전부터 포커스해 둔 패널이라도, 선별 중 작업이 끝나면 무대에 올립니다.

--- a/runtime/fleet-console/core/client/src/operation-idle-arrival.ts
+++ b/runtime/fleet-console/core/client/src/operation-idle-arrival.ts
@@ -20,6 +20,10 @@ export function setIdleArrivalAcknowledgementSuspended(suspended: boolean): void
   acknowledgementSuspended = suspended;
 }
 
+export function isIdleArrivalAcknowledgementSuspended(): boolean {
+  return acknowledgementSuspended;
+}
+
 export function clearIdleArrival(id: string): void {
   if (!idleArrivalIds.has(id)) return;
   idleArrivalIds = new Set(idleArrivalIds);

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -4,7 +4,7 @@ import { useCallback, useSyncExternalStore } from "react";
 import type { OperationRuntimeState } from "@fleet-console/sdk/plugin";
 
 import { clearDeparture, markDeparture, resetDepartureForTests } from "../operation-departure.js";
-import { clearIdleArrival, markIdleArrival, resetIdleArrivalForTests } from "../operation-idle-arrival.js";
+import { clearIdleArrival, isIdleArrivalAcknowledgementSuspended, markIdleArrival, resetIdleArrivalForTests } from "../operation-idle-arrival.js";
 import { resolveOperationActivity } from "../operation-activity.js";
 import { getState, subscribe } from "../store.js";
 import type { OperationNode } from "../types.js";
@@ -201,9 +201,16 @@ export function trackOperationActivityTransitions(input: {
   movedIds.forEach((id) => pendingStatusLandingIds.add(id));
   for (const operation of input.operations) {
     if (!movedIds.includes(operation.id)) continue;
+    // 확인 처리가 정지된 동안(War Room)에는 어떤 활성도 "이미 확인됨"으로 치지 않는다. 그
+    // 정지는 선별 중 활성화를 미인정으로 만들지만 진입 전에 인정된 활성은 건드리지 못하는데,
+    // 그 패널이 선별 중 완료하면 여기서 도착 마크를 통째로 건너뛴다. 마크는 전이 순간에만 붙어
+    // 되살아나지 않으므로, 그 Operation은 대기 큐로 돌아오지 못한 채 덱 카드에 남는다.
+    // 판정만 정지에 맞추고 activeOperationAcknowledged 자체는 두어야 한다 — 그 값을 진입에서
+    // 내리면 종료 복구(setActiveOperation)가 진입 전부터 있던 도착 마크까지 확인 처리해 지운다.
     const focusedAndAcknowledged = operation.id === input.activeOperationId
       && operation.theaterId === input.activeTheaterId
-      && input.activeOperationAcknowledged === true;
+      && input.activeOperationAcknowledged === true
+      && !isIdleArrivalAcknowledgementSuspended();
     if (nextStatuses.get(operation.id) === "running") {
       if (!focusedAndAcknowledged) markDeparture(operation.id);
     } else {

--- a/runtime/fleet-console/tests/warroom-stage-promotion.test.ts
+++ b/runtime/fleet-console/tests/warroom-stage-promotion.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+// War Room 완료 승격 계약 — 사이드바 활동 추적기(도착 마크)와 선별 큐가 만나는 지점을 고정한다.
+// 두 스토어를 함께 태워야만 관측되는 계약이라 triage-store.test.ts가 아니라 여기에 둔다.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { resetIdleArrivalForTests, getIdleArrivalIds } from "../core/client/src/operation-idle-arrival.js";
+import { getState, setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
+import { loadForTheater } from "../core/client/src/canvas/canvas-store.js";
+import {
+  resetSideBarStatusRecencyForTests,
+  trackOperationActivityTransitions,
+} from "../core/client/src/sidebar/operations-side-bar-store.js";
+import {
+  enterTriage,
+  recordTriageActivity,
+  resolveTriageQueue,
+  setTriageActive,
+} from "../core/client/src/canvas/triage-store.js";
+import type { OperationNode } from "../core/client/src/types.js";
+
+const THEATER_ID = "theater-a";
+
+function operation(id: string, createdAt: number, theaterId = THEATER_ID): OperationNode {
+  return {
+    id,
+    theaterId,
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    ts: { createdAt, updatedAt: createdAt },
+  };
+}
+
+const OPS = [operation("panel-a", 1), operation("panel-b", 2)];
+
+// app.tsx:170의 전역 구독이 하는 일과 같다 — store 스냅샷을 제품 writer에 그대로 넘긴다.
+function pumpActivityTracking(): void {
+  const state = getState();
+  trackOperationActivityTransitions({
+    operations: state.operations,
+    operationRuntime: state.operationRuntime,
+    activeTheaterId: state.activeTheaterId,
+    activeOperationId: state.activeOperationId,
+    activeOperationAcknowledged: state.activeOperationAcknowledged,
+  });
+  recordTriageActivity(state.operations, state.operationRuntime);
+}
+
+function setRuntime(runtime: Record<string, { lifecycle: "live"; activity: "running" | "idle" }>): void {
+  setConsoleState({ operationRuntime: runtime });
+  pumpActivityTracking();
+}
+
+function queueIds(): readonly string[] {
+  const state = getState();
+  return resolveTriageQueue(state.operations, state.operationRuntime).map((entry) => entry.operation.id);
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  loadForTheater(THEATER_ID);
+  setTriageActive(false);
+  resetIdleArrivalForTests();
+  resetSideBarStatusRecencyForTests();
+  setConsoleState({
+    theaters: [{ id: THEATER_ID, label: "Alpha", createdAt: "2026-08-18T00:00:00.000Z", lastOpenedAt: "2026-08-18T00:00:00.000Z", hasWiki: false, activeAdmiralCount: 0 }],
+    operations: OPS,
+    activeTheaterId: THEATER_ID,
+    activeOperationId: null,
+    activeOperationAcknowledged: true,
+    operationRuntime: {},
+  });
+  // 두 패널 모두 running으로 baseline을 잡는다(firstLive 처리).
+  setRuntime({
+    "panel-a": { lifecycle: "live", activity: "running" },
+    "panel-b": { lifecycle: "live", activity: "running" },
+  });
+});
+
+describe("War Room 완료 승격", () => {
+  it("대조군: 비활성 패널이 완료되면 대기 큐에 든다", () => {
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "running" },
+      "panel-b": { lifecycle: "live", activity: "idle" },
+    });
+    expect(getIdleArrivalIds().has("panel-b")).toBe(true);
+    expect(queueIds()).toContain("panel-b");
+  });
+
+  it("대조군: 큐가 빈 채 War Room에 들어가면 enterTriage가 활성을 지워 완료가 큐에 든다", () => {
+    setActiveOperation("panel-a");
+    expect(getState().activeOperationAcknowledged).toBe(true);
+
+    enterTriage(null);
+    expect(getState().activeOperationId).toBeNull();
+
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "idle" },
+      "panel-b": { lifecycle: "live", activity: "running" },
+    });
+    expect(queueIds()).toContain("panel-a");
+  });
+
+  it("선별 중에는 인정된 활성의 완료도 대기 큐에 든다", () => {
+    // 1) Cruise에서 panel-a를 클릭해 활성화 — 도착 마크가 없으므로 acknowledged=true.
+    setActiveOperation("panel-a");
+    expect(getState().activeOperationAcknowledged).toBe(true);
+
+    // 2) panel-b가 먼저 완료되어 대기 큐가 생긴다.
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "running" },
+      "panel-b": { lifecycle: "live", activity: "idle" },
+    });
+    expect(queueIds()).toEqual(["panel-b"]);
+
+    // 3) 큐가 비어있지 않으므로 enterTriage는 활성을 지우지 않는다. 인정 플래그도 그대로 둔다 —
+    //    바뀌는 것은 확인 처리의 정지뿐이고, 억제 판정이 그 정지를 읽는다.
+    enterTriage(null);
+    expect(getState().activeOperationId).toBe("panel-a");
+    expect(getState().activeOperationAcknowledged).toBe(true);
+
+    // 4) panel-a가 완료되면 도착 마크가 붙어 대기 큐에 든다.
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "idle" },
+      "panel-b": { lifecycle: "live", activity: "idle" },
+    });
+    expect(getIdleArrivalIds().has("panel-a")).toBe(true);
+    expect(queueIds()).toContain("panel-a");
+  });
+
+  it("무대가 서지 않아 자동 포커스가 활성을 덮어쓰지 못해도 완료가 큐에 든다", () => {
+    // 스포트라이트 OFF·투어/모달·패널 안 입력 포커스는 무대 자동 포커스를 건너뛰게 한다.
+    // 그 구제가 없어도 선별 중에는 억제가 정지하므로 완료는 큐로 들어와야 한다.
+    setActiveOperation("panel-a");
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "running" },
+      "panel-b": { lifecycle: "live", activity: "idle" },
+    });
+    enterTriage(null);
+
+    // 무대 자동 포커스(setActiveOperation(stage, { acknowledged: false }))를 일부러 호출하지 않는다.
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "idle" },
+      "panel-b": { lifecycle: "live", activity: "idle" },
+    });
+
+    expect(queueIds()).toContain("panel-a");
+  });
+
+  it("선별을 나오면 인정된 활성의 완료 억제가 되살아난다", () => {
+    setActiveOperation("panel-a");
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "running" },
+      "panel-b": { lifecycle: "live", activity: "idle" },
+    });
+    enterTriage(null);
+    setTriageActive(false);
+    expect(getState().activeOperationAcknowledged).toBe(true);
+
+    // 선별 밖에서 포커스한 패널이 눈앞에서 끝나는 것은 "미확인 도착"이 아니다 — 기존 계약이다.
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "idle" },
+      "panel-b": { lifecycle: "live", activity: "idle" },
+    });
+    expect(getIdleArrivalIds().has("panel-a")).toBe(false);
+    expect(queueIds()).not.toContain("panel-a");
+  });
+
+  it("선별 왕복이 진입 전부터 있던 도착 마크를 지우지 않는다", () => {
+    // Theater만 바꾸면 activeOperationId는 남는다. 그 잔류 활성이 다른 Theater에서 완료하면
+    // Theater 불일치로 도착 마크가 붙는다. 선별을 여닫는 것만으로 그 마크가 사라지면 안 된다.
+    setConsoleState({ activeTheaterId: "theater-other" });
+    setActiveOperation("panel-a");
+    expect(getState().activeOperationAcknowledged).toBe(true);
+
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "running" },
+      "panel-b": { lifecycle: "live", activity: "running" },
+    });
+    setRuntime({
+      "panel-a": { lifecycle: "live", activity: "idle" },
+      "panel-b": { lifecycle: "live", activity: "running" },
+    });
+    expect(getIdleArrivalIds().has("panel-a")).toBe(true);
+
+    setTriageActive(true);
+    setTriageActive(false);
+
+    expect(getIdleArrivalIds().has("panel-a")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- War Room에서 완료된 패널이 무대로 오르지 못하고 덱 카드에 남는 결함을 고칩니다. 무대 승격의 유일한 입구인 `resolveTriageQueue`는 도착 마크가 붙은 완료만 받는데, 그 마크를 다는 판정이 War Room의 확인 처리 정지를 읽지 않아 **진입 전에 인정된 활성**만 정책 밖에 남아 있었습니다. 마크는 전이 순간에만 붙어 되살아나지 않으므로, 그 Operation은 영구히 대기 큐 밖에 머물렀습니다.
- `isIdleArrivalAcknowledgementSuspended()`를 노출하고 `trackOperationActivityTransitions`의 `focusedAndAcknowledged` 판정이 그 정지를 함께 보도록 했습니다. 저장된 `activeOperationAcknowledged` 값은 건드리지 않습니다 — 진입에서 그 값을 내리면 종료 복구(`setActiveOperation`)가 진입 전부터 있던 도착 마크까지 확인 처리해 지우기 때문입니다(적대 리뷰에서 확인된 회귀).
- 선별 밖(Cruise)에서 포커스한 패널이 눈앞에서 끝나는 경우의 기존 억제 계약은 그대로입니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console test` — 2281 passed / 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 양방향 잠금 — 수정을 되돌리면 신규 계약 테스트 2건 실패, 이전 접근(진입 시 인정 하향)을 적용하면 마크 보존 테스트가 실패
- [x] 헤드리스 e2e (`claude-gateway--cursor--auto` Agent Operation 2건): 활성+인정+실행 중 상태에서 Alt+T 진입, 스포트라이트 OFF로 무대 자동 포커스 구제를 차단한 조건에서 완료 → 도착 마크 부여 확인, War Room 사이드바 `대기 1 / 유휴 1` → `대기 2 / 유휴 0`