### PR TITLE
fix(fleet-console): persist quaker stay-put across restarts

### DIFF
--- a/.changelog.d/quaker-keep-in-place-persist.md
+++ b/.changelog.d/quaker-keep-in-place-persist.md
@@ -1,0 +1,8 @@
+---
+branch: quaker-keep-in-place-persist
+---
+
+### fleet-console
+#### Fixed
+- Stay put on Tori, Bori, and Dori now survives a Console restart or update, so the aides remain moored at the last place you left them until you switch it off.
+  ko: 토리·보리·도리의 제자리에 두기가 콘솔을 다시 시작하거나 업데이트한 뒤에도 유지되어, 끄기 전까지 마지막으로 둔 자리에 정박해 있습니다.

--- a/runtime/fleet-plugins/scuttlebutt/client/flock.tsx
+++ b/runtime/fleet-plugins/scuttlebutt/client/flock.tsx
@@ -18,6 +18,8 @@ import {
   createBirdBody,
   PERSONAS,
   pickWaypoint,
+  placeStayPut,
+  stayPutFractions,
   stepFlock,
   type BirdBody,
   type BirdFrame,
@@ -25,6 +27,7 @@ import {
 import {
   getScuttlebuttSettings,
   subscribeScuttlebuttSettings,
+  writeAideStayPut,
 } from "./settings-store.js";
 
 const MORPHS = ["tori", "bori", "dori"] as const;
@@ -105,7 +108,16 @@ export function ScuttlebuttFlock({ context }: { readonly context: FloatingWidget
   });
   const bodiesRef = React.useRef<readonly BirdBody[] | null>(null);
   if (bodiesRef.current === null) {
-    bodiesRef.current = MORPHS.map((_, index) => createBirdBody(index, viewportRef.current, Math.random));
+    const stored = getScuttlebuttSettings();
+    bodiesRef.current = MORPHS.map((morph, index) => {
+      const body = createBirdBody(index, viewportRef.current, Math.random);
+      const stay = stored.stayPut[morph];
+      body.moored = stay.enabled;
+      if (stay.enabled && stay.nx != null && stay.ny != null) {
+        placeStayPut(body, viewportRef.current, stay.nx, stay.ny);
+      }
+      return body;
+    });
   }
   const birdRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
   // 소식은 근무 중인 첫 제독이 전한다 — 토리에 고정하면 토리를 끈 순간 알릴 곳이 사라진다.
@@ -136,16 +148,20 @@ export function ScuttlebuttFlock({ context }: { readonly context: FloatingWidget
   const [answering, setAnswering] = React.useState<readonly AdmiralId[]>([]);
   // 답을 세우려고 우리가 정박시킨 부관들. 사용자가 직접 세운 정박과 구분해야 되돌릴 때 남의 것을 내리지 않는다.
   const mentionMooredRef = React.useRef(new Set<AdmiralId>());
-  // 정박은 이 세션 동안만 산다 — 설정에도 preferences에도 남기지 않는다.
-  const [moored, setMoored] = React.useState<readonly boolean[]>([false, false, false]);
+  // 사용자가 켠 정박은 설정에 남긴다 — 멘션이 답을 읽으라고 잠깐 세운 정박만 이 세션에서 끝난다.
+  const [moored, setMoored] = React.useState<readonly boolean[]>(() =>
+    MORPHS.map((morph) => getScuttlebuttSettings().stayPut[morph].enabled),
+  );
   const [positionRevision, setPositionRevision] = React.useState(0);
 
   const applyMoored = React.useCallback((index: number, resolve: (current: boolean) => boolean) => {
     setMoored((current) => {
-      const next = replaceAt(current, index, resolve(current[index] ?? false));
+      const nextValue = resolve(current[index] ?? false);
+      const next = replaceAt(current, index, nextValue);
+      if (next === current) return current;
       const body = bodiesRef.current?.[index];
       if (body) {
-        body.moored = next[index] ?? false;
+        body.moored = nextValue;
         // 풀어 주면 자던 새도 깨워 가까운 새 항로부터 다시 시작한다.
         if (!body.moored) {
           body.mode = "fly";
@@ -159,7 +175,17 @@ export function ScuttlebuttFlock({ context }: { readonly context: FloatingWidget
   }, []);
 
   const toggleMoored = React.useCallback((index: number) => {
-    applyMoored(index, (current) => !current);
+    const admiral = MORPHS[index]!;
+    let next = false;
+    applyMoored(index, (current) => {
+      next = !current;
+      return next;
+    });
+    const body = bodiesRef.current?.[index];
+    const fractions = body ? stayPutFractions(body, viewportRef.current) : { nx: null, ny: null };
+    void writeAideStayPut(admiral, next
+      ? { enabled: true, nx: fractions.nx, ny: fractions.ny }
+      : { enabled: false, nx: null, ny: null });
   }, [applyMoored]);
 
   /**
@@ -195,8 +221,37 @@ export function ScuttlebuttFlock({ context }: { readonly context: FloatingWidget
    */
   const releaseMentionMoor = React.useCallback((admiral: AdmiralId) => {
     if (!mentionMooredRef.current.delete(admiral)) return;
-    applyMoored(MORPHS.indexOf(admiral), () => false);
+    applyMoored(MORPHS.indexOf(admiral), () => getScuttlebuttSettings().stayPut[admiral].enabled);
   }, [applyMoored]);
+
+  // 설정 읽기가 늦게 도착해도 첫 페인트 전에 정박을 얹는다 — 한 프레임 순항했다가 붙으면 튄다.
+  React.useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    const bodies = bodiesRef.current;
+    if (!bodies) return;
+    const frames = [...motionFramesRef.current];
+    let placed = false;
+    for (let index = 0; index < MORPHS.length; index += 1) {
+      const admiral = MORPHS[index]!;
+      if (mentionMooredRef.current.has(admiral)) continue;
+      const stay = settings.stayPut[admiral];
+      applyMoored(index, () => stay.enabled);
+      const body = bodies[index]!;
+      if (stay.enabled && stay.nx != null && stay.ny != null) {
+        placeStayPut(body, viewport, stay.nx, stay.ny);
+        const left = body.x - BIRD_HALF_WIDTH;
+        const top = body.y - BIRD_HALF_HEIGHT;
+        frames[index] = { left, top, tilt: 0, flight: "hover", mode: body.mode };
+        const element = birdRefs.current[index];
+        if (element) element.style.transform = `translate(${left}px, ${top}px) rotate(0deg)`;
+        placed = true;
+      }
+    }
+    if (placed) {
+      motionFramesRef.current = frames;
+      setMotionFrames(frames);
+    }
+  }, [applyMoored, settings.stayPut]);
 
   const closeAnswer = React.useCallback((admiral: AdmiralId) => {
     setAnswering((current) => current.filter((candidate) => candidate !== admiral));
@@ -476,6 +531,11 @@ export function ScuttlebuttFlock({ context }: { readonly context: FloatingWidget
     pickWaypoint(body, viewportRef.current, Math.random);
     gesturesRef.current[index] = null;
     setGrabbed((current) => replaceAt(current, index, false));
+    const admiral = MORPHS[index]!;
+    if (body.moored && !mentionMooredRef.current.has(admiral) && moved >= 7) {
+      const { nx, ny } = stayPutFractions(body, viewportRef.current);
+      void writeAideStayPut(admiral, { enabled: true, nx, ny });
+    }
   }, [clearTimer, clickAction]);
 
   const t = getT(context.language);

--- a/runtime/fleet-plugins/scuttlebutt/client/roaming.ts
+++ b/runtime/fleet-plugins/scuttlebutt/client/roaming.ts
@@ -98,6 +98,23 @@ export function stepMooredBehavior(body: BirdBody, time: number, random: () => n
   body.modeUntil = time + rand(picked.span[0], picked.span[1], random);
 }
 
+/** 저장된 화면비 좌표를 현재 뷰포트에 다시 얹는다 — 창 크기가 바뀌어도 같은 자리에 가깝게 선다. */
+export function placeStayPut(body: BirdBody, viewport: Viewport, nx: number, ny: number): void {
+  body.x = clamp(nx * viewport.width, BIRD_HALF_WIDTH + 6, viewport.width - BIRD_HALF_WIDTH - 6);
+  body.y = clamp(ny * viewport.height, BIRD_HALF_HEIGHT + 10, viewport.height - BIRD_HALF_HEIGHT - 2);
+  body.vx = 0;
+  body.vy = 0;
+}
+
+export function stayPutFractions(body: BirdBody, viewport: Viewport): { nx: number; ny: number } {
+  const nx = viewport.width > 0 ? body.x / viewport.width : 0.5;
+  const ny = viewport.height > 0 ? body.y / viewport.height : 0.5;
+  return {
+    nx: clamp(nx, 0, 1),
+    ny: clamp(ny, 0, 1),
+  };
+}
+
 export function pickWaypoint(body: BirdBody, viewport: Viewport, random: () => number): void {
   body.deckPlan = false;
   body.tx = rand(70, viewport.width - 70, random);

--- a/runtime/fleet-plugins/scuttlebutt/client/settings-store.ts
+++ b/runtime/fleet-plugins/scuttlebutt/client/settings-store.ts
@@ -1,11 +1,29 @@
 import type { ClientSettingsCapability } from "@fleet-console/sdk/plugin";
 
+export type ScuttlebuttAideId = "tori" | "bori" | "dori";
+
+export interface AideStayPut {
+  readonly enabled: boolean;
+  readonly nx: number | null;
+  readonly ny: number | null;
+}
+
+export type StayPutMap = Record<ScuttlebuttAideId, AideStayPut>;
+
 export interface ScuttlebuttSettings {
   readonly tori: boolean;
   readonly bori: boolean;
   readonly dori: boolean;
   readonly departureBell: boolean;
+  readonly stayPut: StayPutMap;
 }
+
+const IDLE_STAY_PUT: AideStayPut = Object.freeze({ enabled: false, nx: null, ny: null });
+const DEFAULT_STAY_PUT: StayPutMap = Object.freeze({
+  tori: IDLE_STAY_PUT,
+  bori: IDLE_STAY_PUT,
+  dori: IDLE_STAY_PUT,
+});
 
 // 실험 기능이라 아무것도 켜지 않은 채로 출발한다 — 상주하는 마스코트는 스스로 골라 들이는 것이다.
 const DEFAULT_SETTINGS: ScuttlebuttSettings = {
@@ -13,6 +31,7 @@ const DEFAULT_SETTINGS: ScuttlebuttSettings = {
   bori: false,
   dori: false,
   departureBell: true,
+  stayPut: DEFAULT_STAY_PUT,
 };
 
 let settings = DEFAULT_SETTINGS;
@@ -53,6 +72,16 @@ export async function writeScuttlebuttSettings(patch: Partial<ScuttlebuttSetting
   }
 }
 
+export async function writeAideStayPut(
+  admiral: ScuttlebuttAideId,
+  next: AideStayPut,
+): Promise<void> {
+  const current = getScuttlebuttSettings();
+  await writeScuttlebuttSettings({
+    stayPut: { ...current.stayPut, [admiral]: next },
+  });
+}
+
 function parseSettings(value: Record<string, unknown> | null): ScuttlebuttSettings {
   if (!value) return DEFAULT_SETTINGS;
   return {
@@ -60,7 +89,34 @@ function parseSettings(value: Record<string, unknown> | null): ScuttlebuttSettin
     bori: typeof value.bori === "boolean" ? value.bori : false,
     dori: typeof value.dori === "boolean" ? value.dori : false,
     departureBell: typeof value.departureBell === "boolean" ? value.departureBell : true,
+    stayPut: parseStayPutMap(value.stayPut),
   };
+}
+
+function parseStayPutMap(value: unknown): StayPutMap {
+  if (!value || typeof value !== "object") return DEFAULT_STAY_PUT;
+  const rec = value as Record<string, unknown>;
+  return {
+    tori: parseAideStayPut(rec.tori),
+    bori: parseAideStayPut(rec.bori),
+    dori: parseAideStayPut(rec.dori),
+  };
+}
+
+function parseAideStayPut(value: unknown): AideStayPut {
+  if (value === true) return { enabled: true, nx: null, ny: null };
+  if (value === false || value == null || typeof value !== "object") return IDLE_STAY_PUT;
+  const rec = value as Record<string, unknown>;
+  const enabled = rec.enabled === true;
+  const nx = parseFraction(rec.nx);
+  const ny = parseFraction(rec.ny);
+  if (nx == null || ny == null) return { enabled, nx: null, ny: null };
+  return { enabled, nx, ny };
+}
+
+function parseFraction(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(1, value));
 }
 
 function emit(): void {

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-mention-delivery.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-mention-delivery.test.ts
@@ -39,6 +39,17 @@ describe("mention delivery ownership", () => {
   it("never releases a moor the user set themselves", () => {
     expect(flock).toMatch(/if \(!current\) mentionMooredRef\.current\.add\(admiral\);/u);
     expect(flock).toMatch(/if \(!mentionMooredRef\.current\.delete\(admiral\)\) return;/u);
+    expect(flock).toMatch(/getScuttlebuttSettings\(\)\.stayPut\[admiral\]\.enabled/u);
+  });
+
+  it("persists a user stay-put switch and never persists a mention moor", () => {
+    expect(flock).toMatch(/void writeAideStayPut\(/u);
+    const mention = flock.match(/const askFromMention = React\.useCallback\(async \(admiral: AdmiralId, text: string\) => \{[\s\S]*?\}, \[applyMoored, sessions\]\);/u);
+    expect(mention?.[0]).toBeTruthy();
+    expect(mention?.[0]).not.toMatch(/writeAideStayPut/u);
+    const release = flock.match(/const releaseMentionMoor = React\.useCallback\(\(admiral: AdmiralId\) => \{[\s\S]*?\}, \[applyMoored\]\);/u);
+    expect(release?.[0]).toBeTruthy();
+    expect(release?.[0]).not.toMatch(/writeAideStayPut/u);
   });
 
   it("returns focus to the aide only when the answer was closed from the keyboard", () => {

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-roaming.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-roaming.test.ts
@@ -5,6 +5,8 @@ import {
   BIRD_HALF_WIDTH,
   PERSONAS,
   deckY,
+  placeStayPut,
+  stayPutFractions,
   stepFlock,
   type BirdBody,
   type BirdPersona,
@@ -193,6 +195,16 @@ describe("Scuttlebutt roaming engine", () => {
     const body = bird({ moored: true, modeUntil: 0, mode: "fly" });
     stepFlock([body], [persona], viewport, 0.1, 5, sequence(roll, 0));
     expect(body.mode).toBe(mode);
+  });
+
+  it("restores a stay-put fraction onto the current viewport and records it back", () => {
+    const body = bird({ x: 10, y: 10, vx: 80, vy: -40 });
+    placeStayPut(body, viewport, 0.25, 0.5);
+    expect(body.x).toBeCloseTo(200);
+    expect(body.y).toBeCloseTo(300);
+    expect(body.vx).toBeCloseTo(0);
+    expect(body.vy).toBeCloseTo(0);
+    expect(stayPutFractions(body, viewport)).toEqual({ nx: 0.25, ny: 0.5 });
   });
 
   it("keeps a moored bird out of the separation force", () => {

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-settings-store.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-settings-store.test.ts
@@ -4,8 +4,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
   connectScuttlebuttSettings,
   getScuttlebuttSettings,
+  writeAideStayPut,
   writeScuttlebuttSettings,
 } from "../client/settings-store.js";
+
+const idleStay = { enabled: false, nx: null, ny: null };
+const idleStayPut = { tori: idleStay, bori: idleStay, dori: idleStay };
 
 describe("Scuttlebutt settings store", () => {
   // 실험 기능이라 켠 적 없는 항목은 전부 꺼진 상태로 읽는다.
@@ -18,6 +22,7 @@ describe("Scuttlebutt settings store", () => {
       bori: false,
       dori: false,
       departureBell: true,
+      stayPut: idleStayPut,
     });
     disconnect();
   });
@@ -31,6 +36,7 @@ describe("Scuttlebutt settings store", () => {
       bori: false,
       dori: false,
       departureBell: true,
+      stayPut: idleStayPut,
     });
     disconnect();
   });
@@ -50,6 +56,7 @@ describe("Scuttlebutt settings store", () => {
       bori: true,
       dori: false,
       departureBell: false,
+      stayPut: idleStayPut,
     });
     await writeScuttlebuttSettings({ bori: false });
     expect(getScuttlebuttSettings().bori).toBe(false);
@@ -58,6 +65,7 @@ describe("Scuttlebutt settings store", () => {
       bori: false,
       dori: false,
       departureBell: false,
+      stayPut: idleStayPut,
     });
     disconnect();
   });
@@ -72,6 +80,80 @@ describe("Scuttlebutt settings store", () => {
     await settleRead();
     expect(getScuttlebuttSettings().departureBell).toBe(true);
     unset();
+  });
+
+  it("reads a boolean stay-put flag as enabled without a saved spot", async () => {
+    const disconnect = connectScuttlebuttSettings(capability({ stayPut: { tori: true } }));
+    await settleRead();
+
+    expect(getScuttlebuttSettings().stayPut).toEqual({
+      tori: { enabled: true, nx: null, ny: null },
+      bori: idleStay,
+      dori: idleStay,
+    });
+    disconnect();
+  });
+
+  it("reads a stay-put spot and clamps fractions onto the unit interval", async () => {
+    const disconnect = connectScuttlebuttSettings(capability({
+      stayPut: {
+        bori: { enabled: true, nx: 0.25, ny: 1.4 },
+        dori: { enabled: true, nx: "0.3", ny: 0.4 },
+      },
+    }));
+    await settleRead();
+
+    expect(getScuttlebuttSettings().stayPut).toEqual({
+      tori: idleStay,
+      bori: { enabled: true, nx: 0.25, ny: 1 },
+      dori: { enabled: true, nx: null, ny: null },
+    });
+    disconnect();
+  });
+
+  it("writes one aide's stay-put without touching the roster switches", async () => {
+    const settings = capability({ tori: true, bori: true });
+    const disconnect = connectScuttlebuttSettings(settings);
+    await settleRead();
+
+    await writeAideStayPut("bori", { enabled: true, nx: 0.4, ny: 0.7 });
+    expect(getScuttlebuttSettings()).toEqual({
+      tori: true,
+      bori: true,
+      dori: false,
+      departureBell: true,
+      stayPut: {
+        tori: idleStay,
+        bori: { enabled: true, nx: 0.4, ny: 0.7 },
+        dori: idleStay,
+      },
+    });
+    expect(settings.write).toHaveBeenCalledWith("scuttlebutt", {
+      tori: true,
+      bori: true,
+      dori: false,
+      departureBell: true,
+      stayPut: {
+        tori: idleStay,
+        bori: { enabled: true, nx: 0.4, ny: 0.7 },
+        dori: idleStay,
+      },
+    });
+    disconnect();
+  });
+
+  it("keeps stay-put when a roster switch is written", async () => {
+    const settings = capability({
+      tori: true,
+      stayPut: { tori: { enabled: true, nx: 0.2, ny: 0.3 } },
+    });
+    const disconnect = connectScuttlebuttSettings(settings);
+    await settleRead();
+
+    await writeScuttlebuttSettings({ bori: true });
+    expect(getScuttlebuttSettings().stayPut.tori).toEqual({ enabled: true, nx: 0.2, ny: 0.3 });
+    expect(getScuttlebuttSettings().bori).toBe(true);
+    disconnect();
   });
 });
 


### PR DESCRIPTION
## Summary
- 토리·보리·도리의 **제자리에 두기**를 플러그인 설정에 저장해 콘솔 재시작·업데이트 뒤에도 유지합니다.
- 마지막으로 둔 자리(화면비 좌표)를 함께 복원하고, 정박 중 끌어다 옮긴 위치만 갱신합니다.
- Quick Launch 멘션이 답을 읽으라고 잠깐 세운 정박은 세션에서만 끝나며, 사용자가 켠 정박은 건드리지 않습니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/scuttlebutt test` (145)
- [x] `pnpm --filter @fleet-plugins/scuttlebutt typecheck`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] 카드에서 제자리에 두기를 켜고 콘솔을 다시 열면 그 부관이 같은 자리에 붙어 있는지
- [ ] 정박 중 새를 끌어다 옮긴 뒤 다시 열면 그 자리로 복원되는지
- [ ] 멘션으로 물은 답을 닫으면 사용자가 켜지 않은 새는 다시 순항하는지