### PR TITLE
feat(ai-gateway): add five Cursor lineup models

### DIFF
--- a/.changelog.d/cursor-model-additions.md
+++ b/.changelog.d/cursor-model-additions.md
@@ -1,0 +1,13 @@
+---
+branch: cursor-model-additions
+---
+
+### fleet-cli
+#### Added
+- Offer Cursor's GPT-5.6 Sol, Terra, and Luna, Gemini 3.7 Flash, and Kimi K3 as gateway models, each with the reasoning rungs Cursor publishes for it.
+  ko: Cursor의 GPT-5.6 Sol·Terra·Luna, Gemini 3.7 Flash, Kimi K3를 게이트웨이 모델로 제공하며, 각 모델은 Cursor가 공개한 추론 단계를 그대로 따릅니다.
+
+### fleet-console
+#### Added
+- Offer Cursor's GPT-5.6 Sol, Terra, and Luna, Gemini 3.7 Flash, and Kimi K3 as gateway models, each with the reasoning rungs Cursor publishes for it.
+  ko: Cursor의 GPT-5.6 Sol·Terra·Luna, Gemini 3.7 Flash, Kimi K3를 게이트웨이 모델로 제공하며, 각 모델은 Cursor가 공개한 추론 단계를 그대로 따릅니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-19T00:00:00Z",
+  "updatedAt": "2026-08-20T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
@@ -396,7 +396,7 @@
     "cursor": {
       "name": "Cursor",
       "defaultModel": "auto",
-      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); cursor-agent 2026.08.11-e8db854 observed 2026-08-13 for grok-4.6; claude-opus-5 and claude-fable-5 standard/Max Mode windows observed 2026-08-10; quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
+      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); cursor-agent 2026.08.11-e8db854 observed 2026-08-13 for grok-4.6; claude-opus-5 and claude-fable-5 standard/Max Mode windows observed 2026-08-10; quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05); gpt-5.6-sol/terra/luna, gemini-3.7-flash, and kimi-k3 ids, effort rungs, and api quotaScope observed 2026-08-20 from live GetUsableModels (cursor-agent 2026.08.11-e8db854) and GetCurrentPeriodUsage autoBucketModels. Their windows are unmeasured because Cursor answers a first-turn Run with an empty token_details, so each carries the conservative cross-provider figure (272000 from the Codex catalog for the GPT-5.6 lineup, 256000 elsewhere); no Max Mode or -fast sibling is published for them",
       "models": [
         {
           "modelId": "auto",
@@ -578,6 +578,96 @@
             "upstreamModelIdTemplate": "claude-fable-5-{effort}"
           },
           "benchmarkKey": "claude-fable-5"
+        },
+        {
+          "modelId": "gpt-5.6-sol",
+          "name": "GPT-5.6-Sol",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "contextWindow": 272000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "gpt-5.6-sol-{effort}"
+          },
+          "benchmarkKey": "gpt-5.6-sol"
+        },
+        {
+          "modelId": "gpt-5.6-terra",
+          "name": "GPT-5.6-Terra",
+          "capabilityClass": "standard",
+          "quotaScope": "api",
+          "contextWindow": 272000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "gpt-5.6-terra-{effort}"
+          },
+          "benchmarkKey": "gpt-5.6-terra"
+        },
+        {
+          "modelId": "gpt-5.6-luna",
+          "name": "GPT-5.6-Luna",
+          "capabilityClass": "light",
+          "quotaScope": "api",
+          "contextWindow": 272000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "gpt-5.6-luna-{effort}"
+          },
+          "benchmarkKey": "gpt-5.6-luna"
+        },
+        {
+          "modelId": "gemini-3.7-flash",
+          "name": "Gemini-3.7-Flash",
+          "capabilityClass": "light",
+          "quotaScope": "api",
+          "contextWindow": 256000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "upstreamModelIdTemplate": "gemini-3.7-flash-{effort}"
+          }
+        },
+        {
+          "modelId": "kimi-k3",
+          "name": "Kimi-K3",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "contextWindow": 256000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "kimi-k3-{effort}"
+          },
+          "benchmarkKey": "kimi-k3"
         }
       ]
     },

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -1954,7 +1954,7 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(44);
+    expect(list.data).toHaveLength(49);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-luna");
@@ -1988,7 +1988,12 @@ describe("route surface", () => {
     expect(ids).toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
     expect(ids).toContain("claude-gateway--cursor--claude-fable-5");
     expect(ids).toContain("claude-gateway--cursor--claude-fable-5-1m[1m]");
-    expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
+    expect(ids).toContain("claude-gateway--cursor--gpt-5.6-sol");
+    expect(ids).toContain("claude-gateway--cursor--gpt-5.6-terra");
+    expect(ids).toContain("claude-gateway--cursor--gpt-5.6-luna");
+    expect(ids).toContain("claude-gateway--cursor--gemini-3.7-flash");
+    expect(ids).toContain("claude-gateway--cursor--kimi-k3");
+    expect(ids).not.toContain("claude-gateway--cursor--kimi-k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
     expect(ids).toContain("claude-gateway--opencode--minimax-m3[1m]");

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -848,7 +848,7 @@ describe("model catalog", () => {
 
   it("contains only the approved provider families", () => {
     expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(18);
-    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(11);
+    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(16);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(11);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
@@ -889,6 +889,11 @@ describe("model catalog", () => {
       "claude-opus-5-1m",
       "claude-fable-5",
       "claude-fable-5-1m",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gemini-3.7-flash",
+      "kimi-k3",
     ]);
     expect(Object.fromEntries(CURSOR_SUBSCRIPTION_MODELS.map((model) => [
       model.upstreamId,
@@ -904,6 +909,11 @@ describe("model catalog", () => {
       "claude-opus-5-1m": 1_000_000,
       "claude-fable-5": 300_000,
       "claude-fable-5-1m": 1_000_000,
+      "gpt-5.6-sol": 272_000,
+      "gpt-5.6-terra": 272_000,
+      "gpt-5.6-luna": 272_000,
+      "gemini-3.7-flash": 256_000,
+      "kimi-k3": 256_000,
       default: 256_000,
     });
     for (const id of ["cursor--claude-opus-5-1m", "cursor--claude-fable-5-1m"]) {
@@ -1424,7 +1434,23 @@ describe("model catalog", () => {
       contextWindow: 1_000_000,
       cursorMaxMode: true,
     });
-    expect(findGatewayModel("claude-gateway--cursor--kimi-k3")).toBeUndefined();
+    expect(findGatewayModel("claude-gateway--cursor--kimi-k3")).toMatchObject({
+      id: "cursor--kimi-k3",
+      upstreamId: "kimi-k3",
+      contextWindow: 256_000,
+    });
+    expect(findGatewayModel("claude-gateway--cursor--kimi-k3[1m]")).toBeUndefined();
+    expect(findGatewayModel("claude-gateway--cursor--gemini-3.7-flash")).toMatchObject({
+      id: "cursor--gemini-3.7-flash",
+      upstreamId: "gemini-3.7-flash",
+      contextWindow: 256_000,
+    });
+    expect(findGatewayModel("claude-gateway--cursor--gpt-5.6-sol")).toMatchObject({
+      id: "cursor--gpt-5.6-sol",
+      upstreamId: "gpt-5.6-sol",
+      contextWindow: 272_000,
+    });
+    expect(findGatewayModel("claude-gateway--cursor--minimax-m3")).toBeUndefined();
     expect(findGatewayModel("claude-gateway--cursor--glm-5.2[1m]")).toBeUndefined();
     expect(findGatewayModel("claude-gateway--k3[1m]")).toBeUndefined();
     expect(findGatewayModel("k3[1m]")).toBeUndefined();

--- a/packages/core-ai-gateway/tests/settings/index.test.ts
+++ b/packages/core-ai-gateway/tests/settings/index.test.ts
@@ -127,7 +127,7 @@ describe("ai-gateway settings", () => {
   it("resolves stale ids out of the exposed selection", () => {
     const selection = resolveAiGatewaySelection({
       version: 1,
-      models: [{ id: "cursor--grok-4.5" }, { id: "cursor--kimi-k3" }],
+      models: [{ id: "cursor--grok-4.5" }, { id: "cursor--minimax-m3" }],
     });
     expect(selection.models.map((model) => model.id)).toEqual(["cursor--grok-4.5"]);
   });

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -673,7 +673,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(44);
+    expect(cache.models).toHaveLength(49);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-524k-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-1m-fast[1m]");
@@ -687,7 +687,12 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(ids).toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
     expect(ids).toContain("claude-gateway--cursor--claude-fable-5");
     expect(ids).toContain("claude-gateway--cursor--claude-fable-5-1m[1m]");
-    expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
+    expect(ids).toContain("claude-gateway--cursor--gpt-5.6-sol");
+    expect(ids).toContain("claude-gateway--cursor--gpt-5.6-terra");
+    expect(ids).toContain("claude-gateway--cursor--gpt-5.6-luna");
+    expect(ids).toContain("claude-gateway--cursor--gemini-3.7-flash");
+    expect(ids).toContain("claude-gateway--cursor--kimi-k3");
+    expect(ids).not.toContain("claude-gateway--cursor--kimi-k3[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-luna[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");


### PR DESCRIPTION
## Summary
- Cursor 프로바이더에 `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gemini-3.7-flash`, `kimi-k3`를 추가합니다. 각 모델의 effort 사다리는 Cursor가 실제로 게시한 wire id에서만 가져왔습니다 — GPT-5.6 3종은 low/medium/high/xhigh/max, Gemini 3.7 Flash는 low/medium/high, Kimi K3는 low/high/max(Cursor에 `kimi-k3-medium`이 없습니다).
- 모델 id, effort 단, `quotaScope: "api"`는 2026-08-20 라이브 `GetUsableModels`(cursor-agent 2026.08.11-e8db854)와 `DashboardService/GetCurrentPeriodUsage`의 `autoBucketModels` 실측에서 왔습니다. 5종 모두 auto 버킷 밖이라 API 풀에 과금됩니다.
- contextWindow는 미측정입니다. Cursor는 첫 턴 Run에 `token_details: {}`를 돌려주므로(opus-5로 대조 확인) 기존 항목처럼 실측할 수 없어, 보수적인 교차 프로바이더 값을 씁니다 — GPT-5.6 계열은 Codex 카탈로그의 272000, 나머지는 256000. 과소 선언은 조기 compaction에 그치지만 과대 선언은 컨텍스트 오버플로를 냅니다. 런타임에서는 어댑터가 첫 checkpoint의 `max_tokens`로 덮어씁니다.
- Max Mode(1M) 변형과 `-fast` 변형은 추가하지 않습니다. Cursor가 이 5종에 대해 어느 쪽도 게시하지 않습니다.
- CursorBench 근거가 있는 4종에만 `benchmarkKey`를 답니다. `gemini-3.7-flash`는 벤치 행이 없어 `capabilityClass` 사전 확률만 갖습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 788 passed
- [x] `pnpm test` (전체 18개 워크스페이스) — 전부 통과
- [x] `pnpm typecheck` — 전부 통과
- [x] `pnpm build`
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 2 fragment entries validated
- [x] `pnpm check:core-boundary`, `pnpm check:localized-attributes`
- [x] 라이브 프로브: 5종 중 `gemini-3.7-flash-low`로 실제 Cursor Run 1회 성공 (id/래더 해석 검증). 나머지는 카탈로그 대조만 수행 — Cursor API 쿼터(API 풀 98.7% 소진) 때문에 전 계열 실행 검증은 하지 않았습니다.