### PR TITLE
feat(fleet-admiral)!: require a roster lookup before delegating

### DIFF
--- a/.changelog.d/gateway-lookup-gate.md
+++ b/.changelog.d/gateway-lookup-gate.md
@@ -1,0 +1,8 @@
+---
+branch: gateway-lookup-gate
+---
+
+### fleet-cli
+#### Changed
+- A delegation is now refused until the session has actually called `gateway_models`. Naming a `fleet:*` identity is no longer enough on its own: the roster is resolved at call time, so a name carried in from memory or from another session is refused with the lookup instruction instead of dispatching against a roster nobody read. Built-in agent types still need no lookup, and a session whose transcript cannot be read is not blocked.
+  ko: 이제 세션이 `gateway_models`를 실제로 호출하기 전까지는 위임이 거부됩니다. `fleet:*` 정체성을 적어 넣는 것만으로는 부족합니다 — 로스터는 호출 시점에 결정되므로, 기억이나 다른 세션에서 가져온 이름은 아무도 읽지 않은 로스터로 디스패치되는 대신 조회 안내와 함께 거부됩니다. 내장 에이전트 타입은 여전히 조회가 필요 없고, 트랜스크립트를 읽을 수 없는 세션은 차단되지 않습니다.

--- a/.changelog.d/gateway-lookup-gate.md
+++ b/.changelog.d/gateway-lookup-gate.md
@@ -4,5 +4,5 @@ branch: gateway-lookup-gate
 
 ### fleet-cli
 #### Changed
-- A delegation is now refused until the session has actually called `gateway_models`. Naming a `fleet:*` identity is no longer enough on its own: the roster is resolved at call time, so a name carried in from memory or from another session is refused with the lookup instruction instead of dispatching against a roster nobody read. Built-in agent types still need no lookup, and a session whose transcript cannot be read is not blocked.
-  ko: 이제 세션이 `gateway_models`를 실제로 호출하기 전까지는 위임이 거부됩니다. `fleet:*` 정체성을 적어 넣는 것만으로는 부족합니다 — 로스터는 호출 시점에 결정되므로, 기억이나 다른 세션에서 가져온 이름은 아무도 읽지 않은 로스터로 디스패치되는 대신 조회 안내와 함께 거부됩니다. 내장 에이전트 타입은 여전히 조회가 필요 없고, 트랜스크립트를 읽을 수 없는 세션은 차단되지 않습니다.
+- A delegation is now refused until the session has actually received a roster from `gateway_models`. A call the gateway never answered, and one issued in the same turn as the delegation, do not count. Naming a `fleet:*` identity is no longer enough on its own: the roster is resolved at call time, so a name carried in from memory or from another session is refused with the lookup instruction instead of dispatching against a roster nobody read. Built-in agent types still need no lookup, and a session whose transcript cannot be read is not blocked.
+  ko: 이제 세션이 `gateway_models`로부터 로스터를 실제로 받기 전까지는 위임이 거부됩니다. 게이트웨이가 응답하지 않은 호출과 위임과 같은 턴에 발행된 호출은 인정되지 않습니다. `fleet:*` 정체성을 적어 넣는 것만으로는 부족합니다 — 로스터는 호출 시점에 결정되므로, 기억이나 다른 세션에서 가져온 이름은 아무도 읽지 않은 로스터로 디스패치되는 대신 조회 안내와 함께 거부됩니다. 내장 에이전트 타입은 여전히 조회가 필요 없고, 트랜스크립트를 읽을 수 없는 세션은 차단되지 않습니다.

--- a/docs/admiral-prompt-architecture.md
+++ b/docs/admiral-prompt-architecture.md
@@ -65,10 +65,16 @@ first argument:
 | `gate-delegation` | PreToolUse | `Agent|Workflow` | Blocks a fan-out from a session that has not read the roster, an unpinned `Agent` delegation, and a `Workflow` stage whose model value is misspelled. |
 | `workflow-receipt` | PostToolUse | `Workflow` | States that the dispatch returned a receipt, not a result. |
 
-Before either judgment, `gate-delegation` asks whether this session ever called
-`gateway_models`, by scanning the session transcript for a `tool_use` block naming that
-tool. The spelling of a pin is visible in the payload; whether the name it spells still
-resolves is only in the roster. A gate that reads spelling alone passes a name carried in
+Before either judgment, `gate-delegation` asks whether this session ever received a
+roster, by scanning the session transcript for a `tool_use` block naming `gateway_models`
+and then for the `tool_result` answering that call id. The spelling of a pin is visible in
+the payload; whether the name it spells still resolves is only in the roster. The answer
+is what counts, not the call: a lookup the gateway never answered and one issued in the
+same turn as the delegation both leave the session without a roster, and the harness
+records even parallel calls on separate lines, so a `tool_use` still awaiting its result
+is an ordinary intermediate state rather than an exotic one. A result carrying
+`is_error` is a failure; success is written as that field being absent, and one answered
+call is enough. A gate that reads spelling alone passes a name carried in
 from memory or from another session, and what remains is the appearance of compliance.
 The scan ignores a lookup made inside a subagent — the host is what decides the
 delegation — and it ignores the string `gateway_models` wherever it appears outside a

