### PR TITLE
fix(ai-gateway): retry an xAI capacity refusal and name it an overload

### DIFF
--- a/.changelog.d/xai-capacity-retry.md
+++ b/.changelog.d/xai-capacity-retry.md
@@ -1,0 +1,13 @@
+---
+branch: xai-capacity-retry
+---
+
+### fleet-cli
+#### Fixed
+- Retry a Grok turn that xAI refused for capacity, and name the refusal an overload when the retry is refused too. xAI announces it with an empty error type and code, so the gateway read it as a plain API error, never retried it, and ended the turn on a message that only asked you to try again in a few minutes.
+  ko: xAI가 용량 부족으로 거절한 Grok 턴을 재시도하고, 재시도까지 거절당하면 과부하로 알립니다. xAI가 오류 종류와 코드를 비워 보내는 탓에 게이트웨이가 일반 API 오류로 읽어 재시도 없이, 잠시 뒤 다시 시도하라는 안내만 남긴 채 턴을 끝냈습니다.
+
+### fleet-console
+#### Fixed
+- Retry a Grok turn that xAI refused for capacity, and name the refusal an overload when the retry is refused too. xAI announces it with an empty error type and code, so the gateway read it as a plain API error, never retried it, and ended the turn on a message that only asked you to try again in a few minutes.
+  ko: xAI가 용량 부족으로 거절한 Grok 턴을 재시도하고, 재시도까지 거절당하면 과부하로 알립니다. xAI가 오류 종류와 코드를 비워 보내는 탓에 게이트웨이가 일반 API 오류로 읽어 재시도 없이, 잠시 뒤 다시 시도하라는 안내만 남긴 채 턴을 끝냈습니다.

--- a/packages/core-ai-gateway/src/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/xai/responses/adapter.ts
@@ -400,10 +400,20 @@ async function* generateXaiRetryEvents(
       }
 
       if (result.done) {
-        yield* lead;
+        // A held error that no `response.failed` ever joined, on a stream that then closed
+        // without committing a byte: the turn produced nothing, so the pair it was waiting for
+        // is never coming. Measured on xAI's capacity refusal, which arrives as a lone `error`
+        // frame and ends the stream — holding it here surfaced a retryable overload untried.
         if (pendingError !== undefined) {
-          yield pendingError;
+          wireLog("xai-responses.retry.discarded", {
+            reason: "error_stream_end",
+            errorTypes: [pendingError.error.type],
+          });
+          lead.length = 0;
+          yield* await retry(controller.signal);
+          return;
         }
+        yield* lead;
         normalCompletion = true;
         return;
       }
