### PR TITLE
fix(core-ai-gateway): bound a Grok stream that stops emitting events

### DIFF
--- a/.changelog.d/xai-stall-watchdog.md
+++ b/.changelog.d/xai-stall-watchdog.md
@@ -1,0 +1,8 @@
+---
+branch: xai-stall-watchdog
+---
+
+### fleet-console
+#### Fixed
+- End a Grok turn whose upstream went quiet mid-stream, instead of waiting on it indefinitely because the proxy keeps the connection alive without sending anything.
+  ko: 스트리밍 도중 업스트림이 조용해진 Grok 턴을 끝냅니다. 프록시가 아무것도 보내지 않으면서 연결만 살려 두어도 무한정 기다리지 않습니다.

--- a/packages/core-ai-gateway/src/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/xai/responses/adapter.ts
@@ -27,6 +27,16 @@ export const XAI_CLI_CLIENT_VERSION = "1.0.3";
 export const DEFAULT_XAI_RESPONSES_MAX_UPSTREAM_BODY_BYTES = 64 * 1024 * 1024;
 export const DEFAULT_XAI_RESPONSES_UPSTREAM_IDLE_TIMEOUT_MS = 30_000;
 export const DEFAULT_XAI_RESPONSES_FUNCTION_CALL_TIMEOUT_MS = 30_000;
+/**
+ * Longest gap tolerated between two canonical events on one Grok CLI stream.
+ *
+ * The transport idle timeout watches bytes, so a proxy that keeps writing SSE comments while the
+ * model produces nothing resets it forever. Wire captures show that exact shape: streams that fell
+ * silent after `content_part.added` or mid `output_text.delta` and were still parked ten minutes
+ * later. Measured gaps inside healthy turns are p99 0.38s and 5.9s at worst, so a minute is two
+ * orders of magnitude of headroom while still bounding a hang that used to be unbounded.
+ */
+export const DEFAULT_XAI_RESPONSES_SEMANTIC_STALL_TIMEOUT_MS = 60_000;
 const XAI_RETRY_DELAY_MS = 200;
 
 /**
@@ -49,6 +59,7 @@ export interface XaiResponsesAdapterOptions {
   maxBodyBytes?: number;
   idleTimeoutMs?: number;
   functionCallTimeoutMs?: number;
+  semanticStallTimeoutMs?: number;
   /** 구독 경로가 요구하는 추가 헤더. */
   headers?: Readonly<Record<string, string>>;
 }
@@ -60,6 +71,7 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
   private readonly maxBodyBytes: number;
   private readonly idleTimeoutMs: number;
   private readonly functionCallTimeoutMs: number;
+  private readonly semanticStallTimeoutMs: number;
   private readonly url: string;
   private readonly extraHeaders: Readonly<Record<string, string>>;
 
@@ -82,6 +94,10 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
     this.functionCallTimeoutMs = positiveInteger(
       options.functionCallTimeoutMs ?? DEFAULT_XAI_RESPONSES_FUNCTION_CALL_TIMEOUT_MS,
       "functionCallTimeoutMs"
+    );
+    this.semanticStallTimeoutMs = positiveInteger(
+      options.semanticStallTimeoutMs ?? DEFAULT_XAI_RESPONSES_SEMANTIC_STALL_TIMEOUT_MS,
+      "semanticStallTimeoutMs"
     );
   }
 
@@ -189,7 +205,7 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
         idleTimeoutMs: this.idleTimeoutMs,
         maxBodyBytes: this.maxBodyBytes,
         onClose: () => undefined
-      }, this.functionCallTimeoutMs)
+      }, this.functionCallTimeoutMs, this.semanticStallTimeoutMs)
     };
   }
 