--- a/docs/admiral-prompt-architecture.md
+++ b/docs/admiral-prompt-architecture.md
@@ -52,21 +52,37 @@ and the standalone `fleet` launcher — read that one option, and it binds new s
 
 The policy that used to live in the Standing Orders now lives in one embedded hook,
 `packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs`, rendered into the
-Fleet plugin at `hooks/fleet-gateway-model-guard.mjs`. It is stateless — every judgment
-is made from one stdin payload, so a hook timeout cannot silently open the gate through a
-missing state file. One script serves three roles, selected by its first argument:
+Fleet plugin at `hooks/fleet-gateway-model-guard.mjs`. It keeps no state of its own: a
+file the hook wrote itself would carry freshness, cleanup, and contention, and a gate that
+opens when its own bookkeeping goes missing is not a gate. What it needs to remember about
+the session it reads from the transcript the harness already writes, addressed by the
+`transcript_path` the payload carries. One script serves three roles, selected by its
+first argument:
 
 | Subcommand | Event | Matcher | Effect |
 |---|---|---|---|
 | `remind` | UserPromptSubmit | — | Injects the pin contract every turn. This is the only path by which the contract reaches the model. |
-| `gate-delegation` | PreToolUse | `Agent|Workflow` | Blocks an unpinned `Agent` delegation, and a `Workflow` stage whose model value is misspelled. |
+| `gate-delegation` | PreToolUse | `Agent|Workflow` | Blocks a fan-out from a session that has not read the roster, an unpinned `Agent` delegation, and a `Workflow` stage whose model value is misspelled. |
 | `workflow-receipt` | PostToolUse | `Workflow` | States that the dispatch returned a receipt, not a result. |
+
+Before either judgment, `gate-delegation` asks whether this session ever called
+`gateway_models`, by scanning the session transcript for a `tool_use` block naming that
+tool. The spelling of a pin is visible in the payload; whether the name it spells still
+resolves is only in the roster. A gate that reads spelling alone passes a name carried in
+from memory or from another session, and what remains is the appearance of compliance.
+The scan ignores a lookup made inside a subagent — the host is what decides the
+delegation — and it ignores the string `gateway_models` wherever it appears outside a
+call, which is every turn: the contract injected by `remind` contains it, and so does the
+tool listing. A fan-out onto a built-in agent type needs no lookup, because nothing on
+that path is drawn from the roster. When the transcript cannot be read at all the gate
+stays open: a harness path that stops carrying `transcript_path` would otherwise block
+every delegation, which is a worse failure than missing one lookup.
 
 `gate-delegation` blocks an `Agent` call whose `subagent_type` is `general-purpose` or
 `claude`, or absent. Built-in specialist types and `fork` pass — `fork` inherits parent
 context by design, so moving it to another model removes the point of that surface.
 
-For `Workflow` the gate judges spelling only. A stage that names no model is allowed and
+Past that lookup, for `Workflow` the gate judges spelling only. A stage that names no model is allowed and
 runs on the session model; whether a fan-out is worth spreading across providers is a
 reading of the work, not a property the hook can see, and a gate that demanded a pin per
 stage only taught the host to fill every stage with one value — the spread it was meant to

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -9,21 +9,29 @@
 // 세 곳에서 따로 늙는다.
 //
 //   remind            UserPromptSubmit          매 턴 규약 주입 (무조건)
-//   gate-delegation   PreToolUse  Agent|Workflow  Agent의 핀 누락과 workflow의 틀린 모델 철자를 차단
+//   gate-delegation   PreToolUse  Agent|Workflow  로스터를 읽지 않은 팬아웃, Agent의 핀 누락,
+//                                                 workflow의 틀린 모델 철자를 차단
 //   workflow-receipt  PostToolUse Workflow        접수증을 결과로 읽는 사고를 차단
 //
-// 상태를 남기지 않는다. 훅은 호출마다 새 프로세스로 뜨므로 프로세스 간 기억은 파일로만
-// 가능한데, 그 파일은 곧 신선도·정리·경합을 떠안는 두 번째 진실이 된다. 세 판정 모두
-// stdin 한 번으로 끝나도록 짰다 — 그래서 타임아웃으로 게이트가 조용히 열릴 여지도 작다.
+// 자체 상태를 남기지 않는다. 프로세스 간 기억을 위해 훅이 직접 쓰는 파일은 곧 신선도·정리·
+// 경합을 떠안는 두 번째 진실이 되고, 그 파일이 사라지면 게이트가 조용히 열린다. 조회 여부는
+// 그래서 하네스가 이미 소유한 트랜스크립트에서 읽는다 — 새 진실을 만들지 않고, 훅이 관리할
+// 수명도 없다.
 import { readFileSync } from "node:fs";
 
 // 모델에게 주는 지시이므로 영어로 쓴다.