@@ -461,7 +471,8 @@ function isRetryableXaiFailure(event: CanonicalResponseEvent): event is
 function isRetryableXaiErrorType(type: string): boolean {
   return type === "server_error"
     || type === "server_is_overloaded"
-    || type === "service_unavailable_error";
+    || type === "service_unavailable_error"
+    || type === XAI_OVERLOADED_ERROR_TYPE;
 }
 
 function commitsXaiOutput(event: CanonicalResponseEvent): boolean {
@@ -1060,16 +1071,35 @@ function outputItem(value: unknown): CanonicalOutputItem | undefined {
 }
 
 
+/**
+ * Anthropic's own name for the overload class, which the client-facing encoder forwards verbatim.
+ *
+ * A capacity refusal reaches this adapter with both class-bearing fields empty — measured as
+ * `{"type":"error","code":null,"message":"The model is currently at capacity due to high
+ * demand..."}` — so the projection below used to synthesize `api_error` and the class was gone
+ * before `isRetryableXaiErrorType` ever saw it: an overload the retry path exists to absorb was
+ * indistinguishable from a malformed request. The message is the only surviving discriminator,
+ * so it is read here, at the one site that decides the class, rather than at each consumer.
+ *
+ * Naming it in Anthropic's vocabulary rather than xAI's earns the second half: when the single
+ * retry also fails, the client is handed an error its own backoff recognizes instead of a flat
+ * `api_error` that ends the turn.
+ */
+const XAI_OVERLOADED_ERROR_TYPE = "overloaded_error";
+/** Deliberately narrow: a false positive costs one extra pre-commit attempt, nothing more. */
+const XAI_CAPACITY_MESSAGE = /\bat capacity\b|\boverloaded\b/i;
+
 function canonicalError(value: unknown): CanonicalError {
   const error = record(value, "error");
   const message = string(error.message, "error.message");
-  const type =
-    typeof error.type === "string" && error.type !== "error"
-      ? error.type
-      : typeof error.code === "string"
-        ? error.code
-        : "api_error";
-  return { type, message };
+  return { type: xaiErrorType(error, message), message };
+}
+
+/** An upstream-declared class always wins; the message is consulted only where none was sent. */
+function xaiErrorType(error: Record<string, unknown>, message: string): string {
+  if (typeof error.type === "string" && error.type !== "error") return error.type;
+  if (typeof error.code === "string") return error.code;
+  return XAI_CAPACITY_MESSAGE.test(message) ? XAI_OVERLOADED_ERROR_TYPE : "api_error";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -1028,6 +1028,10 @@ describe("Grok Responses stall watchdog", () => {
 });
 
 describe("Grok Responses retry", () => {
+  const CAPACITY_MESSAGE = "The model is currently at capacity due to high demand."
+    + " Please try again in a few minutes, or use a higher service tier for priority processing:"
+    + " https://docs.x.ai/developers/advanced-api-usage/priority-processing";
+
   function failed(type = "server_error", id = "r1"): CanonicalResponseEvent {
     return {
       type: "response.failed",
@@ -1156,6 +1160,87 @@ describe("Grok Responses retry", () => {
     if (!response.ok) throw new Error("expected ok");
 
     await expect(collectXaiEvents(response.events)).resolves.toEqual([failed("invalid_prompt")]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  /** Captured verbatim from `xai-responses.wire.event`: both class-bearing fields are empty. */
+  function capacityFrame(message = CAPACITY_MESSAGE): string {
+    return xaiFrame({ sequence_number: 0, type: "error", code: null, message, param: null });
+  }
+
+  it("retries a capacity refusal that ends the stream without a paired failure", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(xaiResponse(
+        xaiFrame(responseCreated("r1")),
+        xaiFrame(reasoning("discarded reasoning")),
+        capacityFrame(),
+      ))
+      .mockResolvedValueOnce(xaiResponse(xaiFrame(responseCreated("r2")), xaiFrame(textDelta("ok"))));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      responseCreated("r2"),
+      textDelta("ok"),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("hands a second capacity refusal to the client as overloaded_error", async () => {
+    // A fresh Response per attempt: one instance would hand the retry an already-locked body.
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => xaiResponse(capacityFrame()));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      { type: "error", error: { type: "overloaded_error", message: CAPACITY_MESSAGE } },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("records the stream-end discard with payload-light fields", async () => {
+    const wire = wireLogFixture("fleet-xai-capacity-");
+    try {
+      const fetchMock = vi.fn<typeof fetch>()
+        .mockResolvedValueOnce(xaiResponse(capacityFrame()))
+        .mockResolvedValueOnce(xaiResponse(xaiFrame(textDelta("terminal"))));
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      await collectXaiEvents(response.events);
+
+      const entries = wire.read().filter((entry) => entry.event === "xai-responses.retry.discarded");
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.payload).toEqual({ reason: "error_stream_end", errorTypes: ["overloaded_error"] });
+      expect(JSON.stringify(entries)).not.toMatch(/capacity|demand|message/);
+    } finally {
+      wire.cleanup();
+    }
+  });
+
+  it("leaves an unclassified error frame as api_error and does not retry it", async () => {
+    const message = "Tool call arguments were not valid JSON";
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(xaiResponse(capacityFrame(message)));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      { type: "error", error: { type: "api_error", message } },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an upstream-declared code over the message it carries", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(xaiResponse(xaiFrame({
+      type: "error",
+      code: "invalid_prompt",
+      message: CAPACITY_MESSAGE,
+    })));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      { type: "error", error: { type: "invalid_prompt", message: CAPACITY_MESSAGE } },
+    ]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -1726,7 +1726,7 @@ describe("triage store", () => {
       operations,
       operationRuntime: status,
       operationNotifications: {},
-      catalog: [{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }],
+      catalog: [{ id: "terminal", title: "Terminal", kinds: [{ id: "claude-gateway", type: "agent", title: "Claude (Gateway)" }] }],
       plugins: [],
       renderKindIcon: () => null,
       canLaunch: true,
@@ -1755,15 +1755,18 @@ describe("triage store", () => {
     // 시각 헤더는 반복하지 않고, 메뉴 역할은 접근 이름으로만 유지한다.
     expect(launchMenu?.getAttribute("aria-label")).toBe("Operation launcher");
     expect(launchMenu?.querySelector(".canvas-context-menu-head")).toBeNull();
-    const shellItem = launchMenu?.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]');
-    expect(shellItem).not.toBeNull();
-    expect(shellItem?.disabled).toBe(false);
+    // Terminal Shell은 우측 rail 아이콘이 소유하므로 이 메뉴에 없다 — 여기서 짚는 항목은
+    // 우클릭 실행 목록에 남는 에이전트 종류다.
+    const launchItem = launchMenu?.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]');
+    expect(launchItem).not.toBeNull();
+    expect(launchItem?.disabled).toBe(false);
+    expect(launchMenu?.querySelector('[data-operation-launch-kind="shell"]')).toBeNull();
     expect(onOpenOperationMenu).not.toHaveBeenCalled();
 
     // 항목은 실제로 실행을 배선한다 — 열리기만 하는 메뉴는 진입점이 아니다.
-    act(() => shellItem?.click());
+    act(() => launchItem?.click());
     // 변형이 없는 종류는 실행 변형 인자를 비운 채 배선된다 — 계약의 세 번째 인자까지 못 박는다.
-    expect(onLaunchKind).toHaveBeenCalledWith("terminal", expect.objectContaining({ id: "shell" }), undefined);
+    expect(onLaunchKind).toHaveBeenCalledWith("terminal", expect.objectContaining({ id: "claude-gateway" }), undefined);
     expect(document.querySelector(".canvas-context-menu")).toBeNull();
 
     // 캔버스가 Map 클릭에서 보내는 같은 신호로도 닫힌다(pan이 mousedown 합성을 끊어 외부-클릭이 못 잡는다).
@@ -1805,7 +1808,7 @@ describe("triage store", () => {
       operations: [],
       operationRuntime: {},
       operationNotifications: {},
-      catalog: [{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }],
+      catalog: [{ id: "terminal", title: "Terminal", kinds: [{ id: "claude-gateway", type: "agent", title: "Claude (Gateway)" }] }],
       plugins: [],
       renderKindIcon: () => null,
       canLaunch: false,
@@ -1827,7 +1830,7 @@ describe("triage store", () => {
     document.body.append(container);
     triagePlateRoot = createRoot(container);
     setTriageActive(true);
-    const catalog = [{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }];
+    const catalog = [{ id: "terminal", title: "Terminal", kinds: [{ id: "claude-gateway", type: "agent", title: "Claude (Gateway)" }] }];
     const props = {
       operations: [],
       operationRuntime: {},

--- a/runtime/fleet-plugins/ledger/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/ledger/client/rail-panel.tsx
@@ -419,10 +419,13 @@ function LedgerIcon() {
   );
 }
 
-export const ledgerPanel: RailPanelDescriptor = {
+// `satisfies`, not an annotation: `RailPanelDescriptor` is a union of a rendering panel and an
+// activate-only rail action, so annotating erases which arm this is and leaves `render` optional
+// to every caller. The check against the contract is identical; the concrete shape survives it.
+export const ledgerPanel = {
   id: "ledger",
   title: (locale) => getT(locale)("ledger.panel.title"),
   icon: LedgerIcon,
   defaultWidth: 392,
   render: (ctx) => <LedgerPanelBody ctx={ctx} />,
-};
+} satisfies RailPanelDescriptor;


### PR DESCRIPTION
## Summary
- xAI announces its capacity refusal with both class-bearing fields empty (`{"type":"error","code":null,"message":"The model is currently at capacity ..."}`), so the projection synthesized `api_error` and the class was gone before the retry classifier read it. Wire captures show the frame arriving alone and ending the stream with no paired `response.failed`, so the held error was surfaced untried and the turn died on an API Error. The overload is now classified at the one site that decides the class, accepted into the retryable set, and a still-uncommitted held error retries when its stream ends without a pair. Naming it `overloaded_error` also hands the client an error its own backoff recognizes when the retry is refused too.
- Repairs two consumers #835 left red on `canary`, unrelated to the gateway change but blocking a green run. `RailPanelDescriptor` became a union of a rendering panel and an activate-only rail action, so `ledgerPanel`'s annotation erased which arm it is and left `render` optional to its own test; `satisfies` checks the same contract and keeps the concrete shape. `triage-store`'s bare-sidebar launcher test drove the menu through a shell-only catalog that now renders empty, so it moves to an agent kind the menu still carries and pins Shell's absence explicitly.

## Evidence
Measured from `~/.fleet/console/plugins/terminal/ai-gateway/wire-log.jsonl` during a live xAI degradation:

```
13:41:55.440  xai-responses.wire.event   error {"type":"error","code":null,"message":"...at capacity..."}
13:41:55.440  canonical.event            {"type":"error","error":{"type":"api_error", ...}}
13:41:55.451  canonical.request          <- a fresh stream() call: the caller retried, the gateway never did
```

A gateway retry would leave `xai-responses.retry.discarded` and no new `canonical.request`; neither appeared.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 793 passed (5 new cases: retry on a lone capacity refusal, `overloaded_error` surfaced when the retry is refused too, payload-light `error_stream_end` discard record, a non-capacity message still `api_error` and unretried, an upstream-declared code still winning over the message)
- [x] `pnpm build` — all workspaces
- [x] `pnpm typecheck` — all workspaces (red on `canary` before this branch)
- [x] `pnpm test` — 17/17 workspaces, 0 failures (1 failure on `canary` before this branch)
- [x] `pnpm check:core-boundary`, `check:claude-agent-sdk-boundary`, `check:localized-attributes`
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty`