### PR TITLE
feat(fleet-console): keep one Shell per Theater and label its caption

### DIFF
--- a/.changelog.d/shell-panel-routing.md
+++ b/.changelog.d/shell-panel-routing.md
@@ -4,5 +4,5 @@ branch: shell-panel-routing
 
 ### fleet-console
 #### Changed
-- Move Shell creation from the canvas context menu and expandable right rail panel to a direct right rail action that creates a Shell Operation on the canvas.
-  ko: Shell 생성을 캔버스 컨텍스트 메뉴와 펼침형 우측 레일 패널에서 제거하고, 캔버스에 Shell Operation을 만드는 우측 레일 직접 동작으로 옮겼습니다.
+- Move Shell creation from the canvas context menu and expandable right rail panel to a direct right rail action that creates one Shell Operation per Theater on the canvas. Pressing the action again focuses the existing panel. The Shell caption shows its Theater name.
+  ko: Shell 생성을 캔버스 컨텍스트 메뉴와 펼침형 우측 레일 패널에서 제거하고, Theater당 하나의 Shell Operation을 캔버스에 만드는 우측 레일 직접 동작으로 옮겼습니다. 이미 있으면 다시 눌러도 그 패널에 포커스만 줍니다. 캡션에는 소속 Theater 이름도 보입니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -952,6 +952,9 @@ export function OperationsCanvas({
             accentKey: canvas.operationAccent[operation.id] ?? operationAccentFromNode(operation),
             groupName: operationGroup?.name ?? null,
             groupColor: operationGroupColor,
+            theaterLabel: operation.type === "shell"
+              ? state.theaters.find((theater) => theater.id === operation.theaterId)?.label || null
+              : null,
             onActivate: () => {
               setActiveOperation(operation.id);
               // 선별 중에는 기록하지 않는다 — 무대는 슬롯 geometry이고, 외부 Theater 무대의 기록은
@@ -1270,6 +1273,7 @@ function renderPluginOperation(operation: OperationNode, options: {
   readonly accentKey: string | null;
   readonly groupName: string | null;
   readonly groupColor: string | null;
+  readonly theaterLabel: string | null;
   readonly onActivate: () => void;
   readonly onClose: () => void;
   readonly onMinimize: () => void;
@@ -1317,6 +1321,7 @@ function renderPluginOperation(operation: OperationNode, options: {
         accentKey={options.accentKey}
         groupName={options.groupName}
         groupColor={options.groupColor}
+        theaterLabel={options.theaterLabel}
         onActivate={options.onActivate}
         onClose={options.onClose}
         onMinimize={options.onMinimize}

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -30,6 +30,8 @@ interface OperationFrameProps {
   readonly accentKey?: string | null;
   readonly groupName?: string | null;
   readonly groupColor?: string | null;
+  /** Shell 캡션의 소속 Theater. 저장 제목과 별개라 Theater 이름이 바뀌어도 따라간다. */
+  readonly theaterLabel?: string | null;
   readonly children: ReactNode;
   /**
    * 캡션 동작 선반 — 이 Operation의 플러그인이 채우는 마크 버튼들. 자리는 프레임이 정한다:
@@ -84,7 +86,7 @@ const ARRIVAL_FLASH_DURATION_MS = 360;
 // 위상을 한 박자로 묶는 레일 애니메이션 — components.css의 상태 레일 선언과 한 벌이다.
 const PHASE_LOCKED_RAIL_ANIMATIONS = new Set(["caption-rail-flow", "caption-rail-call", "caption-rail-tide"]);
 
-export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, deckTile = false, glanceHud, accentKey = null, groupName = null, groupColor = null, children, captionActions = null, onActivate, onClose, onMinimize, onMaximize, onRename, onOpenMenu, onRenderHiddenDismissMenu, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
+export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, deckTile = false, glanceHud, accentKey = null, groupName = null, groupColor = null, theaterLabel = null, children, captionActions = null, onActivate, onClose, onMinimize, onMaximize, onRename, onOpenMenu, onRenderHiddenDismissMenu, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
   const t = useT();
   const operationRef = useRef<HTMLElement | null>(null);
   const terminalRef = useRef<HTMLDivElement | null>(null);
@@ -118,6 +120,7 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
   // 그룹 소속은 개인 accent와 다른 축이므로 자기 마크(도트)와 중립 티어 이름으로 따로 선다 —
   // 색은 도트만 지고 이름은 캡션의 기존 중립 메타 티어를 그대로 상속한다.
   const groupLabelVisible = Boolean(groupName && groupColor);
+  const theaterLabelVisible = Boolean(theaterLabel);
   const className = [
     "canvas-operation",
     unseen ? "is-unseen" : "",
@@ -428,7 +431,7 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
       aria-label={t("canvas.frame.operationAria", {
         title: displayTitle,
         groupContext: groupLabelVisible ? t("canvas.frame.inGroup", { name: groupName ?? "" }) : "",
-      })}
+      }) + (theaterLabelVisible ? t("canvas.frame.inTheater", { name: theaterLabel ?? "" }) : "")}
       aria-hidden={renderHidden || undefined}
       tabIndex={focusLayerTarget ? -1 : undefined}
       inert={minimized || renderHidden ? true : undefined}
@@ -479,6 +482,15 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
             {displayTitle}
           </button>
         )}
+        {theaterLabelVisible ? (
+          <span
+            className="canvas-operation-theater-label"
+            title={t("canvas.frame.theaterTitle", { name: theaterLabel ?? "" })}
+            aria-hidden="true"
+          >
+            {theaterLabel}
+          </span>
+        ) : null}
         {triagePicked ? <span className="canvas-operation-triage-picked">{t("canvas.triage.picked")}</span> : null}
         {/* 캡션은 상태를 말하지 않는다 — 패널 자신의 보더·글로우가 이미 상태 채널을 지고 있고,
             목록에서 상태를 읽는 자리는 사이드바 칩이다. 이 자리는 그 Operation에 대한 동작을

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -48,7 +48,9 @@ export const canvasEn = {
 
   "canvas.frame.operationAria": "Operation {title}{groupContext}",
   "canvas.frame.inGroup": " in group {name}",
+  "canvas.frame.inTheater": " in {name}",
   "canvas.frame.groupTitle": "Group {name}",
+  "canvas.frame.theaterTitle": "Theater {name}",
   "canvas.frame.renameAria": "Rename operation {title}",
   "canvas.frame.renameTitle": "{title} — Drag to move. Double-click, Enter, or F2 to rename",
   "canvas.frame.openMenuAria": "Open menu for operation {title}",
@@ -246,7 +248,9 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
 
   "canvas.frame.operationAria": "Operation {title}{groupContext}",
   "canvas.frame.inGroup": " · {name} 그룹",
+  "canvas.frame.inTheater": " · {name}",
   "canvas.frame.groupTitle": "{name} 그룹",
+  "canvas.frame.theaterTitle": "Theater {name}",
   "canvas.frame.renameAria": "Operation {title} 이름 바꾸기",
   "canvas.frame.renameTitle": "{title} — 드래그로 이동. 더블클릭, Enter 또는 F2로 이름 변경",
   "canvas.frame.openMenuAria": "Operation {title} 메뉴 열기",

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -33,7 +33,7 @@ import { availableCompanionPanels, resolveCompanionShortcutToggle, usableCompani
 import { resolveOperationsArrowShortcutAction } from "../operations-arrow-shortcut.js";
 import { blocksOperationsShortcutWhileEditing } from "../operations-editing-shortcut-guard.js";
 import { cancelAddTheater, compareOperationCreatedAt, consumeOperationFocus, consumeQuickLaunch, reopenQuickLaunchWithDraft, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaters, nextOperationId, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
-import { findTheaterShellId, isTheaterShellLaunch, theaterShellDecisionRequiresHydration } from "../theater-shell.js";
+import { findTheaterShellId, isTheaterShellLaunch } from "../theater-shell.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 import { MobileShell } from "../mobile/mobile-shell.js";
 import { OperationBodyPool, type OperationBodyConfig } from "../mobile/operation-body-pool.js";
@@ -958,9 +958,14 @@ async function launchViaPlugin(
   if (inflightTheaterShellLaunches.has(theaterId)) return;
   inflightTheaterShellLaunches.add(theaterId);
   try {
-    // 부트 중 operations는 빈 배열이다. 그 상태를 "Shell 없음"으로 읽으면 복원분 옆에 하나를 더 만든다.
-    if (theaterShellDecisionRequiresHydration(kind, getState().operationsHydrated)) {
-      await fetchOperations(null).then(hydrateInitialOperations).catch(() => {});
+    // SSE `operation:changed`는 이미 아는 id만 패치한다. 다른 탭이 만든 Shell은 목록에 안 들어오므로
+    // 결정 직전에 서버 목록을 다시 읽는다. 부트(미hydrate)는 초기 합치기, 그 다음부터는 교체다.
+    try {
+      const operations = await fetchOperations(null);
+      if (getState().operationsHydrated) hydrateOperations(operations);
+      else hydrateInitialOperations(operations);
+    } catch {
+      // 조회 실패 시 로컬 스냅샷으로 결정한다.
     }
     const snapshot = getState();
     const existingId = findTheaterShellId(snapshot.operations, theaterId, {

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -960,12 +960,14 @@ async function launchViaPlugin(
   try {
     // SSE `operation:changed`는 이미 아는 id만 패치한다. 다른 탭이 만든 Shell은 목록에 안 들어오므로
     // 결정 직전에 서버 목록을 다시 읽는다. 부트(미hydrate)는 초기 합치기, 그 다음부터는 교체다.
+    let rosterFresh = false;
     try {
       const operations = await fetchOperations(null);
       if (getState().operationsHydrated) hydrateOperations(operations);
       else hydrateInitialOperations(operations);
+      rosterFresh = true;
     } catch {
-      // 조회 실패 시 로컬 스냅샷으로 결정한다.
+      // 조회 실패. 로컬에 Shell이 있으면 포커스하고, 없으면 만들지 않는다.
     }
     const snapshot = getState();
     const existingId = findTheaterShellId(snapshot.operations, theaterId, {
@@ -977,6 +979,7 @@ async function launchViaPlugin(
       focusOperation(existingId);
       return;
     }
+    if (!rosterFresh) return;
     await createLaunchedOperation(pluginId, kind, geometry, theaterId, plugins, variant);
   } finally {
     inflightTheaterShellLaunches.delete(theaterId);

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -32,7 +32,8 @@ import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-s
 import { availableCompanionPanels, resolveCompanionShortcutToggle, usableCompanionShortcuts } from "../companion-shortcut.js";
 import { resolveOperationsArrowShortcutAction } from "../operations-arrow-shortcut.js";
 import { blocksOperationsShortcutWhileEditing } from "../operations-editing-shortcut-guard.js";
-import { cancelAddTheater, compareOperationCreatedAt, consumeOperationFocus, consumeQuickLaunch, reopenQuickLaunchWithDraft, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
+import { cancelAddTheater, compareOperationCreatedAt, consumeOperationFocus, consumeQuickLaunch, reopenQuickLaunchWithDraft, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaters, nextOperationId, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
+import { findTheaterShellId, isTheaterShellLaunch, theaterShellDecisionRequiresHydration } from "../theater-shell.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 import { MobileShell } from "../mobile/mobile-shell.js";
 import { OperationBodyPool, type OperationBodyConfig } from "../mobile/operation-body-pool.js";
@@ -44,6 +45,9 @@ const DEFAULT_SHELL_WIDTH = 560;
 const DEFAULT_SHELL_HEIGHT = 360;
 // 사용자 close와 PTY 자가종료가 같은 operation의 close path를 중복 실행하는 것을 막는다.
 const closingOperationIds = new Set<string>();
+// Theater당 Shell 생성은 하나다. hydrate 전 빈 목록을 "없음"으로 읽거나 더블클릭이 두 장을 심지 않게,
+// 생성·목록 대기 중인 Theater를 붙잡는다.
+const inflightTheaterShellLaunches = new Set<string>();
 
 interface OperationsProps {
   readonly state: ConsoleState;
@@ -940,6 +944,41 @@ function canvasPointToGeometry(point: CanvasPoint): Omit<OperationGeometry, "zIn
 }
 
 async function launchViaPlugin(
+  pluginId: string,
+  kind: OperationLaunchKind,
+  geometry: OperationGeometry,
+  theaterId: string,
+  plugins: readonly FleetClientPlugin[],
+  variant?: Readonly<Record<string, string>>,
+): Promise<void> {
+  if (!isTheaterShellLaunch(kind)) {
+    await createLaunchedOperation(pluginId, kind, geometry, theaterId, plugins, variant);
+    return;
+  }
+  if (inflightTheaterShellLaunches.has(theaterId)) return;
+  inflightTheaterShellLaunches.add(theaterId);
+  try {
+    // 부트 중 operations는 빈 배열이다. 그 상태를 "Shell 없음"으로 읽으면 복원분 옆에 하나를 더 만든다.
+    if (theaterShellDecisionRequiresHydration(kind, getState().operationsHydrated)) {
+      await fetchOperations(null).then(hydrateInitialOperations).catch(() => {});
+    }
+    const snapshot = getState();
+    const existingId = findTheaterShellId(snapshot.operations, theaterId, {
+      pluginId,
+      activeOperationId: snapshot.activeOperationId,
+    });
+    if (existingId) {
+      // Theater당 Shell은 하나다. 이미 있으면 생성 대신 그 패널을 포커스한다(최소화 복원·카메라 이동).
+      focusOperation(existingId);
+      return;
+    }
+    await createLaunchedOperation(pluginId, kind, geometry, theaterId, plugins, variant);
+  } finally {
+    inflightTheaterShellLaunches.delete(theaterId);
+  }
+}
+
+async function createLaunchedOperation(
   pluginId: string,
   kind: OperationLaunchKind,
   geometry: OperationGeometry,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4654,6 +4654,27 @@ body[data-side-bar-animating="true"] .canvas-operation {
   text-overflow: ellipsis;
 }
 
+/* Shell 소속 Theater — 그룹과 같은 중립 메타 티어. 색 마크는 없다(위치이지 정체성·그룹이 아니다).
+   제목보다 먼저 양보한다. 긴 Theater 이름이 "Shell"을 밀어내면 캡션 1순위가 뒤집힌다. */
+.canvas-operation-theater-label {
+  flex: 0 8 auto;
+  min-width: 0;
+  max-width: min(40%, 18ch);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  transition: color var(--duration-base) var(--ease-spring);
+}
+
+.canvas-operation.is-active > .canvas-operation-titlebar .canvas-operation-theater-label {
+  color: var(--text-secondary);
+}
+
 /* 진행 중 캐리어 스트림을 패널 바깥 아래에 floating으로 띄우는 dock. left/top/width는 패널 geometry를
    인라인으로 받고(top=패널 하단 모서리), translateY로 작은 간격만큼 아래로 내려 패널 하단에 정렬한다. */
 .canvas-operation-jobdock {
@@ -6468,6 +6489,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   .canvas-operation-titlebar,
   .canvas-operation-titlebar::after,
   .canvas-operation-group-label,
+  .canvas-operation-theater-label,
   .canvas-operation-window-controls,
   .canvas-operation-icon-button {
     transition-duration: 0.01ms;

--- a/runtime/fleet-console/core/client/src/theater-shell.ts
+++ b/runtime/fleet-console/core/client/src/theater-shell.ts
@@ -1,0 +1,74 @@
+import type { OperationLaunchKind } from "@fleet-console/sdk/operations";
+
+import type { OperationNode } from "./types.js";
+
+const SHELL_OPERATION_TYPE = "shell";
+
+export type TheaterShellLaunchDecision =
+  | { readonly action: "create" }
+  | { readonly action: "reuse"; readonly operationId: string }
+  | { readonly action: "busy" };
+
+export function isTheaterShellLaunch(kind: Pick<OperationLaunchKind, "type">): boolean {
+  return kind.type === SHELL_OPERATION_TYPE;
+}
+
+/** 목록이 비어 있는 부트 구간을 "Shell 없음"으로 읽으면 복원분 옆에 하나를 더 만든다. */
+export function theaterShellDecisionRequiresHydration(
+  kind: Pick<OperationLaunchKind, "type">,
+  operationsHydrated: boolean,
+): boolean {
+  return isTheaterShellLaunch(kind) && !operationsHydrated;
+}
+
+/** Theater 안의 기존 Shell Operation. 없으면 null. 활성 패널이 Shell이면 그것을, 아니면 가장 최근 것을 고른다. */
+export function findTheaterShellId(
+  operations: readonly OperationNode[],
+  theaterId: string,
+  options: {
+    readonly pluginId: string;
+    readonly activeOperationId?: string | null;
+  },
+): string | null {
+  const shells = operations.filter((operation) => (
+    operation.theaterId === theaterId
+    && operation.type === SHELL_OPERATION_TYPE
+    && operation.pluginId === options.pluginId
+  ));
+  if (shells.length === 0) return null;
+  const activeId = options.activeOperationId;
+  if (activeId !== undefined && activeId !== null && shells.some((operation) => operation.id === activeId)) {
+    return activeId;
+  }
+  return shells.reduce((best, candidate) => preferLaterShell(best, candidate)).id;
+}
+
+/**
+ * Shell 실행 요청을 생성 / 기존 패널 재사용 / 생성 중 무시로 가른다.
+ * 에이전트 등 다른 종류는 항상 생성이다.
+ */
+export function resolveTheaterShellLaunch(
+  operations: readonly OperationNode[],
+  theaterId: string,
+  pluginId: string,
+  kind: Pick<OperationLaunchKind, "type">,
+  options: {
+    readonly activeOperationId?: string | null;
+    readonly inflightTheaterIds?: ReadonlySet<string>;
+  } = {},
+): TheaterShellLaunchDecision {
+  if (!isTheaterShellLaunch(kind)) return { action: "create" };
+  const existingId = findTheaterShellId(operations, theaterId, {
+    pluginId,
+    activeOperationId: options.activeOperationId,
+  });
+  if (existingId) return { action: "reuse", operationId: existingId };
+  if (options.inflightTheaterIds?.has(theaterId)) return { action: "busy" };
+  return { action: "create" };
+}
+
+function preferLaterShell(left: OperationNode, right: OperationNode): OperationNode {
+  if (right.ts.updatedAt !== left.ts.updatedAt) return right.ts.updatedAt > left.ts.updatedAt ? right : left;
+  if (right.ts.createdAt !== left.ts.createdAt) return right.ts.createdAt > left.ts.createdAt ? right : left;
+  return right.id > left.id ? right : left;
+}

--- a/runtime/fleet-console/tests/i18n.test.ts
+++ b/runtime/fleet-console/tests/i18n.test.ts
@@ -49,6 +49,7 @@ const IDENTICAL_LOCALE_VALUE_ALLOWLIST = new Set([
   "Activity Rail",
   "Quick Launch",
   "Theater",
+  "Theater {name}",
   "Codex",
   // 실행 그룹은 공급자 제품명을 그대로 읽는다 — Codex와 같은 자리다.
   "Claude",

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -946,6 +946,26 @@ describe("Instrument core design contract", () => {
     expect(reducedMotion).toContain(".canvas-operation-group-label,");
   });
 
+  it("pins the Shell caption Theater label — neutral meta, no colour mark, yields before the title", () => {
+    const frame = source("canvas/operation-frame.tsx");
+    const canvas = source("canvas/canvas.tsx");
+    const components = source("styles/components.css");
+    const labelBlock = components.match(/\.canvas-operation-theater-label \{[^}]*\}/)?.[0] ?? "";
+
+    expect(canvas).toContain("operation.type === \"shell\"");
+    expect(frame).toContain('className="canvas-operation-theater-label"');
+    expect(labelBlock).not.toMatch(/border|background/);
+    expect(labelBlock).toContain("color: var(--text-tertiary);");
+    expect(labelBlock).toContain("flex: 0 8 auto;");
+    expect(labelBlock).toContain("max-width: min(40%, 18ch);");
+    expect(labelBlock).toContain("min-width: 0;");
+    expect(labelBlock).toContain("text-overflow: ellipsis;");
+    expect(labelBlock).not.toMatch(/animation/);
+    expect(components).toMatch(/\.canvas-operation\.is-active > \.canvas-operation-titlebar \.canvas-operation-theater-label \{\s*color: var\(--text-secondary\);/);
+    const reducedMotion = components.slice(components.indexOf("@media (prefers-reduced-motion: reduce)"));
+    expect(reducedMotion).toContain(".canvas-operation-theater-label,");
+  });
+
   it("pins the AI Gateway capability-class badge grammar — ink rank, no signal colour, dashed for unclassed", () => {
     // 등급은 Operation 상태가 아니라 프로바이더가 자기 라인업에 대해 주장하는 속성이다.
     // 신호색을 빌리면 같은 행에서 등급이 상태처럼 읽혀 활동 축과 서로를 부정한다.

--- a/runtime/fleet-console/tests/operation-frame-identity.test.ts
+++ b/runtime/fleet-console/tests/operation-frame-identity.test.ts
@@ -165,6 +165,49 @@ describe("OperationFrame identity rename", () => {
     expect(document.querySelector(".canvas-operation")!.className).toContain("is-top-edge");
   });
 
+  it("shows a Theater name after the Shell title without putting it in the rename draft", () => {
+    act(() => root!.render(createElement(OperationFrame, {
+      operation: {
+        id: "operation-identity",
+        theaterId: "theater-identity",
+        type: "shell",
+        pluginId: "terminal",
+        title: "Shell",
+        payload: {},
+        geometry: null,
+        ts: { createdAt: 1, updatedAt: 1 },
+      },
+      active: false,
+      unseen: false,
+      theaterLabel: "fleet-harness",
+      glanceHud: { index: "01", hints: [] },
+      geometry: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 },
+      zoom: 1,
+      onActivate: () => {},
+      onClose: () => {},
+      onMinimize: () => {},
+      onMaximize: () => {},
+      onRename: () => {},
+      onOpenMenu: () => {},
+      onGeometryChange: () => {},
+      onGeometryCommit: () => {},
+      children: createElement("div"),
+    })));
+
+    const titlebar = document.querySelector(".canvas-operation-titlebar")!;
+    const children = Array.from(titlebar.children);
+    const theater = document.querySelector(".canvas-operation-theater-label");
+    expect(theater?.textContent).toBe("fleet-harness");
+    expect(children[0]?.className).toBe("canvas-operation-identity-name");
+    expect(children[1]?.className).toBe("canvas-operation-theater-label");
+    expect(identityTrigger().textContent).toBe("Shell");
+    expect(document.querySelector("article")?.getAttribute("aria-label")).toContain("fleet-harness");
+
+    beginRename(identityTrigger());
+    expect(identityInput()?.value).toBe("Shell");
+    expect(document.querySelector(".canvas-operation-theater-label")?.textContent).toBe("fleet-harness");
+  });
+
   it("keeps active identity in the name → More → controls order", () => {
     renderFrame(vi.fn(), true);
     const children = Array.from(document.querySelector(".canvas-operation-titlebar")!.children);

--- a/runtime/fleet-console/tests/theater-shell.test.ts
+++ b/runtime/fleet-console/tests/theater-shell.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findTheaterShellId,
+  isTheaterShellLaunch,
+  resolveTheaterShellLaunch,
+  theaterShellDecisionRequiresHydration,
+} from "../core/client/src/theater-shell.js";
+import type { OperationNode } from "../core/client/src/types.js";
+
+const THEATER = "theater-a";
+const OTHER = "theater-b";
+const PLUGIN = "terminal";
+
+describe("theater Shell singleton", () => {
+  it("treats only shell launch kinds as the Theater singleton", () => {
+    expect(isTheaterShellLaunch({ type: "shell" })).toBe(true);
+    expect(isTheaterShellLaunch({ type: "agent" })).toBe(false);
+  });
+
+  it("does not treat an empty unhydrated list as proof that the Theater has no Shell", () => {
+    expect(theaterShellDecisionRequiresHydration({ type: "shell" }, false)).toBe(true);
+    expect(theaterShellDecisionRequiresHydration({ type: "shell" }, true)).toBe(false);
+    expect(theaterShellDecisionRequiresHydration({ type: "agent" }, false)).toBe(false);
+  });
+
+  it("returns null when the Theater has no Shell", () => {
+    expect(findTheaterShellId([
+      operation("agent-1", { type: "agent" }),
+      operation("shell-other", { theaterId: OTHER }),
+    ], THEATER, { pluginId: PLUGIN })).toBeNull();
+  });
+
+  it("returns the Theater Shell and ignores other Theaters, types, and plugins", () => {
+    expect(findTheaterShellId([
+      operation("shell-a"),
+      operation("shell-other", { theaterId: OTHER, ts: later(2) }),
+      operation("agent-a", { type: "agent", ts: later(3) }),
+      operation("foreign-shell", { pluginId: "other", ts: later(4) }),
+    ], THEATER, { pluginId: PLUGIN })).toBe("shell-a");
+  });
+
+  it("prefers the active Shell when several already exist", () => {
+    expect(findTheaterShellId([
+      operation("older", { ts: later(1) }),
+      operation("newer", { ts: later(5) }),
+    ], THEATER, { pluginId: PLUGIN, activeOperationId: "older" })).toBe("older");
+  });
+
+  it("picks the most recently updated Shell when none of them is active", () => {
+    expect(findTheaterShellId([
+      operation("stale", { ts: { createdAt: 8, updatedAt: 2 } }),
+      operation("fresh", { ts: { createdAt: 1, updatedAt: 9 } }),
+    ], THEATER, { pluginId: PLUGIN, activeOperationId: "agent-elsewhere" })).toBe("fresh");
+  });
+
+  it("breaks equal update times with createdAt, then id", () => {
+    expect(findTheaterShellId([
+      operation("a", { ts: { createdAt: 1, updatedAt: 4 } }),
+      operation("b", { ts: { createdAt: 3, updatedAt: 4 } }),
+    ], THEATER, { pluginId: PLUGIN })).toBe("b");
+    expect(findTheaterShellId([
+      operation("m", { ts: { createdAt: 2, updatedAt: 4 } }),
+      operation("z", { ts: { createdAt: 2, updatedAt: 4 } }),
+    ], THEATER, { pluginId: PLUGIN })).toBe("z");
+  });
+
+  it("reuses an existing Shell instead of creating another", () => {
+    expect(resolveTheaterShellLaunch(
+      [operation("shell-a")],
+      THEATER,
+      PLUGIN,
+      { type: "shell" },
+    )).toEqual({ action: "reuse", operationId: "shell-a" });
+  });
+
+  it("creates when the Theater has no Shell and is not mid-launch", () => {
+    expect(resolveTheaterShellLaunch([], THEATER, PLUGIN, { type: "shell" })).toEqual({ action: "create" });
+    expect(resolveTheaterShellLaunch([], THEATER, PLUGIN, { type: "agent" })).toEqual({ action: "create" });
+  });
+
+  it("drops an overlapping Shell create while one is already in flight", () => {
+    expect(resolveTheaterShellLaunch([], THEATER, PLUGIN, { type: "shell" }, {
+      inflightTheaterIds: new Set([THEATER]),
+    })).toEqual({ action: "busy" });
+  });
+
+  it("does not let an in-flight Shell block an agent launch in the same Theater", () => {
+    expect(resolveTheaterShellLaunch([], THEATER, PLUGIN, { type: "agent" }, {
+      inflightTheaterIds: new Set([THEATER]),
+    })).toEqual({ action: "create" });
+  });
+});
+
+function operation(id: string, overrides: Partial<OperationNode> = {}): OperationNode {
+  return {
+    id,
+    theaterId: THEATER,
+    type: "shell",
+    pluginId: PLUGIN,
+    title: "Shell",
+    payload: {},
+    geometry: null,
+    ts: { createdAt: 1, updatedAt: 1 },
+    ...overrides,
+  };
+}
+
+function later(at: number): OperationNode["ts"] {
+  return { createdAt: at, updatedAt: at };
+}

--- a/runtime/fleet-plugins/terminal/tests/global-shell-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/global-shell-routes.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it, vi } from "vitest";
 import { globalShellPanel } from "../client/global-shell/rail-panel.js";
 
 describe("Shell rail launcher", () => {
-  it("launches a terminal Shell Operation instead of rendering a rail panel", () => {
+  // Theater당 1개 재사용은 호스트 launch 경로가 맡는다. 레일 기여는 실행 요청만 보낸다.
+  it("asks the host to launch a terminal Shell Operation instead of rendering a rail panel", () => {
     const launchOperation = vi.fn();
 
     globalShellPanel.activate?.({ launchOperation } as unknown as RailPanelContext);


### PR DESCRIPTION
## Summary
- Theater당 Shell Operation은 하나만 둡니다. 우측 레일 Shell을 다시 누르면 새로 만들지 않고 기존 패널을 포커스합니다.
- 부트 중 빈 목록을 "Shell 없음"으로 읽지 않도록, 생성 전에 operations hydrate를 기다립니다.
- Shell 캡션에 소속 Theater 이름을 표시합니다. 저장 제목은 그대로 두고 Theater 이름이 바뀌면 캡션이 따라갑니다.

Changelog-Amend: shell-panel-routing.md

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/theater-shell.test.ts tests/operation-frame-identity.test.ts tests/i18n.test.ts tests/instrument-design-contract.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p core/client/tsconfig.json`
- [x] 격리 Console에서 Theater 두 개를 넣고 레일 Shell 재클릭이 포커스만 하는지, 캡션에 Theater 이름이 보이는지 확인
- [ ] War Room에서 `activeTheaterId`의 Shell만 무대에 오르고, 다른 Theater Shell은 그대로인지 확인