+//
+// 조회와 핀은 층위가 다르다. 조회는 무조건이고 핀은 표면마다 조건이 붙는데, 한 문단에 섞으면
+// 핀 쪽 면제("스테이지는 세션 모델에 머물러도 된다")가 조회의 무조건성까지 조건부로 물들인다.
+// 그래서 조회를 먼저 끝내고, 핀 철자는 그 뒤에서 따로 말한다.
 const TURN_REMINDER = [
-  "Call gateway_models before a run leaves the host and pin from what that call reports — allowances and the",
-  "roster itself move while work is in flight, so a remembered name is not evidence that it still resolves.",
+  "Call gateway_models before any Agent or Workflow run leaves the host — every time, not once per session.",
+  "The roster and its allowances are resolved at call time, so a name you remember is not evidence that it",
+  "still resolves.",
+  "Then pin from what that call reports.",
   "Agent: subagent_type = the fleet:* name, always.",
-  "A Workflow stage may stay on the host model; when you do move one, pin it from that same lookup —",
-  "opts.model takes the modelId with the claude-gateway-- prefix, opts.agentType takes the fleet:* name.",
+  "A Workflow stage may stay on the session model; when you do move one, opts.model takes the modelId with",
+  "the claude-gateway-- prefix and opts.agentType takes the fleet:* name.",
   "The spellings are never interchangeable.",
 ].join(" ");
 
