### PR TITLE
feat(fleet-admiral): stop forcing a model pin on every workflow stage

### DIFF
--- a/.changelog.d/workflow-model-pin-relax.md
+++ b/.changelog.d/workflow-model-pin-relax.md
@@ -1,0 +1,8 @@
+---
+branch: workflow-model-pin-relax
+---
+
+### fleet-cli
+#### Changed
+- A workflow stage no longer has to name a gateway model. Stages that name none run on the session's own model, and a stage may pin an identity through `agentType` again; only a model value that would kill the run at dispatch is still refused. Naming a gateway identity remains required for `Agent` delegation.
+  ko: 워크플로 스테이지가 더 이상 게이트웨이 모델을 반드시 지정하지 않아도 됩니다. 지정하지 않은 스테이지는 세션 자신의 모델로 돌고, `agentType`으로 정체성을 핀하는 것도 다시 허용되며, 디스패치 즉시 실행을 죽이는 모델 값만 여전히 거부됩니다. `Agent` 위임은 그대로 게이트웨이 정체성 지정이 필요합니다.

--- a/docs/admiral-prompt-architecture.md
+++ b/docs/admiral-prompt-architecture.md
@@ -59,16 +59,21 @@ missing state file. One script serves three roles, selected by its first argumen
 | Subcommand | Event | Matcher | Effect |
 |---|---|---|---|
 | `remind` | UserPromptSubmit | — | Injects the pin contract every turn. This is the only path by which the contract reaches the model. |
-| `gate-delegation` | PreToolUse | `Agent|Workflow` | Blocks an unpinned delegation before it runs and states how to pin it. |
+| `gate-delegation` | PreToolUse | `Agent|Workflow` | Blocks an unpinned `Agent` delegation, and a `Workflow` stage whose model value is misspelled. |
 | `workflow-receipt` | PostToolUse | `Workflow` | States that the dispatch returned a receipt, not a result. |
 
 `gate-delegation` blocks an `Agent` call whose `subagent_type` is `general-purpose` or
 `claude`, or absent. Built-in specialist types and `fork` pass — `fork` inherits parent
-context by design, so moving it to another model removes the point of that surface. For
-`Workflow` it blocks `agentType` in a script, a malformed `opts.model`, and any
-`agent()` stage that pins no model at all. It does not rewrite the script: assigning one
-model to every stage would erase the model spread that is the whole reason to use that
-surface, so the block carries the instruction and the host does the assignment.
+context by design, so moving it to another model removes the point of that surface.
+
+For `Workflow` the gate judges spelling only. A stage that names no model is allowed and
+runs on the session model; whether a fan-out is worth spreading across providers is a
+reading of the work, not a property the hook can see, and a gate that demanded a pin per
+stage only taught the host to fill every stage with one value — the spread it was meant to
+produce, spelled as compliance. What survives is the failure a host cannot recover from:
+a `model` value that is neither a lineage alias nor a `claude-gateway--` modelId kills
+every branch at dispatch, so it is refused before the run rather than after. `agentType`
+is a stage's other legitimate pin and is no longer refused.
 
 Two properties of the harness make this shape necessary, both measured on
 Claude Code 2.1.235:

--- a/docs/admiral-prompt-architecture.md
+++ b/docs/admiral-prompt-architecture.md
@@ -73,7 +73,10 @@ stage only taught the host to fill every stage with one value — the spread it 
 produce, spelled as compliance. What survives is the failure a host cannot recover from:
 a `model` value that is neither a lineage alias nor a `claude-gateway--` modelId kills
 every branch at dispatch, so it is refused before the run rather than after. `agentType`
