### PR TITLE
revert(fleet-admiral)!: restore the v1.69.0 delegation guard

### DIFF
--- a/.changelog.d/gateway-lookup-gate.md
+++ b/.changelog.d/gateway-lookup-gate.md
@@ -3,6 +3,6 @@ branch: gateway-lookup-gate
 ---
 
 ### fleet-cli
-#### Changed
-- A delegation is now refused until the session has actually received a roster from `gateway_models`. A call the gateway never answered, and one issued in the same turn as the delegation, do not count. Naming a `fleet:*` identity is no longer enough on its own: the roster is resolved at call time, so a name carried in from memory or from another session is refused with the lookup instruction instead of dispatching against a roster nobody read. Built-in agent types still need no lookup, and a session whose transcript cannot be read is not blocked.
-  ko: 이제 세션이 `gateway_models`로부터 로스터를 실제로 받기 전까지는 위임이 거부됩니다. 게이트웨이가 응답하지 않은 호출과 위임과 같은 턴에 발행된 호출은 인정되지 않습니다. `fleet:*` 정체성을 적어 넣는 것만으로는 부족합니다 — 로스터는 호출 시점에 결정되므로, 기억이나 다른 세션에서 가져온 이름은 아무도 읽지 않은 로스터로 디스패치되는 대신 조회 안내와 함께 거부됩니다. 내장 에이전트 타입은 여전히 조회가 필요 없고, 트랜스크립트를 읽을 수 없는 세션은 차단되지 않습니다.
+#### Breaking Changes
+- Every `Workflow` stage must name a gateway model again. A stage that pins none is refused before the run instead of falling back to the session model, and `agentType` is refused in a script rather than accepted as a stage's other pin. Delegation is judged from the call payload alone: no roster lookup has to land first, so naming a `fleet:*` identity is enough to dispatch.
+  ko: 모든 `Workflow` 스테이지가 다시 게이트웨이 모델을 지정해야 합니다. 아무것도 핀하지 않은 스테이지는 세션 모델로 넘어가지 않고 실행 전에 거부되며, `agentType`은 스테이지의 또 다른 핀으로 인정되지 않고 스크립트에서 거부됩니다. 위임은 호출 페이로드만으로 판정되므로 로스터 조회가 선행될 필요 없이 `fleet:*` 정체성을 적는 것만으로 디스패치됩니다.

--- a/docs/admiral-prompt-architecture.md
+++ b/docs/admiral-prompt-architecture.md
@@ -52,53 +52,23 @@ and the standalone `fleet` launcher — read that one option, and it binds new s
 
 The policy that used to live in the Standing Orders now lives in one embedded hook,
 `packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs`, rendered into the
-Fleet plugin at `hooks/fleet-gateway-model-guard.mjs`. It keeps no state of its own: a
-file the hook wrote itself would carry freshness, cleanup, and contention, and a gate that
-opens when its own bookkeeping goes missing is not a gate. What it needs to remember about
-the session it reads from the transcript the harness already writes, addressed by the
-`transcript_path` the payload carries. One script serves three roles, selected by its
-first argument:
+Fleet plugin at `hooks/fleet-gateway-model-guard.mjs`. It is stateless — every judgment
+is made from one stdin payload, so a hook timeout cannot silently open the gate through a
+missing state file. One script serves three roles, selected by its first argument:
 
 | Subcommand | Event | Matcher | Effect |
 |---|---|---|---|
 | `remind` | UserPromptSubmit | — | Injects the pin contract every turn. This is the only path by which the contract reaches the model. |
-| `gate-delegation` | PreToolUse | `Agent|Workflow` | Blocks a fan-out from a session that has not read the roster, an unpinned `Agent` delegation, and a `Workflow` stage whose model value is misspelled. |
+| `gate-delegation` | PreToolUse | `Agent|Workflow` | Blocks an unpinned delegation before it runs and states how to pin it. |
 | `workflow-receipt` | PostToolUse | `Workflow` | States that the dispatch returned a receipt, not a result. |
-
-Before either judgment, `gate-delegation` asks whether this session ever received a
-roster, by scanning the session transcript for a `tool_use` block naming `gateway_models`
-and then for the `tool_result` answering that call id. The spelling of a pin is visible in
-the payload; whether the name it spells still resolves is only in the roster. The answer
-is what counts, not the call: a lookup the gateway never answered and one issued in the
-same turn as the delegation both leave the session without a roster, and the harness
-records even parallel calls on separate lines, so a `tool_use` still awaiting its result
-is an ordinary intermediate state rather than an exotic one. A result carrying
-`is_error` is a failure; success is written as that field being absent, and one answered
-call is enough. A gate that reads spelling alone passes a name carried in
-from memory or from another session, and what remains is the appearance of compliance.
-The scan ignores a lookup made inside a subagent — the host is what decides the
-delegation — and it ignores the string `gateway_models` wherever it appears outside a
-call, which is every turn: the contract injected by `remind` contains it, and so does the
-tool listing. A fan-out onto a built-in agent type needs no lookup, because nothing on
-that path is drawn from the roster. When the transcript cannot be read at all the gate
-stays open: a harness path that stops carrying `transcript_path` would otherwise block
-every delegation, which is a worse failure than missing one lookup.
 
 `gate-delegation` blocks an `Agent` call whose `subagent_type` is `general-purpose` or
 `claude`, or absent. Built-in specialist types and `fork` pass — `fork` inherits parent
-context by design, so moving it to another model removes the point of that surface.
-
-Past that lookup, for `Workflow` the gate judges spelling only. A stage that names no model is allowed and
-runs on the session model; whether a fan-out is worth spreading across providers is a
-reading of the work, not a property the hook can see, and a gate that demanded a pin per
-stage only taught the host to fill every stage with one value — the spread it was meant to
-produce, spelled as compliance. What survives is the failure a host cannot recover from:
-a `model` value that is neither a lineage alias nor a `claude-gateway--` modelId kills
-every branch at dispatch, so it is refused before the run rather than after. `agentType`
-is a stage's other legitimate pin and is refused only when it carries that same modelId —
-the two spellings swapped the other way, which no registry resolves. A built-in type such
-as `general-purpose` passes, so the check names the modelId rather than demanding a
-`fleet:` prefix.
+context by design, so moving it to another model removes the point of that surface. For
+`Workflow` it blocks `agentType` in a script, a malformed `opts.model`, and any
+`agent()` stage that pins no model at all. It does not rewrite the script: assigning one
+model to every stage would erase the model spread that is the whole reason to use that
+surface, so the block carries the instruction and the host does the assignment.
 
 Two properties of the harness make this shape necessary, both measured on
 Claude Code 2.1.235:

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -53,9 +53,10 @@ const MODEL_ALIASES = /^(fable|opus|sonnet|haiku)$/;
 const PREFIXED_ALIAS_RE = /^claude-gateway--(fable|opus|sonnet|haiku)$/;
 const GATEWAY_MODEL_PREFIX = "claude-gateway--";
 const AGENT_TYPE_RE = /agentType\s*:/;
