### PR TITLE
feat(fleet-console): add xAI Grok Composer 2.5 Fast to the gateway

### DIFF
--- a/.changelog.d/worktree-xai-grok-composer-fast.md
+++ b/.changelog.d/worktree-xai-grok-composer-fast.md
@@ -1,0 +1,8 @@
+---
+branch: worktree-xai-grok-composer-fast
+---
+
+### fleet-console
+#### Added
+- Offer xAI Grok Composer 2.5 Fast in the AI Gateway model picker.
+  ko: AI Gateway 모델 목록에 xAI Grok Composer 2.5 Fast를 넣습니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-17T00:00:00Z",
+  "updatedAt": "2026-08-19T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
@@ -731,7 +731,7 @@
     "xai": {
       "name": "xAI",
       "defaultModel": "grok-4.6",
-      "source": "official Grok CLI 1.0.3 ~/.grok/models_cache.json from GET https://cli-chat-proxy.grok.com/v1/models (observed 2026-08-13)",
+      "source": "official Grok CLI 1.0.4 ~/.grok/models_cache.json from GET https://cli-chat-proxy.grok.com/v1/models (grok-4.6 observed 2026-08-13); grok-composer-2.5-fast is the account-verified OpenCodex xAI identity, live POST /v1/responses accepted on the Grok CLI proxy 2026-08-19 (absent from the public docs.x.ai catalog)",
       "models": [
         {
           "modelId": "grok-4.6",
@@ -749,6 +749,13 @@
             ]
           },
           "benchmarkKey": "grok-4.6"
+        },
+        {
+          "modelId": "grok-composer-2.5-fast",
+          "name": "Grok-Composer-2.5-Fast",
+          "capabilityClass": "light",
+          "wire": "responses",
+          "contextWindow": 200000
         }
       ]
     }

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -1954,7 +1954,7 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(43);
+    expect(list.data).toHaveLength(44);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-luna");
@@ -2003,6 +2003,10 @@ describe("route surface", () => {
     expect(list.data).toContainEqual(expect.objectContaining({
       id: "claude-gateway--xai--grok-4.6",
       display_name: "xAI-Grok-4.6",
+    }));
+    expect(list.data).toContainEqual(expect.objectContaining({
+      id: "claude-gateway--xai--grok-composer-2.5-fast",
+      display_name: "xAI-Grok-Composer-2.5-Fast",
     }));
     expect(list.data.every((entry) => /^(Codex|Cursor|Moonshot-Kimi|OpenCode|xAI)-/.test(entry.display_name))).toBe(true);
   });

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -698,6 +698,7 @@ describe("model catalog", () => {
     // 분배됐다. 이 둘은 provider 스스로 light 로 자리매김한 모델이다.
     expect(findGatewayModel("codex--gpt-5.6-luna")?.capabilityClass).toBe("light");
     expect(findGatewayModel("opencode--deepseek-v4-flash")?.capabilityClass).toBe("light");
+    expect(findGatewayModel("xai--grok-composer-2.5-fast")?.capabilityClass).toBe("light");
     expect(findGatewayModel("codex--gpt-5.6-sol")?.capabilityClass).toBe("flagship");
     // -fast 는 같은 upstream 의 서비스 티어라 base 의 class 를 따른다.
     expect(findGatewayModel("codex--gpt-5.6-sol-fast")?.capabilityClass).toBe("flagship");
@@ -1159,6 +1160,10 @@ describe("model catalog", () => {
       display_name: "xAI-Grok-4.6",
       max_input_tokens: 500_000,
     });
+    expect(list.data.find((entry) => entry.id === "claude-gateway--xai--grok-composer-2.5-fast")).toMatchObject({
+      display_name: "xAI-Grok-Composer-2.5-Fast",
+      max_input_tokens: 200_000,
+    });
     expect(list.data.find((entry) => entry.id.endsWith("cursor--composer-2.5"))).toMatchObject({
       display_name: "Cursor-Composer-2.5",
       max_input_tokens: 200_000,
@@ -1268,6 +1273,7 @@ describe("model catalog", () => {
     const cursorGrok = entries.get("claude-gateway--cursor--grok-4.5");
     const cursorGrok46 = entries.get("claude-gateway--cursor--grok-4.6");
     const cursorComposer = entries.get("claude-gateway--cursor--composer-2.5-fast");
+    const xaiComposer = entries.get("claude-gateway--xai--grok-composer-2.5-fast");
 
     expect(sol?.capabilities.effort).toEqual({
       supported: true,
@@ -1314,6 +1320,16 @@ describe("model catalog", () => {
       xhigh: { supported: true },
     });
     expect(cursorGrok46?.max_input_tokens).toBe(256_000);
+    expect(xaiComposer?.max_input_tokens).toBe(200_000);
+    expect(xaiComposer?.capabilities.effort).toEqual({
+      supported: false,
+      low: { supported: false },
+      medium: { supported: false },
+      high: { supported: false },
+      max: { supported: false },
+      xhigh: null,
+    });
+    expect(xaiComposer?.capabilities.thinking.supported).toBe(false);
   });
 
   it("unwraps the alias a picked model comes back as", () => {

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -639,7 +639,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(43);
+    expect(cache.models).toHaveLength(44);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-524k-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-1m-fast[1m]");
@@ -668,6 +668,10 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.models).toContainEqual(expect.objectContaining({
       id: "claude-gateway--xai--grok-4.6",
       display_name: "xAI-Grok-4.6",
+    }));
+    expect(cache.models).toContainEqual(expect.objectContaining({
+      id: "claude-gateway--xai--grok-composer-2.5-fast",
+      display_name: "xAI-Grok-Composer-2.5-Fast",
     }));
     expect(cache.models.every((model) => model.id.startsWith("claude"))).toBe(true);
     expect(cache.models.every((model) => /^(Codex|Cursor|Moonshot-Kimi|OpenCode|xAI)-/.test(model.display_name))).toBe(true);

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -50,6 +50,8 @@ describe("terminal settings routes", () => {
     const allIds = providers.flatMap((provider) => provider.models.map((model) => model.id));
     // Cursor 경유 Opus/Fable Max Mode와 Kimi 프로바이더는 다른 경로다 — 둘 다 노출한다.
     expect(allIds).toContain("kimi--k3");
+    expect(allIds).toContain("xai--grok-4.6");
+    expect(allIds).toContain("xai--grok-composer-2.5-fast");
     for (const id of [
       "cursor--auto",
       "cursor--composer-2.5",


### PR DESCRIPTION
## Summary
- xAI AI Gateway 카탈로그에 OpenCodex 식별자 `grok-composer-2.5-fast`(Grok Composer 2.5 Fast)를 light, effort 없음, Responses 와이어로 추가합니다.
- Grok CLI 프록시 `POST /v1/responses`가 이 식별자를 수락하는 것을 2026-08-19에 실측했습니다. 공개 docs.x.ai 카탈로그에는 없습니다.
- 설정 피커와 discovery 카운트 핀을 새 카탈로그 길이에 맞춥니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/fleet-console test -- tests/launch.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run tests/settings-routes.test.ts`
- [x] live `e2e:provider-loop` `--model claude-gateway--xai--grok-composer-2.5-fast --operations 1 --trials 1 --confirm-live-provider` (1 caller tool + 1 result, 2 gateway requests)
- [x] `~/.fleet/ai-gateway.json`에 `xai--grok-composer-2.5-fast` 노출