### PR TITLE
fix(fleet-console): deliver multi-line Quick Launch prompts through the Windows cmd shim

### DIFF
--- a/.changelog.d/launch-prompt-multiline-shim.md
+++ b/.changelog.d/launch-prompt-multiline-shim.md
@@ -1,0 +1,8 @@
+---
+branch: launch-prompt-multiline-shim
+---
+
+### fleet-console
+#### Fixed
+- Deliver the whole multi-line Quick Launch prompt on Windows installs that run the agent CLI through a `.cmd` shim, instead of only its first line.
+  ko: `.cmd` shim으로 에이전트 CLI를 실행하는 Windows 설치에서 여러 줄 Quick Launch 프롬프트를 첫 줄만이 아니라 전문 그대로 전달합니다.

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -9,6 +9,7 @@ import { buildClaudeGatewayArgs } from "./builders/claude.js";
 import {
   assertLaunchCommandLineBudget,
   LaunchPromptError,
+  launchPromptHasCmdLineBreak,
   launchPromptHasCmdUnsafeChars,
   writeLaunchPromptPointer,
 } from "./prompt.js";
@@ -119,7 +120,12 @@ export async function injectAgentCliProfile(
     // 올린다. 명령줄 초과는 주입 인자가 합쳐진 뒤에만 알 수 있어 예산 검사에서 옮긴다.
     if (promptArgs.length > 0 && windowsLaunch) {
       const body = takeLaunchPromptBody(promptArgs);
-      if (launchPromptHasCmdUnsafeChars(body)) convertPromptToFile(body);
+      // 줄바꿈은 cmd shim일 때만 문제가 된다 — cmd의 명령줄이 거기서 끊겨 첫 줄만 자식에게
+      // 닿는다. 실행 파일을 직접 부르는 Windows 경로는 인용된 인자 안의 줄바꿈을 그대로
+      // 전달하므로 멀티라인 원문을 argv에 남긴다.
+      if (launchPromptHasCmdUnsafeChars(body) || (cmdWrapped && launchPromptHasCmdLineBreak(body))) {
+        convertPromptToFile(body);
+      }
     }
     const plugin = await createAgentCliPlugin({
       cliId: profile.id,

--- a/packages/fleet-admiral/src/agent-cli/prompt.ts
+++ b/packages/fleet-admiral/src/agent-cli/prompt.ts
@@ -14,6 +14,11 @@ import path from "node:path";
 // 요구**한다고 명시하는데, node-pty로 나가는 이 런치 경로는 둘 다 제공하지 않는다. 따라서
 // 따옴표 안이라는 가정도 성립하지 않는다.
 const CMD_UNSAFE_PROMPT_PATTERN = /["&<>()@^|%]/;
+// cmd.exe의 명령줄은 줄바꿈에서 끝난다. 따옴표 안이어도 파서는 거기서 명령을 끊고, ^는 줄 잇기라
+// 줄바꿈 자체를 지우므로 이스케이프할 수단이 없다 — shim 경유 argv에 실린 멀티라인 프롬프트는
+// 첫 줄만 자식에게 닿고 나머지는 조용히 사라진다. 실행 파일을 직접 부르는 경로(CreateProcess)는
+// 인용된 인자 안의 줄바꿈을 그대로 전달하므로 여기 걸리지 않는다.
+const CMD_LINE_BREAK_PATTERN = /[\n\r]/;
 const LAUNCH_PROMPT_FILE_MODE = 0o600;
 
 export const LAUNCH_PROMPT_TEMP_DIR_PREFIX = "fleet-quick-launch-";
@@ -22,6 +27,14 @@ export const LAUNCH_PROMPT_FILE_INSTRUCTION_PREFIX = "Read and follow the launch
 
 export function launchPromptHasCmdUnsafeChars(prompt: string): boolean {
   return CMD_UNSAFE_PROMPT_PATTERN.test(prompt);
+}
+
+/**
+ * cmd.exe로 감싸인 shim 실행에서만 참인 조건 — 원문에 줄바꿈이 있으면 그 명령줄은 첫 줄에서
+ * 끊긴다. 길이 상한과 무관하게 파일 포인터로 옮겨야 프롬프트 전문이 전달된다.
+ */
+export function launchPromptHasCmdLineBreak(prompt: string): boolean {
+  return CMD_LINE_BREAK_PATTERN.test(prompt);
 }
 
 /**

--- a/packages/fleet-admiral/tests/launch-command-line-budget.test.ts
+++ b/packages/fleet-admiral/tests/launch-command-line-budget.test.ts
@@ -560,6 +560,67 @@ describe("injectAgentCliProfile command-line enforcement", () => {
     }
   });
 
+  // Quick Launch 컴포저는 멀티라인 초안을 그대로 보낸다. cmd.exe는 명령줄을 줄바꿈에서 끊으므로
+  // .cmd shim 경유 argv에 실린 그 원문은 첫 줄만 자식에게 닿고 나머지 줄은 조용히 사라진다.
+  it("moves a multi-line cmd-shim launch prompt into a file so every line survives", async () => {
+    const root = createTempRoot("fleet-admiral-cmdline-cmd-multiline-");
+    const original = "Fix the login redirect bug\n\n- keep the session cookie\n- add a regression test";
+    const isolatedTmp = path.join(root, "tmp");
+    mkdirSync(isolatedTmp);
+    const restoreTmp = isolateTmp(isolatedTmp);
+
+    try {
+      // 이 원문은 cmd 특수문자도 없고 명령줄 상한 안에도 든다 — 줄바꿈만이 유일한 이유다.
+      expect(/["&<>()@^|%]/.test(original)).toBe(false);
+
+      const injected = await injectAgentCliProfile(
+        cmdShimProfile(root, { promptArgs: [original] }),
+        injectOptions(root),
+      );
+      const instruction = injected.args.at(-1)!;
+      expect(instruction.startsWith(LAUNCH_PROMPT_FILE_INSTRUCTION_PREFIX)).toBe(true);
+      expect(injected.args).not.toContain(original);
+      expect(injected.args.some((arg) => arg.includes("\n"))).toBe(false);
+      const filePath = instruction.slice(LAUNCH_PROMPT_FILE_INSTRUCTION_PREFIX.length);
+      expect(readFileSync(filePath, "utf8")).toBe(original);
+      injected.cleanup?.();
+      expect(existsSync(filePath)).toBe(false);
+    } finally {
+      restoreTmp();
+    }
+  });
+
+  // 실행 파일을 직접 부르는 Windows 경로에는 cmd 파서가 없다 — CreateProcess는 인용된 인자
+  // 안의 줄바꿈을 그대로 넘긴다. 여기까지 파일로 밀어내면 멀쩡한 경로에서 원문이 사라진다.
+  it("keeps a multi-line native CreateProcess launch prompt on argv", async () => {
+    const root = createTempRoot("fleet-admiral-cmdline-native-multiline-");
+    const original = "Fix the login redirect bug\n\n- keep the session cookie\n- add a regression test";
+    const isolatedTmp = path.join(root, "tmp");
+    mkdirSync(isolatedTmp);
+    const restoreTmp = isolateTmp(isolatedTmp);
+
+    try {
+      const injected = await injectAgentCliProfile({
+        args: [],
+        bin: "claude.exe",
+        commandLineLimit: { maxChars: WINDOWS_CREATE_PROCESS_COMMAND_LINE_MAX_CHARS, via: "create-process" },
+        cwd: root,
+        env: { HOME: root },
+        id: "claude-gateway",
+        label: "claude-gateway",
+        promptArgs: [original],
+        terminalName: "xterm-256color",
+      }, injectOptions(root));
+
+      expect(injected.args.at(-1)).toBe(original);
+      expect(injected.args.some((arg) => arg.startsWith(LAUNCH_PROMPT_FILE_INSTRUCTION_PREFIX))).toBe(false);
+      expect(readdirSync(isolatedTmp).filter((name) => name.startsWith(LAUNCH_PROMPT_TEMP_DIR_PREFIX))).toEqual([]);
+      injected.cleanup?.();
+    } finally {
+      restoreTmp();
+    }
+  });
+
   it("moves a native CreateProcess launch prompt into a file when the original argv overflows", async () => {
     const root = createTempRoot("fleet-admiral-cmdline-native-overflow-");
     const original = "a".repeat(500);

--- a/packages/fleet-admiral/tests/launch-prompt-shim.test.ts
+++ b/packages/fleet-admiral/tests/launch-prompt-shim.test.ts
@@ -10,6 +10,7 @@ import {
   LAUNCH_PROMPT_FILE_INSTRUCTION_PREFIX,
   LAUNCH_PROMPT_FILE_NAME,
   LAUNCH_PROMPT_TEMP_DIR_PREFIX,
+  launchPromptHasCmdLineBreak,
   launchPromptHasCmdUnsafeChars,
   writeLaunchPromptFile,
   writeLaunchPromptPointer,
@@ -35,6 +36,24 @@ describe("launchPromptHasCmdUnsafeChars", () => {
     expect(launchPromptHasCmdUnsafeChars("Fix the login redirect bug")).toBe(false);
     expect(launchPromptHasCmdUnsafeChars("Summarize %USERPROFILE%")).toBe(true);
     expect(launchPromptHasCmdUnsafeChars("a & b")).toBe(true);
+  });
+
+  // 줄바꿈은 이 집합이 아니다 — 재해석이 아니라 명령줄 자체의 끝이고, shim 경유일 때만
+  // 문제가 된다. 두 갈래를 한 술어로 합치면 실행 파일을 직접 부르는 Windows 경로에서
+  // 멀쩡히 전달되던 멀티라인 원문까지 파일로 밀려난다.
+  it("leaves a line break to the cmd-shim-only predicate", () => {
+    expect(launchPromptHasCmdUnsafeChars("line one\nline two")).toBe(false);
+  });
+});
+
+describe("launchPromptHasCmdLineBreak", () => {
+  // cmd.exe /d /s /c 로 감싼 실행에 멀티라인 인자를 실으면 첫 줄만 자식의 argv에 닿는다.
+  // ^는 줄 잇기라 줄바꿈을 지우고, 따옴표 안이어도 파서가 그 줄에서 명령을 끊는다.
+  it("detects the line breaks that truncate a cmd-shim command line", () => {
+    expect(launchPromptHasCmdLineBreak("Fix the login redirect bug")).toBe(false);
+    expect(launchPromptHasCmdLineBreak("line one\nline two")).toBe(true);
+    expect(launchPromptHasCmdLineBreak("line one\r\nline two")).toBe(true);
+    expect(launchPromptHasCmdLineBreak("line one\rline two")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Windows에서 `claude.cmd` 같은 `.cmd` shim을 경유하는 런치는 `cmd.exe /d /s /c call ...` 로 감싸 실행된다. cmd의 명령줄은 줄바꿈에서 끝나므로, argv에 실린 멀티라인 Quick Launch 프롬프트는 첫 줄만 자식 CLI에 닿고 나머지 줄은 조용히 사라졌다. `^`는 줄 잇기라 줄바꿈 자체를 지우고 따옴표도 파서를 막지 못해, 이스케이프로 해결할 수단이 없다.
- cmd shim 경유일 때만 멀티라인 원문을 기존 temp 파일 포인터 경로(`Read and follow the launch prompt file: ...`)로 옮긴다. cmd 특수문자 집합이 이미 쓰던 것과 같은 장치다.
- 실행 파일을 직접 부르는 Windows 경로(CreateProcess)는 인용된 인자 안의 줄바꿈을 그대로 전달하므로 그대로 argv에 남긴다 — 멀쩡히 동작하던 경로를 파일로 밀어내지 않는다.

## Test Plan
- [x] OS 레벨 실증: 가짜 `claude.cmd` shim에 멀티라인 인자를 실어 `cmd.exe /d /s /c call` 로 실행 → 자식 argv `["Fix the login redirect bug"]` (첫 줄만). 같은 원문을 `node.exe`에 직접 전달 → 전문 보존.
- [x] 종단 실증: 수정된 주입 경로가 만드는 파일 포인터 argv를 같은 shim에 통과 → 자식이 받은 지시로 읽은 프롬프트가 컴포저 원문과 바이트 동일.
- [x] 회귀 증명: 수정을 되돌린 상태에서 신규 테스트 `moves a multi-line cmd-shim launch prompt into a file so every line survives` 실패, 수정 적용 시 통과.
- [x] `pnpm --filter @dotobokuri/fleet-admiral exec vitest run tests/launch-prompt-shim.test.ts tests/launch-command-line-budget.test.ts` — 63 passed.
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck` / `pnpm typecheck` — 통과.
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/quick-launch.test.ts tests/launch.test.ts` — 19 failed / 105 passed, canary 베이스라인과 동일(신규 실패 0, 이 머신의 상시 적색).
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK.