### PR TITLE
fix(fleet-console): keep Cruise Map out of keyboard focus

### DIFF
--- a/.changelog.d/cruise-map-no-focus.md
+++ b/.changelog.d/cruise-map-no-focus.md
@@ -1,0 +1,8 @@
+---
+branch: cruise-map-no-focus
+---
+
+### fleet-console
+#### Fixed
+- Keep Cruise Map from taking keyboard focus, so focusing a chat view and pressing Enter no longer paints a brass line on the map.
+  ko: Cruise Map이 키보드 포커스를 받지 않게 해서, 채팅뷰를 포커스한 뒤 Enter를 눌러도 지도에 금색 띠가 생기지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -817,7 +817,6 @@ export function OperationsCanvas({
       onWheel={interaction.onWheel}
       onContextMenu={handleContextMenu}
       ref={canvasRef}
-      tabIndex={-1}
     >
       <CanvasGrid viewport={canvas.viewport} />
       {triageActive ? <div className="canvas-triage-scan" aria-hidden="true" /> : null}
@@ -946,12 +945,9 @@ export function OperationsCanvas({
             operationBodyPoolAvailable,
             deckSlot,
             onRenderHiddenFocus: () => {
-              const focusTarget = canvasRef.current?.querySelector<HTMLElement>("[data-focus-layer-target='true']");
-              if (focusTarget) {
-                focusTarget.focus();
-                return;
-              }
-              canvasRef.current?.focus();
+              // 숨은 peer의 포커스는 전면 프레임만 받는다. Map <main>은 키보드 정거장이 아니라서
+              // 폴백으로 가져가면 채팅 본문 클릭·Enter가 바다에 :focus-visible brass 링을 남긴다.
+              canvasRef.current?.querySelector<HTMLElement>("[data-focus-layer-target='true']")?.focus();
             },
             accentKey: canvas.operationAccent[operation.id] ?? operationAccentFromNode(operation),
             groupName: operationGroup?.name ?? null,

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -179,7 +179,8 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
     return () => terminal.removeEventListener("pointerdown", activate);
   }, [onActivate]);
 
-  // focus layer가 현재 포커스를 담은 peer를 숨길 때는 body로 흘려보내지 않고 새 전면 frame(없으면 Canvas)으로 옮긴다.
+  // focus layer가 현재 포커스를 담은 peer를 숨길 때는 body로 흘려보내지 않고 새 전면 frame으로 옮긴다.
+  // Map 바다는 싱크가 아니다 — 전면 프레임이 없으면 브라우저가 inert peer에서 포커스를 걷는다.
   // 메뉴 회수를 포커스 이관보다 먼저 한다 — 뒤에 두면 부모가 메뉴를 닫으며 되돌리는 포커스가
   // 방금 inert가 된 이 프레임의 트리거를 향한다.
   useLayoutEffect(() => {

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -554,6 +554,14 @@ a {
   border-radius: var(--radius-xs);
 }
 
+/* Map <main>은 키보드 정거장이 아니다. 채팅 로그처럼 포커스 불가한 본문을 누르면
+   브라우저는 document(body)로 포커스를 올린다. 그 자리에 전역 링을 그리면 Enter가
+   뷰포트 전체를 금색으로 감싼다. 선택(복사)을 지키려면 mousedown을 막지 않고 링만 끈다. */
+body:focus-visible,
+html:focus-visible {
+  outline: none;
+}
+
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -496,6 +496,21 @@ describe("CanvasMinimap collapse behavior", () => {
     expect(document.querySelector<HTMLElement>('[aria-label="Operation Peer"]')?.contains(document.activeElement)).toBe(false);
   });
 
+  // Map <main>은 제스처·우클릭 판이지 키보드 정거장이 아니다. tabindex=-1이면 채팅 로그처럼
+  // 포커스 불가한 본문을 누른 뒤 Enter가 :focus-visible brass 링을 바다 왼쪽에 남긴다.
+  it("does not accept keyboard focus on the Map canvas", () => {
+    renderOperationsCanvas();
+    const canvas = document.querySelector<HTMLElement>("main.operations-canvas");
+    expect(canvas).not.toBeNull();
+    expect(canvas!.hasAttribute("tabindex")).toBe(false);
+    canvas!.focus();
+    expect(document.activeElement).not.toBe(canvas);
+    const peer = document.querySelector<HTMLElement>('[aria-label="Operation Peer"]');
+    expect(peer).not.toBeNull();
+    peer!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    expect(document.activeElement).not.toBe(canvas);
+  });
+
   // 메뉴는 페이지가 소유하고 프레임은 자기가 숨는 것만 안다 — 숨는 순간 그 사실을 주인 id와 함께
   // 올려야, 보이지 않는 패널의 메뉴가 화면에 남아 조작 가능한 채로 버티지 않는다.
   it("reports its own id when a hidden peer's menu owner leaves the focus layer", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -518,6 +518,16 @@ describe("Instrument core design contract", () => {
     expect(contextMenu).toContain("menuRef.current?.focus({ preventScroll: true });");
   });
 
+  it("keeps the Map canvas out of the keyboard focus order", () => {
+    const canvas = source("canvas/canvas.tsx");
+    const theme = source("styles/theme.css");
+    // tabindex=-1이면 채팅 로그처럼 포커스 불가한 본문을 누른 뒤 Enter가 바다에 brass 링을 남긴다.
+    expect(canvas).not.toContain("tabIndex={-1}");
+    expect(canvas).not.toContain("canvasRef.current?.focus()");
+    expect(theme).toContain("body:focus-visible,");
+    expect(theme).toContain("html:focus-visible {");
+  });
+
   it("replaces the launch menu's native scrollbar with edge strips and a scroll gauge", () => {
     const components = source("styles/components.css");
     const contextMenu = source("canvas/canvas-context-menu.tsx");


### PR DESCRIPTION
## Summary

- Cruise Map (`<main class="operations-canvas">`) is a gesture and right-click surface, not a keyboard stop.
- `tabIndex={-1}` let a chat-body click plus Enter paint a brass `:focus-visible` ring on the sea. The Map no longer takes focus; hidden-peer focus moves only to the front frame.
- Clicking a non-focusable chat log can still land on `document.body`; the global ring is suppressed there so Enter does not outline the viewport. Text selection is unchanged.

## Test Plan

- [x] `corepack pnpm --filter @dotobokuri/fleet-console test -- tests/canvas-minimap-formation.test.ts tests/instrument-design-contract.test.ts tests/canvas-context-menu-formation-launch.test.tsx tests/warroom-canvas-context-menu.test.tsx`
- [ ] Cruise: focus a chat view (click the log, not the composer), press Enter — no brass line on the Map left seam
- [ ] Cruise: panel caption still shows `is-active` wash; right-click on empty Map still opens the canvas menu
- [ ] Maximize a panel that held focus in a hidden peer — focus lands on the front frame, not the Map