-is a stage's other legitimate pin and is no longer refused.
+is a stage's other legitimate pin and is refused only when it carries that same modelId —
+the two spellings swapped the other way, which no registry resolves. A built-in type such
+as `general-purpose` passes, so the check names the modelId rather than demanding a
+`fleet:` prefix.
 
 Two properties of the harness make this shape necessary, both measured on
 Claude Code 2.1.235:

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -19,10 +19,12 @@ import { readFileSync } from "node:fs";
 
 // 모델에게 주는 지시이므로 영어로 쓴다.
 const TURN_REMINDER = [
-  "Before any Agent run leaves the host, call gateway_models and pin an identity from what it reports —",
-  "allowances move while work is in flight. Agent: subagent_type = the fleet:* name.",
-  "A Workflow stage may stay on the host model; when you do move one, opts.model takes the modelId with the",
-  "claude-gateway-- prefix and opts.agentType takes the fleet:* name. The spellings are never interchangeable.",
+  "Call gateway_models before a run leaves the host and pin from what that call reports — allowances and the",
+  "roster itself move while work is in flight, so a remembered name is not evidence that it still resolves.",
+  "Agent: subagent_type = the fleet:* name, always.",
+  "A Workflow stage may stay on the host model; when you do move one, pin it from that same lookup —",
+  "opts.model takes the modelId with the claude-gateway-- prefix, opts.agentType takes the fleet:* name.",
+  "The spellings are never interchangeable.",
 ].join(" ");
 
 const IN_FLIGHT_CONTRACT = [

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -9,7 +9,7 @@
 // 세 곳에서 따로 늙는다.
 //
 //   remind            UserPromptSubmit          매 턴 규약 주입 (무조건)
-//   gate-delegation   PreToolUse  Agent|Workflow  핀되지 않은 위임을 차단
+//   gate-delegation   PreToolUse  Agent|Workflow  Agent의 핀 누락과 workflow의 틀린 모델 철자를 차단
 //   workflow-receipt  PostToolUse Workflow        접수증을 결과로 읽는 사고를 차단
 //
 // 상태를 남기지 않는다. 훅은 호출마다 새 프로세스로 뜨므로 프로세스 간 기억은 파일로만
@@ -19,10 +19,10 @@ import { readFileSync } from "node:fs";
 
 // 모델에게 주는 지시이므로 영어로 쓴다.
 const TURN_REMINDER = [
-  "Before any Agent or Workflow run leaves the host, call gateway_models and pin an identity from what it",
-  "reports — allowances move while work is in flight.",
-  "Agent: subagent_type = the fleet:* name. Workflow: opts.model = the modelId, the claude-gateway-- prefix",
-  "included. The two spellings are never interchangeable.",
+  "Before any Agent run leaves the host, call gateway_models and pin an identity from what it reports —",
+  "allowances move while work is in flight. Agent: subagent_type = the fleet:* name.",
+  "A Workflow stage may stay on the host model; when you do move one, opts.model takes the modelId with the",
+  "claude-gateway-- prefix and opts.agentType takes the fleet:* name. The spellings are never interchangeable.",
 ].join(" ");
 
 const IN_FLIGHT_CONTRACT = [
@@ -33,11 +33,8 @@ const IN_FLIGHT_CONTRACT = [
   "Report the finding once, in the turn the result arrives. If asked before then, say it is still running.",
 ].join(" ");
 
-const PIN_INSTRUCTION = [
-  "Call gateway_models first, then pin the identity it reports:",
-  "Agent — subagent_type = the fleet:* name;",
-  "Workflow — opts.model = the modelId with the claude-gateway-- prefix, written as a literal.",
-].join(" ");
+const PIN_INSTRUCTION =
+  "Call gateway_models first, then pin the identity it reports: subagent_type = the fleet:* name.";
 
 /**
  * 정체성이 핀되지 않은 위임으로 취급하는 Agent 타입.
@@ -52,9 +49,7 @@ const GATEWAY_AGENT_PREFIX = "fleet:";
 const MODEL_ALIASES = /^(fable|opus|sonnet|haiku)$/;
 const PREFIXED_ALIAS_RE = /^claude-gateway--(fable|opus|sonnet|haiku)$/;
 const GATEWAY_MODEL_PREFIX = "claude-gateway--";
-const AGENT_TYPE_RE = /agentType\s*:/;
 const MODEL_VALUE_RE = /model:\s*['"]([^'"]+)['"]/g;
-const AGENT_CALL_RE = /\bagent\s*\(/g;
 
 function block(message) {
   process.stderr.write(`[fleet-gateway-model-guard] ${message}\n`);
@@ -76,61 +71,13 @@ function readHookInput() {
 }
 
 /**
- * `agent(` 호출 하나가 차지하는 원문 범위. 괄호 균형으로 끝을 찾되 문자열·주석 안의 괄호는
- * 세지 않는다 — 프롬프트 텍스트에 괄호가 흔해서, 세는 순간 호출 경계가 엉뚱한 곳에서 닫힌다.
+ * 워크플로우가 쓴 모델 값의 철자 검사.
  *
- * 끝을 찾지 못하면 undefined를 돌려주고 호출자는 그 호출을 검사하지 않는다. 이 스캐너는
- * 파서가 아니므로, 판정할 수 없는 형태를 "핀 없음"으로 몰아 멀쩡한 스크립트를 막는 쪽이
- * 검사 한 건을 놓치는 쪽보다 나쁘다.
+ * 스테이지를 옮길지 말지는 호스트가 정한다 — 핀하지 않은 스테이지는 세션 모델로 돌면 그만이다.
+ * 여기서 막는 것은 옮기기로 해놓고 값을 잘못 쓴 경우뿐이다. 로스터 이름이나 prefix가 빠진
+ * modelId가 `model` 자리에 들어가면 모든 분기가 시작 즉시 죽으므로, 그 실패는 실행 전에 잡는
+ * 편이 훨씬 싸다.
  */
-function sliceCall(script, openParenIndex) {
-  let depth = 0;
-  let quote;
-  let escaped = false;
-  for (let i = openParenIndex; i < script.length; i += 1) {
-    const char = script[i];
-    if (quote !== undefined) {
-      if (escaped) escaped = false;
-      else if (char === "\\") escaped = true;
-      else if (char === quote) quote = undefined;
-      continue;
-    }
-    if (char === "'" || char === '"' || char === "`") {
-      quote = char;
-      continue;
-    }
-    if (char === "/" && script[i + 1] === "/") {
-      const lineEnd = script.indexOf("\n", i);
-      if (lineEnd === -1) return undefined;
-      i = lineEnd;
-      continue;
-    }
-    if (char === "/" && script[i + 1] === "*") {
-      const blockEnd = script.indexOf("*/", i + 2);
-      if (blockEnd === -1) return undefined;
-      i = blockEnd + 1;
-      continue;
-    }
-    if (char === "(") depth += 1;
-    else if (char === ")") {
-      depth -= 1;
-      if (depth === 0) return script.slice(openParenIndex, i + 1);
-    }
-  }
-  return undefined;
-}
-
-/** model 옵션이 없는 `agent(` 호출의 개수. 경계를 못 읽은 호출은 세지 않는다. */
-function countUnpinnedAgentCalls(script) {
-  let unpinned = 0;
-  for (const match of script.matchAll(AGENT_CALL_RE)) {
-    const call = sliceCall(script, match.index + match[0].length - 1);
-    if (call === undefined) continue;
-    if (!/\bmodel\s*:/.test(call)) unpinned += 1;
-  }
-  return unpinned;
-}
-
 function assertWorkflowModelValues(script) {
   for (const match of script.matchAll(MODEL_VALUE_RE)) {
     const value = match[1];
@@ -144,7 +91,8 @@ function assertWorkflowModelValues(script) {
     if (value.startsWith(GATEWAY_MODEL_PREFIX)) continue;
     block(
       `opts.model 값이 올바르지 않습니다: "${value}". gateway_models의 modelId(claude-gateway-- prefix 포함)를 ` +
-        "그대로 복사하거나 lineage alias(fable|opus|sonnet|haiku)를 사용하세요."
+        "그대로 복사하거나 lineage alias(fable|opus|sonnet|haiku)를 사용하세요. " +
+        "fleet:* 이름은 opts.agentType 자리입니다."
     );
   }
 }
@@ -178,20 +126,6 @@ function gateAgentDelegation(toolInput) {
 function gateWorkflowDelegation(toolInput) {
   const script = resolveWorkflowScript(toolInput);
   if (script === undefined) process.exit(0);
-  if (AGENT_TYPE_RE.test(script)) {
-    block(
-      "dynamic workflow 스크립트에 agentType이 금지됩니다. agentType은 팀메이트/서브에이전트 표면 전용이고, " +
-        "워크플로우는 opts.model로만 팬아웃해야 합니다."
-    );
-  }
-  const unpinned = countUnpinnedAgentCalls(script);
-  if (unpinned > 0) {
-    block(
-      `model이 지정되지 않은 agent() 호출이 ${unpinned}건 있습니다. ` +
-        PIN_INSTRUCTION +
-        " 스테이지마다 모델을 나누는 것이 이 표면의 목적이므로, 한 값으로 채우지 말고 역할별로 배분하세요."
-    );
-  }
   assertWorkflowModelValues(script);
   process.exit(0);
 }

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -52,6 +52,7 @@ const MODEL_ALIASES = /^(fable|opus|sonnet|haiku)$/;
 const PREFIXED_ALIAS_RE = /^claude-gateway--(fable|opus|sonnet|haiku)$/;
 const GATEWAY_MODEL_PREFIX = "claude-gateway--";
 const MODEL_VALUE_RE = /model:\s*['"]([^'"]+)['"]/g;
+const AGENT_TYPE_VALUE_RE = /agentType:\s*['"]([^'"]+)['"]/g;
 
 function block(message) {
   process.stderr.write(`[fleet-gateway-model-guard] ${message}\n`);
@@ -99,6 +100,24 @@ function assertWorkflowModelValues(script) {
   }
 }
 
+/**
+ * 이름 자리에 들어간 modelId. 두 철자를 맞바꾼 나머지 절반이다.
+ *
+ * `fleet:` 접두만 통과시키지는 않는다 — `general-purpose`처럼 이 저장소가 싣지 않은 내장
+ * agentType도 그 자리의 정당한 값이라, 접두로 거르면 멀쩡한 스크립트가 막힌다. modelId만
+ * 골라 막는다: 그 값은 어떤 레지스트리에도 이름으로 등록되어 있지 않아 반드시 죽는다.
+ */
+function assertWorkflowAgentTypeValues(script) {
+  for (const match of script.matchAll(AGENT_TYPE_VALUE_RE)) {
+    const value = match[1];
+    if (!value.startsWith(GATEWAY_MODEL_PREFIX)) continue;
+    block(
+      `opts.agentType 값이 올바르지 않습니다: "${value}". modelId는 opts.model 자리이고, ` +
+        "agentType에는 gateway_models가 보고한 fleet:* 이름을 씁니다."
+    );
+  }
+}
+
 /** 검사 대상 스크립트 원문. 볼 수 없는 호출 형태는 undefined를 돌려준다. */
 function resolveWorkflowScript(toolInput) {
   if (typeof toolInput.script === "string" && toolInput.script.length > 0) return toolInput.script;
@@ -129,6 +148,7 @@ function gateWorkflowDelegation(toolInput) {
   const script = resolveWorkflowScript(toolInput);
   if (script === undefined) process.exit(0);
   assertWorkflowModelValues(script);
+  assertWorkflowAgentTypeValues(script);
   process.exit(0);
 }
 

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -51,8 +51,9 @@ const GATEWAY_AGENT_PREFIX = "fleet:";
 const MODEL_ALIASES = /^(fable|opus|sonnet|haiku)$/;
 const PREFIXED_ALIAS_RE = /^claude-gateway--(fable|opus|sonnet|haiku)$/;
 const GATEWAY_MODEL_PREFIX = "claude-gateway--";
-const MODEL_VALUE_RE = /model:\s*['"]([^'"]+)['"]/g;
-const AGENT_TYPE_VALUE_RE = /agentType:\s*['"]([^'"]+)['"]/g;
+// 콜론 앞 공백은 유효한 프로퍼티 표기다. 정규식이 정규 표기만 알면 그 한 칸이 검사를 비켜간다.
+const MODEL_VALUE_RE = /model\s*:\s*['"]([^'"]+)['"]/g;
+const AGENT_TYPE_VALUE_RE = /agentType\s*:\s*['"]([^'"]+)['"]/g;
 
 function block(message) {
   process.stderr.write(`[fleet-gateway-model-guard] ${message}\n`);

--- a/packages/fleet-admiral/src/ai-gateway/gateway-models-tool.ts
+++ b/packages/fleet-admiral/src/ai-gateway/gateway-models-tool.ts
@@ -46,7 +46,7 @@ const GATEWAY_MODELS_DOCTRINE = {
   description:
     `Report the gateway models currently available to this session, each model's routing constraints, capability class, and benchmark evidence, and the current provider allowances and the user's provider spend priority.`
     + ` The roster is the models the user exposed in the Console minus the ones reserved for the host session, and it is editable while this session runs, so it is resolved at call time rather than remembered.`
-    + ` Two spellings, never interchangeable: agentTypes names an identity for the Agent tool's subagent_type, while modelId is the model as a value for a workflow stage's opts.model — each is refused where the other belongs.`
+    + ` Two spellings, never interchangeable: agentTypes names an identity — the Agent tool's subagent_type, or a workflow stage's opts.agentType — while modelId is the model as a value for a workflow stage's opts.model, and each is refused where the other belongs.`
     + ` Names are registered once at session start while this roster is re-read live, so a model or reasoning rung exposed mid-session appears here under a name that will not resolve until a new session.`,
   promptSnippet:
     `gateway_models — Live roster of assignable gateway models: constraints, capability class, benchmark evidence, provider allowances, and the user's provider priority.`,

--- a/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
+++ b/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
@@ -426,6 +426,9 @@ describe("gateway_models tool doctrine", () => {
     expect(description).toContain("Two spellings, never interchangeable");
     expect(description).toContain("subagent_type");
     expect(description).toContain("opts.model");
+    // 워크플로우 스테이지도 agentType으로 핀할 수 있다. 이름 축을 Agent 전용으로 적으면
+    // 로스터를 읽은 호스트가 지원되는 경로를 쓰지 않는다.
+    expect(description).toContain("opts.agentType");
     // 세션 중 노출한 모델은 이름이 해석되지 않는다. 이것을 모르면 stale roster를 의심하며
     // 같은 실패를 반복한다.
     expect(description).toContain("registered once at session start");

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -50,6 +50,9 @@ describe("gateway model guard — remind", () => {
     expect(parsed.hookSpecificOutput.additionalContext).toContain("gateway_models");
     expect(parsed.hookSpecificOutput.additionalContext).toContain("subagent_type");
     expect(parsed.hookSpecificOutput.additionalContext).toContain("opts.model");
+    // 핀이 선택이 된 뒤에도 로스터 조회는 핀의 조건이다 — 기억한 이름은 여전히 해석된다는
+    // 증거가 아니다. 워크플로우 스테이지의 두 핀 철자가 그 조회에 함께 묶여 있어야 한다.
+    expect(parsed.hookSpecificOutput.additionalContext).toContain("opts.agentType");
   });
 
   // 주입은 stdin과 무관하게 성립해야 한다. 턴 시작 payload 모양이 바뀌어도 규약은 실려야 한다.

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -143,6 +143,16 @@ describe("gateway model guard — Workflow delegation", () => {
     }
   });
 
+  // 콜론 앞 공백도 유효한 프로퍼티 표기다. 정규 표기만 아는 검사는 그 한 칸으로 비켜간다.
+  it("reads a property written with whitespace before the colon", () => {
+    for (const script of [
+      `agent("x", { agentType : "claude-gateway--codex--gpt-5.6-sol-fast" })`,
+      `agent("x", { model : "codex--gpt-5.6-sol-fast" })`,
+    ]) {
+      expect(gateWorkflow({ script }).status, script).toBe(2);
+    }
+  });
+
   // 두 철자를 맞바꾼 나머지 절반. modelId는 어떤 레지스트리에도 이름으로 없어 반드시 죽는다.
   it("blocks a modelId written into the agentType slot", () => {
     const { status, stderr } = gateWorkflow({

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -135,9 +135,21 @@ describe("gateway model guard — Workflow delegation", () => {
     expect(status).toBe(0);
   });
 
-  // agentType은 스테이지의 또 다른 정당한 핀이다. 값 검사는 model 자리에만 건다.
+  // agentType은 스테이지의 또 다른 정당한 핀이다. 내장 타입도 그 자리의 정당한 값이므로
+  // fleet: 접두를 요구하지 않는다.
   it("passes agentType usage in a dynamic workflow", () => {
-    expect(gateWorkflow({ script: `agent("x", { agentType: "fleet:xai-grok-4-6-low" })` }).status).toBe(0);
+    for (const value of ["fleet:xai-grok-4-6-low", "general-purpose", "code-reviewer"]) {
+      expect(gateWorkflow({ script: `agent("x", { agentType: "${value}" })` }).status, value).toBe(0);
+    }
+  });
+
+  // 두 철자를 맞바꾼 나머지 절반. modelId는 어떤 레지스트리에도 이름으로 없어 반드시 죽는다.
+  it("blocks a modelId written into the agentType slot", () => {
+    const { status, stderr } = gateWorkflow({
+      script: `agent("x", { agentType: "claude-gateway--codex--gpt-5.6-sol-fast" })`,
+    });
+    expect(status).toBe(2);
+    expect(stderr).toContain("opts.model");
   });
 
   // 로스터 이름이 model 자리에 들어가면 전 분기가 디스패치 즉시 죽는다. 그 실패만 미리 잡는다.

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -113,39 +113,33 @@ describe("gateway model guard — Workflow delegation", () => {
     expect(stderr).toContain("prefix");
   });
 
-  // 틀린 핀을 막는 것만으로는 부족하다 — 아예 핀하지 않은 스테이지가 세션 모델을 상속한다.
-  it("blocks a stage that pins no model at all", () => {
+  // 핀하지 않은 스테이지는 세션 모델로 돈다. 스테이지를 옮길지 말지는 작업을 읽어야 나오는
+  // 판단이라 훅이 볼 수 없다 — 요구하면 한 값으로 전부 채우는 순응만 남는다.
+  it("passes a stage that pins no model at all", () => {
     for (const script of [`agent("x")`, `agent("x", { schema: S })`, `const r = await agent(prompt, {})`]) {
-      const { status, stderr } = gateWorkflow({ script });
-      expect(status, script).toBe(2);
-      expect(stderr, script).toContain("model");
+      expect(gateWorkflow({ script }).status, script).toBe(0);
     }
   });
 
-  it("counts every unpinned stage in one script", () => {
-    const { status, stderr } = gateWorkflow({
+  it("passes a script that mixes pinned and unpinned stages", () => {
+    const { status } = gateWorkflow({
       script: [
         `const a = await agent("one", { model: "claude-gateway--xai--grok-4.6" })`,
         `const b = await agent("two", { schema: S })`,
         `const c = await agent("three")`,
       ].join("\n"),
     });
-    expect(status).toBe(2);
-    expect(stderr).toContain("2건");
-  });
-
-  // 프롬프트 텍스트의 괄호를 호출 경계로 세면 멀쩡한 스크립트가 막힌다.
-  it("reads call boundaries past parentheses and quotes inside the prompt", () => {
-    const { status } = gateWorkflow({
-      script: `await agent("check foo(bar) and \\"baz)\\" here", { model: "claude-gateway--xai--grok-4.6" })`,
-    });
     expect(status).toBe(0);
   });
 
-  it("blocks agentType usage in a dynamic workflow", () => {
-    const { status, stderr } = gateWorkflow({
-      script: `agent("x", { agentType: "fleet:codex-gpt-5-6-sol-fast-high" })`,
-    });
+  // agentType은 스테이지의 또 다른 정당한 핀이다. 값 검사는 model 자리에만 건다.
+  it("passes agentType usage in a dynamic workflow", () => {
+    expect(gateWorkflow({ script: `agent("x", { agentType: "fleet:xai-grok-4-6-low" })` }).status).toBe(0);
+  });
+
+  // 로스터 이름이 model 자리에 들어가면 전 분기가 디스패치 즉시 죽는다. 그 실패만 미리 잡는다.
+  it("blocks a roster identity name written into the model slot", () => {
+    const { status, stderr } = gateWorkflow({ script: `agent("x", { model: "fleet:xai-grok-4-6-low" })` });
     expect(status).toBe(2);
     expect(stderr).toContain("agentType");
   });


### PR DESCRIPTION
## Summary
- 워크플로 PreToolUse 게이트에서 **필수 핀** 규칙을 제거했습니다. `model`을 지정하지 않은 `agent()` 스테이지는 이제 통과하고 세션 모델로 돕니다. 스테이지마다 핀을 요구해도 실제로는 한 값을 전 스테이지에 복사하는 순응만 만들어냈고, 그건 애초에 만들려던 모델 분산이 아닙니다.
- dynamic workflow 스크립트의 `agentType` 금지도 해제했습니다. `agentType`은 스테이지의 또 다른 정당한 핀입니다.
- **모델 값 철자 검증은 유지**했습니다. lineage alias도 `claude-gateway--` modelId도 아닌 값이 `model` 자리에 들어가면 디스패치 즉시 전 분기가 죽으므로, 호스트가 복구할 수 없는 그 실패만 실행 전에 막습니다. 로스터 이름(`fleet:*`)이 `model`에 들어간 경우 `agentType` 자리임을 안내합니다.
- 매 턴 주입되는 pin 규약 문구와 Agent 차단 메시지를 개정해, Workflow 절이 더 이상 강제되지 않는 의무가 아니라 *철자 규칙*을 말하도록 했습니다. `docs/admiral-prompt-architecture.md` §2의 게이트 설명도 함께 갱신했습니다.
- `Agent` 위임의 정체성 핀 요구는 그대로입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` — 13 files / 166 tests pass
- [x] `pnpm typecheck` — 전 워크스페이스 Done
- [x] `pnpm test` — 전 워크스페이스 pass (fleet-console 2294 pass / 24 skipped 포함)
- [x] `pnpm build` — 전 워크스페이스 Done
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK: 1 fragment
- [x] 훅 직접 프로브: 핀 없는 `agent()` → exit 0 · `agentType` 핀 → 0 · `model`에 로스터 이름 → 2 · 정상 modelId → 0 · `Agent general-purpose` → 2 · `Agent fleet:*` → 0