### PR TITLE
fix(core-ai-gateway): stop forwarding the harness usage-limit directive

### DIFF
--- a/.changelog.d/gateway-strip-usage-limit-directives.md
+++ b/.changelog.d/gateway-strip-usage-limit-directives.md
@@ -1,0 +1,8 @@
+---
+branch: gateway-strip-usage-limit-directives
+---
+
+### fleet-console
+#### Fixed
+- Keep Claude Code's usage-limit wrap-up directive out of every request the AI gateway forwards, so work running on another provider is no longer told to cut itself short because the Claude subscription is near its limit.
+  ko: Claude Code가 한도 임박 시 대화에 끼워 넣는 마무리 지시를 AI 게이트웨이가 더 이상 전달하지 않습니다. 다른 공급자로 실행 중인 작업이 Claude 구독 사정 때문에 축소되지 않습니다.

--- a/packages/core-ai-gateway/src/anthropic/claude-context.ts
+++ b/packages/core-ai-gateway/src/anthropic/claude-context.ts
@@ -823,7 +823,7 @@ export function omitClaudeWebSearchTools<
  * bracketed line opening with `Usage limit ` that is the entire text of its block is not
  * something a person types into a prompt.
  */
-const CLAUDE_USAGE_LIMIT_DIRECTIVE = /^\[Usage limit [^\]]*\]$/;
+const CLAUDE_USAGE_LIMIT_DIRECTIVE = /^\s*\[Usage limit [^\]]*\]\s*$/;
 
 export interface ClaudeUsageLimitStripResult<M> {
   readonly messages: readonly M[];
@@ -883,6 +883,12 @@ function stripUsageLimitBlocks<M extends ClaudeMessageLike>(
   return { message: { ...message, content: kept } as M, removed };
 }
 
+/**
+ * The surrounding whitespace is matched rather than trimmed away first: every text block of
+ * every message reaches this test, skill bodies included, and one of those was measured at
+ * 162,681 tokens. `trim()` would copy that string in full before the first character could
+ * rule it out, where the anchored pattern rejects it on that character.
+ */
 function isClaudeUsageLimitDirective(text: string): boolean {
-  return CLAUDE_USAGE_LIMIT_DIRECTIVE.test(text.trim());
+  return CLAUDE_USAGE_LIMIT_DIRECTIVE.test(text);
 }

--- a/packages/core-ai-gateway/src/anthropic/claude-context.ts
+++ b/packages/core-ai-gateway/src/anthropic/claude-context.ts
@@ -548,6 +548,7 @@ interface ClaudeTextBlockLike {
 /** Structural shape of an Anthropic message, kept local so this module stays a leaf. */
 interface ClaudeMessageLike {
   readonly content: unknown;
+  readonly role?: unknown;
 }
 
 export interface ClaudeSkillPruneOptions {
@@ -795,4 +796,93 @@ export function omitClaudeWebSearchTools<
     } as R,
     changed: true,
   };
+}
+
+/**
+ * Claude Code's own wrap-up directive, injected when the caller's Anthropic quota nears its
+ * limit.
+ *
+ * The client watches `anthropic-ratelimit-unified-*` on its own account and, once the
+ * five-hour window passes 95%, pushes a message of its own into the conversation: finish
+ * the current step, list three bullets, start no subagents. It is not a user turn — the
+ * client marks it meta and never shows it — and it arrives as the last message of the
+ * request, right behind the tool results it interrupts.
+ *
+ * The premise of that directive is the caller's Claude subscription, which has nothing to
+ * do with the Cursor, Codex, xAI, Kimi or OpenCode budget actually paying for the turn it
+ * lands in. One measured session ran 59 assistant turns entirely on a gateway model and
+ * still carried it. So the text either misleads a provider that is nowhere near a limit, or
+ * truthfully shrinks the work on one whose spend the number does not describe. Neither is
+ * something this gateway should forward, and the strip is unconditional for the same reason
+ * the injection is: the request cannot tell whether the account it describes is the account
+ * being billed.
+ *
+ * Shape is the test, never the wording. These sentences ship inside the client binary,
+ * three variants already differ between the approaching and grace cases, and any of them
+ * can be reworded by the next release — a list of exact strings would go stale silently. A
+ * bracketed line opening with `Usage limit ` that is the entire text of its block is not
+ * something a person types into a prompt.
+ */
+const CLAUDE_USAGE_LIMIT_DIRECTIVE = /^\[Usage limit [^\]]*\]$/;
+
+export interface ClaudeUsageLimitStripResult<M> {
+  readonly messages: readonly M[];
+  readonly changed: boolean;
+  /** Directive blocks dropped from this request. */
+  readonly removed: number;
+}
+
+/**
+ * Drop every usage-limit directive from a conversation before it leaves for a provider.
+ *
+ * A directive owns its whole text block, so removing it empties the message it arrived in
+ * and that message goes too — leaving an empty text block behind would be rejected by the
+ * wire, and leaving the message with no blocks says nothing either.
+ *
+ * Removing the last message of a request is the one way this can do harm: a conversation
+ * that ends on an assistant turn reads as a continuation to ask for, and one that ends
+ * nowhere is not a request at all. Measured, the directive always lands behind a user
+ * message (13 of 14 behind tool results), so the guard never fires in the observed shape —
+ * it exists because the cost of being wrong once is a failed turn, while the cost of
+ * declining to strip is one directive that gets through.
+ */
+export function stripClaudeUsageLimitDirectives<M extends ClaudeMessageLike>(
+  messages: readonly M[],
+): ClaudeUsageLimitStripResult<M> {
+  let removed = 0;
+  const kept: M[] = [];
+  for (const message of messages) {
+    const stripped = stripUsageLimitBlocks(message);
+    removed += stripped.removed;
+    if (stripped.message !== null) kept.push(stripped.message);
+  }
+  if (removed === 0) return { messages, changed: false, removed: 0 };
+  const last = kept[kept.length - 1];
+  if (last === undefined || last.role === "assistant") {
+    return { messages, changed: false, removed: 0 };
+  }
+  return { messages: kept, changed: true, removed };
+}
+
+function stripUsageLimitBlocks<M extends ClaudeMessageLike>(
+  message: M,
+): { readonly message: M | null; readonly removed: number } {
+  const content = message.content;
+  if (typeof content === "string") {
+    return isClaudeUsageLimitDirective(content)
+      ? { message: null, removed: 1 }
+      : { message, removed: 0 };
+  }
+  if (!Array.isArray(content)) return { message, removed: 0 };
+  const kept = content.filter(
+    (block: unknown) => !(isClaudeTextBlock(block) && isClaudeUsageLimitDirective(block.text)),
+  );
+  const removed = content.length - kept.length;
+  if (removed === 0) return { message, removed: 0 };
+  if (kept.length === 0) return { message: null, removed };
+  return { message: { ...message, content: kept } as M, removed };
+}
+
+function isClaudeUsageLimitDirective(text: string): boolean {
+  return CLAUDE_USAGE_LIMIT_DIRECTIVE.test(text.trim());
 }

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -9,6 +9,7 @@ import {
 import {
   omitClaudeWebSearchTools,
   pruneClaudeSkillPayloads,
+  stripClaudeUsageLimitDirectives,
 } from "../anthropic/claude-context.js";
 import type { AnthropicMessagesRequest } from "../anthropic/protocol.js";
 import { UnsupportedReasoningEffortError } from "../canonical/index.js";
@@ -266,6 +267,13 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
       return true;
     }
 
