### PR TITLE
feat(ai-gateway): add OpenCode Go ox-alpha-free and muse-spark-1.2-contributor

### DIFF
--- a/.changelog.d/gateway-ox-alpha-muse-spark.md
+++ b/.changelog.d/gateway-ox-alpha-muse-spark.md
@@ -1,0 +1,13 @@
+---
+branch: gateway-ox-alpha-muse-spark
+---
+
+### fleet-console
+#### Added
+- Offer the OpenCode Go models Ox-Alpha-Free and Muse-Spark-1.2-Contributor, each with the reasoning-effort rungs its backend accepts.
+  ko: OpenCode Go 모델 Ox-Alpha-Free와 Muse-Spark-1.2-Contributor를, 각 백엔드가 받는 추론 강도 단과 함께 제공합니다.
+
+### fleet-cli
+#### Added
+- Offer the OpenCode Go models Ox-Alpha-Free and Muse-Spark-1.2-Contributor, each with the reasoning-effort rungs its backend accepts.
+  ko: OpenCode Go 모델 Ox-Alpha-Free와 Muse-Spark-1.2-Contributor를, 각 백엔드가 받는 추론 강도 단과 함께 제공합니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-20T00:00:00Z",
+  "updatedAt": "2026-08-21T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
@@ -717,7 +717,7 @@
     "opencode": {
       "name": "OpenCode",
       "defaultModel": "minimax-m3",
-      "source": "live GET https://opencode.ai/zen/go/v1/models + per-model wire probes on /messages, /responses, /chat/completions (2026-08-03); contextWindow cross-checked against models.dev api.json opencode-go entries and oh-my-pi packages/catalog/src/models.json (2026-08-03, both agree). Excluded: mimo-v2-pro/mimo-v2-omni (upstream server_error), hy3-preview (listed but Router.ModelNotFound); superseded generations removed 2026-08-08 \u2014 the catalog keeps each lineup's current generation only",
+      "source": "live GET https://opencode.ai/zen/go/v1/models + per-model wire probes on /messages, /responses, /chat/completions (2026-08-03); contextWindow cross-checked against models.dev api.json opencode-go entries and oh-my-pi packages/catalog/src/models.json (2026-08-03, both agree). Excluded: mimo-v2-pro/mimo-v2-omni (upstream server_error), hy3-preview (listed but Router.ModelNotFound); superseded generations removed 2026-08-08 \u2014 the catalog keeps each lineup's current generation only; ox-alpha-free and muse-spark-1.2-contributor added 2026-08-21 from the same live list, each wire chosen by a streaming probe on that date (ox-alpha-free frames natively on /chat/completions and returns reasoning_content deltas; muse-spark-1.2-contributor frames natively on /responses and echoes its own reasoning block) and each effort ladder taken from the upstream's own rejection message (ox-alpha-free: low/high/max; muse-spark-1.2-contributor: none/minimal/low/medium/high/xhigh, so max is refused); their contextWindow comes from models.dev api.json opencode-go entries (2026-08-21). muse-spark-1.2-contributor's Responses backend accepts only tool_choice auto: named function choices, required, and none are refused with a 400 (2026-08-21), so a caller that forces a tool cannot use it",
       "models": [
         {
           "modelId": "minimax-m3",
@@ -764,6 +764,22 @@
             ]
           },
           "benchmarkKey": "grok-4.5"
+        },
+        {
+          "modelId": "muse-spark-1.2-contributor",
+          "name": "Muse-Spark-1.2-Contributor",
+          "capabilityClass": "flagship",
+          "wire": "responses",
+          "contextWindow": 1048576,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
         },
         {
           "modelId": "deepseek-v4-flash",
@@ -815,6 +831,21 @@
           "capabilityClass": "flagship",
           "wire": "chat-completions",
           "contextWindow": 256000
+        },
+        {
+          "modelId": "ox-alpha-free",
+          "name": "Ox-Alpha-Free",
+          "capabilityClass": "flagship",
+          "wire": "chat-completions",
+          "contextWindow": 1000000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
         }
       ]
     },