-// 핀 인식(`\bmodel\s*:`)과 값 검증이 같은 철자를 봐야 한다. 콜론 앞 공백을 여기서만
-// 놓치면 `{ model : "..." }`가 핀으로 세어지고도 값 검증을 받지 않는다.
-const MODEL_VALUE_RE = /model\s*:\s*['"]([^'"]+)['"]/g;
+// 핀 인식(`\bmodel\s*:`)과 값 검증은 같은 철자를 봐야 한다. 경계나 공백 하나가 어긋나면
+// `{ model : "..." }`가 핀으로 세어지고도 검증을 건너뛰고, `response_model:` 같은 설정 키가
+// opts.model로 오인되어 멀쩡한 스크립트가 막힌다.
+const MODEL_VALUE_RE = /\bmodel\s*:\s*['"]([^'"]+)['"]/g;
 const AGENT_CALL_RE = /\bagent\s*\(/g;
 
 function block(message) {

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -52,7 +52,8 @@ const GATEWAY_AGENT_PREFIX = "fleet:";
 const MODEL_ALIASES = /^(fable|opus|sonnet|haiku)$/;
 const PREFIXED_ALIAS_RE = /^claude-gateway--(fable|opus|sonnet|haiku)$/;
 const GATEWAY_MODEL_PREFIX = "claude-gateway--";
-const AGENT_TYPE_RE = /agentType\s*:/;
+// `subagentType:` 같은 접미 식별자를 opts.agentType으로 읽으면 멀쩡한 스크립트가 막힌다.
+const AGENT_TYPE_RE = /\bagentType\s*:/;
 // 핀 인식(`\bmodel\s*:`)과 값 검증은 같은 철자를 봐야 한다. 경계나 공백 하나가 어긋나면
 // `{ model : "..." }`가 핀으로 세어지고도 검증을 건너뛰고, `response_model:` 같은 설정 키가
 // opts.model로 오인되어 멀쩡한 스크립트가 막힌다.

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -9,30 +9,20 @@
 // 세 곳에서 따로 늙는다.
 //
 //   remind            UserPromptSubmit          매 턴 규약 주입 (무조건)
-//   gate-delegation   PreToolUse  Agent|Workflow  로스터를 읽지 않은 팬아웃, Agent의 핀 누락,
-//                                                 workflow의 틀린 모델 철자를 차단
+//   gate-delegation   PreToolUse  Agent|Workflow  핀되지 않은 위임을 차단
 //   workflow-receipt  PostToolUse Workflow        접수증을 결과로 읽는 사고를 차단
 //
-// 자체 상태를 남기지 않는다. 프로세스 간 기억을 위해 훅이 직접 쓰는 파일은 곧 신선도·정리·
-// 경합을 떠안는 두 번째 진실이 되고, 그 파일이 사라지면 게이트가 조용히 열린다. 조회 여부는
-// 그래서 하네스가 이미 소유한 트랜스크립트에서 읽는다 — 새 진실을 만들지 않고, 훅이 관리할
-// 수명도 없다.
+// 상태를 남기지 않는다. 훅은 호출마다 새 프로세스로 뜨므로 프로세스 간 기억은 파일로만
+// 가능한데, 그 파일은 곧 신선도·정리·경합을 떠안는 두 번째 진실이 된다. 세 판정 모두
+// stdin 한 번으로 끝나도록 짰다 — 그래서 타임아웃으로 게이트가 조용히 열릴 여지도 작다.
 import { readFileSync } from "node:fs";
 
 // 모델에게 주는 지시이므로 영어로 쓴다.
-//
-// 조회와 핀은 층위가 다르다. 조회는 무조건이고 핀은 표면마다 조건이 붙는데, 한 문단에 섞으면
-// 핀 쪽 면제("스테이지는 세션 모델에 머물러도 된다")가 조회의 무조건성까지 조건부로 물들인다.
-// 그래서 조회를 먼저 끝내고, 핀 철자는 그 뒤에서 따로 말한다.
 const TURN_REMINDER = [
-  "Call gateway_models before any Agent or Workflow run leaves the host — every time, not once per session.",
-  "The roster and its allowances are resolved at call time, so a name you remember is not evidence that it",
-  "still resolves.",
-  "Then pin from what that call reports.",
-  "Agent: subagent_type = the fleet:* name, always.",
-  "A Workflow stage may stay on the session model; when you do move one, opts.model takes the modelId with",
-  "the claude-gateway-- prefix and opts.agentType takes the fleet:* name.",
-  "The spellings are never interchangeable.",
+  "Before any Agent or Workflow run leaves the host, call gateway_models and pin an identity from what it",
+  "reports — allowances move while work is in flight.",
+  "Agent: subagent_type = the fleet:* name. Workflow: opts.model = the modelId, the claude-gateway-- prefix",
+  "included. The two spellings are never interchangeable.",
 ].join(" ");
 
 const IN_FLIGHT_CONTRACT = [
@@ -43,13 +33,11 @@ const IN_FLIGHT_CONTRACT = [
   "Report the finding once, in the turn the result arrives. If asked before then, say it is still running.",
 ].join(" ");
 
-const PIN_INSTRUCTION =
-  "Call gateway_models first, then pin the identity it reports: subagent_type = the fleet:* name.";
-
-const LOOKUP_INSTRUCTION =
-  "Call gateway_models now, then pin from what it reports. The roster is resolved at call time —"
-  + " a name carried in from memory, from another session, or from this tool's own description is not evidence"
-  + " that it still resolves.";
+const PIN_INSTRUCTION = [
+  "Call gateway_models first, then pin the identity it reports:",
+  "Agent — subagent_type = the fleet:* name;",
+  "Workflow — opts.model = the modelId with the claude-gateway-- prefix, written as a literal.",
+].join(" ");
 
 /**
  * 정체성이 핀되지 않은 위임으로 취급하는 Agent 타입.
@@ -64,14 +52,9 @@ const GATEWAY_AGENT_PREFIX = "fleet:";
 const MODEL_ALIASES = /^(fable|opus|sonnet|haiku)$/;
 const PREFIXED_ALIAS_RE = /^claude-gateway--(fable|opus|sonnet|haiku)$/;
 const GATEWAY_MODEL_PREFIX = "claude-gateway--";
-// 콜론 앞 공백은 유효한 프로퍼티 표기다. 정규식이 정규 표기만 알면 그 한 칸이 검사를 비켜간다.
-const MODEL_VALUE_RE = /model\s*:\s*['"]([^'"]+)['"]/g;
-const AGENT_TYPE_VALUE_RE = /agentType\s*:\s*['"]([^'"]+)['"]/g;
-
-// MCP 이름은 서버 등록명에 따라 접두가 달라진다. 서버 이름을 하드코딩하면 등록명이 바뀌는 날
-// 게이트가 조용히 전부 통과시키므로, 접두는 모양으로만 받고 도구 이름으로 판정한다.
-const LOOKUP_TOOL_NAME_RE = /^(?:mcp__[A-Za-z0-9_.-]+__)?gateway_models$/;
-const LOOKUP_CALL_HINT_RE = /"name"\s*:\s*"(?:mcp__[A-Za-z0-9_.-]+__)?gateway_models"/;
+const AGENT_TYPE_RE = /agentType\s*:/;
+const MODEL_VALUE_RE = /model:\s*['"]([^'"]+)['"]/g;
+const AGENT_CALL_RE = /\bagent\s*\(/g;
 
 function block(message) {
   process.stderr.write(`[fleet-gateway-model-guard] ${message}\n`);
@@ -93,88 +76,61 @@ function readHookInput() {
 }
 
 /**
- * 이 세션이 로스터를 읽었는가. 판정 근거는 하네스가 쓰는 세션 트랜스크립트다.
+ * `agent(` 호출 하나가 차지하는 원문 범위. 괄호 균형으로 끝을 찾되 문자열·주석 안의 괄호는
+ * 세지 않는다 — 프롬프트 텍스트에 괄호가 흔해서, 세는 순간 호출 경계가 엉뚱한 곳에서 닫힌다.
  *
- * 호출이 아니라 `tool_result`가 판정 대상이다. 호출만 세면 게이트웨이가 응답하지 않아 실패로
- * 끝난 조회와, 위임과 같은 턴에 발행되어 아직 결과가 없는 조회가 성공한 조회와 구별되지 않는다
- * — 둘 다 로스터를 받지 못한 세션인데, 그 세션이 기억해둔 이름으로 위임하는 것이 이 게이트가
- * 막으려는 바로 그 경우다. 하네스는 한 턴에 병렬로 발행된 호출도 각각 별도 라인으로 적으므로,
- * 결과 없는 `tool_use`는 예외적인 모양이 아니라 흔한 중간 상태다.
- *
- * 트랜스크립트를 볼 수 없으면 참을 돌린다. 훅이 이 필드를 받지 못하는 경로가 생겼을 때 모든
- * 위임이 막히는 쪽이, 조회 한 번을 놓치는 쪽보다 훨씬 나쁘다 — 게이트는 근거가 있을 때만 닫는다.
+ * 끝을 찾지 못하면 undefined를 돌려주고 호출자는 그 호출을 검사하지 않는다. 이 스캐너는
+ * 파서가 아니므로, 판정할 수 없는 형태를 "핀 없음"으로 몰아 멀쩡한 스크립트를 막는 쪽이
+ * 검사 한 건을 놓치는 쪽보다 나쁘다.
  */
-function sessionReadRoster(input) {
-  const transcriptPath = typeof input?.transcript_path === "string" ? input.transcript_path : undefined;
-  if (transcriptPath === undefined || transcriptPath.length === 0) return true;
-  let raw;
-  try {
-    raw = readFileSync(transcriptPath, "utf8");
-  } catch {
-    return true;
-  }
-  // 값싼 부정 먼저. `gateway_models`라는 문자열 자체는 매 턴 주입되는 규약문, 도구 목록,
-  // 사용자 프롬프트에도 흔해서 그것만으로는 호출의 증거가 못 된다. 힌트가 걸린 뒤에야 라인을
-  // 파싱해 진짜 tool_use인지 가린다.
-  if (!LOOKUP_CALL_HINT_RE.test(raw)) return false;
-  // 결과를 기다리는 조회 호출. 결과 라인에는 도구 이름이 없으므로 id로만 이어 붙일 수 있다.
-  const awaitedLookupIds = new Set();
-  for (const line of raw.split("\n")) {
-    const namesLookup = line.includes("gateway_models");
-    const answersLookup = awaitedLookupIds.size > 0 && idMentionedIn(line, awaitedLookupIds);
-    if (!namesLookup && !answersLookup) continue;
-    let entry;
-    try {
-      entry = JSON.parse(line);
-    } catch {
+function sliceCall(script, openParenIndex) {
+  let depth = 0;
+  let quote;
+  let escaped = false;
+  for (let i = openParenIndex; i < script.length; i += 1) {
+    const char = script[i];
+    if (quote !== undefined) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) quote = undefined;
       continue;
     }
-    // 서브에이전트가 읽은 로스터는 호스트의 조회가 아니다. 위임을 결정하는 것은 호스트다.
-    if (entry?.isSidechain === true) continue;
-    const content = entry?.message?.content;
-    if (!Array.isArray(content)) continue;
-    for (const contentBlock of content) {
-      if (contentBlock?.type === "tool_use") {
-        if (typeof contentBlock.name !== "string" || typeof contentBlock.id !== "string") continue;
-        if (LOOKUP_TOOL_NAME_RE.test(contentBlock.name)) awaitedLookupIds.add(contentBlock.id);
-        continue;
-      }
-      if (contentBlock?.type !== "tool_result") continue;
-      if (!awaitedLookupIds.delete(contentBlock.tool_use_id)) continue;
-      // 성공은 `is_error`의 부재로 적힌다 — 참인 경우만 실패다. 하나만 도착하면 충분하다.
-      if (contentBlock.is_error !== true) return true;
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "/" && script[i + 1] === "/") {
+      const lineEnd = script.indexOf("\n", i);
+      if (lineEnd === -1) return undefined;
+      i = lineEnd;
+      continue;
+    }
+    if (char === "/" && script[i + 1] === "*") {
+      const blockEnd = script.indexOf("*/", i + 2);
+      if (blockEnd === -1) return undefined;
+      i = blockEnd + 1;
+      continue;
+    }
+    if (char === "(") depth += 1;
+    else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) return script.slice(openParenIndex, i + 1);
     }
   }
-  return false;
+  return undefined;
 }
 
-/** 이 라인이 아직 결과를 기다리는 호출 id를 언급하는가. 조회 id는 세션당 한 줌이라 선형 검사로 충분하다. */
-function idMentionedIn(line, ids) {
-  for (const id of ids) {
-    if (line.includes(id)) return true;
+/** model 옵션이 없는 `agent(` 호출의 개수. 경계를 못 읽은 호출은 세지 않는다. */
+function countUnpinnedAgentCalls(script) {
+  let unpinned = 0;
+  for (const match of script.matchAll(AGENT_CALL_RE)) {
+    const call = sliceCall(script, match.index + match[0].length - 1);
+    if (call === undefined) continue;
+    if (!/\bmodel\s*:/.test(call)) unpinned += 1;
   }
-  return false;
+  return unpinned;
 }
 
-/**
- * 로스터를 읽지 않은 팬아웃을 차단한다.
- *
- * 핀의 철자는 볼 수 있어도 그 이름이 아직 해석되는지는 로스터에만 있다. 철자만 검사하면
- * 기억한 이름이 통과하고, 그 순간 규약은 지켜졌다는 외양만 남는다.
- */
-function assertRosterWasRead(input, subject) {
-  if (sessionReadRoster(input)) return;
-  block(`${subject} 이 세션은 아직 gateway_models를 호출하지 않았습니다. ` + LOOKUP_INSTRUCTION);
-}
-
-/**
- * 워크플로우가 쓴 모델 값의 철자 검사.
- *
- * 스테이지를 옮길지 말지는 호스트가 정한다 — 핀하지 않은 스테이지는 세션 모델로 돌면 그만이다.
- * 여기서 막는 것은 옮기기로 해놓고 값을 잘못 쓴 경우뿐이다. 로스터 이름이나 prefix가 빠진
- * modelId가 `model` 자리에 들어가면 모든 분기가 시작 즉시 죽으므로, 그 실패는 실행 전에 잡는
- * 편이 훨씬 싸다.
- */
 function assertWorkflowModelValues(script) {
   for (const match of script.matchAll(MODEL_VALUE_RE)) {
     const value = match[1];
@@ -188,26 +144,7 @@ function assertWorkflowModelValues(script) {
     if (value.startsWith(GATEWAY_MODEL_PREFIX)) continue;
     block(
       `opts.model 값이 올바르지 않습니다: "${value}". gateway_models의 modelId(claude-gateway-- prefix 포함)를 ` +
-        "그대로 복사하거나 lineage alias(fable|opus|sonnet|haiku)를 사용하세요. " +
-        "fleet:* 이름은 opts.agentType 자리입니다."
-    );
-  }
-}
-
-/**
- * 이름 자리에 들어간 modelId. 두 철자를 맞바꾼 나머지 절반이다.
- *
- * `fleet:` 접두만 통과시키지는 않는다 — `general-purpose`처럼 이 저장소가 싣지 않은 내장
- * agentType도 그 자리의 정당한 값이라, 접두로 거르면 멀쩡한 스크립트가 막힌다. modelId만
- * 골라 막는다: 그 값은 어떤 레지스트리에도 이름으로 등록되어 있지 않아 반드시 죽는다.
- */
-function assertWorkflowAgentTypeValues(script) {
-  for (const match of script.matchAll(AGENT_TYPE_VALUE_RE)) {
-    const value = match[1];
-    if (!value.startsWith(GATEWAY_MODEL_PREFIX)) continue;
-    block(
-      `opts.agentType 값이 올바르지 않습니다: "${value}". modelId는 opts.model 자리이고, ` +
-        "agentType에는 gateway_models가 보고한 fleet:* 이름을 씁니다."
+        "그대로 복사하거나 lineage alias(fable|opus|sonnet|haiku)를 사용하세요."
     );
   }
 }
@@ -228,14 +165,9 @@ function resolveWorkflowScript(toolInput) {
   return undefined;
 }
 
-function gateAgentDelegation(toolInput, input) {
+function gateAgentDelegation(toolInput) {
   const agentType = typeof toolInput.subagent_type === "string" ? toolInput.subagent_type : undefined;
-  if (agentType !== undefined && agentType.startsWith(GATEWAY_AGENT_PREFIX)) {
-    // 게이트웨이 정체성으로 나가는 위임만 로스터를 요구한다. 내장 타입은 호스트 모델로 도는
-    // 도구 선택이라 로스터에 걸린 것이 없다.
-    assertRosterWasRead(input, `게이트웨이 위임(${agentType})이 거부되었습니다:`);
-    process.exit(0);
-  }
+  if (agentType !== undefined && agentType.startsWith(GATEWAY_AGENT_PREFIX)) process.exit(0);
   if (agentType !== undefined && !UNPINNED_AGENT_TYPES.has(agentType)) process.exit(0);
   block(
     `이 위임은 정체성이 핀되지 않았습니다(subagent_type: ${agentType ?? "미지정"}). ` +
@@ -243,14 +175,24 @@ function gateAgentDelegation(toolInput, input) {
   );
 }
 
-function gateWorkflowDelegation(toolInput, input) {
-  // 스테이지를 옮기지 않는 워크플로우도 호스트를 떠나는 팬아웃이다. 옮길지 말지를 판단하려면
-  // 그 판단의 재료인 로스터를 먼저 읽어야 하므로, 스크립트를 보기 전에 조회부터 확인한다.
-  assertRosterWasRead(input, "이 워크플로우 디스패치가 거부되었습니다:");
+function gateWorkflowDelegation(toolInput) {
   const script = resolveWorkflowScript(toolInput);
   if (script === undefined) process.exit(0);
+  if (AGENT_TYPE_RE.test(script)) {
+    block(
+      "dynamic workflow 스크립트에 agentType이 금지됩니다. agentType은 팀메이트/서브에이전트 표면 전용이고, " +
+        "워크플로우는 opts.model로만 팬아웃해야 합니다."
+    );
+  }
+  const unpinned = countUnpinnedAgentCalls(script);
+  if (unpinned > 0) {
+    block(
+      `model이 지정되지 않은 agent() 호출이 ${unpinned}건 있습니다. ` +
+        PIN_INSTRUCTION +
+        " 스테이지마다 모델을 나누는 것이 이 표면의 목적이므로, 한 값으로 채우지 말고 역할별로 배분하세요."
+    );
+  }
   assertWorkflowModelValues(script);
-  assertWorkflowAgentTypeValues(script);
   process.exit(0);
 }
 
@@ -270,8 +212,8 @@ if (subcommand === "workflow-receipt") {
 }
 
 if (subcommand === "gate-delegation") {
-  if (toolName === "Agent") gateAgentDelegation(toolInput, input);
-  if (toolName === "Workflow") gateWorkflowDelegation(toolInput, input);
+  if (toolName === "Agent") gateAgentDelegation(toolInput);
+  if (toolName === "Workflow") gateWorkflowDelegation(toolInput);
   process.exit(0);
 }
 

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -53,7 +53,9 @@ const MODEL_ALIASES = /^(fable|opus|sonnet|haiku)$/;
 const PREFIXED_ALIAS_RE = /^claude-gateway--(fable|opus|sonnet|haiku)$/;
 const GATEWAY_MODEL_PREFIX = "claude-gateway--";
 const AGENT_TYPE_RE = /agentType\s*:/;
-const MODEL_VALUE_RE = /model:\s*['"]([^'"]+)['"]/g;
+// 핀 인식(`\bmodel\s*:`)과 값 검증이 같은 철자를 봐야 한다. 콜론 앞 공백을 여기서만
+// 놓치면 `{ model : "..." }`가 핀으로 세어지고도 값 검증을 받지 않는다.
+const MODEL_VALUE_RE = /model\s*:\s*['"]([^'"]+)['"]/g;
 const AGENT_CALL_RE = /\bagent\s*\(/g;
 
 function block(message) {

--- a/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-gateway-model-guard.mjs
@@ -17,7 +17,7 @@
 // stdin 한 번으로 끝나도록 짰다 — 그래서 타임아웃으로 게이트가 조용히 열릴 여지도 작다.
 import { readFileSync } from "node:fs";
 
-// 모델에게 주는 지시이므로 영어로 쓴다.
+// 아래 상주 텍스트와 block()이 내보내는 차단 사유는 모두 모델이 읽는다. 그래서 영어로 쓴다.
 const TURN_REMINDER = [
   "Before any Agent or Workflow run leaves the host, call gateway_models and pin an identity from what it",
   "reports — allowances move while work is in flight.",
@@ -137,14 +137,14 @@ function assertWorkflowModelValues(script) {
     if (MODEL_ALIASES.test(value)) continue;
     if (PREFIXED_ALIAS_RE.test(value)) {
       block(
-        `lineage alias에는 claude-gateway-- prefix를 붙이면 안 됩니다: "${value}". ` +
-          "alias는 그대로(fable|opus|sonnet|haiku) 사용하세요."
+        `A lineage alias must not carry the claude-gateway-- prefix: "${value}". ` +
+          "Write the alias bare (fable|opus|sonnet|haiku)."
       );
     }
     if (value.startsWith(GATEWAY_MODEL_PREFIX)) continue;
     block(
-      `opts.model 값이 올바르지 않습니다: "${value}". gateway_models의 modelId(claude-gateway-- prefix 포함)를 ` +
-        "그대로 복사하거나 lineage alias(fable|opus|sonnet|haiku)를 사용하세요."
+      `opts.model is not a value this run can resolve: "${value}". Copy a modelId from gateway_models verbatim, ` +
+        "the claude-gateway-- prefix included, or use a lineage alias (fable|opus|sonnet|haiku)."
     );
   }
 }
@@ -170,8 +170,7 @@ function gateAgentDelegation(toolInput) {
   if (agentType !== undefined && agentType.startsWith(GATEWAY_AGENT_PREFIX)) process.exit(0);
   if (agentType !== undefined && !UNPINNED_AGENT_TYPES.has(agentType)) process.exit(0);
   block(
-    `이 위임은 정체성이 핀되지 않았습니다(subagent_type: ${agentType ?? "미지정"}). ` +
-      PIN_INSTRUCTION
+    `This delegation pins no identity (subagent_type: ${agentType ?? "absent"}). ` + PIN_INSTRUCTION
   );
 }
 
@@ -180,16 +179,17 @@ function gateWorkflowDelegation(toolInput) {
   if (script === undefined) process.exit(0);
   if (AGENT_TYPE_RE.test(script)) {
     block(
-      "dynamic workflow 스크립트에 agentType이 금지됩니다. agentType은 팀메이트/서브에이전트 표면 전용이고, " +
-        "워크플로우는 opts.model로만 팬아웃해야 합니다."
+      "agentType is not allowed in a dynamic workflow script. It belongs to the teammate and subagent surfaces; " +
+        "a workflow fans out through opts.model alone."
     );
   }
   const unpinned = countUnpinnedAgentCalls(script);
   if (unpinned > 0) {
     block(
-      `model이 지정되지 않은 agent() 호출이 ${unpinned}건 있습니다. ` +
+      `${unpinned} agent() call(s) pin no model. ` +
         PIN_INSTRUCTION +
-        " 스테이지마다 모델을 나누는 것이 이 표면의 목적이므로, 한 값으로 채우지 말고 역할별로 배분하세요."
+        " Spreading stages across models is the point of this surface, so assign one per role rather than " +
+        "filling every stage with a single value."
     );
   }
   assertWorkflowModelValues(script);

--- a/packages/fleet-admiral/src/ai-gateway/gateway-models-tool.ts
+++ b/packages/fleet-admiral/src/ai-gateway/gateway-models-tool.ts
@@ -46,7 +46,7 @@ const GATEWAY_MODELS_DOCTRINE = {
   description:
     `Report the gateway models currently available to this session, each model's routing constraints, capability class, and benchmark evidence, and the current provider allowances and the user's provider spend priority.`
     + ` The roster is the models the user exposed in the Console minus the ones reserved for the host session, and it is editable while this session runs, so it is resolved at call time rather than remembered.`
-    + ` Two spellings, never interchangeable: agentTypes names an identity — the Agent tool's subagent_type, or a workflow stage's opts.agentType — while modelId is the model as a value for a workflow stage's opts.model, and each is refused where the other belongs.`
+    + ` Two spellings, never interchangeable: agentTypes names an identity for the Agent tool's subagent_type, while modelId is the model as a value for a workflow stage's opts.model — each is refused where the other belongs.`
     + ` Names are registered once at session start while this roster is re-read live, so a model or reasoning rung exposed mid-session appears here under a name that will not resolve until a new session.`,
   promptSnippet:
     `gateway_models — Live roster of assignable gateway models: constraints, capability class, benchmark evidence, provider allowances, and the user's provider priority.`,

--- a/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
+++ b/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
@@ -426,9 +426,6 @@ describe("gateway_models tool doctrine", () => {
     expect(description).toContain("Two spellings, never interchangeable");
     expect(description).toContain("subagent_type");
     expect(description).toContain("opts.model");
-    // 워크플로우 스테이지도 agentType으로 핀할 수 있다. 이름 축을 Agent 전용으로 적으면
-    // 로스터를 읽은 호스트가 지원되는 경로를 쓰지 않는다.
-    expect(description).toContain("opts.agentType");
     // 세션 중 노출한 모델은 이름이 해석되지 않는다. 이것을 모르면 stale roster를 의심하며
     // 같은 실패를 반복한다.
     expect(description).toContain("registered once at session start");

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -131,7 +131,7 @@ describe("gateway model guard — Workflow delegation", () => {
       ].join("\n"),
     });
     expect(status).toBe(2);
-    expect(stderr).toContain("2건");
+    expect(stderr).toContain("2 agent() call(s)");
   });
 
   // 프롬프트 텍스트의 괄호를 호출 경계로 세면 멀쩡한 스크립트가 막힌다.

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -167,6 +167,11 @@ describe("gateway model guard — Workflow delegation", () => {
     expect(stderr).toContain("agentType");
   });
 
+  it("does not read a suffixed identifier as opts.agentType", () => {
+    const script = `const cfg = { subagentType: "helper" }; agent("x", { model: "opus" })`;
+    expect(gateWorkflow({ script }).status).toBe(0);
+  });
+
   it("reads the script from scriptPath for resume-style runs", () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), "gateway-model-guard-"));
     tempDirs.push(dir);

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -107,6 +107,13 @@ describe("gateway model guard — Workflow delegation", () => {
     expect(stderr).toContain("claude-gateway--");
   });
 
+  // 핀 인식은 콜론 앞 공백을 허용한다. 값 검증만 놓치면 핀으로 세어진 스테이지가 검사 없이 나간다.
+  it("validates a model value written with whitespace before the colon", () => {
+    const { status, stderr } = gateWorkflow({ script: `agent("x", { model : "codex--gpt-5.6-sol-fast" })` });
+    expect(status).toBe(2);
+    expect(stderr).toContain("claude-gateway--");
+  });
+
   it("blocks a lineage alias that carries the gateway prefix", () => {
     const { status, stderr } = gateWorkflow({ script: `agent("x", { model: "claude-gateway--fable" })` });
     expect(status).toBe(2);

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -50,12 +50,6 @@ describe("gateway model guard — remind", () => {
     expect(parsed.hookSpecificOutput.additionalContext).toContain("gateway_models");
     expect(parsed.hookSpecificOutput.additionalContext).toContain("subagent_type");
     expect(parsed.hookSpecificOutput.additionalContext).toContain("opts.model");
-    // 핀이 선택이 된 뒤에도 로스터 조회는 핀의 조건이다 — 기억한 이름은 여전히 해석된다는
-    // 증거가 아니다. 워크플로우 스테이지의 두 핀 철자가 그 조회에 함께 묶여 있어야 한다.
-    expect(parsed.hookSpecificOutput.additionalContext).toContain("opts.agentType");
-    // 조회는 무조건이고 핀은 표면마다 조건이 붙는다. 한 문단에 섞으면 핀 쪽 면제가 조회의
-    // 무조건성까지 조건부로 물들이므로, 주입문은 조회를 먼저 끝내고 핀 철자를 뒤에서 말한다.
-    expect(parsed.hookSpecificOutput.additionalContext).toContain("every time, not once per session");
   });
 
   // 주입은 stdin과 무관하게 성립해야 한다. 턴 시작 payload 모양이 바뀌어도 규약은 실려야 한다.
@@ -119,55 +113,39 @@ describe("gateway model guard — Workflow delegation", () => {
     expect(stderr).toContain("prefix");
   });
 
-  // 핀하지 않은 스테이지는 세션 모델로 돈다. 스테이지를 옮길지 말지는 작업을 읽어야 나오는
-  // 판단이라 훅이 볼 수 없다 — 요구하면 한 값으로 전부 채우는 순응만 남는다.
-  it("passes a stage that pins no model at all", () => {
+  // 틀린 핀을 막는 것만으로는 부족하다 — 아예 핀하지 않은 스테이지가 세션 모델을 상속한다.
+  it("blocks a stage that pins no model at all", () => {
     for (const script of [`agent("x")`, `agent("x", { schema: S })`, `const r = await agent(prompt, {})`]) {
-      expect(gateWorkflow({ script }).status, script).toBe(0);
+      const { status, stderr } = gateWorkflow({ script });
+      expect(status, script).toBe(2);
+      expect(stderr, script).toContain("model");
     }
   });
 
-  it("passes a script that mixes pinned and unpinned stages", () => {
-    const { status } = gateWorkflow({
+  it("counts every unpinned stage in one script", () => {
+    const { status, stderr } = gateWorkflow({
       script: [
         `const a = await agent("one", { model: "claude-gateway--xai--grok-4.6" })`,
         `const b = await agent("two", { schema: S })`,
         `const c = await agent("three")`,
       ].join("\n"),
     });
+    expect(status).toBe(2);
+    expect(stderr).toContain("2건");
+  });
+
+  // 프롬프트 텍스트의 괄호를 호출 경계로 세면 멀쩡한 스크립트가 막힌다.
+  it("reads call boundaries past parentheses and quotes inside the prompt", () => {
+    const { status } = gateWorkflow({
+      script: `await agent("check foo(bar) and \\"baz)\\" here", { model: "claude-gateway--xai--grok-4.6" })`,
+    });
     expect(status).toBe(0);
   });
 
-  // agentType은 스테이지의 또 다른 정당한 핀이다. 내장 타입도 그 자리의 정당한 값이므로
-  // fleet: 접두를 요구하지 않는다.
-  it("passes agentType usage in a dynamic workflow", () => {
-    for (const value of ["fleet:xai-grok-4-6-low", "general-purpose", "code-reviewer"]) {
-      expect(gateWorkflow({ script: `agent("x", { agentType: "${value}" })` }).status, value).toBe(0);
-    }
-  });
-
-  // 콜론 앞 공백도 유효한 프로퍼티 표기다. 정규 표기만 아는 검사는 그 한 칸으로 비켜간다.
-  it("reads a property written with whitespace before the colon", () => {
-    for (const script of [
-      `agent("x", { agentType : "claude-gateway--codex--gpt-5.6-sol-fast" })`,
-      `agent("x", { model : "codex--gpt-5.6-sol-fast" })`,
-    ]) {
-      expect(gateWorkflow({ script }).status, script).toBe(2);
-    }
-  });
-
-  // 두 철자를 맞바꾼 나머지 절반. modelId는 어떤 레지스트리에도 이름으로 없어 반드시 죽는다.
-  it("blocks a modelId written into the agentType slot", () => {
+  it("blocks agentType usage in a dynamic workflow", () => {
     const { status, stderr } = gateWorkflow({
-      script: `agent("x", { agentType: "claude-gateway--codex--gpt-5.6-sol-fast" })`,
+      script: `agent("x", { agentType: "fleet:codex-gpt-5-6-sol-fast-high" })`,
     });
-    expect(status).toBe(2);
-    expect(stderr).toContain("opts.model");
-  });
-
-  // 로스터 이름이 model 자리에 들어가면 전 분기가 디스패치 즉시 죽는다. 그 실패만 미리 잡는다.
-  it("blocks a roster identity name written into the model slot", () => {
-    const { status, stderr } = gateWorkflow({ script: `agent("x", { model: "fleet:xai-grok-4-6-low" })` });
     expect(status).toBe(2);
     expect(stderr).toContain("agentType");
   });
@@ -221,176 +199,5 @@ describe("gateway model guard — workflow receipt", () => {
     });
     expect(status).toBe(0);
     expect(stdout).toContain("still in flight");
-  });
-});
-
-describe("gateway model guard — roster lookup", () => {
-  // 트랜스크립트는 하네스가 쓰는 그 파일이다. 훅이 따로 만드는 상태 파일이 아니므로 신선도와
-  // 정리를 떠안지 않는다 — 픽스처도 같은 모양으로 만든다.
-  function transcript(lines: readonly unknown[]): string {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "gateway-model-guard-transcript-"));
-    tempDirs.push(dir);
-    const transcriptPath = path.join(dir, "session.jsonl");
-    writeFileSync(transcriptPath, lines.map((line) => JSON.stringify(line)).join("\n"));
-    return transcriptPath;
-  }
-
-  // 조회는 호출이 아니라 결과로 완성된다. 픽스처도 tool_use와 tool_result를 쌍으로 적는다.
-  function lookupCall(
-    toolName = "mcp__fleet__gateway_models",
-    extra: Record<string, unknown> = {},
-    id = "toolu_lookup",
-  ) {
-    return [
-      { type: "assistant", ...extra, message: { role: "assistant", content: [{ type: "tool_use", id, name: toolName, input: {} }] } },
-      {
-        type: "user",
-        ...extra,
-        message: { role: "user", content: [{ type: "tool_result", tool_use_id: id, content: `{"models":[]}` }] },
-      },
-    ];
-  }
-
-  /** 게이트웨이가 응답하지 않아 실패로 끝난 조회. 세션은 로스터를 받지 못했다. */
-  function failedLookupCall(id = "toolu_failed") {
-    return [
-      { type: "assistant", message: { role: "assistant", content: [{ type: "tool_use", id, name: "mcp__fleet__gateway_models", input: {} }] } },
-      {
-        type: "user",
-        message: {
-          role: "user",
-          content: [{ type: "tool_result", tool_use_id: id, is_error: true, content: "MCP error: gateway unavailable" }],
-        },
-      },
-    ];
-  }
-
-  /** 위임과 같은 턴에 발행되어 아직 결과가 없는 조회. 병렬 호출도 각각 별도 라인으로 적힌다. */
-  function unansweredLookupCall(id = "toolu_pending") {
-    return [
-      { type: "assistant", message: { role: "assistant", content: [{ type: "tool_use", id, name: "mcp__fleet__gateway_models", input: {} }] } },
-    ];
-  }
-
-  // 매 턴 주입되는 규약문에는 `gateway_models`가 그대로 들어 있다. 도구 목록과 사용자 프롬프트도
-  // 마찬가지다. 문자열이 보인다는 사실은 호출의 증거가 아니다.
-  const MENTION_WITHOUT_CALL = [
-    {
-      type: "user",
-      message: { role: "user", content: [{ type: "text", text: "왜 gateway_models 없이 팬아웃하지?" }] },
-    },
-    {
-      type: "system",
-      attachment: { type: "hook_additional_context", content: ["Call gateway_models before any Agent or Workflow run"] },
-    },
-    {
-      type: "assistant",
-      message: {
-        role: "assistant",
-        content: [{ type: "tool_use", id: "toolu_0", name: "ToolSearch", input: { query: "select:mcp__fleet__gateway_models" } }],
-      },
-    },
-  ];
-
-  function gateAgentWith(transcriptPath: string, subagentType: string) {
-    return run("gate-delegation", {
-      tool_name: "Agent",
-      transcript_path: transcriptPath,
-      tool_input: { subagent_type: subagentType },
-    });
-  }
-
-  function gateWorkflowWith(transcriptPath: string, toolInput: unknown) {
-    return run("gate-delegation", { tool_name: "Workflow", transcript_path: transcriptPath, tool_input: toolInput });
-  }
-
-  it("passes a gateway delegation once the session has read the roster", () => {
-    const transcriptPath = transcript(lookupCall());
-    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(0);
-    expect(gateWorkflowWith(transcriptPath, { script: `agent("x")` }).status).toBe(0);
-  });
-
-  // 이 게이트가 존재하는 이유. 철자만 보면 기억한 이름이 통과하고, 규약은 지켜졌다는 외양만 남는다.
-  it("blocks a fan-out from a session that never called gateway_models", () => {
-    const transcriptPath = transcript(MENTION_WITHOUT_CALL);
-    const agent = gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low");
-    expect(agent.status).toBe(2);
-    expect(agent.stderr).toContain("gateway_models");
-
-    const workflow = gateWorkflowWith(transcriptPath, { script: `agent("x")` });
-    expect(workflow.status).toBe(2);
-    expect(workflow.stderr).toContain("gateway_models");
-  });
-
-  // 스테이지를 하나도 옮기지 않는 워크플로우도 호스트를 떠나는 팬아웃이다. 옮길지 말지를
-  // 판단하려면 그 재료인 로스터를 먼저 읽어야 한다.
-  it("blocks an unread-roster Workflow whichever form the dispatch takes", () => {
-    const transcriptPath = transcript(MENTION_WITHOUT_CALL);
-    for (const toolInput of [{ script: `agent("x")` }, { name: "saved-workflow" }, { scriptPath: "/tmp/absent.js" }]) {
-      expect(gateWorkflowWith(transcriptPath, toolInput).status, JSON.stringify(toolInput)).toBe(2);
-    }
-  });
-
-  // 서브에이전트가 읽은 로스터는 호스트의 조회가 아니다. 위임을 결정하는 것은 호스트다.
-  it("does not count a lookup made inside a subagent", () => {
-    const transcriptPath = transcript(lookupCall("mcp__fleet__gateway_models", { isSidechain: true }));
-    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(2);
-  });
-
-  // MCP 서버 등록명은 바뀔 수 있다. 접두를 하드코딩하면 그날 게이트가 조용히 전부 통과시킨다.
-  it("recognises the lookup under any MCP server prefix", () => {
-    for (const toolName of ["gateway_models", "mcp__fleet__gateway_models", "mcp__fleet-console__gateway_models"]) {
-      const transcriptPath = transcript(lookupCall(toolName));
-      expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status, toolName).toBe(0);
-    }
-  });
-
-  // 내장 타입은 호스트 모델로 도는 도구 선택이라 로스터에 걸린 것이 없다.
-  it("does not demand a lookup for built-in agent types", () => {
-    const transcriptPath = transcript(MENTION_WITHOUT_CALL);
-    for (const subagentType of ["Explore", "Plan", "fork"]) {
-      expect(gateAgentWith(transcriptPath, subagentType).status, subagentType).toBe(0);
-    }
-  });
-
-  // 근거가 없으면 닫지 않는다. 훅이 이 필드를 받지 못하는 경로가 생겼을 때 모든 위임이 막히는
-  // 쪽이, 조회 한 번을 놓치는 쪽보다 훨씬 나쁘다.
-  it("stays open when the transcript cannot be read", () => {
-    expect(gateAgent({ subagent_type: "fleet:xai-grok-4-6-low" }).status).toBe(0);
-    expect(gateWorkflowWith("/nonexistent/session.jsonl", { script: `agent("x")` }).status).toBe(0);
-    expect(gateWorkflowWith("", { script: `agent("x")` }).status).toBe(0);
-  });
-
-  // 호출만 세면 실패로 끝난 조회가 성공한 조회와 구별되지 않는다. 그 세션은 로스터를 받지
-  // 못했으므로, 기억해둔 이름으로 나가는 위임이 이 게이트를 그대로 통과한다.
-  it("does not count a lookup that failed", () => {
-    const transcriptPath = transcript(failedLookupCall());
-    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(2);
-    expect(gateWorkflowWith(transcriptPath, { script: `agent("x")` }).status).toBe(2);
-  });
-
-  // 조회를 위임과 같은 턴에 발행하면 호출은 트랜스크립트에 있어도 로스터는 아직 오지 않았다.
-  it("does not count a lookup whose result has not arrived", () => {
-    const transcriptPath = transcript(unansweredLookupCall());
-    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(2);
-  });
-
-  // 실패는 재시도로 회복된다. 성공한 결과가 하나 도착하면 그것으로 충분하다.
-  it("counts a successful retry after a failed lookup", () => {
-    const transcriptPath = transcript([
-      ...failedLookupCall("toolu_first"),
-      ...lookupCall("mcp__fleet__gateway_models", {}, "toolu_second"),
-    ]);
-    expect(gateAgentWith(transcriptPath, "fleet:xai-grok-4-6-low").status).toBe(0);
-  });
-
-  // 조회를 마친 세션에서도 철자 검사는 그대로다. 두 판정은 독립이다.
-  it("still judges spelling after the roster was read", () => {
-    const transcriptPath = transcript(lookupCall());
-    const { status, stderr } = gateWorkflowWith(transcriptPath, {
-      script: `agent("x", { model: "codex--gpt-5.6-sol-fast" })`,
-    });
-    expect(status).toBe(2);
-    expect(stderr).toContain("claude-gateway--");
   });
 });

--- a/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/gateway-model-guard-hook.test.ts
@@ -114,6 +114,16 @@ describe("gateway model guard — Workflow delegation", () => {
     expect(stderr).toContain("claude-gateway--");
   });
 
+  // 값 검증이 핀 인식보다 넓으면 `response_model` 같은 설정 키가 opts.model로 오인된다.
+  it("does not read a suffixed configuration key as a stage pin", () => {
+    for (const script of [
+      `const cfg = { response_model : "compact" }; agent(cfg.response_model, { model: "opus" })`,
+      `const cfg = { response_model: "compact" }; agent(cfg.response_model, { model: "opus" })`,
+    ]) {
+      expect(gateWorkflow({ script }).status, script).toBe(0);
+    }
+  });
+
   it("blocks a lineage alias that carries the gateway prefix", () => {
     const { status, stderr } = gateWorkflow({ script: `agent("x", { model: "claude-gateway--fable" })` });
     expect(status).toBe(2);


### PR DESCRIPTION
## Summary
- `#836`(워크플로 스테이지 모델 핀 완화)과 `#843`(위임 전 로스터 조회 강제)을 되돌려, 게이트웨이 모델 가드의 서브에이전트/팀메이트/워크플로 동작을 v1.69.0과 동일하게 복원합니다.
- 가드는 다시 무상태입니다. 트랜스크립트를 읽지 않고 `Agent`/`Workflow` 호출을 stdin 페이로드만으로 판정하며, 모든 `Workflow` 스테이지가 모델을 지정해야 하고 스크립트 내 `agentType`은 거부됩니다.
- `docs/admiral-prompt-architecture.md`와 훅 테스트도 pre-#836 상태로 되돌렸습니다. 되돌린 5개 파일은 `3c22f328c^` 트리와 바이트 단위로 동일합니다.

## Changelog
미출시 프래그먼트 `gateway-lookup-gate.md`를 개정했습니다. 이 프래그먼트가 예고한 로스터 조회 게이트(#843)는 출시된 적이 없으므로 노트를 삭제 대신 재작성했고, v1.70.0 사용자가 실제로 겪는 유일한 델타(스테이지별 모델 핀 복귀)를 기록합니다.

Changelog-Amend: gateway-lookup-gate.md

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` — 13 files / 170 tests passed
- [x] `pnpm typecheck` — 전체 워크스페이스 통과
- [x] `pnpm test` — fleet-console 2301 passed / 24 skipped, terminal 968 passed, desktop 302 passed 등 전체 통과
- [x] `pnpm build` — 통과
- [x] `pnpm check:core-boundary` / `check:claude-agent-sdk-boundary` / `check:core-unified-agent-absent` / `check:localized-attributes` — 위반 없음
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty` — 4 entries validated