### PR TITLE
fix(fleet-console): match Analyst model picker type to context menu

### DIFF
--- a/.changelog.d/analyst-model-menu-typography.md
+++ b/.changelog.d/analyst-model-menu-typography.md
@@ -1,0 +1,8 @@
+---
+branch: analyst-model-menu-typography
+---
+
+### fleet-console
+#### Changed
+- Session Analyst model names in the picker now use the same mono type, size, and glyph-column indent as the canvas context menu.
+  ko: Session Analyst 모델 선택 목록의 모델명이 캔버스 우클릭 메뉴와 같은 모노 서체, 크기, 글리프 열 들여쓰기를 씁니다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -797,6 +797,8 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(captions).toEqual(["Claude", "Codex", "Moonshot-Kimi"]);
     expect(menu.querySelectorAll(".operation-launch-provider-glyph")).toHaveLength(3);
     expect(chip.querySelector(".operation-launch-provider-glyph")).not.toBeNull();
+    expect(menu.querySelectorAll(".operation-launch-variant-row")).toHaveLength(4);
+    expect(menu.querySelector(".session-analyst__model-row")).toBeNull();
     expect(rows).toEqual(["Sonnet", "Opus [1M]", "GPT-5.6-Sol", "K3-1M"]);
     expect(menu.style.overflowY).toBe("auto");
     expect(Number.parseFloat(menu.style.maxHeight)).toBeLessThanOrEqual(520);

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -858,7 +858,7 @@ function AnalystModelChip({
                     <button
                       key={item.id}
                       type="button"
-                      className="session-analyst__model-row"
+                      className="operation-launch-variant-row"
                       role="menuitemradio"
                       aria-checked={item.id === value}
                       onClick={() => {
@@ -867,7 +867,7 @@ function AnalystModelChip({
                         chipRef.current?.focus();
                       }}
                     >
-                      <span>{shortModelLabel(item.label, caption)}</span>
+                      <span className="operation-launch-variant-row-label">{shortModelLabel(item.label, caption)}</span>
                       {item.id === value ? <span className="session-analyst__model-check" aria-hidden="true">✓</span> : null}
                     </button>
                   ))}

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
@@ -49,6 +49,9 @@ describe("Session Analyst contract", () => {
     // 모델은 Quick Launch 칩, 강도는 공용 트랙이다.
     expect(css).toContain(".session-analyst__model-chip");
     expect(css).toContain(".session-analyst__effort");
+    // 드롭다운 모델명은 우클릭 실행 메뉴와 같은 variant-row 조판이다.
+    expect(css).not.toContain(".session-analyst__model-row");
+    expect(css).toContain(".session-analyst__model-menu .operation-launch-variant-row");
     expect(css).not.toContain("--fc-select-compact-tone: var(--effort-tone, var(--text-secondary));");
     expect(css).toContain("user-select: text");
     expect(css).toContain(":is(button, select) { user-select: none; }");

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -229,9 +229,10 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__model-chip[aria-expanded="true"] .session-analyst__model-chip-label { color: var(--brass); }
 .session-analyst__model-chip-caret { flex: none; color: var(--text-tertiary); font-size: var(--t-2xs); }
 .session-analyst__model-menu { right: auto; width: 216px; max-width: calc(100vw - 16px); max-height: 520px; overflow-y: auto; }
-.session-analyst__model-row { display: flex; align-items: center; justify-content: space-between; gap: 7px; width: 100%; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); padding: 7px var(--space-2); font-family: inherit; font-size: var(--t-md); font-weight: var(--weight-medium); text-align: left; cursor: pointer; }
-.session-analyst__model-row:hover, .session-analyst__model-row:focus-visible { background: color-mix(in oklch, var(--ink-mid) 55%, transparent); color: var(--text-primary); }
-.session-analyst__model-row[aria-checked="true"] { color: var(--text-primary); }
+/* 모델 행은 우클릭 실행 메뉴와 같은 .operation-launch-variant-row(mono / --t-xs)다.
+   표식이 없으므로 캡션 글리프(16px)+간격(6px)만큼 들여 글자 열을 머리글과 맞춘다. */
+.session-analyst__model-menu .operation-launch-variant-row { padding-left: calc(var(--space-2) + 16px + 6px); }
+.session-analyst__model-menu .operation-launch-variant-row[aria-checked="true"] { color: var(--text-primary); }
 .session-analyst__model-check { color: var(--brass); font-size: var(--t-xs); }
 .session-analyst__effort { display: inline-flex; min-width: 0; }
 .session-analyst__effort[inert] { opacity: .42; }


### PR DESCRIPTION
## Summary
- Session Analyst 모델 선택 드롭다운의 모델명이 본문체/`--t-md`라 우클릭 실행 메뉴와 서체·크기·들여쓰기가 달랐습니다.
- 공유 `.operation-launch-variant-row`(mono / `--t-xs`)를 재사용하고, 캡션 글리프 열만큼 들여 글자 열을 맞춥니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` (968 passed)
- [ ] Session Analyst 모델 칩을 열어 우클릭 컨텍스트 메뉴와 모델명 서체/크기/들여쓰기가 같은지 확인