### PR TITLE
docs(changelog): point the reading-width note at the panel caption

### DIFF
--- a/.changelog.d/chat-reading-width.md
+++ b/.changelog.d/chat-reading-width.md
@@ -6,5 +6,5 @@ branch: chat-reading-width
 
 #### Added
 
-- Operation chat now has a "Chat reading width" preference with Reading, Wide, and Full presets, adjustable from the chat surface's width chip or the Terminal plugin settings.
-  ko: Operation 채팅에 "채팅 읽기 폭" 선호가 생겼습니다. 기본·넓게·전체 프리셋을 채팅 판면의 폭 칩이나 Terminal 플러그인 설정에서 바꿀 수 있습니다.
+- Operation chat now has a "Chat reading width" preference with Reading, Wide, and Full presets, adjustable from the panel caption or the Terminal plugin settings.
+  ko: Operation 채팅에 "채팅 읽기 폭" 선호가 생겼습니다. 기본·넓게·전체 프리셋을 패널 캡션이나 Terminal 플러그인 설정에서 바꿀 수 있습니다.


### PR DESCRIPTION
## Summary

- 미릴리스 프래그먼트 `chat-reading-width.md`가 읽기 폭 프리셋을 "채팅 판면의 폭 칩"에서 바꾼다고 적고 있는데, 그 컨트롤은 패널 캡션의 마크로 옮겨 갔습니다(#819). 아직 어떤 릴리스에도 나가지 않은 동작이므로 별도 `Changed` 항목 대신 그 프래그먼트를 정정합니다.

Changelog-Amend: chat-reading-width.md

## Test Plan

- [x] `node scripts/compile-changelog-fragments.mjs --check` (18 entries)