### PR TITLE
fix(fleet-console): drop a caption tooltip when the pointer leaves the button

### DIFF
--- a/.changelog.d/caption-tip-focus.md
+++ b/.changelog.d/caption-tip-focus.md
@@ -1,0 +1,8 @@
+---
+branch: caption-tip-focus
+---
+
+### fleet-console
+#### Fixed
+- A caption button's name tag now clears as soon as the pointer leaves the button. Clicking one - maximizing a panel, for example - no longer leaves its tooltip standing until you click somewhere else, while keyboard focus still shows the name.
+  ko: 캡션 버튼의 이름표가 포인터가 버튼을 벗어나는 즉시 사라집니다. 패널 최대화처럼 버튼을 눌러도 말풍선이 다른 곳을 클릭할 때까지 떠 있지 않으며, 키보드로 짚은 포커스에서는 이름이 그대로 보입니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6403,8 +6403,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   transition: opacity var(--duration-fast) var(--ease-spring);
 }
 
+/* 이름표는 **지금 이 버튼을 겨누고 있는 동안**만 뜬다. 포인터가 겨눔을 놓으면 이름표도 놓아야
+   하는데, 클릭은 버튼에 포커스를 남긴다 — `:focus-within`으로 열면 최대화처럼 눌러도 그 자리에
+   남는 버튼에서 마우스를 치운 뒤에도 풍선이 계속 서 있다(다른 곳을 눌러야 사라진다). 키보드로
+   짚어 온 포커스만 겨눔으로 치는 `:focus-visible`이 그 둘을 가른다. */
 .fleet-caption-slot:hover .fleet-caption-tip,
-.fleet-caption-slot:focus-within .fleet-caption-tip {
+.fleet-caption-slot:has(:focus-visible) .fleet-caption-tip {
   opacity: 1;
   transition-delay: 0.35s;
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -519,6 +519,12 @@ describe("Instrument core design contract", () => {
     expect(tip).toContain("right: 0;");
     expect(tip).toContain("pointer-events: none;");
 
+    // 이름표는 겨누는 동안만 뜬다 — 클릭이 남긴 포커스로 열면 눌러도 그 자리에 남는 버튼(최대화)에서
+    // 풍선이 붙박이가 된다. 키보드로 짚어 온 포커스만 겨눔으로 친다.
+    const tipReveal = components.match(/\.fleet-caption-slot:hover \.fleet-caption-tip,\n[^{]*\{[^}]*\}/)?.[0] ?? "";
+    expect(tipReveal).toContain(":has(:focus-visible)");
+    expect(tipReveal).not.toContain(":focus-within");
+
     // 폭을 아는 것은 밴드다 — 뜻이 사라지는 컨트롤은 캡션 컨테이너 질의로 물러난다.
     const titlebar = components.match(/^\.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
     expect(titlebar).toContain("container-type: inline-size;");


### PR DESCRIPTION
## Summary
- 캡션 버튼의 말풍선이 `:focus-within`으로 열려, 눌러도 그 자리에 남는 버튼(패널 최대화)에서는 클릭이 남긴 포커스 때문에 포인터를 치운 뒤에도 이름표가 계속 서 있었습니다. 다른 곳을 클릭해야만 사라졌습니다.
- 이름표를 `:has(:focus-visible)`로 엽니다 — 호버와 키보드로 짚어 온 포커스만 "겨눔"으로 치고, 클릭이 남긴 포커스는 치지 않습니다.
- 새 노출 선택자를 `instrument-design-contract` 계약에 못박았습니다.

## Test Plan
- [x] `vitest run tests/instrument-design-contract.test.ts tests/operation-frame-identity.test.ts tests/operation-frame-caption-actions.test.tsx` — 3 files / 98 tests 통과
- [x] 격리 Console 헤드리스 실측(수정 전): 최대화 클릭 후 `activeIsBtn: true`, `hoverSlot: false`인데 `tipOpacity: 1` — 스크린샷에 "Operation 복원" 풍선 잔류
- [x] 동일 시나리오(수정 후): 같은 조건에서 `tipOpacity: 0` — 풍선 사라짐
- [x] 회귀 방향: 호버 시 `tipOpacity: 1`, 포인터를 치운 순수 키보드 Tab 포커스에서도 `focusVisible: true` / `tipOpacity: 1` 유지
- [x] `node scripts/compile-changelog-fragments.mjs --check`