@@ -37,6 +45,11 @@ const IN_FLIGHT_CONTRACT = [
 
 const PIN_INSTRUCTION =
   "Call gateway_models first, then pin the identity it reports: subagent_type = the fleet:* name.";
+
+const LOOKUP_INSTRUCTION =
+  "Call gateway_models now, then pin from what it reports. The roster is resolved at call time —"
+  + " a name carried in from memory, from another session, or from this tool's own description is not evidence"
+  + " that it still resolves.";
 
 /**
  * 정체성이 핀되지 않은 위임으로 취급하는 Agent 타입.
@@ -55,6 +68,11 @@ const GATEWAY_MODEL_PREFIX = "claude-gateway--";
 const MODEL_VALUE_RE = /model\s*:\s*['"]([^'"]+)['"]/g;
 const AGENT_TYPE_VALUE_RE = /agentType\s*:\s*['"]([^'"]+)['"]/g;
 
+// MCP 이름은 서버 등록명에 따라 접두가 달라진다. 서버 이름을 하드코딩하면 등록명이 바뀌는 날
+// 게이트가 조용히 전부 통과시키므로, 접두는 모양으로만 받고 도구 이름으로 판정한다.
+const LOOKUP_TOOL_NAME_RE = /^(?:mcp__[A-Za-z0-9_.-]+__)?gateway_models$/;
+const LOOKUP_CALL_HINT_RE = /"name"\s*:\s*"(?:mcp__[A-Za-z0-9_.-]+__)?gateway_models"/;
+
 function block(message) {
   process.stderr.write(`[fleet-gateway-model-guard] ${message}\n`);
   process.exit(2);
@@ -72,6 +90,57 @@ function readHookInput() {
     // 입력을 읽지 못하면 판정할 근거가 없다. 차단은 근거가 있을 때만 한다.
     process.exit(0);
   }
+}
+
+/**
+ * 이 세션이 로스터를 읽었는가. 판정 근거는 하네스가 쓰는 세션 트랜스크립트다.
+ *
+ * 트랜스크립트를 볼 수 없으면 참을 돌린다. 훅이 이 필드를 받지 못하는 경로가 생겼을 때 모든
+ * 위임이 막히는 쪽이, 조회 한 번을 놓치는 쪽보다 훨씬 나쁘다 — 게이트는 근거가 있을 때만 닫는다.
+ */
+function sessionReadRoster(input) {
+  const transcriptPath = typeof input?.transcript_path === "string" ? input.transcript_path : undefined;
+  if (transcriptPath === undefined || transcriptPath.length === 0) return true;
+  let raw;
+  try {
+    raw = readFileSync(transcriptPath, "utf8");
+  } catch {
+    return true;
+  }
+  // 값싼 부정 먼저. `gateway_models`라는 문자열 자체는 매 턴 주입되는 규약문, 도구 목록,
+  // 사용자 프롬프트에도 흔해서 그것만으로는 호출의 증거가 못 된다. 힌트가 걸린 뒤에야 라인을
+  // 파싱해 진짜 tool_use인지 가린다.
+  if (!LOOKUP_CALL_HINT_RE.test(raw)) return false;
+  for (const line of raw.split("\n")) {
+    if (!line.includes("gateway_models")) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    // 서브에이전트가 읽은 로스터는 호스트의 조회가 아니다. 위임을 결정하는 것은 호스트다.
+    if (entry?.isSidechain === true) continue;
+    const content = entry?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const contentBlock of content) {
+      if (contentBlock?.type !== "tool_use") continue;
+      if (typeof contentBlock.name !== "string") continue;
+      if (LOOKUP_TOOL_NAME_RE.test(contentBlock.name)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * 로스터를 읽지 않은 팬아웃을 차단한다.
+ *
+ * 핀의 철자는 볼 수 있어도 그 이름이 아직 해석되는지는 로스터에만 있다. 철자만 검사하면
+ * 기억한 이름이 통과하고, 그 순간 규약은 지켜졌다는 외양만 남는다.
+ */
+function assertRosterWasRead(input, subject) {
+  if (sessionReadRoster(input)) return;
+  block(`${subject} 이 세션은 아직 gateway_models를 호출하지 않았습니다. ` + LOOKUP_INSTRUCTION);
 }
 
 /**
@@ -135,9 +204,14 @@ function resolveWorkflowScript(toolInput) {
   return undefined;
 }
 
-function gateAgentDelegation(toolInput) {
+function gateAgentDelegation(toolInput, input) {
   const agentType = typeof toolInput.subagent_type === "string" ? toolInput.subagent_type : undefined;
-  if (agentType !== undefined && agentType.startsWith(GATEWAY_AGENT_PREFIX)) process.exit(0);
+  if (agentType !== undefined && agentType.startsWith(GATEWAY_AGENT_PREFIX)) {
+    // 게이트웨이 정체성으로 나가는 위임만 로스터를 요구한다. 내장 타입은 호스트 모델로 도는
+    // 도구 선택이라 로스터에 걸린 것이 없다.
+    assertRosterWasRead(input, `게이트웨이 위임(${agentType})이 거부되었습니다:`);
+    process.exit(0);
+  }
   if (agentType !== undefined && !UNPINNED_AGENT_TYPES.has(agentType)) process.exit(0);
   block(
     `이 위임은 정체성이 핀되지 않았습니다(subagent_type: ${agentType ?? "미지정"}). ` +
@@ -145,7 +219,10 @@ function gateAgentDelegation(toolInput) {
   );
 }
 
-function gateWorkflowDelegation(toolInput) {
+function gateWorkflowDelegation(toolInput, input) {
+  // 스테이지를 옮기지 않는 워크플로우도 호스트를 떠나는 팬아웃이다. 옮길지 말지를 판단하려면
+  // 그 판단의 재료인 로스터를 먼저 읽어야 하므로, 스크립트를 보기 전에 조회부터 확인한다.
+  assertRosterWasRead(input, "이 워크플로우 디스패치가 거부되었습니다:");
   const script = resolveWorkflowScript(toolInput);
   if (script === undefined) process.exit(0);
   assertWorkflowModelValues(script);
@@ -169,8 +246,8 @@ if (subcommand === "workflow-receipt") {
 }
 
 if (subcommand === "gate-delegation") {
-  if (toolName === "Agent") gateAgentDelegation(toolInput);
-  if (toolName === "Workflow") gateWorkflowDelegation(toolInput);
+  if (toolName === "Agent") gateAgentDelegation(toolInput, input);
+  if (toolName === "Workflow") gateWorkflowDelegation(toolInput, input);
   process.exit(0);
 }
 

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -95,6 +95,12 @@ function readHookInput() {
 /**
  * 이 세션이 로스터를 읽었는가. 판정 근거는 하네스가 쓰는 세션 트랜스크립트다.
  *
+ * 호출이 아니라 `tool_result`가 판정 대상이다. 호출만 세면 게이트웨이가 응답하지 않아 실패로
+ * 끝난 조회와, 위임과 같은 턴에 발행되어 아직 결과가 없는 조회가 성공한 조회와 구별되지 않는다
+ * — 둘 다 로스터를 받지 못한 세션인데, 그 세션이 기억해둔 이름으로 위임하는 것이 이 게이트가
+ * 막으려는 바로 그 경우다. 하네스는 한 턴에 병렬로 발행된 호출도 각각 별도 라인으로 적으므로,
+ * 결과 없는 `tool_use`는 예외적인 모양이 아니라 흔한 중간 상태다.
+ *
  * 트랜스크립트를 볼 수 없으면 참을 돌린다. 훅이 이 필드를 받지 못하는 경로가 생겼을 때 모든
  * 위임이 막히는 쪽이, 조회 한 번을 놓치는 쪽보다 훨씬 나쁘다 — 게이트는 근거가 있을 때만 닫는다.
  */
@@ -111,8 +117,12 @@ function sessionReadRoster(input) {
   // 사용자 프롬프트에도 흔해서 그것만으로는 호출의 증거가 못 된다. 힌트가 걸린 뒤에야 라인을
   // 파싱해 진짜 tool_use인지 가린다.
   if (!LOOKUP_CALL_HINT_RE.test(raw)) return false;
+  // 결과를 기다리는 조회 호출. 결과 라인에는 도구 이름이 없으므로 id로만 이어 붙일 수 있다.
+  const awaitedLookupIds = new Set();
   for (const line of raw.split("\n")) {
-    if (!line.includes("gateway_models")) continue;
+    const namesLookup = line.includes("gateway_models");
+    const answersLookup = awaitedLookupIds.size > 0 && idMentionedIn(line, awaitedLookupIds);
+    if (!namesLookup && !answersLookup) continue;
     let entry;
     try {
       entry = JSON.parse(line);
@@ -124,10 +134,24 @@ function sessionReadRoster(input) {
     const content = entry?.message?.content;
     if (!Array.isArray(content)) continue;
     for (const contentBlock of content) {
-      if (contentBlock?.type !== "tool_use") continue;
-      if (typeof contentBlock.name !== "string") continue;
-      if (LOOKUP_TOOL_NAME_RE.test(contentBlock.name)) return true;
+      if (contentBlock?.type === "tool_use") {
+        if (typeof contentBlock.name !== "string" || typeof contentBlock.id !== "string") continue;
+        if (LOOKUP_TOOL_NAME_RE.test(contentBlock.name)) awaitedLookupIds.add(contentBlock.id);
+        continue;
+      }
+      if (contentBlock?.type !== "tool_result") continue;
+      if (!awaitedLookupIds.delete(contentBlock.tool_use_id)) continue;
+      // 성공은 `is_error`의 부재로 적힌다 — 참인 경우만 실패다. 하나만 도착하면 충분하다.
+      if (contentBlock.is_error !== true) return true;
     }
+  }
+  return false;
+}
+
+/** 이 라인이 아직 결과를 기다리는 호출 id를 언급하는가. 조회 id는 세션당 한 줌이라 선형 검사로 충분하다. */
+function idMentionedIn(line, ids) {
+  for (const id of ids) {
+    if (line.includes(id)) return true;
   }
   return false;
 }

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -53,6 +53,9 @@ describe("gateway model guard — remind", () => {
     // 핀이 선택이 된 뒤에도 로스터 조회는 핀의 조건이다 — 기억한 이름은 여전히 해석된다는
     // 증거가 아니다. 워크플로우 스테이지의 두 핀 철자가 그 조회에 함께 묶여 있어야 한다.
     expect(parsed.hookSpecificOutput.additionalContext).toContain("opts.agentType");
+    // 조회는 무조건이고 핀은 표면마다 조건이 붙는다. 한 문단에 섞으면 핀 쪽 면제가 조회의
+    // 무조건성까지 조건부로 물들이므로, 주입문은 조회를 먼저 끝내고 핀 철자를 뒤에서 말한다.
+    expect(parsed.hookSpecificOutput.additionalContext).toContain("every time, not once per session");
   });
 
   // 주입은 stdin과 무관하게 성립해야 한다. 턴 시작 payload 모양이 바뀌어도 규약은 실려야 한다.
@@ -218,5 +221,124 @@ describe("gateway model guard — workflow receipt", () => {
     });
     expect(status).toBe(0);
     expect(stdout).toContain("still in flight");
+  });
+});
+
+describe("gateway model guard — roster lookup", () => {
+  // 트랜스크립트는 하네스가 쓰는 그 파일이다. 훅이 따로 만드는 상태 파일이 아니므로 신선도와
+  // 정리를 떠안지 않는다 — 픽스처도 같은 모양으로 만든다.
+  function transcript(lines: readonly unknown[]): string {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "gateway-model-guard-transcript-"));
+    tempDirs.push(dir);
+    const transcriptPath = path.join(dir, "session.jsonl");
+    writeFileSync(transcriptPath, lines.map((line) => JSON.stringify(line)).join("\n"));
+    return transcriptPath;
+  }
+
+  function lookupCall(toolName = "mcp__fleet__gateway_models", extra: Record<string, unknown> = {}) {
+    return {
+      type: "assistant",
+      ...extra,
+      message: { role: "assistant", content: [{ type: "tool_use", id: "toolu_1", name: toolName, input: {} }] },
+    };
+  }
+
+  // 매 턴 주입되는 규약문에는 `gateway_models`가 그대로 들어 있다. 도구 목록과 사용자 프롬프트도
+  // 마찬가지다. 문자열이 보인다는 사실은 호출의 증거가 아니다.
+  const MENTION_WITHOUT_CALL = [
+    {
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: "왜 gateway_models 없이 팬아웃하지?" }] },
+    },
+    {
+      type: "system",
+      attachment: { type: "hook_additional_context", content: ["Call gateway_models before any Agent or Workflow run"] },
+    },
+    {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_0", name: "ToolSearch", input: { query: "select:mcp__fleet__gateway_models" } }],
+      },
+    },
+  ];
+
+  function gateAgentWith(transcriptPath: string, subagentType: string) {
+    return run("gate-delegation", {
+      tool_name: "Agent",
+      transcript_path: transcriptPath,
+      tool_input: { subagent_type: subagentType },
+    });
+  }
+
+  function gateWorkflowWith(transcriptPath: string, toolInput: unknown) {
+    return run("gate-delegation", { tool_name: "Workflow", transcript_path: transcriptPath, tool_input: toolInput });
+  }
+
+  it("passes a gateway delegation once the session has read the roster", () => {
+    const transcriptPath = transcript([lookupCall()]);
+    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(0);
+    expect(gateWorkflowWith(transcriptPath, { script: `agent("x")` }).status).toBe(0);
+  });
+
+  // 이 게이트가 존재하는 이유. 철자만 보면 기억한 이름이 통과하고, 규약은 지켜졌다는 외양만 남는다.
+  it("blocks a fan-out from a session that never called gateway_models", () => {
+    const transcriptPath = transcript(MENTION_WITHOUT_CALL);
+    const agent = gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low");
+    expect(agent.status).toBe(2);
+    expect(agent.stderr).toContain("gateway_models");
+
+    const workflow = gateWorkflowWith(transcriptPath, { script: `agent("x")` });
+    expect(workflow.status).toBe(2);
+    expect(workflow.stderr).toContain("gateway_models");
+  });
+
+  // 스테이지를 하나도 옮기지 않는 워크플로우도 호스트를 떠나는 팬아웃이다. 옮길지 말지를
+  // 판단하려면 그 재료인 로스터를 먼저 읽어야 한다.
+  it("blocks an unread-roster Workflow whichever form the dispatch takes", () => {
+    const transcriptPath = transcript(MENTION_WITHOUT_CALL);
+    for (const toolInput of [{ script: `agent("x")` }, { name: "saved-workflow" }, { scriptPath: "/tmp/absent.js" }]) {
+      expect(gateWorkflowWith(transcriptPath, toolInput).status, JSON.stringify(toolInput)).toBe(2);
+    }
+  });
+
+  // 서브에이전트가 읽은 로스터는 호스트의 조회가 아니다. 위임을 결정하는 것은 호스트다.
+  it("does not count a lookup made inside a subagent", () => {
+    const transcriptPath = transcript([lookupCall("mcp__fleet__gateway_models", { isSidechain: true })]);
+    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(2);
+  });
+
+  // MCP 서버 등록명은 바뀔 수 있다. 접두를 하드코딩하면 그날 게이트가 조용히 전부 통과시킨다.
+  it("recognises the lookup under any MCP server prefix", () => {
+    for (const toolName of ["gateway_models", "mcp__fleet__gateway_models", "mcp__fleet-console__gateway_models"]) {
+      const transcriptPath = transcript([lookupCall(toolName)]);
+      expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status, toolName).toBe(0);
+    }
+  });
+
+  // 내장 타입은 호스트 모델로 도는 도구 선택이라 로스터에 걸린 것이 없다.
+  it("does not demand a lookup for built-in agent types", () => {
+    const transcriptPath = transcript(MENTION_WITHOUT_CALL);
+    for (const subagentType of ["Explore", "Plan", "fork"]) {
+      expect(gateAgentWith(transcriptPath, subagentType).status, subagentType).toBe(0);
+    }
+  });
+
+  // 근거가 없으면 닫지 않는다. 훅이 이 필드를 받지 못하는 경로가 생겼을 때 모든 위임이 막히는
+  // 쪽이, 조회 한 번을 놓치는 쪽보다 훨씬 나쁘다.
+  it("stays open when the transcript cannot be read", () => {
+    expect(gateAgent({ subagent_type: "fleet:xai-grok-4-6-low" }).status).toBe(0);
+    expect(gateWorkflowWith("/nonexistent/session.jsonl", { script: `agent("x")` }).status).toBe(0);
+    expect(gateWorkflowWith("", { script: `agent("x")` }).status).toBe(0);
+  });
+
+  // 조회를 마친 세션에서도 철자 검사는 그대로다. 두 판정은 독립이다.
+  it("still judges spelling after the roster was read", () => {
+    const transcriptPath = transcript([lookupCall()]);
+    const { status, stderr } = gateWorkflowWith(transcriptPath, {
+      script: `agent("x", { model: "codex--gpt-5.6-sol-fast" })`,
+    });
+    expect(status).toBe(2);
+    expect(stderr).toContain("claude-gateway--");
   });
 });

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -235,12 +235,41 @@ describe("gateway model guard — roster lookup", () => {
     return transcriptPath;
   }
 
-  function lookupCall(toolName = "mcp__fleet__gateway_models", extra: Record<string, unknown> = {}) {
-    return {
-      type: "assistant",
-      ...extra,
-      message: { role: "assistant", content: [{ type: "tool_use", id: "toolu_1", name: toolName, input: {} }] },
-    };
+  // 조회는 호출이 아니라 결과로 완성된다. 픽스처도 tool_use와 tool_result를 쌍으로 적는다.
+  function lookupCall(
+    toolName = "mcp__fleet__gateway_models",
+    extra: Record<string, unknown> = {},
+    id = "toolu_lookup",
+  ) {
+    return [
+      { type: "assistant", ...extra, message: { role: "assistant", content: [{ type: "tool_use", id, name: toolName, input: {} }] } },
+      {
+        type: "user",
+        ...extra,
+        message: { role: "user", content: [{ type: "tool_result", tool_use_id: id, content: `{"models":[]}` }] },
+      },
+    ];
+  }
+
+  /** 게이트웨이가 응답하지 않아 실패로 끝난 조회. 세션은 로스터를 받지 못했다. */
+  function failedLookupCall(id = "toolu_failed") {
+    return [
+      { type: "assistant", message: { role: "assistant", content: [{ type: "tool_use", id, name: "mcp__fleet__gateway_models", input: {} }] } },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: id, is_error: true, content: "MCP error: gateway unavailable" }],
+        },
+      },
+    ];
+  }
+
+  /** 위임과 같은 턴에 발행되어 아직 결과가 없는 조회. 병렬 호출도 각각 별도 라인으로 적힌다. */
+  function unansweredLookupCall(id = "toolu_pending") {
+    return [
+      { type: "assistant", message: { role: "assistant", content: [{ type: "tool_use", id, name: "mcp__fleet__gateway_models", input: {} }] } },
+    ];
   }
 
   // 매 턴 주입되는 규약문에는 `gateway_models`가 그대로 들어 있다. 도구 목록과 사용자 프롬프트도