@@ -461,7 +477,8 @@ async function abortableXaiDelay(delayMs: number, signal: AbortSignal): Promise<
 function parseXaiEventStream(
   body: ReadableStream<Uint8Array> | null,
   options: ReadOptions & { onClose: () => void },
-  functionCallTimeoutMs: number
+  functionCallTimeoutMs: number,
+  semanticStallTimeoutMs: number,
 ): AsyncGenerator<CanonicalResponseEvent> {
   return assembleXaiFunctionCalls(
     parseUpstreamSseStream(
@@ -471,6 +488,7 @@ function parseXaiEventStream(
     ),
     options.controller,
     functionCallTimeoutMs,
+    semanticStallTimeoutMs,
   );
 }
 
@@ -489,27 +507,47 @@ async function* assembleXaiFunctionCalls(
   source: AsyncIterable<CanonicalResponseEvent>,
   controller: AbortController,
   timeoutMs: number,
+  semanticStallTimeoutMs: number,
 ): AsyncGenerator<CanonicalResponseEvent> {
   const iterator = source[Symbol.asyncIterator]();
   const pending = new Map<string, PendingXaiFunctionCall>();
   let snapshot: CanonicalResponseSnapshot | undefined;
   let completedNormally = false;
+  // The stall clock starts at the first read, so a proxy that accepts the request and then never
+  // writes an event is bounded too — not only one that goes quiet mid-turn.
+  let lastEventAt = Date.now();
+  let lastEventType: string | undefined;
   try {
     while (true) {
-      const deadlineAt = earliestXaiFunctionCallDeadline(pending);
-      const result = deadlineAt === undefined
-        ? await iterator.next()
-        : await nextXaiEventBeforeDeadline(iterator, deadlineAt);
+      const callDeadlineAt = earliestXaiFunctionCallDeadline(pending);
+      const stallDeadlineAt = lastEventAt + semanticStallTimeoutMs;
+      const callDeadlineFirst = callDeadlineAt !== undefined && callDeadlineAt <= stallDeadlineAt;
+      const result = await nextXaiEventBeforeDeadline(
+        iterator,
+        Math.min(stallDeadlineAt, callDeadlineAt ?? Number.POSITIVE_INFINITY),
+      );
       if (result === XAI_ASSEMBLY_DEADLINE) {
-        yield* salvageXaiPendingCalls(
+        if (callDeadlineFirst) {
+          yield* salvageXaiPendingCalls(
+            pending,
+            snapshot,
+            `function call assembly exceeded ${timeoutMs}ms`,
+            controller,
+          );
+          completedNormally = true;
+          return;
+        }
+        yield* failXaiSemanticStall(
           pending,
           snapshot,
-          `function call assembly exceeded ${timeoutMs}ms`,
+          semanticStallTimeoutMs,
+          lastEventType,
           controller,
         );
         completedNormally = true;
         return;
       }
+      lastEventAt = Date.now();
       if (result.done) {
         if (pending.size > 0) {
           yield* salvageXaiPendingCalls(
@@ -524,6 +562,7 @@ async function* assembleXaiFunctionCalls(
       }
 
       const event = result.value;
+      lastEventType = event.type;
       if (event.type === "response.created") {
         snapshot = event.response;
       }
@@ -650,6 +689,39 @@ async function* salvageXaiPendingCalls(
   }
   // The client-facing encoder requires a terminal frame, and usage is genuinely unknown here.
   yield { type: "response.completed", response: { ...snapshot, usage: null } };
+}
+
+/**
+ * The stream went quiet without a terminal frame. A pending function call is still worth the
+ * salvage rule above — the model may have finished writing it — but a turn with nothing pending
+ * has only a partial answer to show for itself, and sealing that as `response.completed` would
+ * present a truncated reply as a finished one. Failing is the honest outcome there.
+ */
+async function* failXaiSemanticStall(
+  pending: Map<string, PendingXaiFunctionCall>,
+  snapshot: CanonicalResponseSnapshot | undefined,
+  semanticStallTimeoutMs: number,
+  lastEventType: string | undefined,
+  controller: AbortController,
+): AsyncGenerator<CanonicalResponseEvent> {
+  const reason = `upstream emitted no event for ${semanticStallTimeoutMs}ms`;
+  wireLog("xai-responses.stream.stalled", {
+    semanticStallTimeoutMs,
+    pendingFunctionCalls: pending.size,
+    lastEvent: lastEventType ?? null,
+  });
+  if (pending.size > 0) {
+    yield* salvageXaiPendingCalls(pending, snapshot, reason, controller);
+    return;
+  }
+  const error = xaiSemanticStallError(reason);
+  // The upstream read is parked on a stream that stopped writing; aborting is what unwinds it.
+  controller.abort(error);
+  throw error;
+}
+
+function xaiSemanticStallError(reason: string): UpstreamProtocolError {
+  return new UpstreamProtocolError(`Grok CLI ${reason}`);
 }
 
 /** The absorbed buffer, or the streamed `.done` payload, only when it is a complete JSON object. */

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -791,6 +791,147 @@ describe("Grok Responses function-call assembly", () => {
   });
 });
 
+describe("Grok Responses stall watchdog", () => {
+  it("requires a positive semantic stall timeout option", () => {
+    expect(() => new XaiResponsesAdapter({ semanticStallTimeoutMs: 0 })).toThrow("semanticStallTimeoutMs must be a positive integer");
+    expect(() => new XaiResponsesAdapter({ semanticStallTimeoutMs: -1 })).toThrow("semanticStallTimeoutMs must be a positive integer");
+    expect(() => new XaiResponsesAdapter({ semanticStallTimeoutMs: 1.5 })).toThrow("semanticStallTimeoutMs must be a positive integer");
+  });
+
+  it("fails a stream that stops emitting events while keepalive bytes keep arriving", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, semanticStallTimeoutMs: 100 })
+        .stream(xaiRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      const eventsExpectation = expect(events).rejects.toThrow("emitted no event for 100ms");
+      controlled.push(xaiFrame(responseCreated()));
+      controlled.push(xaiFrame(textDelta("partial")));
+      await flushXaiStream();
+      // Comments feed the byte-level idle watchdog without carrying an event; before the stall
+      // clock existed this was enough to park the read indefinitely.
+      await vi.advanceTimersByTimeAsync(60);
+      controlled.push(": keepalive\n\n");
+      await flushXaiStream();
+      await vi.advanceTimersByTimeAsync(60);
+      await eventsExpectation;
+      expect(controlled.wasCancelled()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds a stream that never emits its first event", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, semanticStallTimeoutMs: 100 })
+        .stream(xaiRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      const eventsExpectation = expect(events).rejects.toThrow("emitted no event for 100ms");
+      await flushXaiStream();
+      await vi.advanceTimersByTimeAsync(100);
+      await eventsExpectation;
+      expect(controlled.wasCancelled()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a slow but progressing stream alive past the stall timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, semanticStallTimeoutMs: 100 })
+        .stream(xaiRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      controlled.push(xaiFrame(responseCreated()));
+      await flushXaiStream();
+      // Total elapsed time far exceeds the timeout; every individual gap stays under it.
+      for (const chunk of ["one", "two", "three"]) {
+        await vi.advanceTimersByTimeAsync(60);
+        controlled.push(xaiFrame(textDelta(chunk)));
+        await flushXaiStream();
+      }
+      controlled.push(xaiFrame(responseCompleted()));
+      controlled.close();
+      await expect(events).resolves.toEqual([
+        responseCreated(),
+        textDelta("one"),
+        textDelta("two"),
+        textDelta("three"),
+        responseCompleted(),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still salvages a complete pending call when the stall fires first", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({
+        fetch: fetchMock,
+        functionCallTimeoutMs: 10_000,
+        semanticStallTimeoutMs: 100,
+      }).stream(functionCallRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      controlled.push(xaiFrame(responseCreated()));
+      controlled.push(xaiFrame(functionCallAdded("call-1")));
+      controlled.push(xaiFrame(argumentsDelta("call-1", 0, '{"path":"a.ts"}')));
+      await flushXaiStream();
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(events).resolves.toEqual([
+        responseCreated(),
+        functionCallAdded("call-1"),
+        argumentsDone("call-1", 0, '{"path":"a.ts"}'),
+        functionCallDone("call-1", 0, '{"path":"a.ts"}'),
+        { type: "response.completed", response: xaiSnapshot() },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("records the stall with the last event it saw", async () => {
+    vi.useFakeTimers();
+    const wire = wireLogFixture("fleet-xai-stall-");
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, semanticStallTimeoutMs: 100 })
+        .stream(xaiRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      const eventsExpectation = expect(events).rejects.toThrow("emitted no event for 100ms");
+      controlled.push(xaiFrame(responseCreated()));
+      await flushXaiStream();
+      await vi.advanceTimersByTimeAsync(100);
+      await eventsExpectation;
+      const stalled = wire.read().filter((entry) => entry.event === "xai-responses.stream.stalled");
+      expect(stalled).toHaveLength(1);
+      expect(stalled[0]?.payload).toEqual({
+        semanticStallTimeoutMs: 100,
+        pendingFunctionCalls: 0,
+        lastEvent: "response.created",
+      });
+    } finally {
+      wire.cleanup();
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("Grok Responses retry", () => {
   function failed(type = "server_error", id = "r1"): CanonicalResponseEvent {
     return {


### PR DESCRIPTION
## Summary
- Grok CLI 스트림의 이벤트 간격에 데드라인을 추가했습니다. 전송 계층의 idle 타임아웃은 바이트 기준이라, 프록시가 SSE comment만 계속 흘리면 영원히 리셋됩니다. 와이어 로그에는 `content_part.added` 직후나 `output_text.delta` 도중 조용해진 뒤 10분 넘게 종결 프레임 없이 매달린 스트림이 남아 있었습니다.
- 스톨 시각에 pending 함수호출이 있으면 기존 salvage 규칙을 그대로 태우고, pending이 없으면 오류로 끝냅니다. 부분 답변을 `response.completed`로 봉인하면 잘린 응답을 완성된 것으로 제시하게 되므로 실패가 정직한 결과입니다.
- 기본값 60초는 실측 근거로 정했습니다. 정상 턴의 이벤트 간격은 p99 0.38초, 최악 5.9초입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 779 passed (35 files), 신규 6건 포함
- [x] `pnpm --filter @dotobokuri/core-ai-gateway exec tsc --noEmit -p tsconfig.json`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty` — 18 entries validated
- [x] `pnpm check:core-boundary` / `check:claude-agent-sdk-boundary` / `check:core-unified-agent-absent`
- [x] 역검증: 워치독 로직을 제거하면 신규 테스트 4건이 매달려 타임아웃 실패 (프로덕션에서 관측한 무한 대기와 동일 증상)
- 미실행: 워크스페이스 전체 typecheck는 `fleet-admiral`/`fleet-console`에 선존 실패(`InjectAgentCliProfileOptions.buildSystemPrompt`)가 있어 통과하지 않습니다. 본 변경 없이 `git stash` 상태에서 동일 오류를 재현해 선존임을 확인했습니다.