### PR TITLE
feat(fleet-console): move an Operation panel's own controls into its caption

### DIFF
--- a/.changelog.d/panel-caption-controls.md
+++ b/.changelog.d/panel-caption-controls.md
@@ -1,0 +1,17 @@
+---
+branch: panel-caption-controls
+---
+
+### fleet-console
+
+#### Changed
+
+- An Operation panel's own controls now live in its caption instead of floating over the body: Session Analyst, the chat/terminal switch, and the chat reading width stand as marks to the left of the panel menu, and every caption control names itself in a hover bubble. The reading width appears only in the chat view and steps aside on a narrow panel; a War Room card keeps its caption clear of them. With no chip row over the body, a chat log now starts at the top of the panel.
+  ko: Operation 패널의 컨트롤이 본문 위에 떠 있지 않고 캡션으로 들어갔습니다. Session Analyst, 채팅/터미널 전환, 채팅 읽기 폭이 패널 메뉴 왼쪽에 마크로 서고, 캡션의 모든 컨트롤은 마우스를 올리면 말풍선으로 자기 이름을 말합니다. 읽기 폭은 채팅 뷰에서만 서고 좁은 패널에서는 물러나며, War Room 카드의 캡션에는 서지 않습니다. 본문 위의 칩 줄이 사라져 채팅 로그는 이제 패널 맨 위에서 시작합니다.
+- The chat context meter moved from the floating chip row into the composer control row, one step to the left of the send control, so what is left in the window reads where the message is written.
+  ko: 채팅 문맥 미터가 떠 있던 칩 줄에서 컴포저 컨트롤 행으로 옮겨, 전송 버튼 바로 왼쪽에 앉았습니다. 창에 얼마나 남았는지를 메시지를 쓰는 자리에서 읽습니다.
+
+#### Fixed
+
+- A pressed caption control (a maximized panel, an open Session Analyst) draws its brass fill on the brass hue in every theme; it previously landed on green or magenta because the color mix took the long way around the hue circle.
+  ko: 눌린 상태의 캡션 컨트롤(최대화된 패널, 열린 Session Analyst)이 모든 테마에서 brass 색조로 그려집니다. 이전에는 색 혼합이 색상환을 먼 쪽으로 돌아 초록이나 자홍에 착지했습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -1327,6 +1327,32 @@ function renderPluginOperation(operation: OperationNode, options: {
         onGeometryChange={options.onGeometryChange}
         onGeometryCommit={options.onGeometryCommit}
         onRenderHiddenFocus={options.onRenderHiddenFocus}
+        captionActions={descriptor.captionActions === undefined || options.deckSlot !== null ? null : (
+          // 본문과 같은 context로 그린다 — 캡션이 본문과 다른 사실을 말하는 프레임이 나오지 않게.
+          // 실패해도 32px 밴드에 오류 상자를 세울 자리는 없으므로, 선반만 조용히 비운다.
+          // (fallback을 생략하거나 null로 두면 `??`가 기본 오류 상자를 되살린다 — 빈 조각이라야 빈다.)
+          <PluginErrorBoundary fallback={<></>}>
+            <PluginOperationRenderer
+              active={options.active}
+              capabilities={capabilities}
+              geometry={geometry}
+              operation={operation}
+              theme={options.theme}
+              language={options.language}
+              viewportZoom={options.viewportZoom}
+              runtimeState={options.runtimeState}
+              onActivate={options.onActivate}
+              onClose={options.onClose}
+              onGeometryChange={options.onGeometryChange}
+              onRequestCompanions={onRequestCompanions}
+              companionsOpen={options.companion}
+              hiddenCompanionPanelIds={options.hiddenCompanionPanelIds}
+              onSetCompanionPanelVisible={onSetCompanionPanelVisible}
+              bodyLive={!options.minimized && !options.focusLayerHidden}
+              render={descriptor.captionActions}
+            />
+          </PluginErrorBoundary>
+        )}
       >
         {options.operationBodyPoolAvailable ? (
           <OperationBodySlot

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type WheelEvent as ReactWheelEvent } from "react";
 
+import { CaptionTipHost } from "@fleet-console/sdk/components/caption-actions";
 import type { OperationNode, OperationGeometry } from "@fleet-console/sdk/operations";
 
 import { useT } from "../i18n/index.js";
@@ -30,6 +31,12 @@ interface OperationFrameProps {
   readonly groupName?: string | null;
   readonly groupColor?: string | null;
   readonly children: ReactNode;
+  /**
+   * 캡션 동작 선반 — 이 Operation의 플러그인이 채우는 마크 버튼들. 자리는 프레임이 정한다:
+   * 메뉴 버튼 왼쪽, 창 컨트롤 앞. 덱 타일에서는 부모가 아예 넘기지 않는다(카드 본문은 inert라
+   * 동작하지 않는 버튼이 서면 거짓 약속이 된다).
+   */
+  readonly captionActions?: ReactNode;
   readonly onActivate: () => void;
   readonly onClose: () => void;
   readonly onMinimize: () => void;
@@ -77,7 +84,7 @@ const ARRIVAL_FLASH_DURATION_MS = 360;
 // 위상을 한 박자로 묶는 레일 애니메이션 — components.css의 상태 레일 선언과 한 벌이다.
 const PHASE_LOCKED_RAIL_ANIMATIONS = new Set(["caption-rail-flow", "caption-rail-call", "caption-rail-tide"]);
 
-export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, deckTile = false, glanceHud, accentKey = null, groupName = null, groupColor = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onOpenMenu, onRenderHiddenDismissMenu, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
+export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, deckTile = false, glanceHud, accentKey = null, groupName = null, groupColor = null, children, captionActions = null, onActivate, onClose, onMinimize, onMaximize, onRename, onOpenMenu, onRenderHiddenDismissMenu, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
   const t = useT();
   const operationRef = useRef<HTMLElement | null>(null);
   const terminalRef = useRef<HTMLDivElement | null>(null);
@@ -476,35 +483,44 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
         {/* 캡션은 상태를 말하지 않는다 — 패널 자신의 보더·글로우가 이미 상태 채널을 지고 있고,
             목록에서 상태를 읽는 자리는 사이드바 칩이다. 이 자리는 그 Operation에 대한 동작을
             여는 문(사이드바 우클릭과 같은 메뉴)이 가져간다. */}
+        {/* 플러그인 동작 선반 — 이 줄에서 마크만 서는 버튼은 전부 같은 말풍선을 쓴다. */}
+        {captionActions ? <span className="canvas-operation-caption-actions">{captionActions}</span> : null}
         {onOpenMenu ? (
-          <button
-            type="button"
-            className="canvas-operation-more-button"
-            onPointerDown={stopButtonPointer}
-            onClick={(event) => openOperationMenu(event.currentTarget.getBoundingClientRect(), event.currentTarget)}
-            aria-label={t("canvas.frame.openMenuAria", { title: displayTitle })}
-            aria-haspopup="menu"
-            title={t("canvas.frame.openMenuTitle")}
-          >
-            <MoreIcon />
-          </button>
+          <CaptionTipHost label={t("canvas.frame.openMenuTitle")}>
+            <button
+              type="button"
+              className="canvas-operation-more-button"
+              onPointerDown={stopButtonPointer}
+              onClick={(event) => openOperationMenu(event.currentTarget.getBoundingClientRect(), event.currentTarget)}
+              aria-label={t("canvas.frame.openMenuAria", { title: displayTitle })}
+              aria-haspopup="menu"
+            >
+              <MoreIcon />
+            </button>
+          </CaptionTipHost>
         ) : null}
         <div className="canvas-operation-window-controls">
           <span className="canvas-operation-controls-divider" aria-hidden="true" />
           {/* 최소화는 무대에서도 쓴다 — War Room의 최소화는 창을 접는 동작이 아니라 판(deck)에서
               내리는 동작이고, 무대에 선 패널이면 무대까지 함께 비운다. 최대화만 계속 빠진다:
               무대는 이미 캔버스 전체라 더 키울 자리가 없다. */}
-          <button type="button" className="canvas-operation-icon-button" onPointerDown={stopButtonPointer} onClick={minimize} aria-label={t("canvas.frame.minimizeAria", { title: displayTitle })} title={t("canvas.frame.minimizeTitle")}>
-            <MinimizeIcon />
-          </button>
-          {!triageStage && !deckTile && onMaximize ? (
-            <button type="button" className={`canvas-operation-icon-button ${maximized ? "is-active" : ""}`} onPointerDown={stopButtonPointer} onClick={maximize} aria-label={maximized ? t("canvas.frame.restoreAria", { title: displayTitle }) : t("canvas.frame.maximizeAria", { title: displayTitle })} aria-pressed={maximized} title={maximized ? t("canvas.frame.restoreTitle") : t("canvas.frame.maximizeTitle")}>
-              {maximized ? <RestorePanelIcon /> : <MaximizePanelIcon />}
+          <CaptionTipHost label={t("canvas.frame.minimizeTitle")}>
+            <button type="button" className="canvas-operation-icon-button" onPointerDown={stopButtonPointer} onClick={minimize} aria-label={t("canvas.frame.minimizeAria", { title: displayTitle })}>
+              <MinimizeIcon />
             </button>
+          </CaptionTipHost>
+          {!triageStage && !deckTile && onMaximize ? (
+            <CaptionTipHost label={maximized ? t("canvas.frame.restoreTitle") : t("canvas.frame.maximizeTitle")}>
+              <button type="button" className={`canvas-operation-icon-button ${maximized ? "is-active" : ""}`} onPointerDown={stopButtonPointer} onClick={maximize} aria-label={maximized ? t("canvas.frame.restoreAria", { title: displayTitle }) : t("canvas.frame.maximizeAria", { title: displayTitle })} aria-pressed={maximized}>
+                {maximized ? <RestorePanelIcon /> : <MaximizePanelIcon />}
+              </button>
+            </CaptionTipHost>
           ) : null}
-          <button type="button" className={`canvas-operation-icon-button ${isCloseArmed ? "is-armed-close" : ""}`} onPointerDown={stopButtonPointer} onClick={close} aria-label={isCloseArmed ? t("canvas.frame.confirmCloseAria", { title: displayTitle }) : t("canvas.frame.closeAria", { title: displayTitle })} title={isCloseArmed ? t("canvas.frame.confirmCloseTitle") : t("canvas.frame.closeTitle")}>
-            {isCloseArmed ? t("canvas.frame.closeArmed") : <CloseIcon />}
-          </button>
+          <CaptionTipHost label={isCloseArmed ? t("canvas.frame.confirmCloseTitle") : t("canvas.frame.closeTitle")}>
+            <button type="button" className={`canvas-operation-icon-button ${isCloseArmed ? "is-armed-close" : ""}`} onPointerDown={stopButtonPointer} onClick={close} aria-label={isCloseArmed ? t("canvas.frame.confirmCloseAria", { title: displayTitle }) : t("canvas.frame.closeAria", { title: displayTitle })}>
+              {isCloseArmed ? t("canvas.frame.closeArmed") : <CloseIcon />}
+            </button>
+          </CaptionTipHost>
         </div>
       </div>
       {/* 무장 중에는 Alt를 놓아도 안내가 남아야 한다 — 확인 기한이 1.5초뿐이라 Alt를 다시 눌러 확인할 시간이 없다. */}

--- a/runtime/fleet-console/core/client/src/mobile/mobile-session-view.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/mobile-session-view.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { ConsoleTheme, OperationRuntimeState } from "@fleet-console/sdk/plugin";
+import { PluginErrorBoundary } from "@fleet-console/sdk/react/browser";
+import type { ConsoleTheme, OperationKindDescriptor, OperationRenderContext, OperationRuntimeState } from "@fleet-console/sdk/plugin";
 
 import { useT } from "../i18n/index.js";
+import type { createHostCapabilities } from "../plugin-capabilities.js";
 import type { OperationGeometry, OperationNode } from "../types.js";
 import { OperationBodySlot, type OperationBodyConfig } from "./operation-body-pool.js";
 
@@ -14,12 +16,14 @@ const CLOSE_ARM_DURATION_MS = 1500;
  * gesture, which this shell already answers. Close is a separate two-tap control on that
  * title row so the phone can dispose the Operation the same way the desktop frame does.
  */
-export function MobileSessionView({ operation, theme, language, active, runtimeState, onActivate, onClose }: {
+export function MobileSessionView({ operation, theme, language, active, runtimeState, operationKinds, capabilities, onActivate, onClose }: {
   readonly operation: OperationNode;
   readonly theme: ConsoleTheme;
   readonly language: "en" | "ko";
   readonly active: boolean;
   readonly runtimeState: OperationRuntimeState | null;
+  readonly operationKinds: readonly OperationKindDescriptor[];
+  readonly capabilities: ReturnType<typeof createHostCapabilities>;
   readonly onActivate: () => void;
   readonly onClose: () => void;
 }) {
@@ -102,10 +106,47 @@ export function MobileSessionView({ operation, theme, language, active, runtimeS
 
   const title = operation.title;
 
+  // 캔버스 프레임의 캡션 동작 선반과 같은 것 — 이 레이아웃의 제목 줄이 그 밴드다. 여기서 빠지면
+  // 채팅 뷰로 들어간 세션이 터미널로 돌아갈 문을 잃는다(본문에는 더 이상 그 칩이 없다).
+  const descriptor = operationKinds.find((kind) => kind.pluginId === operation.pluginId && kind.type === operation.type);
+  const captionActions = descriptor?.captionActions?.({
+    operationId: operation.id,
+    theaterId: operation.theaterId,
+    pluginId: operation.pluginId,
+    type: operation.type,
+    operation,
+    geometry,
+    active,
+    zoom: 1,
+    theme,
+    language,
+    api: capabilities.api,
+    lifecycle: capabilities.lifecycle,
+    terminal: capabilities.terminal,
+    notifications: capabilities.notifications,
+    operations: capabilities.operations,
+    preferences: capabilities.preferences,
+    settings: capabilities.settings,
+    runtime: capabilities.runtime,
+    runtimeState,
+    bodyLive: true,
+    statusDetail: capabilities.statusDetail,
+    composer: capabilities.composer,
+    onActivate,
+    onClose,
+    onGeometryChange: setGeometry,
+    // 본문과 같은 이유로 companion 콜백은 싣지 않는다 — 그 부재가 "여기엔 드로어가 없다"는 말이다.
+  } satisfies OperationRenderContext);
+
   return (
     <section className="mobile-session-view">
       <div className="mobile-session-bar">
         <h1 className="mobile-session-title">{title}</h1>
+        {captionActions ? (
+          <span className="mobile-session-caption-actions">
+            <PluginErrorBoundary fallback={<></>}>{captionActions}</PluginErrorBoundary>
+          </span>
+        ) : null}
         <button
           type="button"
           className={`mobile-session-close${isCloseArmed ? " is-armed" : ""}`}

--- a/runtime/fleet-console/core/client/src/mobile/mobile-shell.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/mobile-shell.tsx
@@ -1,7 +1,9 @@
 import { pluginRuntimeState } from "../operation-activity.js";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import type { ConsoleTheme, OperationRuntimeHydration, OperationRuntimeState } from "@fleet-console/sdk/plugin";
+import type { ConsoleTheme, OperationKindDescriptor, OperationRuntimeHydration, OperationRuntimeState } from "@fleet-console/sdk/plugin";
+
+import type { createHostCapabilities } from "../plugin-capabilities.js";
 
 import { useT } from "../i18n/index.js";
 import type { OperationNode, OperationNotification } from "../types.js";
@@ -10,7 +12,7 @@ import { MobileSessionView } from "./mobile-session-view.js";
 import { setMobileSessionOpen, useMobileTab } from "./mobile-store.js";
 import "../styles/mobile.css";
 
-export function MobileShell({ operations, activeOperationId, operationRuntime, operationRuntimeHydration, operationNotifications, theaterLabel, theme, language, onSelectOperation, onCloseOperation }: {
+export function MobileShell({ operations, activeOperationId, operationRuntime, operationRuntimeHydration, operationNotifications, theaterLabel, theme, language, operationKinds, capabilities, onSelectOperation, onCloseOperation }: {
   readonly operations: readonly OperationNode[];
   readonly activeOperationId: string | null;
   readonly operationRuntime: Readonly<Record<string, OperationRuntimeState>>;
@@ -19,6 +21,8 @@ export function MobileShell({ operations, activeOperationId, operationRuntime, o
   readonly theaterLabel: string | null;
   readonly theme: ConsoleTheme;
   readonly language: "en" | "ko";
+  readonly operationKinds: readonly OperationKindDescriptor[];
+  readonly capabilities: ReturnType<typeof createHostCapabilities>;
   readonly onSelectOperation: (operationId: string | null) => void;
   readonly onCloseOperation: (operationId: string) => void;
 }) {
@@ -90,6 +94,8 @@ export function MobileShell({ operations, activeOperationId, operationRuntime, o
         operation={selectedOperation}
         theme={theme}
         language={language}
+        operationKinds={operationKinds}
+        capabilities={capabilities}
         active={activeOperationId === selectedOperation.id}
         runtimeState={pluginRuntimeState(operationRuntime, operationRuntimeHydration, selectedOperation.id)}
         onActivate={() => onSelectOperation(selectedOperation.id)}

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -698,6 +698,8 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
       theaterLabel={state.theaters.find((theater) => theater.id === state.activeTheaterId)?.label ?? null}
       theme={state.activeTheme}
       language={language}
+      operationKinds={registry.operationKinds}
+      capabilities={poolCapabilities}
       onSelectOperation={setActiveOperation}
       onCloseOperation={handleClose}
     />

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5733,6 +5733,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
   min-height: 32px;
   height: 32px;
   padding: 0 10px;
+  /* 폭을 아는 것은 이 줄이다 — 동작 선반의 접힘 판정이 여기에 질의한다. 레이아웃 격리만 걸고
+     그리기는 그대로라, 말풍선은 여전히 밴드 밖으로 나가 그려진다. */
+  container-type: inline-size;
   /* 보더는 본문과 같은 중립 rim이다. inherit는 부모의 계산색을 받는데, 본문 윗변을
      비운 뒤에도 캡션 선이 빠지거나 currentColor로 갈라지는 경로가 남는다.
      포커스·상태는 채움과 아랫변 레일이 나르므로 이 선은 구조만 진다. */
@@ -6273,26 +6276,147 @@ body[data-side-bar-animating="true"] .canvas-operation {
     background var(--duration-fast) var(--ease-spring);
 }
 
+/* 믹스는 oklab이다 — oklch는 hue를 극좌표 호로 보간하므로 brass(78)와 중립 rim(245)의 믹스가
+   엉뚱한 hue에 착지한다(실측: instrument·maritime 테두리 hue 144 초록, carbon 354 자홍,
+   채움 208~289 청록·보라). 위치 채널이 신호 채널 옆으로 새던 자리이고, 같은 함정을 채팅 좌표
+   칩에서 한 번 치렀다. 투명과 섞는 outline만 hue가 하나뿐이라 호가 생기지 않는다. */
 .canvas-operation-icon-button:hover,
-.canvas-operation-icon-button:focus-visible {
+.canvas-operation-icon-button:focus-visible,
+.fleet-caption-action:hover:not(:disabled),
+.fleet-caption-action:focus-visible {
   color: var(--brass-bright);
-  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
+  border-color: color-mix(in oklab, var(--brass) 45%, var(--surface-rim));
+  background: color-mix(in oklab, var(--brass) 12%, var(--surface-glass));
   outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
   outline-offset: 2px;
 }
 
-.canvas-operation-icon-button.is-active {
+.canvas-operation-icon-button.is-active,
+.fleet-caption-action[aria-pressed="true"] {
   color: var(--brass-bright);
-  border-color: color-mix(in oklch, var(--brass) 60%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 22%, var(--surface-glass));
+  border-color: color-mix(in oklab, var(--brass) 60%, var(--surface-rim));
+  background: color-mix(in oklab, var(--brass) 22%, var(--surface-glass));
   box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 30%, transparent);
 }
 
-.canvas-operation-icon-button svg {
+.canvas-operation-icon-button svg,
+.fleet-caption-action svg {
   display: block;
   width: 14px;
   height: 14px;
+}
+
+/* ── 캡션 동작 선반 ────────────────────────────────────────────────────────
+   플러그인이 채우고 호스트가 자리를 정하는 마크 버튼들. 창 컨트롤과 같은 24px 격자를 쓰되
+   메뉴 버튼 왼쪽에 서서, 이 Operation에 **대한** 동작(패널을 다루는 창 컨트롤)과 이 Operation
+   **안의** 동작을 한 줄에서 구분한다. 규칙을 창 컨트롤과 한 선택자에 적는 이유는 밴드 하나에
+   두 벌의 문법이 서지 않게 하기 위해서다. */
+.canvas-operation-caption-actions,
+.mobile-session-caption-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  /* auto 마진은 쓰지 않는다 — 이름 버튼이 이미 남는 폭을 전부 먹어 오른쪽으로 밀고 있고,
+     여기에 두 번째 auto가 서면 남는 폭이 둘로 갈려 창 컨트롤과의 사이가 벌어진다. */
+}
+
+.fleet-caption-slot {
+  position: relative;
+  display: inline-flex;
+  flex: none;
+}
+
+.fleet-caption-action {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-xs);
+  color: var(--text-tertiary);
+  background: transparent;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.fleet-caption-action:disabled {
+  cursor: default;
+  opacity: 0.42;
+}
+
+/* 진행 표시는 aurora(상태 채널) 점 하나다 — brass(위치)와 겹치지 않으므로 열린 버튼 위에서도
+   무엇이 도는지 따로 읽힌다. */
+.fleet-caption-action-live {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 5px;
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--aurora);
+  box-shadow: 0 0 6px var(--aurora-glow);
+  animation: caption-action-live 1.6s ease-in-out infinite;
+}
+
+@keyframes caption-action-live {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.fleet-caption-action.is-pending svg {
+  transform-origin: 50% 50%;
+  animation: caption-action-pending 1.1s linear infinite;
+}
+
+@keyframes caption-action-pending {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* 말풍선 — 라벨 없는 마크가 서는 줄의 이름표. 오른쪽 가장자리에 붙여 왼쪽으로 자란다:
+   이 줄의 버튼은 언제나 패널 오른쪽 끝에 있어, 가운데 정렬하면 마지막 풍선이 패널 밖으로 나간다.
+   지연을 두는 쪽만 transition을 갖는다 — 스치는 포인터가 줄 전체를 깜빡이게 하지 않는다. */
+.fleet-caption-tip {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 12;
+  padding: 4px 8px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-xs);
+  background: var(--surface-panel-raised);
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-soft);
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.04em;
+  line-height: 1.35;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-fast) var(--ease-spring);
+}
+
+.fleet-caption-slot:hover .fleet-caption-tip,
+.fleet-caption-slot:focus-within .fleet-caption-tip {
+  opacity: 1;
+  transition-delay: 0.35s;
+}
+
+/* 판면이 100ch(reading 상한)보다 좁으면 읽기 폭 프리셋 사이에 그려질 차이가 없다 — 뜻이 없어진
+   컨트롤은 밴드에서 물린다. 가르는 것은 뷰포트가 아니라 이 패널의 폭이고, 그 폭을 아는 것은
+   캡션 자신이다(본문의 컨테이너는 캡션 밖에 있다). 임계는 본문 폭 719px + 보더 2px. */
+@container (max-width: 721px) {
+  .canvas-operation-caption-actions .fleet-caption-action[data-caption-action="reading-width"],
+  .mobile-session-caption-actions .fleet-caption-action[data-caption-action="reading-width"] {
+    display: none;
+  }
 }
 
 .canvas-operation .canvas-operation-window-controls .canvas-operation-icon-button.is-armed-close {

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -68,6 +68,26 @@
   min-height: 44px;
   padding-inline: var(--space-1);
   background: var(--canvas-sea-core);
+  /* 캡션 동작 선반의 접힘 판정이 질의하는 컨테이너 — 캔버스 캡션과 같은 규칙을 쓴다. */
+  container-type: inline-size;
+}
+
+/* 이 레이아웃의 캡션 동작 선반 — 제목 왼쪽. 손가락이 닿는 면이므로 격자는 24px이 아니라
+   이 줄의 다른 컨트롤(닫기)과 같은 44px이다. */
+.mobile-session-caption-actions {
+  grid-column: 1;
+  justify-self: start;
+}
+
+.mobile-session-caption-actions .fleet-caption-action {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-pill);
+}
+
+/* 터치에는 hover가 없다 — 뜨지 않을 말풍선이 자리를 잡고 있으면 다음 탭을 가로챌 수 있다. */
+.mobile-session-caption-actions .fleet-caption-tip {
+  display: none;
 }
 
 .mobile-session-title {

--- a/runtime/fleet-console/sdk/components/caption-actions.tsx
+++ b/runtime/fleet-console/sdk/components/caption-actions.tsx
@@ -1,0 +1,180 @@
+import type { ReactNode } from "react";
+
+/**
+ * 캡션 밴드의 동작 선반.
+ *
+ * 밴드는 호스트 소유다 — 기하·면·모서리·창 컨트롤은 프레임이 진다. 이 모듈은 그 밴드에 서는
+ * 버튼 한 벌과 마크를 호스트와 플러그인이 **같은 모듈에서** 가져다 쓰게 해, 같은 줄에 두 벌의
+ * 문법이 서지 않게 한다(`launch-provider-glyphs`와 같은 이유의 공유 모듈이다).
+ *
+ * 클래스 이름을 이 모듈이 고정하는 것도 그래서다: 호출부가 자기 클래스를 실어 오면 밴드마다
+ * 다른 모양이 태어난다. 실제 규칙은 코어 `components.css`가 창 컨트롤과 한 선택자로 적는다.
+ */
+
+/** 마크 하나 크기의 뷰박스 — 캡션 아이콘은 전부 이 격자 위에 그린다. */
+function CaptionGlyph({ children }: { readonly children: ReactNode }) {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      {children}
+    </svg>
+  );
+}
+
+const STROKE = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.35,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+} as const;
+
+/** Session Analyst — 제품이 이미 쓰는 ✳ 표식을 선으로 옮겨 그린 것. */
+export function CaptionAnalystGlyph() {
+  return (
+    <CaptionGlyph>
+      <path d="M8 3.3v9.4" {...STROKE} />
+      <path d="M4.03 5.65 11.97 10.35" {...STROKE} />
+      <path d="M11.97 5.65 4.03 10.35" {...STROKE} />
+    </CaptionGlyph>
+  );
+}
+
+/** 채팅 뷰 — 오가는 말의 줄. 마지막 줄이 짧아 목록이 아니라 글로 읽힌다. */
+export function CaptionChatGlyph() {
+  return (
+    <CaptionGlyph>
+      <path d="M3.6 5.4h8.8" {...STROKE} />
+      <path d="M3.6 8h8.8" {...STROKE} />
+      <path d="M3.6 10.6h5.6" {...STROKE} />
+    </CaptionGlyph>
+  );
+}
+
+/** 터미널 — 프롬프트 갈매기와 커서 자리. ❯ 표식과 같은 뜻이다. */
+export function CaptionTerminalGlyph() {
+  return (
+    <CaptionGlyph>
+      <path d="M4.4 4.9 7.6 8l-3.2 3.1" {...STROKE} />
+      <path d="M9.4 11.1h2.6" {...STROKE} />
+    </CaptionGlyph>
+  );
+}
+
+export type CaptionReadingWidthPreset = "reading" | "wide" | "full";
+
+/**
+ * 읽기 폭 — 라벨이 곧 값이던 칩을 글리프로 옮기면 값이 사라진다. 그래서 값을 **그린다**:
+ * 두 기둥 사이가 넓어지고, 전체에서는 가운데 선이 서서 판을 꽉 채웠음을 말한다.
+ */
+export function CaptionReadingWidthGlyph({ preset }: { readonly preset: CaptionReadingWidthPreset }) {
+  if (preset === "full") {
+    return (
+      <CaptionGlyph>
+        <path d="M2.4 4v8" {...STROKE} />
+        <path d="M13.6 4v8" {...STROKE} />
+        <path d="M4.2 8h7.6" {...STROKE} />
+        <path d="M5.1 7.1 4.2 8l.9.9" {...STROKE} />
+        <path d="M10.9 7.1l.9.9-.9.9" {...STROKE} />
+        <path d="M8 5.8v4.4" {...STROKE} />
+      </CaptionGlyph>
+    );
+  }
+  if (preset === "wide") {
+    return (
+      <CaptionGlyph>
+        <path d="M2.4 4v8" {...STROKE} />
+        <path d="M13.6 4v8" {...STROKE} />
+        <path d="M4.9 8h6.2" {...STROKE} />
+        <path d="M5.8 7.1 4.9 8l.9.9" {...STROKE} />
+        <path d="M10.2 7.1l.9.9-.9.9" {...STROKE} />
+      </CaptionGlyph>
+    );
+  }
+  return (
+    <CaptionGlyph>
+      <path d="M3.3 4v8" {...STROKE} />
+      <path d="M12.7 4v8" {...STROKE} />
+      <path d="M6.1 8h3.8" {...STROKE} />
+      <path d="M7 7.1 6.1 8l.9.9" {...STROKE} />
+      <path d="M9 7.1l.9.9-.9.9" {...STROKE} />
+    </CaptionGlyph>
+  );
+}
+
+export interface CaptionTipHostProps {
+  /** 말풍선에 적히는 문장. 버튼의 접근 이름과 같은 문자열이어야 한다. */
+  readonly label: string;
+  readonly children: ReactNode;
+}
+
+/**
+ * 말풍선을 다는 자리.
+ *
+ * 브라우저 기본 `title` 툴팁은 밴드마다 지연·모양이 제각각이고 터치에서는 아예 뜨지 않는다.
+ * 캡션은 라벨 없는 마크만 서는 줄이므로, 그 줄의 모든 버튼이 같은 말풍선을 쓴다.
+ * 오른쪽 가장자리에 붙여 자란다 — 이 줄의 버튼은 언제나 패널 오른쪽에 있어, 가운데 정렬하면
+ * 마지막 버튼의 풍선이 패널 밖으로 나간다.
+ */
+export function CaptionTipHost({ label, children }: CaptionTipHostProps) {
+  return (
+    <span className="fleet-caption-slot">
+      {children}
+      <span className="fleet-caption-tip" aria-hidden="true">{label}</span>
+    </span>
+  );
+}
+
+export interface CaptionActionButtonProps {
+  /** 접근 이름이자 말풍선 문장 — 하나의 문자열이 둘을 함께 진다. */
+  readonly label: string;
+  readonly children: ReactNode;
+  /** 이 면이 지금 서 있는가. brass 채움(위치 채널)으로 그려진다. */
+  readonly pressed?: boolean;
+  readonly disabled?: boolean;
+  /** 뒤에서 무언가 돌고 있다 — 모서리 aurora 점(상태 채널). */
+  readonly busy?: boolean;
+  /** 명령을 받았고 아직 안 끝났다 — 마크가 돈다. */
+  readonly pending?: boolean;
+  /** 크로스 번들 DOM 계약(`data-chat-tour`)을 이 버튼에 세운다. */
+  readonly tourAnchor?: string;
+  /**
+   * 이 동작이 무엇인지 밴드에게 알리는 이름(`data-caption-action`). 좁은 밴드에서 무엇이 먼저
+   * 물러나는지는 폭을 아는 쪽 — 즉 밴드의 CSS — 가 정하고, 이 이름이 그 규칙의 손잡이다.
+   */
+  readonly actionId?: string;
+  readonly onClick: () => void;
+}
+
+/** 캡션에 서는 동작 버튼. 창 컨트롤과 같은 24px 격자·같은 hover 문법을 쓴다. */
+export function CaptionActionButton({
+  label,
+  children,
+  pressed,
+  disabled = false,
+  busy = false,
+  pending = false,
+  tourAnchor,
+  actionId,
+  onClick,
+}: CaptionActionButtonProps) {
+  const className = `fleet-caption-action${pending ? " is-pending" : ""}`;
+  return (
+    <CaptionTipHost label={label}>
+      <button
+        type="button"
+        className={className}
+        aria-label={label}
+        {...(pressed === undefined ? {} : { "aria-pressed": pressed })}
+        {...(tourAnchor === undefined ? {} : { "data-chat-tour": tourAnchor })}
+        {...(actionId === undefined ? {} : { "data-caption-action": actionId })}
+        disabled={disabled}
+        // 캡션은 창을 끄는 면이다 — 여기서 멈추지 않으면 버튼을 누르는 순간 패널이 따라온다.
+        onPointerDown={(event) => { event.stopPropagation(); }}
+        onClick={onClick}
+      >
+        {children}
+        {busy ? <span className="fleet-caption-action-live" aria-hidden="true" /> : null}
+      </button>
+    </CaptionTipHost>
+  );
+}

--- a/runtime/fleet-console/sdk/package.json
+++ b/runtime/fleet-console/sdk/package.json
@@ -107,6 +107,12 @@
       "import": "./components/effort-track.tsx",
       "default": "./components/effort-track.tsx"
     },
+    "./components/caption-actions": {
+      "types": "./components/caption-actions.tsx",
+      "browser": "./components/caption-actions.tsx",
+      "import": "./components/caption-actions.tsx",
+      "default": "./components/caption-actions.tsx"
+    },
     "./components/launch-provider-glyphs": {
       "types": "./components/launch-provider-glyphs.tsx",
       "browser": "./components/launch-provider-glyphs.tsx",

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -223,6 +223,14 @@ export interface OperationKindDescriptor {
   readonly subtitle?: (operation: OperationNode) => string | undefined;
   readonly render?: (context: OperationRenderContext) => ReactNode;
   /**
+   * Fills the caption band's action shelf, left of the host's own menu and window controls.
+   * The band stays host-owned exactly as it does for a companion panel's `caption`: the host
+   * places the shelf, paints the surface, and drops it entirely on a War Room deck tile, where a
+   * card body is inert and its controls would be a false promise. Build the buttons with
+   * `@fleet-console/sdk/components/caption-actions` so one band cannot carry two grammars.
+   */
+  readonly captionActions?: (context: OperationRenderContext) => ReactNode;
+  /**
    * Current height in panel pixels of fixed bottom chrome this body always paints below its live
    * content (e.g. an agent CLI's input composer and status lines). A host preview that crops the
    * body may push that band out of frame so the live area fills the preview. The host reads it

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -46,6 +46,7 @@ const TERMINAL_CHAT_CSS_PATH = new URL("../../fleet-plugins/terminal/client/agen
 const QUOTA_CSS_PATH = new URL("../../fleet-plugins/quota/client/quota.css", import.meta.url);
 const QUOTA_PANEL_PATH = new URL("../../fleet-plugins/quota/client/rail-panel.tsx", import.meta.url);
 const SDK_RAIL_TYPES_PATH = new URL("../sdk/rail/types.ts", import.meta.url);
+const SDK_CAPTION_ACTIONS_PATH = new URL("../sdk/components/caption-actions.tsx", import.meta.url);
 const SDK_VERSION_PATH = new URL("../sdk/version.ts", import.meta.url);
 const OWNED_SOURCES = [
   "app.tsx",
@@ -481,6 +482,47 @@ describe("Instrument core design contract", () => {
     expect(narrowContainer).toContain(".backend-api-row {");
     expect(narrowContainer).toContain("grid-template-columns: minmax(0, 1fr);");
     expect(components).not.toMatch(/@media \(max-width: 720px\) \{\s*\.backend-api-row/);
+  });
+
+  it("keeps one control grammar on the caption band", () => {
+    const components = source("styles/components.css");
+    const frame = source("canvas/operation-frame.tsx");
+    const shelf = externalSource(SDK_CAPTION_ACTIONS_PATH);
+
+    // 마크 버튼은 창 컨트롤과 한 선택자에서 규칙을 받는다 — 밴드 하나가 두 벌의 격자를 갖지 않게.
+    const grid = components.match(/\.canvas-operation-icon-button,\n\.fleet-caption-action \{[^}]*\}/)?.[0]
+      ?? components.match(/\.fleet-caption-action \{[^}]*\}/)?.[0] ?? "";
+    expect(grid).toContain("width: 24px;");
+    expect(grid).toContain("height: 24px;");
+    const svgSize = components.match(/\.canvas-operation-icon-button svg,\n\.fleet-caption-action svg \{[^}]*\}/)?.[0] ?? "";
+    expect(svgSize).toContain("width: 14px;");
+
+    // 위치 채널은 oklab으로만 섞는다 — oklch의 hue 호가 brass를 초록·자홍에 내려놓았다(실측).
+    const pressed = components.match(/\.canvas-operation-icon-button\.is-active,\n\.fleet-caption-action\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
+    expect(pressed).toContain("color-mix(in oklab, var(--brass) 60%, var(--surface-rim))");
+    expect(pressed).toContain("color-mix(in oklab, var(--brass) 22%, var(--surface-glass))");
+    expect(pressed).not.toContain("color-mix(in oklch, var(--brass) 60%");
+    const hover = components.match(/\.canvas-operation-icon-button:hover,[\s\S]{0,200}?\.fleet-caption-action:focus-visible \{[^}]*\}/)?.[0] ?? "";
+    expect(hover).toContain("color-mix(in oklab, var(--brass) 45%, var(--surface-rim))");
+
+    // 진행은 aurora(상태)로, 위치는 brass로 — 한 버튼 위에서도 두 채널이 겹치지 않는다.
+    const live = components.match(/\.fleet-caption-action-live \{[^}]*\}/)?.[0] ?? "";
+    expect(live).toContain("background: var(--aurora);");
+    expect(live).not.toContain("--brass");
+
+    // 라벨 없는 마크가 서는 줄이므로 이름표는 전부 같은 말풍선이다 — 브라우저 기본 title은 쓰지 않는다.
+    expect(shelf).toContain('className="fleet-caption-slot"');
+    expect(shelf).toContain('className="fleet-caption-tip"');
+    expect(frame).toContain("<CaptionTipHost label={t(\"canvas.frame.openMenuTitle\")}>");
+    expect(frame).not.toMatch(/canvas-operation-icon-button[\s\S]{0,400}?title=\{t\(/);
+    const tip = components.match(/\.fleet-caption-tip \{[^}]*\}/)?.[0] ?? "";
+    expect(tip).toContain("right: 0;");
+    expect(tip).toContain("pointer-events: none;");
+
+    // 폭을 아는 것은 밴드다 — 뜻이 사라지는 컨트롤은 캡션 컨테이너 질의로 물러난다.
+    const titlebar = components.match(/^\.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
+    expect(titlebar).toContain("container-type: inline-size;");
+    expect(components).toMatch(/@container \(max-width: 721px\) \{[\s\S]{0,300}?data-caption-action="reading-width"/);
   });
 
   it("keeps SDK v1 rail compatibility as a deprecated root-only facade", () => {
@@ -1938,16 +1980,19 @@ describe("Instrument core design contract", () => {
     for (const signal of ["--aurora", "--positive", "--warn", "--coral", "--brass", "--id-"]) {
       expect(chatJobGlyphBlock).not.toContain(signal);
     }
-    // 두 뷰의 전환 진입은 같은 칩 클래스를 공유한다 — 같은 자리·같은 모양이라야 한 쌍으로 읽힌다.
+    // 두 뷰의 전환 진입은 캡션 밴드의 한 버튼이 진다 — 목적지 마크만 바뀐다.
     const chatView = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_VIEW_PATH), "utf8");
     const terminalEntry = fs.readFileSync(fileURLToPath(TERMINAL_AGENT_PATH), "utf8");
-    expect(chatView).toContain('className="agent-chat-mode-chip"');
+    expect(chatView).not.toContain("agent-chat-mode-chip");
+    expect(chatView).not.toContain("agent-view-chip-row");
     // 구간 문장은 답변과 같은 마크다운 경로다. italic을 통째로 씌우면 `**굵게**`가 별표로 남고
     // 문장만 기울어진다 — 기울임은 문법(*강조*)이 질 몫이다.
     expect(chatView).toContain('className="agent-chat-ledger-note markdown-body"');
     expect(chat).toContain(".agent-chat .agent-chat-ledger-note.markdown-body");
     expect(chat).not.toMatch(/\.agent-chat-ledger-note[^{]*\{[^}]*font-style:\s*italic/);
-    expect(terminalEntry).toContain('className="agent-chat-mode-chip"');
+    expect((terminalEntry.match(/actionId="view-switch"/g) ?? [])).toHaveLength(2);
+    expect(terminalEntry).toContain("<CaptionTerminalGlyph />");
+    expect(terminalEntry).toContain("<CaptionChatGlyph />");
     // 패널 컴포저는 언제나 서 있다 — 접힘도, 되돌아오는 쉬는 줄도 없다.
     expect(chat).not.toContain(".agent-chat-composer-rest");
     expect(chatView).not.toContain("ComposerRestStrip");
@@ -1996,10 +2041,12 @@ describe("Instrument core design contract", () => {
     expect(chatFollowHoverBlock).toContain("outline: none;");
     // 떠 있는 컨트롤은 자기 몫의 로그 여백을 함께 가진다 — 스크롤 컨테이너가 그만큼 비워 두지
     // 않으면 바닥까지 내린 마지막 줄이 컨트롤 뒤에 갇혀 스크롤로도 빠져나오지 못한다.
-    // 위아래 두 여백이 각자의 컨트롤(전환 칩 32px · 중지 버튼 40px)을 넘어서는지 함께 고정한다.
+    // 위쪽 34px은 전환 칩 줄의 몫이었고, 그 줄이 캡션으로 떠난 지금 로그는 패널 상단에서 바로
+    // 시작한다. 아래 여백만 남아 자기 컨트롤(작업 스트립)을 넘어서는지 고정한다.
     const chatLogBlock = chat.match(/^\.agent-chat-log \{[^}]*\}/m)?.[0] ?? "";
     const chatLogPadding = chatLogBlock.match(/padding: ([^;]+);/)?.[1] ?? "";
-    expect(chatLogPadding).toContain("calc(var(--space-3) + 34px)");
+    expect(chatLogPadding.startsWith("var(--space-3) ")).toBe(true);
+    expect(chatLogPadding).not.toContain("34px");
     expect(chatLogPadding).toContain("calc(var(--space-3) + 45px)");
     // 아래 여백이 피하는 것은 이제 작업 스트립이다 — 중지는 컴포저의 발사 자리로 들어가
     // 더 이상 로그 위에 얹히지 않는다.
@@ -2097,10 +2144,12 @@ describe("Instrument core design contract", () => {
     const terminalAgentEntry = externalSource(TERMINAL_AGENT_PATH);
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__modechip \{/);
     expect(terminalAnalysisCss).not.toContain(".session-analyst-handle");
-    // Analyst 진입은 뷰 칩 클러스터의 일원이다 — 채팅 전환 칩과 같은 줄·같은 문법.
-    expect(terminalChatCss).toMatch(/\.agent-view-chip-row \{/);
-    expect(terminalChatCss).toContain(".agent-view-chip-row .agent-chat-mode-chip");
-    expect(terminalAgentEntry).toContain('className="agent-chat-mode-chip agent-analyst-chip"');
+    // Analyst 진입은 캡션 동작 선반의 첫 버튼이다 — 전환·읽기 폭과 같은 줄·같은 문법.
+    expect(terminalChatCss).not.toContain(".agent-view-chip-row");
+    expect(terminalChatCss).not.toContain(".agent-analyst-chip");
+    expect(terminalAgentEntry).toContain('actionId="analyst"');
+    expect(terminalAgentEntry).toContain("<CaptionAnalystGlyph />");
+    expect(terminalAgentEntry).toContain("captionActions: (context) => <AgentCaptionActions context={context} />");
     // 캡션 밴드는 호스트가 자리를 비워 둔다 — 채우지 않으면 빈 띠가 남고 프레임의 위 모서리가 각진다.
     expect(terminalAgentEntry).toContain("caption: (context) => <AnalystCaption context={context} />");
     expect(terminalAgentEntry).not.toContain("hideCaption");
@@ -3041,8 +3090,9 @@ describe("War Room deck panel grammar", () => {
     // 카드 본문은 inert이고 승격 면이 클릭을 가로채므로 컨트롤은 눌러도 동작하지 않는다.
     // 무대에 오른 패널은 is-deck-tile이 아니므로 컨트롤이 기존처럼 보인다.
     const terminalChatCss = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_CSS_PATH), "utf8");
-    expect(terminalChatCss).toContain(".canvas-operation.is-deck-tile .agent-view-chip-row");
-    expect(terminalChatCss).toContain(".canvas-operation.is-deck-tile .agent-chat-mode-chip");
+    // 분석가·전환·읽기 폭은 캡션 선반으로 옮겨 갔고, 카드에서는 호스트가 그 선반을 아예 넘기지
+    // 않는다 — CSS로 감추는 것이 아니라 태어나지 않는다.
+    expect(canvas).toContain("descriptor.captionActions === undefined || options.deckSlot !== null ? null");
     expect(terminalChatCss).toContain(".canvas-operation.is-deck-tile .agent-chat-dormant-open");
     expect(terminalChatCss).toContain(".canvas-operation.is-deck-tile .agent-chat-follow");
     // 카드뷰에서는 컴포저가 스트립조차 서지 않는다 — 입력은 무대에 올라야 가능한 행동이다.
@@ -3050,16 +3100,16 @@ describe("War Room deck panel grammar", () => {
     // 컴포저가 물러난 자리에는 그 받침(중앙 배치용 비율)도 함께 물러난다 — 남겨 두면 대화가
     // 카드 위쪽으로 몰린다.
     expect(terminalChatCss).toContain(".canvas-operation.is-deck-tile .agent-chat-settle");
-    const hide = terminalChatCss.match(/\.canvas-operation\.is-deck-tile \.agent-view-chip-row,[\s\S]{0,400}?\.canvas-operation\.is-deck-tile \.agent-chat-composer \{[^}]*\}/)?.[0] ?? "";
+    const hide = terminalChatCss.match(/\.canvas-operation\.is-deck-tile \.agent-chat-dormant-open,[\s\S]{0,400}?\.canvas-operation\.is-deck-tile \.agent-chat-composer \{[^}]*\}/)?.[0] ?? "";
     expect(hide).toContain("display: none;");
     // 선택(무대) 축은 카드 클래스의 부재다 — is-active나 is-quicklook에 묶이면 카드이면서
     // 선택된 칸, 또는 확대된 칸에서 다시 그려진다.
     expect(hide).not.toContain("is-active");
     expect(hide).not.toContain("is-quicklook");
-    // 칩을 숨긴 카드에서는 그 자리를 피하던 상단 여백만 거둔다. 하단 45px는 작업 스트립이 쓰므로
-    // 타일 규칙은 padding-top만 적는다 — padding-bottom/padding 단축을 쓰면 베이스의 45px가 죽는다.
+    // 카드의 로그는 초대 하한만 되돌린다. 여백은 손대지 않는다 — 피할 부유 칩이 사라져 베이스가
+    // 이미 space-3이고, 하단 45px는 작업 스트립의 몫이라 단축 padding으로 덮으면 죽는다.
     const logOnTile = terminalChatCss.match(/\.canvas-operation\.is-deck-tile \.agent-chat-log \{[^}]*\}/)?.[0] ?? "";
-    expect(logOnTile).toContain("padding-top: var(--space-3);");
+    expect(logOnTile).toContain("min-height: 0;");
     expect(logOnTile).not.toContain("45px");
     expect(logOnTile).not.toContain("padding-bottom");
     expect(logOnTile).not.toMatch(/(?:^|[^-])padding:/);

--- a/runtime/fleet-console/tests/operation-frame-caption-actions.test.tsx
+++ b/runtime/fleet-console/tests/operation-frame-caption-actions.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CaptionActionButton, CaptionAnalystGlyph } from "../sdk/components/caption-actions.js";
+import { OperationFrame } from "../core/client/src/canvas/operation-frame.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => { callback(0); return 0; });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.unstubAllGlobals();
+});
+
+describe("OperationFrame caption action shelf", () => {
+  // 자리는 프레임이 정한다: 이 Operation **안의** 동작이 먼저, 그 뒤로 메뉴와 창 컨트롤.
+  it("seats the plugin shelf between the title and the menu button", () => {
+    renderFrame({ onSelect: vi.fn() });
+    const titlebar = document.querySelector(".canvas-operation-titlebar")!;
+    const classes = Array.from(titlebar.children).map((child) => child.className);
+    expect(classes).toEqual([
+      "canvas-operation-identity-name",
+      "canvas-operation-caption-actions",
+      "fleet-caption-slot",
+      "canvas-operation-window-controls",
+    ]);
+    expect(titlebar.querySelector(".canvas-operation-caption-actions .fleet-caption-action")).not.toBeNull();
+  });
+
+  // 카드 본문은 inert이고 승격 면이 클릭을 가로챈다 — 그 위의 캡션에만 동작 버튼이 살아 있으면
+  // 카드가 조용히 다른 문법을 갖는다. 호스트가 아예 넘기지 않으므로 태어나지도 않는다.
+  it("drops the shelf entirely on a War Room deck tile", () => {
+    renderFrame({ onSelect: vi.fn(), captionActions: null });
+    expect(document.querySelector(".canvas-operation-caption-actions")).toBeNull();
+    expect(document.querySelector(".fleet-caption-action")).toBeNull();
+  });
+
+  // 캡션은 창을 끄는 면이다 — 버튼을 누르는 순간 패널이 따라오면 안 된다.
+  it("keeps a shelf press from starting a panel drag", () => {
+    const onSelect = vi.fn();
+    const onGeometryChange = vi.fn();
+    renderFrame({ onSelect, onGeometryChange });
+    const button = document.querySelector<HTMLButtonElement>(".fleet-caption-action")!;
+
+    act(() => {
+      button.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true, clientX: 10, clientY: 10 }));
+      window.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: 90, clientY: 90 }));
+    });
+    act(() => button.click());
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onGeometryChange).not.toHaveBeenCalled();
+  });
+
+  // 이름표는 말풍선이 진다 — 브라우저 기본 툴팁은 밴드마다 지연·모양이 다르고 접근 이름과 갈린다.
+  it("names a mark-only button with one string in both the label and the bubble", () => {
+    renderFrame({ onSelect: vi.fn() });
+    const button = document.querySelector<HTMLButtonElement>(".fleet-caption-action")!;
+    expect(button.getAttribute("aria-label")).toBe("Open Session Analyst");
+    expect(button.hasAttribute("title")).toBe(false);
+    const tip = button.parentElement?.querySelector(".fleet-caption-tip");
+    expect(tip?.textContent).toBe("Open Session Analyst");
+    expect(tip?.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+function renderFrame(options: {
+  readonly onSelect: () => void;
+  readonly captionActions?: ReactNode;
+  readonly onGeometryChange?: (geometry: { x: number; y: number; width: number; height: number; zIndex: number }) => void;
+}): void {
+  const shelf = options.captionActions === undefined
+    ? createElement(CaptionActionButton, {
+      actionId: "analyst",
+      label: "Open Session Analyst",
+      onClick: options.onSelect,
+    }, createElement(CaptionAnalystGlyph))
+    : options.captionActions;
+  act(() => root!.render(createElement(OperationFrame, {
+    operation: {
+      id: "operation-caption",
+      theaterId: "theater-caption",
+      type: "agent",
+      pluginId: "terminal",
+      title: "Caption shelf",
+      payload: {},
+      geometry: null,
+      ts: { createdAt: 1, updatedAt: 1 },
+    },
+    active: false,
+    unseen: false,
+    glanceHud: { index: "01", hints: [] },
+    geometry: { x: 0, y: 0, width: 640, height: 400, zIndex: 1 },
+    zoom: 1,
+    captionActions: shelf,
+    onActivate: () => {},
+    onClose: () => {},
+    onMinimize: () => {},
+    onMaximize: () => {},
+    onRename: () => {},
+    onOpenMenu: () => {},
+    onGeometryChange: options.onGeometryChange ?? (() => {}),
+    onGeometryCommit: () => {},
+    children: createElement("div"),
+  })));
+}

--- a/runtime/fleet-console/tests/operation-frame-identity.test.ts
+++ b/runtime/fleet-console/tests/operation-frame-identity.test.ts
@@ -83,10 +83,13 @@ describe("OperationFrame identity rename", () => {
     const titlebar = document.querySelector(".canvas-operation-titlebar")!;
     const children = Array.from(titlebar.children);
 
+    // 캡션의 마크 버튼은 전부 말풍선 자리에 담겨 선다 — 같은 줄이 두 벌의 툴팁 문법을 쓰지 않게.
     expect(children[0]?.className).toBe("canvas-operation-identity-name");
-    expect(children[1]?.className).toBe("canvas-operation-more-button");
+    expect(children[1]?.className).toBe("fleet-caption-slot");
+    expect(children[1]?.firstElementChild?.className).toBe("canvas-operation-more-button");
     expect(children[2]?.className).toBe("canvas-operation-window-controls");
     expect(document.querySelectorAll(".canvas-operation-window-controls .canvas-operation-icon-button")).toHaveLength(3);
+    expect(document.querySelectorAll(".canvas-operation-titlebar .fleet-caption-tip")).toHaveLength(4);
     expect(identityTrigger().title).toBe("A deliberately long Operation title — Drag to move. Double-click, Enter, or F2 to rename");
   });
 
@@ -169,7 +172,8 @@ describe("OperationFrame identity rename", () => {
     expect(identityInput()).toBeNull();
     expect(identityTrigger()).not.toBeNull();
     expect(children[0]?.className).toBe("canvas-operation-identity-name");
-    expect(children[1]?.className).toBe("canvas-operation-more-button");
+    expect(children[1]?.className).toBe("fleet-caption-slot");
+    expect(children[1]?.firstElementChild?.className).toBe("canvas-operation-more-button");
     expect(children[2]?.className).toBe("canvas-operation-window-controls");
   });
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-ready.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-ready.test.tsx
@@ -39,8 +39,8 @@ describe("Session Analyst entry chip readiness", () => {
 
     const handle = analystHandle();
     expect(handle.disabled).toBe(true);
-    expect(handle.getAttribute("aria-disabled")).toBe("true");
-    expect(handle.title).toBe("Send a message in this session first");
+    expect(handle.getAttribute("aria-label")).toBe("Send a message in this session first");
+    expect(analystTip()).toBe("Send a message in this session first");
     expect(readyCalls(fetch)).toHaveLength(1);
   });
 
@@ -54,8 +54,7 @@ describe("Session Analyst entry chip readiness", () => {
 
     const handle = analystHandle();
     expect(handle.disabled).toBe(false);
-    expect(handle.getAttribute("aria-disabled")).toBe("false");
-    expect(handle.hasAttribute("title")).toBe(false);
+    expect(analystTip()).toBe("Open Session Analyst");
     expect(readyCalls(fetch)).toHaveLength(2);
 
     await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
@@ -73,7 +72,7 @@ describe("Session Analyst entry chip readiness", () => {
     const handle = analystHandle();
     expect(resume?.textContent).toContain("Resume");
     expect(handle.disabled).toBe(false);
-    expect(handle.textContent).toContain("Analyst");
+    expect(analystTip()).toContain("Analyst");
 
     act(() => handle.click());
     expect(onRequestCompanions).toHaveBeenCalledWith(true);
@@ -207,7 +206,9 @@ async function renderOperation(
   }
   root ??= createRoot(container);
   const render = agentOperationKind.render;
+  const captionActions = agentOperationKind.captionActions;
   if (!render) throw new Error("Agent operation renderer must exist.");
+  if (!captionActions) throw new Error("Agent caption shelf must exist.");
   await act(async () => {
     applySessionUpdate({
       sessionId: OPERATION_ID,
@@ -220,13 +221,18 @@ async function renderOperation(
       theaterId: "theater",
       resumeAvailable: true,
     });
-    root?.render(render(createContext(
+    const context = createContext(
       createApi(fetch),
       onRequestCompanions,
       companionsOpen,
       hiddenCompanionPanelIds,
       onSetCompanionPanelVisible,
-    )) as React.ReactNode);
+    );
+    // 호스트는 본문과 캡션 선반을 같은 context로 나란히 그린다 — 분석가 문은 캡션 쪽에 산다.
+    root?.render(createElement("div", null, [
+      createElement("div", { key: "caption" }, captionActions(context) as React.ReactNode),
+      createElement("div", { key: "body" }, render(context) as React.ReactNode),
+    ]));
     await Promise.resolve();
     await Promise.resolve();
   });
@@ -278,9 +284,15 @@ function readyResponse(ready: boolean): Response {
 }
 
 function analystHandle(): HTMLButtonElement {
-  const handle = container?.querySelector<HTMLButtonElement>(".agent-analyst-chip");
+  const handle = container?.querySelector<HTMLButtonElement>('.fleet-caption-action[data-caption-action="analyst"]');
   if (!handle) throw new Error("Session Analyst handle must render.");
   return handle;
+}
+
+/** 캡션 버튼은 이름표를 말풍선으로 옮겼다 — 무엇인지 말하는 문자열은 접근 이름과 그 풍선이다. */
+function analystTip(): string {
+  const tip = analystHandle().parentElement?.querySelector(".fleet-caption-tip");
+  return tip?.textContent ?? "";
 }
 
 function analysisFetch(...readiness: boolean[]): ReturnType<typeof vi.fn> {

--- a/runtime/fleet-plugins/terminal/client/agent/caption-actions.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/caption-actions.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { ClientApiCapability, OperationRenderContext } from "@fleet-console/sdk/plugin";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../shared/index.js", () => ({
+  TerminalSurface: () => createElement("div", { className: "terminal-surface-stub" }),
+}));
+
+import { agentOperationKind } from "./index.js";
+import { disposeAnalysisStore } from "./analysis-store.js";
+import { applySessionUpdate, removeSession } from "./store.js";
+
+const OPERATION_ID = "caption-shelf-operation";
+const CATALOG_BODY = JSON.stringify({ clis: [] });
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  disposeAnalysisStore(OPERATION_ID);
+  removeSession(OPERATION_ID);
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("agent caption action shelf", () => {
+  // 순서는 요구다: 분석가 → 뷰 전환 → 읽기 폭 → (호스트의 메뉴·창 컨트롤).
+  it("stands analyst, view switch, and reading width in that order inside the chat view", async () => {
+    await render({ chatMode: true });
+    expect(actionIds()).toEqual(["analyst", "view-switch", "reading-width"]);
+  });
+
+  // 읽기 폭은 대화 면의 선호다 — 터미널 뷰에는 맞출 판면이 없다.
+  it("keeps the reading width out of the terminal view", async () => {
+    await render({ chatMode: false });
+    expect(actionIds()).toEqual(["analyst", "view-switch"]);
+  });
+
+  // 전환은 목적지 하나로 말한다 — 어느 뷰에 서 있느냐가 그 이름을 정한다.
+  it("names the switch by where it goes", async () => {
+    await render({ chatMode: true });
+    expect(labelOf("view-switch")).toBe("Reopen the terminal for this session");
+
+    await render({ chatMode: false });
+    expect(labelOf("view-switch")).toBe("Switch this session to chat view");
+  });
+
+  // 컴패니언을 열 수 없는 호스트(모바일 레이아웃)에는 분석가 문을 세우지 않는다.
+  it("omits the analyst door on a host without companions", async () => {
+    await render({ chatMode: true, companions: false });
+    expect(actionIds()).toEqual(["view-switch", "reading-width"]);
+  });
+});
+
+async function render({ chatMode, companions = true }: { readonly chatMode: boolean; readonly companions?: boolean }): Promise<void> {
+  if (!container) {
+    container = document.createElement("div");
+    document.body.append(container);
+  }
+  root ??= createRoot(container);
+  const captionActions = agentOperationKind.captionActions;
+  if (!captionActions) throw new Error("Agent caption shelf must exist.");
+  await act(async () => {
+    applySessionUpdate({
+      sessionId: OPERATION_ID,
+      terminalSessionId: OPERATION_ID,
+      cwdLabel: "Workspace",
+      label: "Caption shelf",
+      status: "live",
+      turnState: "none",
+      createdAt: 1,
+      theaterId: "theater",
+      resumeAvailable: true,
+      cliId: "claude-gateway",
+    });
+    root?.render(captionActions(context(chatMode, companions)) as React.ReactNode);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function actionIds(): readonly string[] {
+  return Array.from(container?.querySelectorAll("[data-caption-action]") ?? [])
+    .map((node) => node.getAttribute("data-caption-action") ?? "");
+}
+
+function labelOf(actionId: string): string {
+  return container?.querySelector(`[data-caption-action="${actionId}"]`)?.getAttribute("aria-label") ?? "";
+}
+
+function context(chatMode: boolean, companions: boolean): OperationRenderContext {
+  const fetch = vi.fn(async (_pluginId: string, path: string) => new Response(
+    path === "analysis/catalog" ? CATALOG_BODY : JSON.stringify({ ready: true }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  ));
+  const api = { fetch, subscribe: () => () => undefined, resync: vi.fn() } as unknown as ClientApiCapability;
+  return {
+    operationId: OPERATION_ID,
+    theaterId: "theater",
+    pluginId: "terminal",
+    type: "agent",
+    operation: {
+      id: OPERATION_ID,
+      theaterId: "theater",
+      type: "agent",
+      pluginId: "terminal",
+      title: "Caption shelf",
+      payload: { chatMode, cliId: "claude-gateway" },
+      geometry: null,
+      ts: { createdAt: 1, updatedAt: 1 },
+    },
+    api,
+    active: true,
+    zoom: 1,
+    theme: "instrument",
+    language: "en",
+    ...(companions ? { onRequestCompanions: vi.fn(), onSetCompanionPanelVisible: vi.fn() } : {}),
+    companionsOpen: false,
+    hiddenCompanionPanelIds: ["session-analyst-chat"],
+  } as unknown as OperationRenderContext;
+}

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-composer.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-composer.test.tsx
@@ -51,6 +51,7 @@ function mount(options: { readonly turnRunning?: boolean } = {}): void {
   act(() => root?.render(createElement(AgentChatComposer, {
     context,
     coordinate: createElement("span", { className: "coord-stub" }),
+    meter: null,
     tourAnchor: false,
     turnRunning: options.turnRunning ?? false,
     stopping: false,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-context-meter.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-context-meter.test.tsx
@@ -90,7 +90,6 @@ function mount(): void {
   } as unknown as OperationRenderContext;
   act(() => root?.render(createElement(AgentChatView, {
     context,
-    onOpenTerminal: async () => {},
     tourAnchors: false,
   })));
 }
@@ -155,6 +154,23 @@ describe("chat context meter", () => {
     logState = stateWith(measured(), "done");
     mount();
     expect(chip()?.className).not.toContain("is-stale");
+  });
+
+  // 계기는 지시를 쓰는 손 옆에 산다 — 첨부와 발사 사이, 발사 버튼 바로 왼쪽이다.
+  it("rides the composer control row, one step left of the send control", () => {
+    mount();
+    const actions = container?.querySelector(".agent-chat-composer-actions");
+    expect(actions).not.toBeNull();
+    const order = Array.from(actions?.children ?? [])
+      .map((child) => child.className || child.tagName)
+      .filter((name) => name !== "INPUT");
+    expect(order).toEqual([
+      "agent-chat-composer-attach",
+      "agent-chat-ctx",
+      "agent-chat-composer-send",
+    ]);
+    // 떠 있던 칩 줄의 잔재를 물려받지 않는다 — 이 행에서는 컴포저의 컨트롤 문법을 쓴다.
+    expect(chip()?.className).not.toContain("agent-chat-mode-chip");
   });
 
   it("says nothing at all before the first number arrives", () => {

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-first-turn.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-first-turn.test.tsx
@@ -71,7 +71,6 @@ function mount(language: "en" | "ko" = "en"): void {
   } as unknown as OperationRenderContext;
   act(() => root?.render(createElement(AgentChatView, {
     context,
-    onOpenTerminal: async () => {},
     tourAnchors: false,
   })));
 }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
@@ -82,7 +82,6 @@ function mount(): void {
   } as unknown as OperationRenderContext;
   act(() => root?.render(createElement(AgentChatView, {
     context,
-    onOpenTerminal: async () => {},
     tourAnchors: false,
   })));
 }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
@@ -68,7 +68,6 @@ function viewProps() {
   } as unknown as OperationRenderContext;
   return {
     context,
-    onOpenTerminal: async () => {},
     tourAnchors: false,
   };
 }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-session-coordinates.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-session-coordinates.test.tsx
@@ -67,7 +67,6 @@ function mount(payload: Record<string, unknown>, language: "en" | "ko" = "en"): 
   } as unknown as OperationRenderContext;
   act(() => root?.render(createElement(AgentChatView, {
     context,
-    onOpenTerminal: async () => {},
     tourAnchors: false,
   })));
 }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -3,8 +3,8 @@ import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
 import { launchProviderGlyph } from "@fleet-console/sdk/components/launch-provider-glyphs";
 
 import { getT, type TerminalMessageKey } from "../../i18n/index.js";
-import { nextChatReadingWidth, setChatReadingWidth, useChatReadingWidth, type ChatReadingWidth } from "../../shared/terminal-preferences.js";
-import { AgentApiError, readAgentChatJobDetail, stopAgentChatJob } from "../api.js";
+import { useChatReadingWidth, type ChatReadingWidth } from "../../shared/terminal-preferences.js";
+import { readAgentChatJobDetail, stopAgentChatJob } from "../api.js";
 import { StreamedMarkdown } from "../streamed-markdown.js";
 import { useAgentChatStream, type AgentChatViewState } from "./chat-store.js";
 import {
@@ -26,11 +26,12 @@ import {
 } from "./chat-events.js";
 import { CHAT_EFFORT_RUNGS, readAgentChatSessionCoordinates, type AgentChatSessionCoordinates } from "./session-coordinates.js";
 import { AgentChatComposer } from "./composer.js";
+import { useViewSwitchState } from "../view-switch-store.js";
 import "@fleet-console/markdown/styles.css";
 import "./chat.css";
 
-// 칩과 설정 Select가 같은 이름을 쓴다 — 한 선호의 두 표면이 다른 어휘를 갖지 않게 한다.
-const READING_WIDTH_LABEL_KEY = {
+// 캡션 버튼과 설정 Select가 같은 이름을 쓴다 — 한 선호의 두 표면이 다른 어휘를 갖지 않게 한다.
+export const READING_WIDTH_LABEL_KEY = {
   reading: "terminal.chat.readingWidth.reading",
   wide: "terminal.chat.readingWidth.wide",
   full: "terminal.chat.readingWidth.full",
@@ -54,16 +55,11 @@ const READING_WIDTH_LABEL_KEY = {
  */
 export function AgentChatView({
   context,
-  onOpenTerminal,
   tourAnchors,
-  leadingChip,
 }: {
   readonly context: OperationRenderContext;
-  readonly onOpenTerminal: () => Promise<void>;
   /** 사용자가 이 마운트에서 직접 채팅 뷰를 연 경우에만 true — 투어 앵커 렌더 여부를 결정한다. */
   readonly tourAnchors: boolean;
-  /** 칩 줄의 선행 칩(Analyst 진입) — 뷰 전환 칩과 같은 줄에 나란히 선다. */
-  readonly leadingChip?: React.ReactNode;
 }) {
   const t = getT(context.language ?? "en");
   const state = useAgentChatStream(context.operationId, context.bodyLive !== false);
@@ -74,8 +70,9 @@ export function AgentChatView({
   // null 을 건네므로 진행 중이라고 주장하지 않는다(그 사실은 전역 배너가 말한다).
   const runtime = context.runtimeState;
   const working = runtime?.lifecycle === "live" && runtime.activity === "running";
-  const [terminalPending, setTerminalPending] = React.useState(false);
-  const [terminalError, setTerminalError] = React.useState<"none" | "busy" | "failed">("none");
+  // 터미널로 넘어가는 문은 캡션에 서고, 그 시도가 왜 막혔는지는 이 면이 말한다 — 버튼과 문장이
+  // 서로 다른 트리에 살므로 사실은 저장소를 거쳐 온다.
+  const { terminalError } = useViewSwitchState(context.operationId);
   const [stopping, setStopping] = React.useState(false);
   // 바닥을 따라가는 중인지 — 칩 가시성의 권위. ref 와 같은 값이지만, 스크롤이 바꾼 뒤에는
   // 그려져야 하므로 state 로도 둔다.
@@ -98,19 +95,6 @@ export function AgentChatView({
   // 프로그램적 복원이 낳은 scroll 이벤트는 사용자 의도가 아니다. 이것을 걸러내지 않으면 복원 자체가
   // 팔로우 상태를 뒤집어, 한 번 튄 스크롤이 영영 바닥으로 돌아오지 못한다.
   const suppressScrollRef = React.useRef(0);
-
-  const handleOpenTerminal = React.useCallback(async () => {
-    setTerminalPending(true);
-    setTerminalError("none");
-    try {
-      await onOpenTerminal();
-    } catch (error) {
-      // 왜 안 되는지가 다음 행동을 가른다 — 진행 중인 턴은 기다리면 풀리고, 그 밖의 실패는 아니다.
-      setTerminalError(error instanceof AgentApiError && error.message === "chat_busy" ? "busy" : "failed");
-    } finally {
-      setTerminalPending(false);
-    }
-  }, [onOpenTerminal]);
 
   // 아직 아무 턴도 오가지 않은 세션. 재생 중이거나 연결 전에는 판단을 미룬다 — 그때의 "비어
   // 있음"은 아직 모른다는 뜻이고, 그것을 초대로 읽으면 과거가 있는 세션에도 초대가 잠깐 스친다.
@@ -286,38 +270,6 @@ export function AgentChatView({
         style={workOpen ? ({ "--agent-chat-work": `${Math.round(workRatio * 1000) / 10}%` } as React.CSSProperties) : undefined}
       >
         <div className="agent-chat-pane">
-          {/* 터미널 복귀는 터미널 뷰의 채팅 전환 칩과 같은 문법이다 — 두 뷰가 서로를 같은
-              자리·같은 모양의 떠 있는 칩으로 가리켜, 전환이 한 쌍의 동작으로 읽힌다.
-              띠바를 두면 채팅 본문이 패널 면과 다른 면 위에 앉아 창이 두 장으로 갈린다.
-              Analyst 진입 칩이 선행하면 같은 줄에 나란히 선다.
-              이 줄이 대화 면 **안에** 사는 이유는 실측이다: 패널 전체에 걸어 두면 작업 면이 열린
-              순간 그 오른쪽 위로 넘어가 접기 컨트롤을 덮고, 히트 테스트가 칩을 집는다. */}
-          <div className="agent-view-chip-row">
-            {/* 세션 좌표 칩은 컴포저 바로 옮겨 앉았다 — 지시를 쓰는 자리가 좌표를 읽는 자리다. */}
-            {leadingChip}
-            <ContextMeterChip context={state.context} working={turnRunning} language={language} />
-            {/* 읽기 폭 칩 — 불편이 보이는 자리에서 프리셋(기본→넓게→전체)을 순환한다. 설정의
-                같은 선호를 읽고 쓰는 두 번째 표면이지 별도 상태가 아니다. */}
-            <button
-              type="button"
-              className="agent-chat-mode-chip agent-chat-width-chip"
-              aria-label={t("terminal.chat.readingWidthAria", { current: t(READING_WIDTH_LABEL_KEY[readingWidth]) })}
-              onClick={() => { setChatReadingWidth(nextChatReadingWidth(readingWidth)); }}
-            >
-              <span aria-hidden="true">⇔</span> {t(READING_WIDTH_LABEL_KEY[readingWidth])}
-            </button>
-            <button
-              type="button"
-              className="agent-chat-mode-chip"
-              {...(tourAnchors ? { "data-chat-tour": "terminal" } : {})}
-              disabled={terminalPending}
-              aria-label={t("terminal.chat.openTerminalAria")}
-              onClick={() => { void handleOpenTerminal(); }}
-            >
-              <span aria-hidden="true">❯</span> {terminalPending ? t("terminal.chat.openingTerminal") : t("terminal.chat.openTerminal")}
-            </button>
-          </div>
-
           {/* 로그와 그 위에 떠 있는 크롬(Follow·잡 스트립·중지)의 좌표계. 컴포저가 pane 하단에
               in-flow로 서면서, pane에 앵커하던 부유물이 컴포저 위에 얹히지 않도록 부유물의
               containing block을 로그 영역으로 좁힌다 — 컴포저 높이가 얼마가 되든 부유물은
@@ -449,6 +401,7 @@ export function AgentChatView({
           <AgentChatComposer
             context={context}
             coordinate={<SessionCoordinate coordinates={coordinates} t={t} />}
+            meter={<ContextMeterChip context={state.context} working={turnRunning} language={language} />}
             tourAnchor={tourAnchors}
             turnRunning={turnRunning}
             stopping={stopping}
@@ -1813,7 +1766,7 @@ function ContextMeterChip({
     <div className={`agent-chat-ctx${contextTone(context)}`} ref={wrapRef}>
       <button
         type="button"
-        className={`agent-chat-mode-chip agent-chat-ctx-chip${stale ? " is-stale" : ""}`}
+        className={`agent-chat-ctx-chip${stale ? " is-stale" : ""}`}
         aria-expanded={open}
         aria-label={t("terminal.chat.contextAria", { percent: String(percent), summary })}
         title={t("terminal.chat.contextAt", { summary })}

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
@@ -78,7 +78,6 @@ function render(): void {
   } as unknown as OperationRenderContext;
   act(() => root?.render(createElement(AgentChatView, {
     context,
-    onOpenTerminal: async () => {},
     tourAnchors: false,
   })));
 }
@@ -155,17 +154,19 @@ describe("chat work surface", () => {
   });
 });
 
-describe("chat work surface — floating controls", () => {
-  it("keeps the floating chip row inside the conversation pane", () => {
-    // 패널 전체에 걸어 두면 작업 면이 열린 순간 그 오른쪽 위로 넘어가 접기 컨트롤을 덮는다.
-    // 실측에서 elementFromPoint가 접기 꺾쇠 자리에서 칩을 집었다 — 눌러도 접히지 않는다.
+describe("chat work surface — panel controls", () => {
+  it("keeps no floating chip row in the body and leaves the composer with the conversation", () => {
+    // 분석가·뷰 전환·읽기 폭은 캡션 밴드로 떠났다 — 본문 위에 떠 있던 그 줄이 남아 있으면
+    // 작업 면이 열리는 순간 그 오른쪽 위로 넘어가 접기 컨트롤을 덮는다(실측으로 겪은 자리다).
     logState = stateWith([job()]);
     mount();
     act(() => { strip()?.click(); });
-    const chips = container?.querySelector(".agent-view-chip-row");
-    expect(chips).not.toBeNull();
-    expect(chips?.closest(".agent-chat-pane")).not.toBeNull();
-    expect(chips?.closest(".agent-chat-work")).toBeNull();
+    expect(container?.querySelector(".agent-view-chip-row")).toBeNull();
+    // 컴포저는 대화 면의 것이다 — 문맥 미터도 그 컨트롤 행에 실려 함께 남는다.
+    const composer = container?.querySelector(".agent-chat-composer");
+    expect(composer).not.toBeNull();
+    expect(composer?.closest(".agent-chat-pane")).not.toBeNull();
+    expect(composer?.closest(".agent-chat-work")).toBeNull();
   });
 });
 

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -44,7 +44,6 @@
 /* 조상 커서를 auto로 되돌렸으므로 채팅의 인터랙티브 요소는 pointer를 직접 진다. */
 .agent-chat-to-term:not(:disabled),
 .agent-chat-inter-button,
-.agent-chat-mode-chip,
 .agent-chat-follow,
 .agent-chat-dormant-open:not(:disabled) {
   cursor: pointer;
@@ -68,12 +67,12 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  /* 세로 여백은 떠 있는 두 컨트롤을 피한다 — 위는 전환 칩(32px + space-3 오프셋), 아래는 중지
-     버튼(40px + space-3 오프셋). 스크롤 컨테이너의 여백이라야 바닥까지 내린 로그의 마지막 줄이
-     버튼 위로 올라온다: 여백 없이 두면 마지막 턴의 아래 36px이 버튼 뒤에 갇혀 스크롤로도
-     빠져나오지 못한다. 가로는 늘리지 않는다 — 모든 줄의 측정폭을 줄이는 대가가, 세로 여백만으로
-     이미 해소되는 겹침보다 크다. */
-  padding: calc(var(--space-3) + 34px) clamp(var(--space-4), 4vw, var(--space-8)) calc(var(--space-3) + 45px);
+  /* 위쪽 34px은 떠 있던 전환 칩 줄의 몫이었다 — 그 줄이 캡션으로 옮겨 간 지금, 로그는 패널
+     상단에서 바로 시작한다. 아래 45px은 여전히 부유 컨트롤(중지·Follow·잡 스트립)의 자리다.
+     스크롤 컨테이너의 여백이라야 바닥까지 내린 로그의 마지막 줄이 버튼 위로 올라온다: 여백 없이
+     두면 마지막 턴의 아래 36px이 버튼 뒤에 갇혀 스크롤로도 빠져나오지 못한다. 가로는 늘리지
+     않는다 — 모든 줄의 측정폭을 줄이는 대가가, 세로 여백만으로 이미 해소되는 겹침보다 크다. */
+  padding: var(--space-3) clamp(var(--space-4), 4vw, var(--space-8)) calc(var(--space-3) + 45px);
 }
 
 /* 모든 로그 항목은 패널 중앙의 한 컬럼을 공유한다 — 에이전트 턴은 컬럼 전폭을 쓰고,
@@ -1169,27 +1168,10 @@
   outline: none;
 }
 
-/* 뷰 칩 줄 — Analyst 진입 칩과 뷰 전환 칩이 같은 자리(우상단)에 나란히 선다.
-   줄이 위치를 지므로 칩 자체는 흐름에 남는다. */
-.agent-view-chip-row {
-  position: absolute;
-  top: var(--space-3);
-  right: var(--space-3);
-  z-index: 3;
-  display: flex;
-  gap: var(--space-2);
-}
-
-.agent-view-chip-row .agent-chat-mode-chip {
-  position: static;
-}
-
 /* War Room 카드의 본문은 읽는 자리다 — 승격 면이 클릭을 가로채고 본문은 inert라
    Analyst·채팅 뷰 칩과 중지·회신 버튼은 눌러도 동작하지 않는다. 무대에 오른 패널은
    is-deck-tile이 아니므로 컨트롤이 기존처럼 보인다. 휴면 카드의 채팅 진입 고스트와
    첫 턴 초대 문구도 본문 안에 있으므로 함께 숨긴다. */
-.canvas-operation.is-deck-tile .agent-view-chip-row,
-.canvas-operation.is-deck-tile .agent-chat-mode-chip,
 .canvas-operation.is-deck-tile .agent-chat-dormant-open,
 .canvas-operation.is-deck-tile .agent-chat-follow,
 .canvas-operation.is-deck-tile .agent-chat-settle,
@@ -1197,11 +1179,10 @@
   display: none;
 }
 
-/* 칩이 없으면 로그가 그 자리를 되찾는다. 하단 45px는 작업 스트립 몫이라 건드리지 않는다.
-   초대 상태의 높이 하한도 여기서 되돌린다 — 그 하한은 받침이 로그를 잠식하지 못하게 막는
-   장치인데 카드에는 받침이 없고, 작은 카드에서는 그 하한이 로그를 카드 밖으로 밀어낸다. */
+/* 초대 상태의 높이 하한을 되돌린다 — 그 하한은 받침이 로그를 잠식하지 못하게 막는 장치인데
+   카드에는 받침이 없고, 작은 카드에서는 그 하한이 로그를 카드 밖으로 밀어낸다.
+   상단 여백은 더 이상 손대지 않는다: 피할 부유 칩이 사라져 베이스가 이미 space-3이다. */
 .canvas-operation.is-deck-tile .agent-chat-log {
-  padding-top: var(--space-3);
   min-height: 0;
 }
 
@@ -1319,16 +1300,6 @@
   height: 100%;
 }
 
-/* 판면이 100ch(reading 상한)보다 좁으면 프리셋 간 차이가 그려지지 않는다 — 뜻이 없어진
-   컨트롤은 크롬에서 물린다. 가르는 것은 뷰포트가 아니라 이 패널의 폭이다.
-   선택자를 한 단 올린다 — @container는 특정성을 더하지 않으므로, 뒤에 오는
-   .agent-chat-mode-chip 기본 display와 동률이면 소스 순서에 진다. */
-@container (max-width: 719px) {
-  .agent-view-chip-row .agent-chat-width-chip {
-    display: none;
-  }
-}
-
 /* 칩 줄은 본문 위에 떠 있고 폭을 스스로 늘린다 — 좌표 칩까지 서면 최소 폭(320px) 패널에서
    줄이 패널 왼쪽 밖으로 나간다(실측: 340px 줄 vs 296px 여유). 그때 물러나는 것은 좌표 칩이다:
    같은 사실을 로그 첫 줄의 태생 기록이 이미 말하고 있고, 그 줄은 폭을 다투지 않는다.
@@ -1346,53 +1317,6 @@
 }
 
 /* Analyst 진입 칩의 진행 표식 — 상태 신호는 aurora 도트만 진다. */
-.agent-analyst-chip-live {
-  width: 6px;
-  height: 6px;
-  flex: none;
-  align-self: center;
-  border-radius: var(--radius-pill);
-  background: var(--aurora);
-  box-shadow: 0 0 8px var(--aurora-glow);
-}
-
-.agent-analyst-chip:disabled {
-  opacity: 0.55;
-}
-
-/* 뷰 전환 칩 — 터미널 뷰의 "채팅 뷰"와 채팅 뷰의 "터미널 열기"가 같은 클래스를 공유해
-   같은 자리·같은 모양으로 서로를 가리킨다. brass는 위치·포커스 채널이므로 hover에만 오른다. */
-.agent-chat-mode-chip {
-  position: absolute;
-  top: var(--space-3);
-  right: var(--space-3);
-  z-index: 3;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-family: var(--font-mono);
-  font-size: var(--t-xs);
-  letter-spacing: 0.06em;
-  padding: 5px var(--space-3);
-  border-radius: var(--radius-xs);
-  background: var(--ink-mid);
-  border: 1px solid var(--hairline-strong);
-  color: var(--text-secondary);
-  transition: border-color var(--duration-fast), color var(--duration-fast), box-shadow var(--duration-fast);
-}
-
-.agent-chat-mode-chip:hover:not(:disabled) {
-  border-color: var(--brass);
-  color: var(--brass-ink);
-  box-shadow: 0 0 14px var(--brass-glow);
-}
-
-/* 전환 요청 중 — 칩은 자리에 남고 판독만 낮춘다(사라지면 어디를 눌렀는지 잃는다). */
-.agent-chat-mode-chip:disabled {
-  color: var(--text-tertiary);
-  cursor: default;
-}
-
 /* 전환 확인 — 패널 내부 오버레이. */
 .agent-chat-interstitial {
   position: absolute;
@@ -2164,9 +2088,34 @@
 .agent-chat-ctx.is-warn { --agent-chat-ctx-ink: var(--warn); }
 .agent-chat-ctx.is-critical { --agent-chat-ctx-ink: var(--coral); }
 
+/* 미터는 컴포저 컨트롤 행에 산다 — 첨부와 발사 사이, 발사 버튼 바로 왼쪽이다. 누르는 것들
+   사이에 앉지만 자신은 읽는 계기이므로, 좌표 배지와 같은 중립 알약을 쓰고 hover에서만 손에
+   닿는 물건임을 밝힌다. */
 .agent-chat-ctx-chip {
-  position: static;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+  padding: 4px 8px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-xs);
+  background: var(--ink-mid);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.04em;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
   font-variant-numeric: tabular-nums;
+  transition: border-color var(--duration-fast), color var(--duration-fast);
+}
+
+.agent-chat-ctx-chip:hover,
+.agent-chat-ctx-chip:focus-visible {
+  border-color: var(--brass);
+  color: var(--brass-ink);
+  outline: none;
 }
 
 .agent-chat-ctx-pct { color: var(--agent-chat-ctx-ink); }
@@ -2198,7 +2147,8 @@
    갉으면 대화가 먼저 밀린다. 오른쪽 끝을 칩에 맞춰 세워 패널 밖으로 넘지 않게 한다. */
 .agent-chat-ctx-pop {
   position: absolute;
-  top: calc(100% + var(--space-2));
+  /* 미터가 패널 바닥의 컴포저 행에 앉으므로 내역은 위로 열린다 — 아래로 열면 패널 밖이다. */
+  bottom: calc(100% + var(--space-2));
   right: 0;
   z-index: 6;
   width: 320px;

--- a/runtime/fleet-plugins/terminal/client/agent/chat/composer.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/composer.tsx
@@ -55,6 +55,7 @@ type AttachmentRejection =
 export function AgentChatComposer({
   context,
   coordinate,
+  meter,
   tourAnchor,
   turnRunning,
   stopping,
@@ -63,6 +64,11 @@ export function AgentChatComposer({
   readonly context: OperationRenderContext;
   /** 세션 좌표의 사실 표시 — 모델·강도 배지가 컨트롤 행 좌측에 앉는다. */
   readonly coordinate: React.ReactNode;
+  /**
+   * 문맥 미터 — 읽는 계기이지 컨트롤이 아니다. 발사 버튼 바로 왼쪽에 앉아, 보내기 직전에
+   * "이 창에 얼마나 남았는가"가 손이 가는 자리에서 읽힌다.
+   */
+  readonly meter: React.ReactNode;
   readonly tourAnchor: boolean;
   /** 지금 이 세션의 턴이 도는가 — 발사 컨트롤이 중지로 바뀌는 축이다. */
   readonly turnRunning: boolean;
@@ -264,6 +270,7 @@ export function AgentChatComposer({
               label={t("terminal.chat.composerAttach")}
               onFiles={addFiles}
             />
+            {meter}
             {turnRunning ? (
               // 도는 턴을 끊는 문. 이 문은 턴만 닫는다 — 이미 태어난 백그라운드 작업은 계속 살고
               // 잡 표면이 그것을 그대로 말한다(잡 하나만 멈추는 제어 경로는 SDK에 없다).

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -5,11 +5,18 @@ import { defineNotificationKind } from "@fleet-console/sdk/notifications/browser
 import { defineOperationKind } from "@fleet-console/sdk/plugin/browser";
 import { definePlugin, React } from "@fleet-console/sdk/plugin/browser";
 import { Select } from "@fleet-console/sdk/react/browser";
+import {
+  CaptionActionButton,
+  CaptionAnalystGlyph,
+  CaptionChatGlyph,
+  CaptionReadingWidthGlyph,
+  CaptionTerminalGlyph,
+} from "@fleet-console/sdk/components/caption-actions";
 import { defineSettingsSection } from "@fleet-console/sdk/settings/browser";
 import type { OperationRenderContext, PluginInstallContext } from "@fleet-console/sdk/plugin";
 import { TerminalSurface } from "../shared/index.js";
 import { CURATED_TERMINAL_FONTS, DEFAULT_TERMINAL_FONT, TERMINAL_FONT_SIZE_RANGE } from "../shared/terminal-preferences.js";
-import { getTerminalPrefsSnapshot, useTerminalPrefs, setChatReadingWidth, setInstalledTerminalFont, setTerminalRenderer, setTerminalInactiveFlush, setTerminalFont, setTerminalFontSize, useChatReadingWidth } from "../shared/terminal-preferences.js";
+import { getTerminalPrefsSnapshot, useTerminalPrefs, nextChatReadingWidth, setChatReadingWidth, setInstalledTerminalFont, setTerminalRenderer, setTerminalInactiveFlush, setTerminalFont, setTerminalFontSize, useChatReadingWidth } from "../shared/terminal-preferences.js";
 import type { ChatReadingWidth, TerminalFontId, TerminalFontSettings, TerminalInactiveFlush, TerminalRenderer } from "../shared/terminal-preferences.js";
 import { AnalystCaption, AnalystChatPanel } from "./analysis-chat-panel.js";
 import { fetchAnalysisReady } from "./analysis-api.js";
@@ -22,11 +29,12 @@ import {
 import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
 import { currentTerminalLocale, getT, useTerminalLocale, type TerminalMessageKey } from "../i18n/index.js";
 import { disposeAnalysisStore, useAnalysisStore } from "./analysis-store.js";
+import { disposeViewSwitch, setChatPromptOpen, setTerminalHandoff, useViewSwitchState } from "./view-switch-store.js";
 import "./analysis.css";
 import "./agent-cli.css";
 
 import { AgentApiError, convertAgentSessionToChat, createAgentSession, discardLaunchAttachment, exitAgentChat, fetchAgentCliDiagnostics, fetchAgentCliState, messageAgentSession, resumeAgentSession, setAgentCliPath, terminateAgentSession, uploadLaunchAttachment } from "./api.js";
-import { AgentChatView } from "./chat/chat-view.js";
+import { AgentChatView, READING_WIDTH_LABEL_KEY } from "./chat/chat-view.js";
 import { startAgentConnection } from "./connection.js";
 import { loadModelAuth, signInModel, signOutModel, useModelAuthStore } from "./model-auth.js";
 import type { ModelAuthProviderState } from "./model-auth.js";
@@ -88,6 +96,8 @@ export const agentOperationKind = defineOperationKind({
   title: (locale) => getT(locale)("terminal.kind.agent"),
   subtitle: (operation) => readPayloadString(operation.payload, "cliLabel") ?? undefined,
   render: (context) => <AgentOperationView context={context} />,
+  // 분석가·뷰 전환·읽기 폭은 캡션 밴드가 진다 — 본문 위에 떠 있던 칩 줄이 하던 일이다.
+  captionActions: (context) => <AgentCaptionActions context={context} />,
   // 에이전트 CLI TUI는 화면 바닥에 입력 컴포저와 상태줄(cwd·모델·권한 모드)을 고정으로 그린다 —
   // 실행 중에도 갱신되지 않으므로 호스트 프리뷰는 이 밴드를 프레임 밖으로 밀어낼 수 있다.
   // 밴드의 단위는 px가 아니라 행이다: 셀 높이가 글꼴 크기를 따르므로(TERMINAL_OPTIONS.lineHeight
@@ -155,6 +165,7 @@ export const agentPlugin = definePlugin({
       await terminateAgentSession(operationId);
     } finally {
       disposeAnalysisStore(operationId);
+      disposeViewSwitch(operationId);
       removeSession(operationId);
     }
   },
@@ -370,42 +381,28 @@ function toggleCompanionPanel(
 
 /** 터미널·채팅·휴면 뷰 공용의 Analyst 진입 칩 — 채팅 전환 칩과 같은 자리·같은 문법으로
     드로어를 여닫는다. 세로 ANALYZE/EXIT 핸들의 후계다. */
-function AnalystEntryChip({
-  context,
-  ready,
-  working,
-}: {
-  readonly context: OperationRenderContext;
-  readonly ready: boolean;
-  readonly working: boolean;
-}) {
-  const open = isCompanionPanelVisible(context, ANALYST_CHAT_COMPANION_ID);
-  const language = context.language ?? "en";
-  const t = getT(language);
-  return (
-    <button
-      type="button"
-      className="agent-chat-mode-chip agent-analyst-chip"
-      aria-label={t(open ? "terminal.analyst.exit" : "terminal.analyst.open")}
-      aria-pressed={open}
-      aria-disabled={!ready}
-      disabled={!ready}
-      title={ready ? undefined : t("terminal.analyst.sendMessageFirst")}
-      onClick={() => { if (ready) toggleCompanionPanel(context, ANALYST_CHAT_COMPANION_ID, ANALYST_COMPANION_IDS); }}
-    >
-      {working ? <span className="agent-analyst-chip-live" aria-hidden="true" /> : null}
-      <span aria-hidden="true">✳</span> {t("terminal.analyst.chipTitle")}
-    </button>
-  );
-}
-
-const SORTIE_RIBBON_INLINE_LIMIT = 2;
-
-function AgentOperationView({ context }: { readonly context: OperationRenderContext }) {
+/**
+ * 캡션 밴드의 동작 선반 — 분석가 · 뷰 전환 · 읽기 폭.
+ *
+ * 본문 위에 떠 있던 칩 줄이 하던 일을 그대로 진다. 자리를 옮기면서 이름표는 말풍선으로 물러나고
+ * 마크만 남는다: 32px 밴드에서 세 개의 라벨은 이름이 설 자리를 먹는다.
+ *
+ * 이 컴포넌트는 본문과 다른 React 트리에 마운트된다(호스트가 캡션에 그린다). 그래서 상태는 전부
+ * 모듈 저장소에서 읽는다 — 세션·분석가·읽기 폭 선호는 이미 그렇고, 전환의 진행/실패만 이번에
+ * 저장소를 하나 얻었다(`view-switch-store`).
+ */
+function AgentCaptionActions({ context }: { readonly context: OperationRenderContext }) {
+  const t = getT(context.language ?? "en");
   const state = useAgentState();
   const session = state.sessions[context.operationId] ?? sessionFromOperation(context);
   const analysisReadiness = useAnalysisReady(context);
   const { state: analysisState } = useAnalysisStore(context);
+  const readingWidth = useChatReadingWidth();
+  const { terminalPending } = useViewSwitchState(context.operationId);
+  const chatMode = context.operation.payload.chatMode === true;
+  const analystOpen = isCompanionPanelVisible(context, ANALYST_CHAT_COMPANION_ID);
+  const analystReady = analysisReadiness === "ready";
+
   React.useEffect(() => {
     if (analysisReadiness !== "not-ready" || !context.companionsOpen || !context.onSetCompanionPanelVisible) return;
     // 단축키는 disabled 핸들 가드를 거치지 않으므로, 준비 전 진입이 빈 companion 배치를 남기지 않게 호스트 레이어까지 함께 정리한다.
@@ -418,46 +415,124 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
     context.onSetCompanionPanelVisible,
   ]);
 
-  // A host that cannot open companions gets no entry chip for them — the mobile layout hands the
-  // whole surface to the session and leaves this callback out, so the chip would open nothing.
-  const analystChip = context.onRequestCompanions === undefined ? null : (
-    <AnalystEntryChip context={context} ready={analysisReadiness === "ready"} working={analysisState.busy} />
-  );
-  const [chatConfirmOpen, setChatConfirmOpen] = React.useState(false);
+  // 투어 앵커는 사용자가 이 마운트에서 직접 채팅 뷰로 넘어온 뒤에만 선다 — 본문의 판정과 같다.
+  const wasChatModeAtMountRef = React.useRef(chatMode);
+  const chatOpenedHere = chatMode && !wasChatModeAtMountRef.current;
 
+  const openTerminal = React.useCallback(async () => {
+    setTerminalHandoff(context.operationId, { pending: true, error: "none" });
+    try {
+      await openTerminalForOperation(context);
+    } catch (error) {
+      // 왜 안 되는지가 다음 행동을 가른다 — 진행 중인 턴은 기다리면 풀리고, 그 밖의 실패는 아니다.
+      setTerminalHandoff(context.operationId, {
+        error: error instanceof AgentApiError && error.message === "chat_busy" ? "busy" : "failed",
+      });
+    } finally {
+      setTerminalHandoff(context.operationId, { pending: false });
+    }
+  }, [context]);
+
+  // 컴패니언을 열 수 없는 호스트에는 분석가 문을 세우지 않는다 — 모바일 레이아웃은 화면 전부를
+  // 세션에 주고 이 콜백을 빼며, 그 부재가 곧 "여기엔 드로어가 없다"는 말이다.
+  const analyst = context.onRequestCompanions === undefined ? null : (
+    <CaptionActionButton
+      actionId="analyst"
+      label={analystReady ? t(analystOpen ? "terminal.analyst.exit" : "terminal.analyst.open") : t("terminal.analyst.sendMessageFirst")}
+      pressed={analystOpen}
+      disabled={!analystReady}
+      busy={analysisState.busy}
+      onClick={() => { if (analystReady) toggleCompanionPanel(context, ANALYST_CHAT_COMPANION_ID, ANALYST_COMPANION_IDS); }}
+    >
+      <CaptionAnalystGlyph />
+    </CaptionActionButton>
+  );
+
+  // 전환은 목적지 하나로 말한다 — 채팅에서는 터미널 마크가, 터미널에서는 채팅 마크가 선다.
+  // 휴면 세션에는 아직 떠날 자리가 없다(휴면 카드의 고스트가 그 전환을 진다).
+  const canSwitch = isSupportedAgentOperationCliId(session.cliId) && (chatMode || session.status !== "dormant");
+  const viewSwitch = !canSwitch ? null : chatMode ? (
+    <CaptionActionButton
+      actionId="view-switch"
+      label={terminalPending ? t("terminal.chat.openingTerminal") : t("terminal.chat.openTerminalAria")}
+      disabled={terminalPending}
+      pending={terminalPending}
+      {...(chatOpenedHere ? { tourAnchor: "terminal" } : {})}
+      onClick={() => { void openTerminal(); }}
+    >
+      <CaptionTerminalGlyph />
+    </CaptionActionButton>
+  ) : (
+    <CaptionActionButton
+      actionId="view-switch"
+      label={t("terminal.chat.openAria")}
+      onClick={() => { setChatPromptOpen(context.operationId, true); }}
+    >
+      <CaptionChatGlyph />
+    </CaptionActionButton>
+  );
+
+  // 읽기 폭은 대화 면의 선호다 — 터미널 뷰에는 맞출 판면이 없으므로 서지 않는다.
+  // 좁은 패널에서 물러나는 판정은 CSS(캡션 컨테이너 질의)가 진다: 폭을 아는 것은 밴드다.
+  const readingWidthAction = !chatMode ? null : (
+    <CaptionActionButton
+      actionId="reading-width"
+      label={t("terminal.chat.readingWidthAria", { current: t(READING_WIDTH_LABEL_KEY[readingWidth]) })}
+      onClick={() => { setChatReadingWidth(nextChatReadingWidth(readingWidth)); }}
+    >
+      <CaptionReadingWidthGlyph preset={readingWidth} />
+    </CaptionActionButton>
+  );
+
+  return (
+    <>
+      {analyst}
+      {viewSwitch}
+      {readingWidthAction}
+    </>
+  );
+}
+
+/** 채팅 → 터미널. 순서가 계약이다: chat 모드 마커를 걷은 뒤에만 resume이 PTY를 되살린다(서버 ticket 가드). */
+async function openTerminalForOperation(context: OperationRenderContext): Promise<void> {
+  await exitAgentChat(context.operationId);
+  try {
+    await resumeSession(context.operationId);
+    context.notifications.dismiss(context.operationId);
+  } catch (error) {
+    context.notifications.emit({
+      kind: agentResumeFailedNotification.id,
+      operationId: context.operationId,
+      message: resumeFailureMessage(error, context.language),
+    });
+    throw error;
+  }
+}
+
+const SORTIE_RIBBON_INLINE_LIMIT = 2;
+
+function AgentOperationView({ context }: { readonly context: OperationRenderContext }) {
+  const state = useAgentState();
+  const session = state.sessions[context.operationId] ?? sessionFromOperation(context);
   const chatMode = context.operation.payload.chatMode === true;
   const sessionStatus = session.status;
+  const { chatPromptOpen } = useViewSwitchState(context.operationId);
   React.useEffect(() => {
     // 확인 오버레이는 라이브 터미널 분기 전용이다 — PTY 종료·채팅 전환으로 분기를 떠나면
     // 상태를 걷어 재개 시 낡은 다이얼로그가 되살아나지 않게 한다(이전 ChatModeEntry의
     // 언마운트-폐기와 등가).
-    if (sessionStatus === "dormant" || chatMode) setChatConfirmOpen(false);
-  }, [sessionStatus, chatMode]);
+    if (sessionStatus === "dormant" || chatMode) setChatPromptOpen(context.operationId, false);
+  }, [context.operationId, sessionStatus, chatMode]);
   // 피처 투어 앵커는 이 마운트에서 사용자가 직접 채팅 뷰로 전환한 뒤에만 세운다 — chatMode는
   // payload에 영속되므로 마운트 시점부터 앵커를 세우면 리로드 직후 캔버스에서 투어가 먼저
   // 떠버린다. "직접 연 순간에만"은 quick-launch-pin 투어와 같은 판정이다.
   const wasChatModeAtMountRef = React.useRef(chatMode);
   const chatOpenedHere = chatMode && !wasChatModeAtMountRef.current;
-  const openTerminal = React.useCallback(async () => {
-    // 순서가 계약이다: chat 모드 마커를 걷은 뒤에만 resume이 PTY를 되살릴 수 있다(서버 ticket 가드).
-    await exitAgentChat(context.operationId);
-    try {
-      await resumeSession(context.operationId);
-      context.notifications.dismiss(context.operationId);
-    } catch (error) {
-      context.notifications.emit({
-        kind: agentResumeFailedNotification.id,
-        operationId: context.operationId,
-        message: resumeFailureMessage(error, context.language),
-      });
-      throw error;
-    }
-  }, [context]);
 
   if (chatMode) {
     return (
       <div className="agent-stream-host">
-        <AgentChatView context={context} onOpenTerminal={openTerminal} tourAnchors={chatOpenedHere} leadingChip={analystChip} />
+        <AgentChatView context={context} tourAnchors={chatOpenedHere} />
       </div>
     );
   }
@@ -465,7 +540,6 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
   if (session.status === "dormant") {
     return (
       <div className="agent-stream-host">
-        {analystChip ? <div className="agent-view-chip-row">{analystChip}</div> : null}
         <DormantOperationView context={context} session={session} />
         {session.resumeAvailable && isSupportedAgentOperationCliId(session.cliId)
           ? <DormantChatEntry context={context} />
@@ -476,22 +550,8 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
 
   return (
     <div className="agent-stream-host">
-      {analystChip || isSupportedAgentOperationCliId(session.cliId) ? (
-        <div className="agent-view-chip-row">
-          {analystChip}
-          {isSupportedAgentOperationCliId(session.cliId) ? (
-            <button
-              type="button"
-              className="agent-chat-mode-chip"
-              aria-label={getT(context.language ?? "en")("terminal.chat.openAria")}
-              onClick={() => setChatConfirmOpen(true)}
-            >
-              <span aria-hidden="true">≣</span> {getT(context.language ?? "en")("terminal.chat.open")}
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-      {chatConfirmOpen ? <ChatModeInterstitial context={context} onClose={() => setChatConfirmOpen(false)} /> : null}
+      {/* 전환을 누르는 곳은 캡션이고, 무엇이 끝나야 넘어갈 수 있는지 말하는 이 오버레이는 본문이다. */}
+      {chatPromptOpen ? <ChatModeInterstitial context={context} onClose={() => setChatPromptOpen(context.operationId, false)} /> : null}
       <TerminalSurface
         operationId={session.sessionId}
         ticketPath={AGENT_TICKET_PATH}

--- a/runtime/fleet-plugins/terminal/client/agent/view-switch-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/view-switch-store.ts
@@ -1,0 +1,76 @@
+import { React } from "@fleet-console/sdk/plugin/browser";
+
+/**
+ * 뷰 전환의 두 조각을 잇는 자리.
+ *
+ * 전환을 **누르는 곳**은 캡션 밴드이고, 그 결과를 **말하는 곳**은 본문이다 — 확인 오버레이도,
+ * "열 수 없었다"는 문장도 대화가 흐르는 면에 서야 뜻이 통한다. 두 면은 서로 다른 React 트리에
+ * 마운트되므로 상태를 props로 건널 수 없고, 그래서 이 작은 저장소가 사이에 선다.
+ *
+ * 호스트 번들과 나눠 갖는 상태가 아니라 이 플러그인 번들 안에서만 쓰는 값이다.
+ */
+export interface ViewSwitchState {
+  /** 터미널 → 채팅 확인 오버레이가 열려 있는가. */
+  readonly chatPromptOpen: boolean;
+  /** 채팅 → 터미널 전환이 진행 중인가. */
+  readonly terminalPending: boolean;
+  /** 그 전환이 왜 안 됐는가 — 진행 중인 턴은 기다리면 풀리고, 그 밖의 실패는 아니다. */
+  readonly terminalError: "none" | "busy" | "failed";
+}
+
+const IDLE: ViewSwitchState = { chatPromptOpen: false, terminalPending: false, terminalError: "none" };
+
+const states = new Map<string, ViewSwitchState>();
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+function read(operationId: string): ViewSwitchState {
+  return states.get(operationId) ?? IDLE;
+}
+
+function write(operationId: string, next: ViewSwitchState): void {
+  const current = read(operationId);
+  if (current.chatPromptOpen === next.chatPromptOpen
+    && current.terminalPending === next.terminalPending
+    && current.terminalError === next.terminalError) return;
+  if (next.chatPromptOpen === IDLE.chatPromptOpen
+    && next.terminalPending === IDLE.terminalPending
+    && next.terminalError === IDLE.terminalError) states.delete(operationId);
+  else states.set(operationId, next);
+  emit();
+}
+
+export function useViewSwitchState(operationId: string): ViewSwitchState {
+  return React.useSyncExternalStore(
+    (listener: () => void) => {
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+    () => read(operationId),
+    () => read(operationId),
+  );
+}
+
+export function setChatPromptOpen(operationId: string, open: boolean): void {
+  write(operationId, { ...read(operationId), chatPromptOpen: open });
+}
+
+export function setTerminalHandoff(
+  operationId: string,
+  patch: { readonly pending?: boolean; readonly error?: ViewSwitchState["terminalError"] },
+): void {
+  const current = read(operationId);
+  write(operationId, {
+    ...current,
+    ...(patch.pending === undefined ? {} : { terminalPending: patch.pending }),
+    ...(patch.error === undefined ? {} : { terminalError: patch.error }),
+  });
+}
+
+export function disposeViewSwitch(operationId: string): void {
+  if (!states.delete(operationId)) return;
+  emit();
+}


### PR DESCRIPTION
## Summary

- 패널 본문 위에 떠 있던 **분석가 · 채팅/터미널 전환 · 읽기 폭**을 캡션의 `…` 왼쪽 마크 버튼으로 옮겼습니다. 순서는 분석가 → 전환 → 읽기 폭 → 메뉴 → 창 컨트롤이고, 읽기 폭은 **채팅 뷰에서만** 서며 패널이 721px보다 좁아지면 물러납니다.
- 캡션의 모든 컨트롤이 같은 **말풍선**으로 자기 이름을 말합니다(브라우저 기본 `title` 툴팁 대체). War Room 덱 카드에는 선반을 아예 넘기지 않습니다 — 카드 본문이 inert라 동작하지 않는 버튼은 거짓 약속입니다.
- 플러그인이 캡션을 채우는 계약을 `OperationKindDescriptor.captionActions`로 열었습니다. 컴패니언 패널의 `caption` 계약과 같은 성질(밴드는 호스트 소유, 내용은 플러그인)이고, 버튼·마크·말풍선은 `@fleet-console/sdk/components/caption-actions` 한 모듈이 소유합니다.
- 문맥 미터가 컴포저 컨트롤 행으로 내려와 **전송 버튼 바로 왼쪽**에 앉고(이미지 버튼은 그 왼쪽), 내역 팝오버는 위로 열립니다.
- 눌린 캡션 컨트롤의 brass 채움을 `oklab`으로 섞습니다. `oklch`는 hue를 극좌표 호로 보간해 실측상 instrument/maritime 테두리가 hue 144(초록), carbon이 354(자홍)에 착지했습니다.
- 칩 줄이 사라져 채팅 로그가 예약하던 상단 34px을 회수했습니다.

## Test Plan

- [x] `pnpm typecheck` (전체 워크스페이스)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] 콘솔 2296 passed / 24 skipped · 터미널 981 passed
- [x] `node scripts/check-core-boundary.mjs` · `check-localized-attributes.mjs`
- [x] `node scripts/compile-changelog-fragments.mjs --check` (21 entries)
- [x] 격리 콘솔 실측(헤드리스): 캡션 순서 = 이름 → 선반(analyst·view-switch·reading-width) → 메뉴 → 창 컨트롤 · hover 말풍선 노출/패널 안 유지 · 읽기 폭 720px에서 사라짐 · 분석가 열림 시 테두리 hue **80.1**(brass 78, 이전 144.8) · 덱 카드 선반 0개, 로그 삐져나옴 없음 · 로그 상단 여백 46px → 12px · 페이지 에러 0
- [ ] 라이브 PTY 세션(터미널 뷰의 채팅 전환 마크)과 실제 문맥 값이 있는 미터는 단위 테스트로만 확인 — 시드로 세울 수 없는 상태입니다.

## Follow-up

`chat-reading-width.md`(미릴리스)가 아직 "width chip"으로 적고 있어 정정이 필요합니다. `changelog-amend`와 브랜치 프래그먼트는 CI가 상호배타로 막으므로 **별도 PR**로 올립니다.