### PR TITLE
fix(ai-gateway): pin the Codex prefix cache to the caller's session

### DIFF
--- a/.changelog.d/codex-prompt-cache-identity.md
+++ b/.changelog.d/codex-prompt-cache-identity.md
@@ -1,0 +1,13 @@
+---
+branch: codex-prompt-cache-identity
+---
+
+### fleet-cli
+#### Fixed
+- Codex turns now reuse the prompt cache instead of paying for the whole conversation again. The gateway sent no session identity, so OpenAI routed each turn to a different machine and only about 4 in 10 turns found their own cached prefix; naming the session lifts that to better than 9 in 10 and cut the input tokens one measured run billed by 71 percent.
+  ko: Codex 턴이 대화 전체를 다시 계산하지 않고 프롬프트 캐시를 재사용합니다. 게이트웨이가 세션 신원을 보내지 않아 OpenAI가 턴마다 다른 머신으로 보냈고 10턴 중 4턴 정도만 자기 캐시를 찾았는데, 세션을 알리자 10턴 중 9턴 이상으로 올라가며 실측 한 회차의 청구 입력 토큰이 71% 줄었습니다.
+
+### fleet-console
+#### Fixed
+- Codex turns now reuse the prompt cache instead of paying for the whole conversation again. The gateway sent no session identity, so OpenAI routed each turn to a different machine and only about 4 in 10 turns found their own cached prefix; naming the session lifts that to better than 9 in 10 and cut the input tokens one measured run billed by 71 percent.
+  ko: Codex 턴이 대화 전체를 다시 계산하지 않고 프롬프트 캐시를 재사용합니다. 게이트웨이가 세션 신원을 보내지 않아 OpenAI가 턴마다 다른 머신으로 보냈고 10턴 중 4턴 정도만 자기 캐시를 찾았는데, 세션을 알리자 10턴 중 9턴 이상으로 올라가며 실측 한 회차의 청구 입력 토큰이 71% 줄었습니다.

--- a/packages/core-ai-gateway/src/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/codex/responses/adapter.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type {
   AdapterCallOptions,
   AdapterResponse,
@@ -90,6 +92,8 @@ type OpenAIResponsesWireRequest = Omit<
   tool_choice?: OpenAIResponsesWireToolChoice;
   /** Requests extra output fields, e.g. `web_search_call.action.sources` for hosted web search results. */
   include?: string[];
+  /** Prefix-cache identity for the ChatGPT backend. See {@link codexSessionIdentity}. */
+  prompt_cache_key?: string;
 };
 
 export interface OpenAIResponsesAdapterOptions {
@@ -128,6 +132,14 @@ export class OpenAIResponsesAdapter implements AiGatewayAdapter {
     );
   }
 
+  /**
+   * Headers a subclass derives from the request itself, merged over the constructor's.
+   * The base Platform API surface derives none.
+   */
+  protected perRequestHeaders(_request: CanonicalResponseRequest): Record<string, string> {
+    return {};
+  }
+
   async stream(
     request: CanonicalResponseRequest,
     options: AdapterCallOptions
@@ -150,7 +162,8 @@ export class OpenAIResponsesAdapter implements AiGatewayAdapter {
           accept: "text/event-stream",
           authorization: `Bearer ${options.apiKey}`,
           "content-type": "application/json",
-          ...this.extraHeaders
+          ...this.extraHeaders,
+          ...this.perRequestHeaders(request)
         },
         body: JSON.stringify(payload),
         signal: controller.signal
@@ -232,6 +245,11 @@ export class CodexResponsesAdapter extends OpenAIResponsesAdapter {
       ...(options.idleTimeoutMs !== undefined ? { idleTimeoutMs: options.idleTimeoutMs } : {}),
     });
     this.isMarkedFetchFailure = fetchFailureTracker.isMarkedFailure;