@@ -276,7 +305,7 @@ describe("gateway model guard — roster lookup", () => {
   }
 
   it("passes a gateway delegation once the session has read the roster", () => {
-    const transcriptPath = transcript([lookupCall()]);
+    const transcriptPath = transcript(lookupCall());
     expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(0);
     expect(gateWorkflowWith(transcriptPath, { script: `agent("x")` }).status).toBe(0);
   });
@@ -304,14 +333,14 @@ describe("gateway model guard — roster lookup", () => {
 
   // 서브에이전트가 읽은 로스터는 호스트의 조회가 아니다. 위임을 결정하는 것은 호스트다.
   it("does not count a lookup made inside a subagent", () => {
-    const transcriptPath = transcript([lookupCall("mcp__fleet__gateway_models", { isSidechain: true })]);
+    const transcriptPath = transcript(lookupCall("mcp__fleet__gateway_models", { isSidechain: true }));
     expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(2);
   });
 
   // MCP 서버 등록명은 바뀔 수 있다. 접두를 하드코딩하면 그날 게이트가 조용히 전부 통과시킨다.
   it("recognises the lookup under any MCP server prefix", () => {
     for (const toolName of ["gateway_models", "mcp__fleet__gateway_models", "mcp__fleet-console__gateway_models"]) {
-      const transcriptPath = transcript([lookupCall(toolName)]);
+      const transcriptPath = transcript(lookupCall(toolName));
       expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status, toolName).toBe(0);
     }
   });
@@ -332,9 +361,32 @@ describe("gateway model guard — roster lookup", () => {
     expect(gateWorkflowWith("", { script: `agent("x")` }).status).toBe(0);
   });
 
+  // 호출만 세면 실패로 끝난 조회가 성공한 조회와 구별되지 않는다. 그 세션은 로스터를 받지
+  // 못했으므로, 기억해둔 이름으로 나가는 위임이 이 게이트를 그대로 통과한다.
+  it("does not count a lookup that failed", () => {
+    const transcriptPath = transcript(failedLookupCall());
+    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(2);
+    expect(gateWorkflowWith(transcriptPath, { script: `agent("x")` }).status).toBe(2);
+  });
+
+  // 조회를 위임과 같은 턴에 발행하면 호출은 트랜스크립트에 있어도 로스터는 아직 오지 않았다.
+  it("does not count a lookup whose result has not arrived", () => {
+    const transcriptPath = transcript(unansweredLookupCall());
+    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(2);
+  });
+
+  // 실패는 재시도로 회복된다. 성공한 결과가 하나 도착하면 그것으로 충분하다.
+  it("counts a successful retry after a failed lookup", () => {
+    const transcriptPath = transcript([
+      ...failedLookupCall("toolu_first"),
+      ...lookupCall("mcp__fleet__gateway_models", {}, "toolu_second"),
+    ]);
+    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(0);
+  });
+
   // 조회를 마친 세션에서도 철자 검사는 그대로다. 두 판정은 독립이다.
   it("still judges spelling after the roster was read", () => {
-    const transcriptPath = transcript([lookupCall()]);
+    const transcriptPath = transcript(lookupCall());
     const { status, stderr } = gateWorkflowWith(transcriptPath, {
       script: `agent("x", { model: "codex--gpt-5.6-sol-fast" })`,
     });


### PR DESCRIPTION
## Summary

- `gate-delegation`이 위임 전에 **세션 트랜스크립트에서 `gateway_models` 호출을 확인**하고, 조회가 없는 Agent(`fleet:*`)·Workflow 팬아웃을 차단합니다. 지금까지 게이트는 핀의 *철자*만 봤을 뿐 그 이름이 나온 로스터를 읽었는지는 보지 않았으므로, 기억해둔 `fleet:*` 이름이 조회 0회로 게이트를 통과했습니다.
- #836이 워크플로 모델 핀 강제를 걷어내면서 조회를 실질적으로 강제하던 마지막 장치가 사라졌습니다. `modelId`는 기억으로 쓸 수 없어서, 그것을 요구하는 것이 조회를 부수효과로 가르치고 있었습니다.
- 매 턴 주입되는 규약문이 조회 문장을 끝낸 뒤에 핀 철자를 말하도록 분리했습니다. 둘이 한 문단에 있으면 스테이지 면제("A Workflow stage may stay on the session model")가 조회의 무조건성까지 조건부로 물들입니다.

## 판정 근거

훅은 **자기 상태를 만들지 않습니다.** 하네스가 이미 쓰는 세션 트랜스크립트를 payload의 `transcript_path`로 읽습니다 — 훅이 직접 쓴 파일이라면 신선도·정리·경합을 떠안고, 그 파일이 사라지면 게이트가 조용히 열립니다.

판정에서 제외하는 것:

- **호출 밖의 문자열** — `remind`가 매 턴 주입하는 규약문과 도구 목록에 `gateway_models`가 그대로 들어 있어, 문자열의 존재는 호출의 증거가 아닙니다. `tool_use` 블록의 `name`으로만 판정합니다.
- **서브에이전트 안의 조회** — 위임을 결정하는 것은 호스트입니다.
- **내장 agent type** — 그 경로에는 로스터에서 가져오는 것이 없습니다.
- **읽을 수 없는 트랜스크립트 → 통과** — 하네스가 `transcript_path`를 싣지 않는 경로가 생겼을 때 모든 위임이 막히는 쪽이, 조회 하나를 놓치는 쪽보다 나쁜 실패입니다.

## Test Plan

- [x] `packages/fleet-admiral` 훅 테스트 29건 통과 (조회 게이트 8건 신규 — 조회 있음/없음, 오탐 방지, 서브에이전트 배제, MCP 접두 변형, 내장 타입, fail-open, 철자 검사 독립성)
- [x] 실제 세션 트랜스크립트로 검증: `gateway_models` 호출 1건이 있는 세션은 통과, `gateway_models` 문자열이 25라인 등장하지만 호출은 없는 세션은 차단
- [x] `pnpm typecheck`
- [x] `pnpm test` — fleet-admiral 176 / fleet-console 2301 / terminal 968 / desktop 302 전부 통과
- [x] `pnpm build` — 새 훅이 `dist/fleet.mjs`와 `dist/fleet-plugins/terminal/routes.mjs`에 임베드됨을 확인
- [x] `check:core-boundary`, `check:claude-agent-sdk-boundary`, `check:core-unified-agent-absent`, `check:localized-attributes`
- [x] 임베드 자산이 저작 원본과 바이트 일치

## Notes for Reviewers

조회 신선도는 **세션당 1회**입니다. 원래 규범(`allowances move while work is in flight`)보다 느슨한 선택이며, 제품 결정으로 확정된 범위입니다. 핀 이름을 최근 조회 응답과 대조하는 검사는 이 PR의 범위 밖입니다 — 트랜스크립트에 `tool_result`가 남아 있어 나중에 얹을 수 있습니다.