--- a/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
@@ -9,7 +9,8 @@ import type {
   CanonicalResponseRequest,
   CanonicalUsage,
 } from "../../canonical/index.js";
-import { canonicalMessageText } from "../../canonical/index.js";
+import { canonicalMessageText, clampReasoningEffort, type ReasoningEffort } from "../../canonical/index.js";
+import { OPENCODE_SUBSCRIPTION_MODELS, upstreamModelId } from "../../models.js";
 import {
   UpstreamProtocolError,
   UpstreamBodyLimitError,
@@ -66,6 +67,8 @@ interface ChatWireRequest {
   tool_choice?: "auto" | "none" | "required" | { type: "function"; function: { name: string } };
   parallel_tool_calls?: boolean;
   max_tokens?: number;
+  /** OpenCode Go 백엔드가 받는 추론 강도. 카탈로그가 사다리를 선언한 모델에만 실린다. */
+  reasoning_effort?: ReasoningEffort;
   stream: true;
   stream_options: { include_usage: true };
 }
@@ -87,9 +90,11 @@ export interface OpenAIChatCompletionsAdapterOptions {
  * - No strict-mode schema rewrite. Chat Completions backends differ on strict
  *   support, so tools ship with their original schemas and the optional-argument
  *   pollution caveat documented for Cursor applies here too.
- * - Chat Completions에는 이식 가능한 `reasoning` 요청 파라미터가 없어 설정은 wire에 싣지
- *   않는다. Provider가 보낸 `reasoning_content`는 canonical reasoning으로 보존하고, 이전
- *   assistant 추론은 wire 요구가 실측된 모델에만 재생한다.
+ * - Chat Completions 규격에는 이식 가능한 `reasoning` 요청 파라미터가 없다. 그래서 effort는
+ *   기본적으로 wire에 싣지 않고, 백엔드가 자기 사다리를 실측으로 밝힌 provider instance의
+ *   선언 모델에 한해 `reasoning_effort`로만 나간다(아래 reasoningEffortPolicy). Provider가
+ *   보낸 `reasoning_content`는 canonical reasoning으로 보존하고, 이전 assistant 추론은 wire
+ *   요구가 실측된 모델에만 재생한다.
  */
 export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
   private readonly fetchImpl: FetchLike;
@@ -124,7 +129,11 @@ export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
     const unlinkAbort = linkAbortSignal(options.signal, controller);
     const supportsImageInput = imageInputPolicy.get(this)?.(request.model) ?? true;
     const omitTools = toolOmissionPolicy.has(this) && shouldOmitTools(request);
-    const payload = forChatCompletionsBackend(request, supportsImageInput, omitTools);
+    const requestedEffort = request.reasoning?.effort;
+    const reasoningEffort = requestedEffort === undefined
+      ? undefined
+      : reasoningEffortPolicy.get(this)?.(request.model, requestedEffort);
+    const payload = forChatCompletionsBackend(request, supportsImageInput, omitTools, reasoningEffort);
     wireLog("openai-chat.wire.request", { url: this.url, payload });
     let response: Response;
 
@@ -192,6 +201,18 @@ const argumentPruningPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
  * 이 omission은 provider 실측에 근거하므로 generic class에는 결합하지 않는다.
  */
 const toolOmissionPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
+
+/**
+ * 어떤 instance가 canonical effort를 wire에 싣는지, 그리고 어떤 모델에 어떤 단으로 싣는지.
+ *
+ * Chat Completions 규격에는 reasoning 파라미터가 없으므로 generic instance는 계속 아무것도
+ * 싣지 않는다. 실을 수 있다는 근거는 백엔드별 실측뿐이라 — image/pruning 정책과 같은 이유로 —
+ * provider instance에만 결합한다. 반환이 undefined면 그 모델에는 싣지 않는다.
+ */
+const reasoningEffortPolicy = new WeakMap<
+  OpenAIChatCompletionsAdapter,
+  (model: string, effort: ReasoningEffort) => ReasoningEffort | undefined
+>();
 const CLAUDE_CODE_SUGGESTION_MODE_PREFIX =
   "[SUGGESTION MODE: Suggest what the user might naturally type next into Claude Code.]";
 const CLAUDE_CODE_SUGGESTION_MODE_SUFFIXES = [
@@ -233,6 +254,10 @@ export class OpencodeGoChatCompletionsAdapter extends OpenAIChatCompletionsAdapt
     // no-tools 조건은 Suggestion Mode에 더해 `tool_choice: "none"`까지 wire에서 catalog를
     // 뺀다 — generic class의 호환 동작은 바꾸지 않고 provider instance에만 결합한다.
     toolOmissionPolicy.set(this, true);
+    // OpenCode Go의 Chat 백엔드는 `reasoning_effort`를 받고, 거부 메시지로 자기 사다리를
+    // 직접 밝힌다(ox-alpha-free: low/high/max, 2026-08-21 실측). 사다리를 선언한 모델에만
+    // 실어야 한다 — 선언 없는 모델에 보내면 그 백엔드가 받는다는 근거가 없다.
+    reasoningEffortPolicy.set(this, opencodeGoChatReasoningEffort);
   }
 
   /**
@@ -242,6 +267,24 @@ export class OpencodeGoChatCompletionsAdapter extends OpenAIChatCompletionsAdapt
   wireTools(request: CanonicalResponseRequest): readonly CanonicalFunctionTool[] {
     return shouldOmitTools(request) ? [] : request.tools ?? [];
   }
+}
+
+/**
+ * 카탈로그가 effort 사다리를 선언한 OpenCode Go chat-completions 모델의 wire effort.
+ *
+ * 사다리는 카탈로그 한 곳에서만 산다. 선언이 없으면 undefined를 돌려 이 wire의 기본 동작
+ * (싣지 않음)을 유지하고, 있으면 그 사다리 안으로 하향 클램프한다 — 라우터가 이미 같은
+ * 사다리로 클램프하지만, canonical을 직접 부르는 호출자에게도 같은 계약이 서야 한다.
+ */
+function opencodeGoChatReasoningEffort(
+  model: string,
+  effort: ReasoningEffort,
+): ReasoningEffort | undefined {
+  const entry = OPENCODE_SUBSCRIPTION_MODELS.find(
+    (candidate) => upstreamModelId(candidate) === model,
+  );
+  if (entry?.effort.supported !== true) return undefined;
+  return clampReasoningEffort(effort, entry.effort.levels, model);
 }
 
 /**
@@ -270,6 +313,7 @@ function forChatCompletionsBackend(
   request: CanonicalResponseRequest,
   supportsImageInput: boolean,
   omitTools = false,
+  reasoningEffort?: ReasoningEffort,
 ): ChatWireRequest {
   const messages: ChatWireMessage[] = [];
   if (request.instructions !== undefined && request.instructions.length > 0) {
@@ -375,6 +419,9 @@ function forChatCompletionsBackend(
   }
   if (request.max_output_tokens !== undefined) {
     payload.max_tokens = request.max_output_tokens;
+  }
+  if (reasoningEffort !== undefined) {
+    payload.reasoning_effort = reasoningEffort;
   }
   return payload;
 }

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -1984,7 +1984,7 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(49);
+    expect(list.data).toHaveLength(51);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-luna");
@@ -2027,6 +2027,8 @@ describe("route surface", () => {
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
     expect(ids).toContain("claude-gateway--opencode--minimax-m3[1m]");
+    expect(ids).toContain("claude-gateway--opencode--ox-alpha-free[1m]");
+    expect(ids).toContain("claude-gateway--opencode--muse-spark-1.2-contributor[1m]");
     expect(list.data).toContainEqual(expect.objectContaining({
       id: "claude-gateway--cursor--grok-4.5",
       display_name: "Cursor-Grok-4.5",

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -892,7 +892,7 @@ describe("model catalog", () => {
     expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(18);
     expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(16);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
-    expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(11);
+    expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(13);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
     expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => model.id.includes("524k")).every((model) => model.contextWindow === 524_288)).toBe(true);
     expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => model.id.includes("-1m")).every((model) => model.contextWindow === 1_000_000)).toBe(true);
@@ -963,13 +963,14 @@ describe("model catalog", () => {
         .toMatchObject({ cursorMaxMode: true });
     }
     expect(KIMI_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual(["k3", "k3-256k"]);
-    // OpenCode Go의 서비스 가능 전 모델(2026-08-03 라이브 프로브). wire 미선언 =
-    // Anthropic passthrough, 그 외에는 선언된 네이티브 wire의 번역 경로를 탄다.
+    // OpenCode Go의 서비스 가능 전 모델(2026-08-03 라이브 프로브, 08-21 두 모델 추가).
+    // wire 미선언 = Anthropic passthrough, 그 외에는 선언된 네이티브 wire의 번역 경로를 탄다.
     expect(OPENCODE_SUBSCRIPTION_MODELS.map((model) => [model.upstreamId, model.wire ?? "anthropic"])).toEqual([
       ["minimax-m3", "anthropic"],
       ["qwen3.8-max", "anthropic"],
       ["gpt-5.6-luna", "responses"],
       ["grok-4.5", "responses"],
+      ["muse-spark-1.2-contributor", "responses"],
       ["deepseek-v4-flash", "chat-completions"],
       ["deepseek-v4-pro", "chat-completions"],
       ["glm-5.2", "chat-completions"],
@@ -977,11 +978,23 @@ describe("model catalog", () => {
       ["mimo-v2.5-pro", "chat-completions"],
       ["mimo-v2.5", "chat-completions"],
       ["hy3", "chat-completions"],
+      ["ox-alpha-free", "chat-completions"],
     ]);
-    // effort는 reasoning 파라미터를 실측으로 수용한 responses wire에서만 연다.
-    expect(OPENCODE_SUBSCRIPTION_MODELS.every((model) => (
-      model.effort.supported === ((model.wire ?? "anthropic") === "responses")
-    ))).toBe(true);
+    // effort는 백엔드가 추론 강도 파라미터를 수용한다고 실측된 모델에서만 연다. responses
+    // wire는 `reasoning`을 받고, ox-alpha-free의 chat-completions 백엔드는 `reasoning_effort`를
+    // 받으며 거부 메시지로 자기 사다리를 직접 밝혔다(2026-08-21 실측). 사다리 역시 그
+    // 거부 메시지가 정한 것이지 wire가 정한 것이 아니다.
+    expect(OPENCODE_SUBSCRIPTION_MODELS
+      .filter((model) => model.effort.supported)
+      .map((model) => [
+        model.upstreamId,
+        model.effort.supported ? model.effort.levels : [],
+      ])).toEqual([
+      ["gpt-5.6-luna", ["low", "medium", "high", "xhigh", "max"]],
+      ["grok-4.5", ["low", "medium", "high"]],
+      ["muse-spark-1.2-contributor", ["low", "medium", "high", "xhigh"]],
+      ["ox-alpha-free", ["low", "high", "max"]],
+    ]);
   });
 
   it("keeps the approved GPT-5.6 and K3 effort ladders in the gateway registry", () => {

--- a/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
@@ -115,6 +115,43 @@ describe("chat completions request translation", () => {
     expect(headers.get("authorization")).toBe("Bearer k");
   });
 
+  it("puts reasoning effort on the wire only for OpenCode models that declare a ladder", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    const body = (): Record<string, unknown> =>
+      JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+
+    // 카탈로그가 사다리를 선언한 모델은 선언된 단 그대로 나간다.
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      model: "ox-alpha-free",
+      reasoning: { summary: "auto", effort: "max" },
+    }), { apiKey: "k" });
+    expect(body().reasoning_effort).toBe("max");
+
+    // 사다리에 없는 단은 그 사다리 안으로 하향 클램프된다 — 백엔드는 medium을 거부한다.
+    fetchMock.mockClear();
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      model: "ox-alpha-free",
+      reasoning: { summary: "auto", effort: "medium" },
+    }), { apiKey: "k" });
+    expect(body().reasoning_effort).toBe("low");
+
+    // 사다리를 선언하지 않은 모델에는 이 wire의 기본 동작대로 아무것도 싣지 않는다.
+    fetchMock.mockClear();
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      model: "deepseek-v4-flash",
+      reasoning: { summary: "auto", effort: "high" },
+    }), { apiKey: "k" });
+    expect(body()).not.toHaveProperty("reasoning_effort");
+
+    // generic instance는 provider 실측이 없으므로 선언 모델에도 싣지 않는다.
+    fetchMock.mockClear();
+    await adapter(fetchMock).stream(request({
+      model: "ox-alpha-free",
+      reasoning: { summary: "auto", effort: "high" },
+    }), { apiKey: "k" });
+    expect(body()).not.toHaveProperty("reasoning_effort");
+  });
+
   it("omits tools only for the exact Claude Code Suggestion Mode turn on OpenCode", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
     const tools: CanonicalResponseRequest["tools"] = [{

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -673,7 +673,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(49);
+    expect(cache.models).toHaveLength(51);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-524k-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-1m-fast[1m]");


### PR DESCRIPTION
## Summary
- OpenCode Go 카탈로그에 `ox-alpha-free`(chat-completions, 1,000,000)와 `muse-spark-1.2-contributor`(responses, 1,048,576)를 추가합니다. 두 모델 모두 구독의 live 모델 목록에 있고, wire는 각각 스트리밍 프로브로 정했습니다.
- 추론 강도 사다리는 wire가 아니라 업스트림의 거부 메시지가 정한 값을 그대로 실었습니다 — `ox-alpha-free`는 low/high/max, `muse-spark-1.2-contributor`는 max를 거부하고 none/minimal/low/medium/high/xhigh를 밝혀 low/medium/high/xhigh를 엽니다.
- Chat Completions 규격에는 reasoning 파라미터가 없어 effort가 그 wire에서 버려지고 있었습니다. OpenCode Go 백엔드는 `reasoning_effort`를 받으므로, 카탈로그가 사다리를 선언한 모델에 한해 provider instance에서만 실어 보냅니다(선언 사다리로 하향 클램프). 범용 Chat Completions 클래스의 동작은 그대로입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (36 files, 821 tests)
- [x] `pnpm build` / `pnpm typecheck` (워크스페이스 전체)
- [x] `pnpm test` (워크스페이스 전체 — console launch 캐시 카운트 49→51 갱신 포함)
- [x] 라이브 프로브: 두 모델의 네이티브 wire 스트리밍, effort 수용/거부 경계
- [x] 라이브 루프: `provider-loop-e2e --model 'claude-gateway--opencode--ox-alpha-free[1m]' --effort max` 성공, wire 로그에서 `reasoning_effort: max` 확인

## Notes
- `muse-spark-1.2-contributor`의 Responses 백엔드는 `tool_choice`를 `auto`만 받습니다(named/required/none은 400). 도구 호출 자체는 auto에서 정상 동작하며, 이 제약은 카탈로그 `source`에 기록했습니다. 강제 tool_choice를 쓰는 provider-loop e2e는 이 이유로 실패합니다 — effort와 무관한 업스트림 제약입니다.