+  }
+
+  protected override perRequestHeaders(request: CanonicalResponseRequest): Record<string, string> {
+    const sessionId = codexSessionIdentity(request);
+    return sessionId === undefined ? {} : { session_id: sessionId };
   }
 
   override async stream(
@@ -634,10 +652,53 @@ function forOpenAIResponsesBackend(
   return payload;
 }
 
+/**
+ * The ChatGPT backend's prefix cache is reached by request identity, not by the prefix alone.
+ *
+ * Measured against `gpt-5.6-luna` over three fresh ~7.9k-token prefixes replayed for eight
+ * turns each (21 warm turns per arm): the bare request the gateway used to send hit the cache
+ * on 8 of 21 turns, and adding `prompt_cache_key` alone changed nothing (8/21). Sending the
+ * `session_id` request header moved it to 19/21 — the same rate as replaying codex-rs's whole
+ * identity header set. So the sticky routing this backend performs keys on that header, and a
+ * request without it is load-balanced away from the machine holding its own prefix.
+ *
+ * `prompt_cache_key` is sent alongside because it is the documented Responses field for this
+ * purpose and codex-rs sends it; it simply is not what makes the difference here.
+ *
+ * The identity has to be the caller's conversation, not this adapter's lifetime — a gateway
+ * builds one adapter per request. Claude Code's `metadata.user_id` is stable for a session and
+ * is already the Cursor path's session source (`resolveCursorSessionIdentity`). A caller that
+ * sends none keeps the un-pinned behavior rather than being handed a fresh identity per turn,
+ * which would pin every turn to a different machine and be strictly worse than sending nothing.
+ */
+export function codexSessionIdentity(request: CanonicalResponseRequest): string | undefined {
+  const userId = request.metadata?.user_id?.trim();
+  if (!userId) return undefined;
+  const digest = createHash("sha256")
+    .update("fleet:codex:claude-session:")
+    .update(userId)
+    .digest("hex");
+  // UUID-shaped, as codex-rs's own `session_id` is. Deterministic, so the same conversation
+  // reaches the same value across the per-request adapters a gateway constructs.
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    digest.slice(12, 16),
+    digest.slice(16, 20),
+    digest.slice(20, 32),
+  ].join("-");
+}
+
 function forChatGptBackend(request: CanonicalResponseRequest): CanonicalResponseRequest {
   const copy: Record<string, unknown> = { ...request };
   for (const field of CHATGPT_UNSUPPORTED_FIELDS) {
     delete copy[field];
+  }
+  // Derived before `metadata` is dropped below: this backend rejects the field itself
+  // ("Unsupported parameter"), but the caller identity inside it is what reaches the cache.
+  const sessionId = codexSessionIdentity(request);
+  if (sessionId !== undefined) {
+    copy.prompt_cache_key = sessionId;
   }
   if (request.tool_choice === "none" || isClaudeCodeSuggestionMode(request)) {
     // 명시적 no-tools 요청과 Claude Code Suggestion turn은 이 stateless backend에 tool

--- a/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
@@ -114,6 +114,52 @@ describe("codex responses adapter", () => {
     expect(body.store).toBe(false);
   });
 
+  it("pins the prefix cache with a session_id header and prompt_cache_key derived from metadata.user_id", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request({
+      metadata: { user_id: "user_abc_account_1_session_2" },
+    }), { apiKey: "k" });
+
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    const sessionId = headers.get("session_id");
+    // Sticky routing on this backend keys on the header, so both spellings must be the
+    // same value; the caller's own metadata still never reaches the wire body.
+    expect(sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(body.prompt_cache_key).toBe(sessionId);
+    expect(body).not.toHaveProperty("metadata");
+  });
+
+  it("derives the same identity for the same user_id and a different one otherwise", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    const adapter = new CodexResponsesAdapter({ fetch: fetchMock });
+    await adapter.stream(request({ metadata: { user_id: "session-a" } }), { apiKey: "k" });
+    // A gateway builds one adapter per request, so the value must come from the caller,
+    // not from adapter lifetime.
+    await new CodexResponsesAdapter({ fetch: fetchMock })
+      .stream(request({ metadata: { user_id: "session-a" } }), { apiKey: "k" });
+    await adapter.stream(request({ metadata: { user_id: "session-b" } }), { apiKey: "k" });
+
+    const sessionIds = fetchMock.mock.calls.map(
+      (call) => new Headers(call[1]?.headers).get("session_id"),
+    );
+    expect(sessionIds[0]).toBe(sessionIds[1]);
+    expect(sessionIds[2]).not.toBe(sessionIds[0]);
+  });
+
+  it("omits both spellings when the caller sent no user_id", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request({
+      metadata: { session: "s" },
+    }), { apiKey: "k" });
+
+    // A per-turn identity would pin every turn to a different machine, which is strictly
+    // worse than sending none.
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("session_id")).toBeNull();
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)))
+      .not.toHaveProperty("prompt_cache_key");
+  });
+
   it("omits all tool controls for explicit tool_choice none", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
     await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request({


### PR DESCRIPTION
## Summary
- ChatGPT Codex 백엔드는 요청에 세션 신원이 없으면 자기 프리픽스를 들고 있는 머신에서 요청을 떼어놓습니다. 게이트웨이는 `originator`와 `chatgpt-account-id`만 보내고 있어서 모든 Codex 턴이 대화 전체를 정가로 다시 읽고 있었습니다.
- Claude Code의 `metadata.user_id`(cursor 경로가 이미 쓰는 출처)에서 안정적 id를 결정적으로 유도해 `session_id` 헤더와 `prompt_cache_key` 본문 필드로 보냅니다. `user_id`가 없는 호출자는 기존 동작을 유지합니다 — 턴마다 새 신원을 발급하면 매 턴 다른 머신에 고정되어 아무것도 안 보내는 것보다 나쁩니다.
- 두 스펠링을 와이어에서 분리 측정한 결과 효과는 전부 `session_id` 헤더에서 나옵니다(워밍 19/21). `prompt_cache_key` 단독은 8/21로 변화가 없었고, Responses의 문서화된 필드이며 codex-rs도 보내기 때문에 함께 싣습니다.

## 실측

게이트웨이 전 경로(`AnthropicMessagesGateway` + `CodexResponsesAdapter`)를 빌드 산출물로 구동. gpt-5.6-luna, 신규 프리픽스(~7.9k 토큰) 6개 × 8턴, `metadata.user_id` 유무로 A/B. t0(콜드)는 양쪽 전 시행에서 미스이므로 워밍 구간 t1–t7 = 42요청/arm.

| | 캐시 적중 | 청구 입력 합계 | 턴당 평균 |
|---|---|---|---|
| 적용 후 | **39/42 (93%)** | 65,382 | 1,556 |
| 적용 전 | 16/42 (38%) | 224,358 | 5,341 |

와이어 로그로 본문도 확인: `prompt_cache_key`는 UUID 형태로 실리고, `metadata`는 여전히 제거되며(백엔드가 400), `store: false`가 유지됩니다.

## Test Plan
- [x] `pnpm exec vitest run` — 796/796 통과 (신규 회귀 3건: 두 스펠링 동일값·`metadata` 미유출 / 같은 user_id는 어댑터 인스턴스가 달라도 동일값 / user_id 없으면 둘 다 생략)
- [x] `pnpm typecheck` — 전 워크스페이스 통과
- [x] `pnpm check:core-boundary` — 통과
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build` — 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 6 entries validated
- [x] 라이브 Codex 백엔드 A/B 실측 (위 표)