+    // 하네스가 자기 Anthropic 계정의 한도 임박을 근거로 대화에 끼워 넣는 마무리 지시는 여기서 끊는다.
+    // 그 지시는 이 턴을 실제로 결제하는 구독을 설명하지 않으므로, 목적지를 가리지 않고 전량 제거한다 —
+    // 근거와 모양 판정은 claude-context.ts가 갖는다.
+    const withoutUsageLimitDirectives = stripClaudeUsageLimitDirectives(body.messages);
+    if (withoutUsageLimitDirectives.changed) {
+      body = { ...body, messages: [...withoutUsageLimitDirectives.messages] };
+    }
     // 스킬 본문은 매 턴 재전송되는 고정 비용이라 클라이언트 압축이 걷어낼 수 없다.
     // 프로바이더 분기보다 앞이어야 canonical을 거치지 않는 passthrough까지 함께 덮는다.
     if (target) {

--- a/packages/core-ai-gateway/tests/anthropic/claude-usage-limit-strip.test.ts
+++ b/packages/core-ai-gateway/tests/anthropic/claude-usage-limit-strip.test.ts
@@ -94,6 +94,19 @@ describe("stripClaudeUsageLimitDirectives", () => {
     expect(result.messages).toBe(messages);
   });
 
+  it("matches a directive padded with whitespace, and leaves a long body untouched", () => {
+    const skillBody = `Base directory for this skill: /tmp/skills/dataviz\n\n${"x".repeat(50_000)}`;
+    const messages = [
+      userText(skillBody),
+      { role: "user", content: [{ type: "text", text: `\n  ${APPROACHING}\n` }] },
+    ];
+
+    const result = stripClaudeUsageLimitDirectives(messages);
+
+    expect(result.changed).toBe(true);
+    expect(result.messages).toEqual([userText(skillBody)]);
+  });
+
   it("returns the same array when nothing matched", () => {
     const messages = [userText("Ship it.")];
     const result = stripClaudeUsageLimitDirectives(messages);

--- a/packages/core-ai-gateway/tests/anthropic/claude-usage-limit-strip.test.ts
+++ b/packages/core-ai-gateway/tests/anthropic/claude-usage-limit-strip.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { stripClaudeUsageLimitDirectives } from "../../src/anthropic/claude-context.js";
+
+/** The three directives measured in Claude Code 2.1.234, verbatim. */
+const APPROACHING = "[Usage limit approaching. Checkpoint now: finish the current step, then list up to 3 short bullets of the most impactful remaining work. Don't start subagents or long-running work.]";
+const GRACE_WRAP_UP = "[Usage limit reached — grace window active. Wrap up: finish or checkpoint; don't start subagents or long work.]";
+const GRACE_CHECKPOINT = "[Usage limit reached — grace window active. Checkpoint now: finish the current step, then list up to 3 short bullets of the most impactful remaining work. Don't start subagents or long-running work.]";
+
+function toolResult(id: string): { role: "user"; content: { type: "tool_result"; tool_use_id: string; content: string }[] } {
+  return { role: "user", content: [{ type: "tool_result", tool_use_id: id, content: "ok" }] };
+}
+
+function userText(text: string): { role: "user"; content: { type: "text"; text: string }[] } {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+describe("stripClaudeUsageLimitDirectives", () => {
+  it("drops the injected directive and keeps the turn it interrupted", () => {
+    const messages = [
+      { role: "user", content: "Fix the composer width." },
+      { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }] },
+      toolResult("t1"),
+      userText(APPROACHING),
+    ];
+
+    const result = stripClaudeUsageLimitDirectives(messages);
+
+    expect(result.changed).toBe(true);
+    expect(result.removed).toBe(1);
+    expect(result.messages).toHaveLength(3);
+    expect(JSON.stringify(result.messages)).not.toContain("Usage limit");
+    // The request still ends on the user turn the directive was pushed behind.
+    expect(result.messages[result.messages.length - 1]).toEqual(toolResult("t1"));
+  });
+
+  it("drops both grace variants, so a reworded release still matches on shape", () => {
+    for (const directive of [GRACE_WRAP_UP, GRACE_CHECKPOINT, "[Usage limit something we have not seen yet.]"]) {
+      const result = stripClaudeUsageLimitDirectives([toolResult("t1"), userText(directive)]);
+      expect(result.changed, directive).toBe(true);
+      expect(result.messages).toHaveLength(1);
+    }
+  });
+
+  it("drops a directive that arrived as a bare string message", () => {
+    const result = stripClaudeUsageLimitDirectives([
+      toolResult("t1"),
+      { role: "user", content: APPROACHING },
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it("removes only the directive block when the message carries other content", () => {
+    const result = stripClaudeUsageLimitDirectives([
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "t1", content: "ok" },
+          { type: "text", text: APPROACHING },
+        ],
+      },
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(result.removed).toBe(1);
+    expect(result.messages).toEqual([
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] },
+    ]);
+  });
+
+  it("leaves a human's own prose alone when it merely quotes the directive", () => {
+    const quoted = `Why did the agent stop? It received ${APPROACHING} mid-task.`;
+    const messages = [userText(quoted)];
+
+    const result = stripClaudeUsageLimitDirectives(messages);
+
+    expect(result.changed).toBe(false);
+    expect(result.messages).toBe(messages);
+  });
+
+  it("declines to strip when doing so would end the request on an assistant turn", () => {
+    const messages = [
+      { role: "user", content: "Go." },
+      { role: "assistant", content: [{ type: "text", text: "Working." }] },
+      userText(APPROACHING),
+    ];
+
+    const result = stripClaudeUsageLimitDirectives(messages);
+
+    expect(result.changed).toBe(false);
+    expect(result.removed).toBe(0);
+    expect(result.messages).toBe(messages);
+  });
+
+  it("returns the same array when nothing matched", () => {
+    const messages = [userText("Ship it.")];
+    const result = stripClaudeUsageLimitDirectives(messages);
+
+    expect(result.changed).toBe(false);
+    expect(result.messages).toBe(messages);
+  });
+});

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -1988,6 +1988,65 @@ describe("route surface", () => {
   });
 });
 
+describe("usage-limit directive", () => {
+  /** Claude Code injects this behind the tool results of the turn it interrupts. */
+  const DIRECTIVE = "[Usage limit approaching. Checkpoint now: finish the current step, then list up to 3 short bullets of the most impactful remaining work. Don't start subagents or long-running work.]";
+  const CONVERSATION = [
+    { role: "user", content: "Fix the composer width." },
+    { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }] },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] },
+    { role: "user", content: [{ type: "text", text: DIRECTIVE }] },
+  ];
+
+  it("never reaches a translated provider", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      "event: message_stop\n\n",
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ));
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      readOpencodeApiKey: async () => "opencode-secret",
+    });
+
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--opencode--minimax-m3[1m]",
+      messages: CONVERSATION,
+    }));
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      readonly messages: ReadonlyArray<{ readonly role: string }>;
+    };
+    expect(JSON.stringify(body.messages)).not.toContain("Usage limit");
+    // The turn the directive interrupted still ends the request.
+    expect(body.messages).toHaveLength(3);
+    expect(body.messages[body.messages.length - 1]?.role).toBe("user");
+  });
+
+  it("is stripped from native Anthropic passthrough too", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      "event: message_stop\n\n",
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ));
+    const router = createAiGatewayRouter({ fetch: fetchMock, readAuth });
+
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-sonnet-4-6",
+      messages: CONVERSATION,
+    }));
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      readonly messages: ReadonlyArray<unknown>;
+    };
+    expect(JSON.stringify(body.messages)).not.toContain("Usage limit");
+    expect(body.messages).toHaveLength(3);
+  });
+});
+
 function createAiGatewayRouter(
   deps: Partial<AiGatewayRouteDeps> = {},
 ) {


### PR DESCRIPTION
## Summary

- Claude Code가 자기 Anthropic 계정의 5시간 창이 95%를 넘으면 대화에 마무리 지시를 스스로 끼워 넣습니다(`isMeta`, UI 비표시, 요청의 마지막 메시지). 그 지시의 근거는 호출자의 Claude 구독이지, 그 턴을 실제로 결제하는 Cursor·Codex·xAI·Kimi·OpenCode 예산이 아닙니다. 실측 세션 하나는 assistant 턴 59개가 전부 `claude-gateway--xai--grok-4.6`인데도 이 지시를 그대로 실어 보냈습니다.
- 게이트웨이가 디스패치 전에 해당 지시를 제거합니다. 프로바이더 분기보다 앞이라 네이티브 Anthropic passthrough까지 함께 덮습니다.
- 판정은 문구가 아니라 모양입니다 — 문자열이 클라이언트 바이너리에 들어 있고 approaching/grace 변형이 이미 서로 다르므로, 정확한 문장 목록은 다음 릴리스에 조용히 낡습니다. 블록을 비우면 그 메시지도 함께 빠지며, 제거 결과가 assistant 턴으로 끝나게 되는 유일한 위험 케이스에서는 스스로 물러납니다(실측 14회 모두 직전이 user 메시지).

## Test Plan

- [x] `npx vitest run` (core-ai-gateway) — 33 files / 747 tests passed (신규 단위 7 + 라우터 통합 2 포함)
- [x] `pnpm typecheck` — 전 워크스페이스 Done
- [x] `pnpm build` — Done
- [x] `pnpm test` — console 2291 passed / terminal 976 passed / desktop 297 passed
- [x] `pnpm check:core-boundary`, `pnpm check:claude-agent-sdk-boundary` — 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty` — OK (18 entries)