### PR TITLE
feat(repository): yield in a fixed order as the rail narrows

### DIFF
--- a/.changelog.d/repo-panel-refit.md
+++ b/.changelog.d/repo-panel-refit.md
@@ -1,0 +1,8 @@
+---
+branch: repo-panel-refit
+---
+
+### fleet-console
+#### Changed
+- The Repository panel now yields in a fixed order as the rail narrows. Toolbar verbs (Pull, Push, Stash) drop their text labels first and keep their glyph plus the ahead/behind count, checkout tab labels shorten, and below 320px a commit row keeps only its graph gutter and subject with a guaranteed 96px of reading width. Identity signals such as ref badges yield before location and action do, and screen reader labels survive every stage.
+  ko: 레일이 좁아지면 저장소 패널이 정해진 순서로 양보합니다. 툴바 동사(Pull, Push, Stash)는 먼저 텍스트 라벨을 내놓고 글리프와 ahead/behind 계수를 유지하며, 체크아웃 탭 라벨은 짧아지고, 320px 아래에서는 커밋 행이 그래프 거터와 제목만 남기되 96px의 읽기 폭이 보장됩니다. 정체 신호(refs)가 위치와 행동보다 먼저 양보하던 기존 동작을 뒤집고, 어느 단계에서도 스크린 리더 낭독은 유지됩니다.

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -159,8 +159,9 @@ interface GraphGutterProps {
   readonly node: GraphNode;
   /**
    * 축소 순서 계약의 최종 단계(320px 아래) — 거터를 1레인 폭으로 압축한다. 뷰포트 축소나
-   * 왼쪽 클립은 lane>0 행의 커밋 노드를 통째로 잘라 내므로, 대신 SVG를 음수 margin으로
-   * 밀어 현재 행의 레인이 14px 창 안에 오게 한다. 종횡비는 viewBox가 그대로라 보존된다.
+   * 왼쪽 클립은 lane>0 행의 커밋 노드를 통째로 잘라 내므로, lane>0 행에만
+   * .history-graph-gutter-compact 클래스를 얹는다. 오프셋 자체는 CSS가 담당하며
+   * 320px 컨테이너 쿼리 안에서만 발동한다 — 전 폭에서 켜면 정상 그래프의 레인 좌표가 어긋난다.
    */
   readonly compact?: boolean;
 }
@@ -232,7 +233,8 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
       height={ROW_HEIGHT}
       viewBox={`0 0 ${width} ${ROW_HEIGHT}`}
       aria-hidden="true"
-      style={{ display: "block", flexShrink: 0, ...(compact && node.lane > 0 ? { marginLeft: `-${node.lane * LANE_WIDTH}px` } : {}) }}
+      className={compact && node.lane > 0 ? "history-graph-gutter-compact" : undefined}
+      style={{ display: "block", flexShrink: 0 }}
     >
       {/* passThrough 수직선 */}
       {node.passThroughLanes.map((lane) => (

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -321,9 +321,10 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
 
       {/* collapse 인디케이터 — compact 모드(320px 아래, CSS 컨테이너 쿼리가 판정)에서는
           SVG가 -lane*14px 밀려나 창은 로컬 좌표 [lane*14, lane*14+14]를 노출한다. 인디케이터를
-          활성 노드 바로 오른쪽(cx + NODE_R + 3)에 두면 어느 레인에서든 창 안에 떨어지고,
-          end-앵커로 글리프 몸통도 시작점 왼쪽에 끝난다. x·앵커 모두 CSS 변수 --gutter-lane과
-          함께 브레이크포인트 안에서만 재정의된다 — prop은 폭을 모른다.
+          활성 노드 바로 오른쪽(cx + NODE_R + 3)에 두면 어느 레인(0 포함)에서든 창 안에
+          떨어지고, end-앵커로 글리프 몸통도 시작점 왼쪽에 끝난다. lane>0 조건은 오프셋(margin)
+          필요성의 조건이지 표식 재배치의 조건이 아니다 — 표식은 compact면 항상 준비한다.
+          적용 자체는 CSS가 브레이크포인트 안에서만 한다 — prop은 폭을 모른다.
           잘림 신호가 사라지면 허위 완결이 된다. */}
       {node.collapsed && (
         <text
@@ -332,8 +333,8 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
           fontSize={10}
           fontFamily="monospace"
           fill="var(--ink-fog)"
-          textAnchor={compact && node.lane > 0 ? "end" : undefined}
-          style={compact && node.lane > 0 ? ({ "--gutter-indicator-x": `${cx + NODE_R + 3}px` } as CSSProperties) : undefined}
+          textAnchor={compact ? "end" : undefined}
+          style={compact ? ({ "--gutter-indicator-x": `${cx + NODE_R + 3}px` } as CSSProperties) : undefined}
         >
           ⋯
         </text>

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -157,6 +157,12 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
 
 interface GraphGutterProps {
   readonly node: GraphNode;
+  /**
+   * 축소 순서 계약의 최종 단계(320px 아래) — 거터를 1레인 폭으로 압축한다. 뷰포트 축소나
+   * 왼쪽 클립은 lane>0 행의 커밋 노드를 통째로 잘라 내므로, 대신 SVG를 음수 margin으로
+   * 밀어 현재 행의 레인이 14px 창 안에 오게 한다. 종횡비는 viewBox가 그대로라 보존된다.
+   */
+  readonly compact?: boolean;
 }
 
 // ─── constants ───────────────────────────────────────────────────────────────
@@ -211,7 +217,7 @@ function branchPath(fromX: number, toLane: number, cy: number): string {
 
 // ─── GraphGutter ─────────────────────────────────────────────────────────────
 
-export function GraphGutter({ node }: GraphGutterProps) {
+export function GraphGutter({ node, compact = false }: GraphGutterProps) {
   // Fork 문법 — 거터 폭은 이 행이 실제로 쓰는 레인만큼이다. 목록 전체 최대 레인 수로 고정하면
   // 분기가 하나도 없는 행까지 빈 레인만큼 본문이 밀려 좁은 rail에서 제목 폭을 상시 잠식한다.
   const lanes = Math.max(node.rowLaneCount, 1);
@@ -226,7 +232,7 @@ export function GraphGutter({ node }: GraphGutterProps) {
       height={ROW_HEIGHT}
       viewBox={`0 0 ${width} ${ROW_HEIGHT}`}
       aria-hidden="true"
-      style={{ display: "block", flexShrink: 0 }}
+      style={{ display: "block", flexShrink: 0, ...(compact && node.lane > 0 ? { marginLeft: `-${node.lane * LANE_WIDTH}px` } : {}) }}
     >
       {/* passThrough 수직선 */}
       {node.passThroughLanes.map((lane) => (

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -319,10 +319,12 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
         fill={laneColor(node.lane)}
       />
 
-      {/* collapse 인디케이터 */}
+      {/* collapse 인디케이터 — compact 모드에서는 레인 내용물이 창 밖으로 밀려나므로,
+          인디케이터를 현재 레인 창 안(노드 오른쪽)에 다시 배치한다. 잘림 신호가 사라지면
+          역사가 온전해 보이는 허위 완결이 된다. */}
       {node.collapsed && (
         <text
-          x={lanes * LANE_WIDTH + 2}
+          x={compact && node.lane > 0 ? LANE_WIDTH - 4 : lanes * LANE_WIDTH + 2}
           y={cy + 4}
           fontSize={10}
           fontFamily="monospace"

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -320,9 +320,9 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
       />
 
       {/* collapse 인디케이터 — compact 모드에서는 SVG 전체가 -lane*14px 밀려나므로,
-          인디케이터 좌표에 같은 오프셋을 더해 활성 노드 바로 오른쪽 창 안에 둔다.
-          lane 0은 밀림이 없어도 기본 위치(lanes*14+2)가 14px 창을 벗어나므로
-          노드 오른쪽으로 당겨 온다. 잘림 신호가 사라지면 허위 완결이 된다. */}
+          인디케이터를 활성 노드 기준으로 배치하되 text-anchor=end로 글리프가 시작점의
+          왼쪽에 끝나게 한다. 시작 앵커 두면 ⋯ 몸통이 14px 창 밖으로 잘려 표식이 사라진다.
+          잘림 신호가 사라지면 허위 완결이 된다. */}
       {node.collapsed && (
         <text
           x={compact ? cx + NODE_R + 3 : lanes * LANE_WIDTH + 2}
@@ -330,6 +330,7 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
           fontSize={10}
           fontFamily="monospace"
           fill="var(--ink-fog)"
+          textAnchor={compact ? "end" : undefined}
         >
           ⋯
         </text>

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -319,18 +319,19 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
         fill={laneColor(node.lane)}
       />
 
-      {/* collapse 인디케이터 — compact 모드에서는 SVG 전체가 -lane*14px 밀려나므로,
-          인디케이터를 활성 노드 기준으로 배치하되 text-anchor=end로 글리프가 시작점의
-          왼쪽에 끝나게 한다. 시작 앵커 두면 ⋯ 몸통이 14px 창 밖으로 잘려 표식이 사라진다.
+      {/* collapse 인디케이터 — compact 모드(320px 아래, CSS 컨테이너 쿼리가 판정)에서는
+          SVG가 -lane*14px 밀려나고 창이 14px로 잘리므로, 인디케이터를 end-앵커로 바꾸고
+          x는 CSS(.history-graph-gutter-compact text)가 브레이크포인트 안에서만 13px로
+          되돌린다. prop은 폭을 모르므로 좌표 분기도 CSS에 맡긴다.
           잘림 신호가 사라지면 허위 완결이 된다. */}
       {node.collapsed && (
         <text
-          x={compact ? cx + NODE_R + 3 : lanes * LANE_WIDTH + 2}
+          x={lanes * LANE_WIDTH + 2}
           y={cy + 4}
           fontSize={10}
           fontFamily="monospace"
           fill="var(--ink-fog)"
-          textAnchor={compact ? "end" : undefined}
+          textAnchor={compact && node.lane > 0 ? "end" : undefined}
         >
           ⋯
         </text>

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -322,10 +322,10 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
       {/* collapse 인디케이터 — compact 모드(320px 아래, CSS 컨테이너 쿼리가 판정)에서는
           SVG가 -lane*14px 밀려나 창은 로컬 좌표 [lane*14, lane*14+14]를 노출한다. 인디케이터를
           활성 노드 바로 오른쪽(cx + NODE_R + 3)에 두면 어느 레인(0 포함)에서든 창 안에
-          떨어지고, end-앵커로 글리프 몸통도 시작점 왼쪽에 끝난다. lane>0 조건은 오프셋(margin)
-          필요성의 조건이지 표식 재배치의 조건이 아니다 — 표식은 compact면 항상 준비한다.
-          적용 자체는 CSS가 브레이크포인트 안에서만 한다 — prop은 폭을 모른다.
-          잘림 신호가 사라지면 허위 완결이 된다. */}
+          떨어지고, compact 전용 CSS의 end-anchor로 글리프 몸통도 시작점 왼쪽에 끝난다.
+          lane>0 조건은 오프셋(margin) 필요성의 조건이지 표식 재배치의 조건이 아니다 — 표식은
+          compact면 항상 준비한다. 좌표와 anchor 적용 자체는 CSS가 브레이크포인트 안에서만 한다 —
+          prop은 폭을 모른다. 잘림 신호가 사라지면 허위 완결이 된다. */}
       {node.collapsed && (
         <text
           x={lanes * LANE_WIDTH + 2}
@@ -333,7 +333,7 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
           fontSize={10}
           fontFamily="monospace"
           fill="var(--ink-fog)"
-          textAnchor={compact ? "end" : undefined}
+          className={compact ? "history-graph-collapse-indicator-compact" : undefined}
           style={compact ? ({ "--gutter-indicator-x": `${cx + NODE_R + 3}px` } as CSSProperties) : undefined}
         >
           ⋯

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -320,9 +320,10 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
       />
 
       {/* collapse 인디케이터 — compact 모드(320px 아래, CSS 컨테이너 쿼리가 판정)에서는
-          SVG가 -lane*14px 밀려나고 창이 14px로 잘리므로, 인디케이터를 end-앵커로 바꾸고
-          x는 CSS(.history-graph-gutter-compact text)가 브레이크포인트 안에서만 13px로
-          되돌린다. prop은 폭을 모르므로 좌표 분기도 CSS에 맡긴다.
+          SVG가 -lane*14px 밀려나 창은 로컬 좌표 [lane*14, lane*14+14]를 노출한다. 인디케이터를
+          활성 노드 바로 오른쪽(cx + NODE_R + 3)에 두면 어느 레인에서든 창 안에 떨어지고,
+          end-앵커로 글리프 몸통도 시작점 왼쪽에 끝난다. x·앵커 모두 CSS 변수 --gutter-lane과
+          함께 브레이크포인트 안에서만 재정의된다 — prop은 폭을 모른다.
           잘림 신호가 사라지면 허위 완결이 된다. */}
       {node.collapsed && (
         <text
@@ -332,6 +333,7 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
           fontFamily="monospace"
           fill="var(--ink-fog)"
           textAnchor={compact && node.lane > 0 ? "end" : undefined}
+          style={compact && node.lane > 0 ? ({ "--gutter-indicator-x": `${cx + NODE_R + 3}px` } as CSSProperties) : undefined}
         >
           ⋯
         </text>

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -319,12 +319,13 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
         fill={laneColor(node.lane)}
       />
 
-      {/* collapse 인디케이터 — compact 모드에서는 레인 내용물이 창 밖으로 밀려나므로,
-          인디케이터를 현재 레인 창 안(노드 오른쪽)에 다시 배치한다. 잘림 신호가 사라지면
-          역사가 온전해 보이는 허위 완결이 된다. */}
+      {/* collapse 인디케이터 — compact 모드에서는 SVG 전체가 -lane*14px 밀려나므로,
+          인디케이터 좌표에 같은 오프셋을 더해 활성 노드 바로 오른쪽 창 안에 둔다.
+          lane 0은 밀림이 없어도 기본 위치(lanes*14+2)가 14px 창을 벗어나므로
+          노드 오른쪽으로 당겨 온다. 잘림 신호가 사라지면 허위 완결이 된다. */}
       {node.collapsed && (
         <text
-          x={compact && node.lane > 0 ? LANE_WIDTH - 4 : lanes * LANE_WIDTH + 2}
+          x={compact ? cx + NODE_R + 3 : lanes * LANE_WIDTH + 2}
           y={cy + 4}
           fontSize={10}
           fontFamily="monospace"

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 import type { LogCommitEntry } from "../server/types.js";
 
 // ═══ graph-layout ════════════════════════════════════════════════════════════
@@ -159,9 +161,9 @@ interface GraphGutterProps {
   readonly node: GraphNode;
   /**
    * 축소 순서 계약의 최종 단계(320px 아래) — 거터를 1레인 폭으로 압축한다. 뷰포트 축소나
-   * 왼쪽 클립은 lane>0 행의 커밋 노드를 통째로 잘라 내므로, lane>0 행에만
-   * .history-graph-gutter-compact 클래스를 얹는다. 오프셋 자체는 CSS가 담당하며
-   * 320px 컨테이너 쿼리 안에서만 발동한다 — 전 폭에서 켜면 정상 그래프의 레인 좌표가 어긋난다.
+   * 왼쪽 클립은 lane>0 행의 커밋 노드를 통째로 잘라 내므로, lane>0 행에만 자기 레인 오프셋을
+   * CSS 변수(--gutter-lane)로 실어 보낸다. 오프셋의 발동은 CSS가 담당해 320px 컨테이너
+   * 쿼리 안에서만 일어난다 — 전 폭에서 켜면 정상 그래프의 레인 좌표가 어긋난다.
    */
   readonly compact?: boolean;
 }
@@ -234,7 +236,7 @@ export function GraphGutter({ node, compact = false }: GraphGutterProps) {
       viewBox={`0 0 ${width} ${ROW_HEIGHT}`}
       aria-hidden="true"
       className={compact && node.lane > 0 ? "history-graph-gutter-compact" : undefined}
-      style={{ display: "block", flexShrink: 0 }}
+      style={{ display: "block", flexShrink: 0, ...(compact && node.lane > 0 ? { "--gutter-lane": String(node.lane) } as CSSProperties : {}) }}
     >
       {/* passThrough 수직선 */}
       {node.passThroughLanes.map((lane) => (

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -247,7 +247,7 @@ export function CommitRow({ entry, checkouts, selected, picked = false, pin = nu
       <span className="history-commit-author"><span className="history-commit-avatar" aria-hidden="true">{initials(entry.authorName)}</span><span className="history-commit-author-name">{entry.authorName}</span></span>
       <span className="history-commit-sha">{entry.shortHash}</span>
       <span className="history-commit-time">{formatCommitTime(entry.authorAt, new Date(), locale)}</span>
-      <span className="history-graph-gutter" aria-hidden="true"><GraphGutter node={graphNode} /></span>
+      <span className="history-graph-gutter" aria-hidden="true"><GraphGutter node={graphNode} compact /></span>
     </button>
     {onCompareAction && <button type="button" className="history-row-compare" aria-label={compareLabel} onClick={() => onCompareAction(entry)}>⇆</button>}
   </div>;

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -108,6 +108,10 @@ function verbCountText(raw: unknown, verb: "pull" | "push", t: T): string {
 /**
  * 툴바 동사 버튼 — 동기화 버튼과 같은 부품으로 조립한다: 진행 중 회전, 성공 시 ✓ 체류,
  * 결과 말풍선, 실패 점. 결과 표면이 버튼 안에 있으므로 어떤 답도 패널 본문을 밀어내지 않는다.
+ *
+ * 라벨 수납 — identity 줄이 좁아지면 CSS 컨테이너 쿼리가 .repository-verb-label을 숨겨
+ * 글리프+계수만 남긴다(1단). 라벨 span은 항상 DOM에 남아 스크린 리더 낭독과 title 대체를
+ * 지키고, 시각적 축소는 표현 계약이므로 design-grammar.test.ts가 단계를 고정한다.
  */
 function VerbToolbarButton({ glyph, label, title, count, disabled, busy, outcome, settled, hinting, failedTitle, onClick }: {
   readonly glyph: string;
@@ -123,12 +127,12 @@ function VerbToolbarButton({ glyph, label, title, count, disabled, busy, outcome
   readonly onClick: () => void;
 }) {
   return (
-    <button type="button" className={`repository-sync-button repository-verb-button${busy ? " is-syncing" : ""}`} title={title} disabled={disabled} onClick={onClick}>
+    <button type="button" className={`repository-sync-button repository-verb-button${busy ? " is-syncing" : ""}`} title={title} aria-label={title} disabled={disabled} onClick={onClick}>
       <span className={`repository-sync-icon${settled ? " is-settled" : ""}`} aria-hidden="true">
         <span className="repository-sync-glyph repository-sync-glyph-idle">{glyph}</span>
         <span className="repository-sync-glyph repository-sync-glyph-settled">✓</span>
       </span>
-      {label}
+      <span className="repository-verb-label">{label}</span>
       {count}
       {outcome?.kind === "error" && <span className="repository-sync-dot" title={failedTitle} aria-hidden="true" />}
       {outcome && <span className={`repository-sync-hint${outcome.kind === "error" ? " is-error" : ""}${hinting ? " is-open" : ""}`} aria-hidden="true">{outcome.text}</span>}

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -110,14 +110,17 @@ function verbCountText(raw: unknown, verb: "pull" | "push", t: T): string {
  * 결과 말풍선, 실패 점. 결과 표면이 버튼 안에 있으므로 어떤 답도 패널 본문을 밀어내지 않는다.
  *
  * 라벨 수납 — identity 줄이 좁아지면 CSS 컨테이너 쿼리가 .repository-verb-label을 숨겨
- * 글리프+계수만 남긴다(1단). 라벨 span은 항상 DOM에 남아 스크린 리더 낭독과 title 대체를
- * 지키고, 시각적 축소는 표현 계약이므로 design-grammar.test.ts가 단계를 고정한다.
+ * 글리프+계수만 남긴다(1단). 접힌 라벨은 display:none이라 접근성 트리에서도 빠지므로,
+ * 접근성 이름은 라벨과 계수 텍스트를 직접 합성해 어느 폭에서도 "Pull 3↓" 전체가 낭독된다.
+ * 시각적 축소는 표현 계약이므로 design-grammar.test.ts가 단계를 고정한다.
  */
-function VerbToolbarButton({ glyph, label, title, count, disabled, busy, outcome, settled, hinting, failedTitle, onClick }: {
+function VerbToolbarButton({ glyph, label, title, count, countText, disabled, busy, outcome, settled, hinting, failedTitle, onClick }: {
   readonly glyph: string;
   readonly label: string;
   readonly title: string;
   readonly count: ReactNode;
+  /** 접근성 이름에 합성되는 계수 텍스트("3↓") — 시각 계수와 같은 출처에서 온다. */
+  readonly countText: string | null;
   readonly disabled: boolean;
   readonly busy: boolean;
   readonly outcome: { readonly kind: "success" | "error"; readonly text: string } | null;
@@ -127,7 +130,7 @@ function VerbToolbarButton({ glyph, label, title, count, disabled, busy, outcome
   readonly onClick: () => void;
 }) {
   return (
-    <button type="button" className={`repository-sync-button repository-verb-button${busy ? " is-syncing" : ""}`} title={title} aria-label={title} disabled={disabled} onClick={onClick}>
+    <button type="button" className={`repository-sync-button repository-verb-button${busy ? " is-syncing" : ""}`} title={title} aria-label={[label, countText].filter(Boolean).join(" ")} disabled={disabled} onClick={onClick}>
       <span className={`repository-sync-icon${settled ? " is-settled" : ""}`} aria-hidden="true">
         <span className="repository-sync-glyph repository-sync-glyph-idle">{glyph}</span>
         <span className="repository-sync-glyph repository-sync-glyph-settled">✓</span>
@@ -786,9 +789,9 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   return (
     <div className="repository-unified is-workspace">
       <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? t("repository.panel.title")}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}<button type="button" className={`repository-sync-button${syncing ? " is-syncing" : ""}`} title={t("repository.sync.title")} aria-label={t("repository.sync.title")} disabled={syncing} onClick={() => { void syncRepository(); }}><span className={`repository-sync-icon${syncSettled ? " is-settled" : ""}`} aria-hidden="true"><span className="repository-sync-glyph repository-sync-glyph-idle">↻</span><span className="repository-sync-glyph repository-sync-glyph-settled">✓</span></span>{t("repository.sync.button")}{syncFailed && <span className="repository-sync-dot" title={t("repository.sync.lastFailed")} aria-hidden="true" />}{syncHintAvailable && <span className={`repository-sync-hint${syncHinting ? " is-open" : ""}`} aria-hidden="true">{t("repository.sync.upToDate")}</span>}</button><span className="repository-verb-cluster">
-        <VerbToolbarButton glyph="⇩" label={t("repository.verb.pull")} title={t("repository.verb.pullTitle")} count={workstate?.behind ? <em className="repository-verb-count" title={t("repository.verb.behindCount", { count: workstate.behind })}>{workstate.behind}↓</em> : null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "pull"} outcome={verbOutcome?.verb === "pull" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "pull"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handlePull} />
-        <VerbToolbarButton glyph="⇧" label={t("repository.verb.push")} title={t("repository.verb.pushTitle")} count={workstate?.ahead ? <em className="repository-verb-count" title={t("repository.verb.aheadCount", { count: workstate.ahead })}>{workstate.ahead}↑</em> : null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "push"} outcome={verbOutcome?.verb === "push" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "push"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handlePush} />
-        <VerbToolbarButton glyph="▤" label={t("repository.verb.stash")} title={t("repository.verb.stashTitle")} count={null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "stash"} outcome={verbOutcome?.verb === "stash" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "stash"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handleStash} />
+        <VerbToolbarButton glyph="⇩" label={t("repository.verb.pull")} title={t("repository.verb.pullTitle")} count={workstate?.behind ? <em className="repository-verb-count" title={t("repository.verb.behindCount", { count: workstate.behind })}>{workstate.behind}↓</em> : null} countText={workstate?.behind ? `${workstate.behind}↓` : null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "pull"} outcome={verbOutcome?.verb === "pull" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "pull"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handlePull} />
+        <VerbToolbarButton glyph="⇧" label={t("repository.verb.push")} title={t("repository.verb.pushTitle")} count={workstate?.ahead ? <em className="repository-verb-count" title={t("repository.verb.aheadCount", { count: workstate.ahead })}>{workstate.ahead}↑</em> : null} countText={workstate?.ahead ? `${workstate.ahead}↑` : null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "push"} outcome={verbOutcome?.verb === "push" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "push"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handlePush} />
+        <VerbToolbarButton glyph="▤" label={t("repository.verb.stash")} title={t("repository.verb.stashTitle")} count={null} countText={null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "stash"} outcome={verbOutcome?.verb === "stash" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "stash"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handleStash} />
       </span></div>
       <div className="repository-checkout-tabs" role="tablist" aria-label={t("repository.tabs.aria")}>
         {checkoutTabs.map((tab) => <button

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1127,10 +1127,10 @@
   /* 오프셋은 각 행의 실제 레인에서 온다 — 고정 -14px는 lane 2+ 노드를 다시 창 밖에 남긴다.
      인디케이터(⋯)도 활성 노드 기준 좌표(--gutter-indicator-x)로 재배치한다 — 창은 로컬
      [lane*14, lane*14+14]를 노출하므로 고정 x는 어느 레인에서든 벗어난다. 표식은 lane 0
-     행에서도 필요하다(기본 x ≥ 16은 14px 창을 벗어난다) — compact 클래스가 없는 행은
-     text-anchor="end" 선택자 대신 인접 형제 규칙으로 잡는다. */
+     행에서도 필요하다(기본 x ≥ 16은 14px 창을 벗어난다). x와 text-anchor를 모두 이 단계에
+     가둬 넓은 폭의 기존 표식 위치와 정렬을 바꾸지 않는다. */
   .history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }
-  .history-graph-gutter text[text-anchor="end"] { x: var(--gutter-indicator-x, 13px); }
+  .history-graph-collapse-indicator-compact { x: var(--gutter-indicator-x, 13px); text-anchor: end; }
   .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
   .history-commit-body-mark { display: none; }
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1111,12 +1111,16 @@
 }
 @container (max-width: 520px) { .history-commit-sha { display: none; } .history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr) auto; } }
 @container (max-width: 420px) { .history-commit-badges { display: none; } .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr) auto; } .history-commit-subject { grid-column: 2; } .history-commit-body-mark { grid-column: 3; } }
-/* 축소 순서 계약의 최종 단계 — 320px 아래에서는 gutter+subject만 남는다. gutter의 행별
-   레인 폭(rowLaneCount)을 1레인으로 고정해 subject 실효폭이 그래프에 잠식되지 않게 한다.
-   정체(refs) 신호는 뱃지 대신 off-head dim·HEAD 링 같은 색 채널로 잔존한다. */
+/* 축소 순서 계약의 최종 단계 — 320px 아래에서는 gutter+subject만 남는다. gutter는 뷰포트
+   축소가 아니라 오버플 클립으로 1레인만 남긴다 — width만 줄이면 viewBox 종횡비가 그림 전체를
+   세로로 눌러 레인 선이 행 사이에서 끊긴다. 본문 마커(↵)도 이 단계에서 양보한다 — 남아 있으면
+   hasBody 커밋에서 최종 단계가 성립하지 않는다. 정체(refs) 신호는 off-head dim·HEAD 링 같은
+   색 채널로 잔존한다. */
 @container (max-width: 320px) {
-  .history-graph-gutter svg { width: 14px; }
-  .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr) auto; gap: 0 6px; padding: 0 8px; }
+  .history-graph-gutter { overflow: hidden; }
+  .history-graph-gutter svg { min-width: 14px; }
+  .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
+  .history-commit-body-mark { display: none; }
 }
 @media (prefers-reduced-motion: reduce) { .history-segmented button { transition-duration: .01ms; } }
 /* Repository sources mirror the approved unified explorer. */

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1126,9 +1126,11 @@
   .history-graph-gutter { width: 14px; overflow: hidden; }
   /* 오프셋은 각 행의 실제 레인에서 온다 — 고정 -14px는 lane 2+ 노드를 다시 창 밖에 남긴다.
      인디케이터(⋯)도 활성 노드 기준 좌표(--gutter-indicator-x)로 재배치한다 — 창은 로컬
-     [lane*14, lane*14+14]를 노출하므로 고정 x는 어느 레인에서든 벗어난다. */
+     [lane*14, lane*14+14]를 노출하므로 고정 x는 어느 레인에서든 벗어난다. 표식은 lane 0
+     행에서도 필요하다(기본 x ≥ 16은 14px 창을 벗어난다) — compact 클래스가 없는 행은
+     text-anchor="end" 선택자 대신 인접 형제 규칙으로 잡는다. */
   .history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }
-  .history-graph-gutter-compact text[text-anchor="end"] { x: var(--gutter-indicator-x, 13px); }
+  .history-graph-gutter text[text-anchor="end"] { x: var(--gutter-indicator-x, 13px); }
   .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
   .history-commit-body-mark { display: none; }
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1093,7 +1093,8 @@
 .history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 24px; height: 24px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: none; color: var(--text-tertiary); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
 .history-inspector-empty { padding: 16px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-sm); }.history-inspector-error { color: var(--coral-ink); }
 /* 진행형 축소 — 컨테이너(패널·트리 리사이즈)가 좁아질수록 작성자 → 시간 → sha → 뱃지 순으로 양보한다.
-   숨긴 셀은 grid item에서 빠지므로 그 자리의 트랙까지 함께 걷어내야 한다(7ch 같은 고정 트랙은 비어도 폭을 잡는다).
+   축소 순서 계약: 정체(badges)보다 부수 메타(author/time/sha)가 먼저 양보하고, 최후에는 gutter+subject만
+   남는다. 숨긴 셀은 grid item에서 빠지므로 그 자리의 트랙까지 함께 걷어내야 한다(7ch 같은 고정 트랙은 비어도 폭을 잡는다).
    제목은 어느 폭에서도 한 줄을 유지한다(기본 규칙의 nowrap+ellipsis): 행 높이는 그래프 gutter의
    ROW_HEIGHT(28px)와 가상 스크롤 기하에 묶여 있어 줄바꿈이 레인 선과 스크롤 위치를 함께 깨뜨린다. */
 @container (max-width: 760px) {
@@ -1110,6 +1111,13 @@
 }
 @container (max-width: 520px) { .history-commit-sha { display: none; } .history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr) auto; } }
 @container (max-width: 420px) { .history-commit-badges { display: none; } .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr) auto; } .history-commit-subject { grid-column: 2; } .history-commit-body-mark { grid-column: 3; } }
+/* 축소 순서 계약의 최종 단계 — 320px 아래에서는 gutter+subject만 남는다. gutter의 행별
+   레인 폭(rowLaneCount)을 1레인으로 고정해 subject 실효폭이 그래프에 잠식되지 않게 한다.
+   정체(refs) 신호는 뱃지 대신 off-head dim·HEAD 링 같은 색 채널로 잔존한다. */
+@container (max-width: 320px) {
+  .history-graph-gutter svg { width: 14px; }
+  .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr) auto; gap: 0 6px; padding: 0 8px; }
+}
 @media (prefers-reduced-motion: reduce) { .history-segmented button { transition-duration: .01ms; } }
 /* Repository sources mirror the approved unified explorer. */
 .repository-unified { display: flex; flex-direction: column; min-width: 0; min-height: 0; height: 100%; container-type: inline-size; }
@@ -1776,6 +1784,11 @@
   top: 1px;
 }
 .repository-checkout-tab-label { overflow: hidden; text-overflow: ellipsis; max-width: 18ch; }
+/* 축소 순서 계약 — identity 축 2단. 라벨이 양보한 뒤에는 탭 라벨이 양보하고,
+   워크트리 표식(wt)은 정체 신호라 마지막까지 남는다. */
+@container (max-width: 380px) {
+  .repository-checkout-tab-label { max-width: 10ch; }
+}
 .repository-checkout-tab-mark {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-style: normal;
@@ -1795,6 +1808,14 @@
   font-size: var(--t-xs);
   margin-left: 4px;
   color: var(--brass-ink);
+}
+/* 동사 라벨 수납 — 축소 순서 계약의 identity 축이다. 패널이 좁아지면 라벨이 먼저 양보하고
+   글리프+계수(ahead/behind 실질)가 남는다. 라벨 span은 DOM에 상주하므로 aria-label과 함께
+   스크린 리더 낭독은 어느 단계에서도 유지된다. Sync 버튼은 이 수납에서 제외한다(글리프만으로
+   이미 최소형). */
+.repository-verb-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+@container (max-width: 460px) {
+  .repository-verb-label { display: none; }
 }
 
 /* ═══ Fork 워크벤치 — 스테이징(Local Changes) ══════════════════════════════ */

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -698,6 +698,9 @@
   position: relative;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
+  /* compact 거터 문법의 컨테이너 — 커밋 행 목록 자체가 기준이라 CSS만으로 브레이크포인트를
+     판정할 수 있다(React prop은 폭을 모른다). */
+  container-type: inline-size;
 }
 
 .history-divider {
@@ -1121,8 +1124,10 @@
      삼는다. SVG는 자연 크기로 남고(종횡비 보존), lane>0 행의 compact 클래스만 음수 margin으로
      현재 레인을 창 안으로 민다 — 왼쪽 고정 클립은 lane>0 행의 노드를 통째로 잃는다. */
   .history-graph-gutter { width: 14px; overflow: hidden; }
-  /* 오프셋은 각 행의 실제 레인에서 온다 — 고정 -14px는 lane 2+ 노드를 다시 창 밖에 남긴다. */
+  /* 오프셋은 각 행의 실제 레인에서 온다 — 고정 -14px는 lane 2+ 노드를 다시 창 밖에 남긴다.
+     인디케이터 재배치(⋯)도 같은 브레이크포인트에서만 발동한다. */
   .history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }
+  .history-graph-gutter-compact text[text-anchor="end"] { x: 13px; }
   .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
   .history-commit-body-mark { display: none; }
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1117,8 +1117,10 @@
    hasBody 커밋에서 최종 단계가 성립하지 않는다. 정체(refs) 신호는 off-head dim·HEAD 링 같은
    색 채널로 잔존한다. */
 @container (max-width: 320px) {
-  .history-graph-gutter { overflow: hidden; }
-  .history-graph-gutter svg { min-width: 14px; }
+  /* 래퍼를 14px로 묶어야 오버플이 생긴다 — auto 트랙은 SVG 고유폭(rowLaneCount*14)을
+     그대로 트랙으로 삼아 클립할 대상 자체가 없었다(2026-08-21 리뷰 정정). SVG는 자연 크기로
+     남아 종횡비가 보존되고, 왼쪽 1레인만 남기고 잘린다. */
+  .history-graph-gutter { width: 14px; overflow: hidden; }
   .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
   .history-commit-body-mark { display: none; }
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1125,9 +1125,10 @@
      현재 레인을 창 안으로 민다 — 왼쪽 고정 클립은 lane>0 행의 노드를 통째로 잃는다. */
   .history-graph-gutter { width: 14px; overflow: hidden; }
   /* 오프셋은 각 행의 실제 레인에서 온다 — 고정 -14px는 lane 2+ 노드를 다시 창 밖에 남긴다.
-     인디케이터 재배치(⋯)도 같은 브레이크포인트에서만 발동한다. */
+     인디케이터(⋯)도 활성 노드 기준 좌표(--gutter-indicator-x)로 재배치한다 — 창은 로컬
+     [lane*14, lane*14+14]를 노출하므로 고정 x는 어느 레인에서든 벗어난다. */
   .history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }
-  .history-graph-gutter-compact text[text-anchor="end"] { x: 13px; }
+  .history-graph-gutter-compact text[text-anchor="end"] { x: var(--gutter-indicator-x, 13px); }
   .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
   .history-commit-body-mark { display: none; }
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1121,7 +1121,8 @@
      삼는다. SVG는 자연 크기로 남고(종횡비 보존), lane>0 행의 compact 클래스만 음수 margin으로
      현재 레인을 창 안으로 민다 — 왼쪽 고정 클립은 lane>0 행의 노드를 통째로 잃는다. */
   .history-graph-gutter { width: 14px; overflow: hidden; }
-  .history-graph-gutter-compact { margin-left: -14px; }
+  /* 오프셋은 각 행의 실제 레인에서 온다 — 고정 -14px는 lane 2+ 노드를 다시 창 밖에 남긴다. */
+  .history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }
   .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
   .history-commit-body-mark { display: none; }
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1117,9 +1117,9 @@
    hasBody 커밋에서 최종 단계가 성립하지 않는다. 정체(refs) 신호는 off-head dim·HEAD 링 같은
    색 채널로 잔존한다. */
 @container (max-width: 320px) {
-  /* 래퍼를 14px로 묶어야 오버플이 생긴다 — auto 트랙은 SVG 고유폭(rowLaneCount*14)을
-     그대로 트랙으로 삼아 클립할 대상 자체가 없었다(2026-08-21 리뷰 정정). SVG는 자연 크기로
-     남아 종횡비가 보존되고, 왼쪽 1레인만 남기고 잘린다. */
+  /* 래퍼를 1레인 폭으로 묶는다 — auto 트랙은 SVG 고유폭(rowLaneCount*14)을 그대로 트랙으로
+     삼는다. SVG는 자연 크기로 남고(종횡비 보존), compact 모드의 음수 margin이 현재 행의
+     레인을 창 안으로 밀어 넣는다 — 왼쪽 고정 클립은 lane>0 행의 노드를 통째로 잃는다. */
   .history-graph-gutter { width: 14px; overflow: hidden; }
   .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
   .history-commit-body-mark { display: none; }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1118,9 +1118,10 @@
    색 채널로 잔존한다. */
 @container (max-width: 320px) {
   /* 래퍼를 1레인 폭으로 묶는다 — auto 트랙은 SVG 고유폭(rowLaneCount*14)을 그대로 트랙으로
-     삼는다. SVG는 자연 크기로 남고(종횡비 보존), compact 모드의 음수 margin이 현재 행의
-     레인을 창 안으로 밀어 넣는다 — 왼쪽 고정 클립은 lane>0 행의 노드를 통째로 잃는다. */
+     삼는다. SVG는 자연 크기로 남고(종횡비 보존), lane>0 행의 compact 클래스만 음수 margin으로
+     현재 레인을 창 안으로 민다 — 왼쪽 고정 클립은 lane>0 행의 노드를 통째로 잃는다. */
   .history-graph-gutter { width: 14px; overflow: hidden; }
+  .history-graph-gutter-compact { margin-left: -14px; }
   .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); gap: 0 6px; padding: 0 8px; }
   .history-commit-body-mark { display: none; }
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1814,9 +1814,10 @@
   color: var(--brass-ink);
 }
 /* 동사 라벨 수납 — 축소 순서 계약의 identity 축이다. 패널이 좁아지면 라벨이 먼저 양보하고
-   글리프+계수(ahead/behind 실질)가 남는다. 라벨 span은 DOM에 상주하므로 aria-label과 함께
-   스크린 리더 낭독은 어느 단계에서도 유지된다. Sync 버튼은 이 수납에서 제외한다(글리프만으로
-   이미 최소형). */
+   글리프+계수(ahead/behind 실질)가 남는다. 라벨 span은 `.repository-identity span`(0,1,1)의
+   brass·mono·t-2xs를 물려받으므로 같은 스코프로 버튼 문법을 되돌린다 — 라벨은 위치 채널이 아니라
+   버튼 텍스트다(2026-08-21 리뷰 정정). Sync 버튼은 이 수납에서 제외한다(글리프만으로 이미 최소형). */
+.repository-verb-button .repository-verb-label { color: inherit; font-family: inherit; font-size: inherit; }
 .repository-verb-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 @container (max-width: 460px) {
   .repository-verb-label { display: none; }

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -374,8 +374,9 @@ describe("Repository design grammar", () => {
     // lane 0 행도 기본 x ≥ 16은 14px 창을 벗어나므로 표식 준비는 compact면 무조건이고,
     // 좌표는 활성 노드 기준(--gutter-indicator-x), 적용은 CSS가 브레이크포인트 안에서만 한다.
     expect(graphSource).toContain('"--gutter-indicator-x": `${cx + NODE_R + 3}px`');
-    expect(graphSource).toContain('textAnchor={compact ? "end" : undefined}');
-    expect(finalStage).toContain('.history-graph-gutter text[text-anchor="end"] { x: var(--gutter-indicator-x, 13px); }');
+    expect(graphSource).toContain('className={compact ? "history-graph-collapse-indicator-compact" : undefined}');
+    expect(graphSource).not.toContain('textAnchor={compact ? "end" : undefined}');
+    expect(finalStage).toContain('.history-graph-collapse-indicator-compact { x: var(--gutter-indicator-x, 13px); text-anchor: end; }');
     // 커밋 행 목록이 compact 문법의 컨테이너다 — CSS만으로 브레이크포인트를 판정한다.
     // .history-list-pane은 규칙 3개(공용 min-width·스택 재선언·본체)라 본체 규칙을 직접 찾는다.
     expect(blocksOf(".history-list-pane").some((body) => body.includes("container-type: inline-size"))).toBe(true);

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -360,7 +360,8 @@ describe("Repository design grammar", () => {
   it("keeps a final commit-row stage where only gutter and subject survive", () => {
     const finalStage = atRuleBodies("(max-width: 320px)");
     expect(finalStage).toContain(".history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr);");
-    expect(finalStage).toContain(".history-graph-gutter { overflow: hidden; }");
+    expect(finalStage).toContain(".history-graph-gutter { width: 14px; overflow: hidden; }");
+    // SVG 자체는 축소하지 않는다 — 뷰포트 축소는 viewBox 종횡비로 그림을 세로로 눌러 레인 선을 끊는다.
     expect(finalStage).not.toMatch(/\.history-graph-gutter svg \{[^}]*(^|[^-])width:/);
     // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
     expect(finalStage).toContain(".history-commit-body-mark { display: none; }");

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -367,8 +367,9 @@ describe("Repository design grammar", () => {
     // 레인을 14px 창 안으로 민다(graph.tsx GraphGutter). 오프셋은 이 컨테이너 쿼리 안에서만
     // 발동한다 — 전 폭에서 켜면 정상 그래프의 레인 좌표가 어긋난다(2026-08-21 리뷰 정정).
     expect(finalStage).not.toMatch(/\.history-graph-gutter svg \{[^}]*(^|[^-])width:/);
-    expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: -14px; }");
-    expect(graphSource).toContain('compact && node.lane > 0 ? "history-graph-gutter-compact" : undefined');
+    // 오프셋은 각 행의 실제 레인(--gutter-lane)에서 온다 — 고정 -14px는 lane 2+ 노드를 다시 창 밖에 남긴다.
+    expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }");
+    expect(graphSource).toContain('"--gutter-lane": String(node.lane)');
     // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
     expect(finalStage).toContain(".history-commit-body-mark { display: none; }");
     // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { WORKSPACE_DOCK_DIVIDER_WIDTH, WORKSPACE_DOCK_MAIN_MIN_WIDTH, WORKSPACE_DOCK_SPLIT_MIN_WIDTH } from "../client/workspace-layout.js";
 
 const css = await fs.readFile(new URL("../client/repository.css", import.meta.url), "utf8");
+const railPanelSource = await fs.readFile(new URL("../client/rail-panel.tsx", import.meta.url), "utf8");
 
 interface CssRule {
   readonly selectors: readonly string[];
@@ -349,13 +350,26 @@ describe("Repository design grammar", () => {
   });
 
   // 2026-08-21 재가 — 축소 순서 계약(history 축). 최종 단계에서 gutter+subject만 남고,
-  // subject 보장폭(minmax 96px)은 어느 단계에서도 유지된다.
+  // subject 보장폭(minmax 96px)은 어느 단계에서도 유지된다. gutter는 뷰포트 축소가 아니라
+  // 오버플 클립으로 줄어든다 — width만 줄이면 viewBox 종횡비가 그림을 세로로 눌러 레인 선이 끊긴다.
   it("keeps a final commit-row stage where only gutter and subject survive", () => {
     const finalStage = atRuleBodies("(max-width: 320px)");
-    expect(finalStage).toContain(".history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr) auto;");
+    expect(finalStage).toContain(".history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr);");
+    expect(finalStage).toContain(".history-graph-gutter { overflow: hidden; }");
+    expect(finalStage).not.toMatch(/\.history-graph-gutter svg \{[^}]*(^|[^-])width:/);
+    // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
+    expect(finalStage).toContain(".history-commit-body-mark { display: none; }");
     // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.
     const badgeStage = atRuleBodies("(max-width: 420px)");
     expect(badgeStage).toContain(".history-commit-badges { display: none; }");
+  });
+
+  // 접힌 동사 라벨은 display:none이라 접근성 트리에서 빠진다 — 접근성 이름은 라벨과 계수를
+  // 직접 합성해 어느 폭에서도 "Pull 3↓" 전체가 낭독된다.
+  it("composes the verb accessible name from label and count", () => {
+    expect(railPanelSource).toContain("aria-label={[label, countText].filter(Boolean).join(\" \")}");
+    expect(railPanelSource).toContain("countText={workstate?.behind ? `${workstate.behind}↓` : null}");
+    expect(railPanelSource).toContain("countText={workstate?.ahead ? `${workstate.ahead}↑` : null}");
   });
 
   // 체크아웃 탭 라벨도 identity 축의 2단으로 양보한다.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -370,6 +370,8 @@ describe("Repository design grammar", () => {
     // 오프셋은 각 행의 실제 레인(--gutter-lane)에서 온다 — 고정 -14px는 lane 2+ 노드를 다시 창 밖에 남긴다.
     expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }");
     expect(graphSource).toContain('"--gutter-lane": String(node.lane)');
+    // compact 모드에서도 잘림 인디케이터(⋯)가 창 안에 남아야 한다 — 사라지면 허위 완결이다.
+    expect(graphSource).toContain("compact && node.lane > 0 ? LANE_WIDTH - 4 : lanes * LANE_WIDTH + 2");
     // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
     expect(finalStage).toContain(".history-commit-body-mark { display: none; }");
     // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -371,10 +371,14 @@ describe("Repository design grammar", () => {
     expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }");
     expect(graphSource).toContain('"--gutter-lane": String(node.lane)');
     // compact 모드에서도 잘림 인디케이터(⋯)가 창 안에 남아야 한다 — 사라지면 허위 완결이다.
-    // 좌표는 활성 노드 기준이고 text-anchor=end로 글리프가 시작점 왼쪽에 끝나므로
-    // ⋯ 몸통이 14px 창 밖으로 잘리지 않는다.
-    expect(graphSource).toContain("x={compact ? cx + NODE_R + 3 : lanes * LANE_WIDTH + 2}");
-    expect(graphSource).toContain('textAnchor={compact ? "end" : undefined}');
+    // 좌표·앵커 분기는 CSS가 브레이크포인트 안에서만 처리한다 — prop은 폭을 모르므로
+    // 전 폭 분기면 정상 그래프의 표식 위치가 어긋난다(2026-08-21 리뷰 정정).
+    expect(graphSource).toContain("x={lanes * LANE_WIDTH + 2}");
+    expect(graphSource).toContain('textAnchor={compact && node.lane > 0 ? "end" : undefined}');
+    expect(finalStage).toContain('.history-graph-gutter-compact text[text-anchor="end"] { x: 13px; }');
+    // 커밋 행 목록이 compact 문법의 컨테이너다 — CSS만으로 브레이크포인트를 판정한다.
+    // .history-list-pane은 규칙 3개(공용 min-width·스택 재선언·본체)라 본체 규칙을 직접 찾는다.
+    expect(blocksOf(".history-list-pane").some((body) => body.includes("container-type: inline-size"))).toBe(true);
     // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
     expect(finalStage).toContain(".history-commit-body-mark { display: none; }");
     // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -363,10 +363,12 @@ describe("Repository design grammar", () => {
     expect(finalStage).toContain(".history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr);");
     expect(finalStage).toContain(".history-graph-gutter { width: 14px; overflow: hidden; }");
     // SVG 자체는 축소하지 않는다 — 뷰포트 축소는 viewBox 종횡비로 그림을 세로로 눌러 레인 선을 끊는다.
-    // lane>0 행의 노드는 왼쪽 고정 클립으로 잃어버리므로, compact 모드의 음수 margin이 현재
-    // 레인을 14px 창 안으로 민다(graph.tsx GraphGutter).
+    // lane>0 행의 노드는 왼쪽 고정 클립으로 잃어버리므로, compact 클래스의 음수 margin이 현재
+    // 레인을 14px 창 안으로 민다(graph.tsx GraphGutter). 오프셋은 이 컨테이너 쿼리 안에서만
+    // 발동한다 — 전 폭에서 켜면 정상 그래프의 레인 좌표가 어긋난다(2026-08-21 리뷰 정정).
     expect(finalStage).not.toMatch(/\.history-graph-gutter svg \{[^}]*(^|[^-])width:/);
-    expect(graphSource).toContain("compact && node.lane > 0 ? { marginLeft: `-${node.lane * LANE_WIDTH}px` }");
+    expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: -14px; }");
+    expect(graphSource).toContain('compact && node.lane > 0 ? "history-graph-gutter-compact" : undefined');
     // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
     expect(finalStage).toContain(".history-commit-body-mark { display: none; }");
     // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -337,11 +337,16 @@ describe("Repository design grammar", () => {
   });
 
   // 2026-08-21 재가 — 축소 순서 계약(identity 축). 패널이 좁아지면 동사 라벨이 먼저 양보하고
-  // 글리프+계수(ahead/behind 실질)가 남는다. 라벨 span은 표현만 숨겨지므로 DOM 상주가 계약이다.
+  // 글리프+계수(ahead/behind 실질)가 남는다. 라벨 span은 `.repository-identity span`(0,1,1)의
+  // brass·mono·t-2xs를 물려받으므로 버튼 스코프의 되돌림 규칙이 반드시 함께 있어야 한다.
   it("collapses verb labels before glyphs under the shrink-order contract", () => {
-    const label = blockOf(".repository-verb-label");
-    expect(label).toContain("white-space: nowrap");
-    expect(label).toContain("text-overflow: ellipsis");
+    const label = blockOf(".repository-verb-button .repository-verb-label");
+    expect(label).toContain("color: inherit");
+    expect(label).toContain("font-family: inherit");
+    expect(label).toContain("font-size: inherit");
+    const base = blockOf(".repository-verb-label");
+    expect(base).toContain("white-space: nowrap");
+    expect(base).toContain("text-overflow: ellipsis");
     const collapsed = rules
       .filter((rule) => rule.selectors.includes(".repository-verb-label") && rule.body.includes("display: none"));
     expect(collapsed).toHaveLength(1);

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -371,9 +371,10 @@ describe("Repository design grammar", () => {
     expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }");
     expect(graphSource).toContain('"--gutter-lane": String(node.lane)');
     // compact 모드에서도 잘림 인디케이터(⋯)가 창 안에 남아야 한다 — 사라지면 허위 완결이다.
-    // 좌표는 SVG 자체가 밀린 만큼을 상쇄하는 활성 노드 기준(cx + NODE_R + 3)이라
-    // lane 값과 무관하게 창 안에 떨어진다.
+    // 좌표는 활성 노드 기준이고 text-anchor=end로 글리프가 시작점 왼쪽에 끝나므로
+    // ⋯ 몸통이 14px 창 밖으로 잘리지 않는다.
     expect(graphSource).toContain("x={compact ? cx + NODE_R + 3 : lanes * LANE_WIDTH + 2}");
+    expect(graphSource).toContain('textAnchor={compact ? "end" : undefined}');
     // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
     expect(finalStage).toContain(".history-commit-body-mark { display: none; }");
     // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -371,7 +371,9 @@ describe("Repository design grammar", () => {
     expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }");
     expect(graphSource).toContain('"--gutter-lane": String(node.lane)');
     // compact 모드에서도 잘림 인디케이터(⋯)가 창 안에 남아야 한다 — 사라지면 허위 완결이다.
-    expect(graphSource).toContain("compact && node.lane > 0 ? LANE_WIDTH - 4 : lanes * LANE_WIDTH + 2");
+    // 좌표는 SVG 자체가 밀린 만큼을 상쇄하는 활성 노드 기준(cx + NODE_R + 3)이라
+    // lane 값과 무관하게 창 안에 떨어진다.
+    expect(graphSource).toContain("x={compact ? cx + NODE_R + 3 : lanes * LANE_WIDTH + 2}");
     // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
     expect(finalStage).toContain(".history-commit-body-mark { display: none; }");
     // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -371,11 +371,11 @@ describe("Repository design grammar", () => {
     expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }");
     expect(graphSource).toContain('"--gutter-lane": String(node.lane)');
     // compact 모드에서도 잘림 인디케이터(⋯)가 창 안에 남아야 한다 — 사라지면 허위 완결이다.
-    // 창은 로컬 [lane*14, lane*14+14]를 노출하므로 좌표는 활성 노드 기준(--gutter-indicator-x)
-    // 이고 CSS가 브레이크포인트 안에서만 적용한다 — prop은 폭을 모른다.
+    // lane 0 행도 기본 x ≥ 16은 14px 창을 벗어나므로 표식 준비는 compact면 무조건이고,
+    // 좌표는 활성 노드 기준(--gutter-indicator-x), 적용은 CSS가 브레이크포인트 안에서만 한다.
     expect(graphSource).toContain('"--gutter-indicator-x": `${cx + NODE_R + 3}px`');
-    expect(graphSource).toContain('textAnchor={compact && node.lane > 0 ? "end" : undefined}');
-    expect(finalStage).toContain('.history-graph-gutter-compact text[text-anchor="end"] { x: var(--gutter-indicator-x, 13px); }');
+    expect(graphSource).toContain('textAnchor={compact ? "end" : undefined}');
+    expect(finalStage).toContain('.history-graph-gutter text[text-anchor="end"] { x: var(--gutter-indicator-x, 13px); }');
     // 커밋 행 목록이 compact 문법의 컨테이너다 — CSS만으로 브레이크포인트를 판정한다.
     // .history-list-pane은 규칙 3개(공용 min-width·스택 재선언·본체)라 본체 규칙을 직접 찾는다.
     expect(blocksOf(".history-list-pane").some((body) => body.includes("container-type: inline-size"))).toBe(true);

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -6,6 +6,7 @@ import { WORKSPACE_DOCK_DIVIDER_WIDTH, WORKSPACE_DOCK_MAIN_MIN_WIDTH, WORKSPACE_
 
 const css = await fs.readFile(new URL("../client/repository.css", import.meta.url), "utf8");
 const railPanelSource = await fs.readFile(new URL("../client/rail-panel.tsx", import.meta.url), "utf8");
+const graphSource = await fs.readFile(new URL("../client/graph.tsx", import.meta.url), "utf8");
 
 interface CssRule {
   readonly selectors: readonly string[];
@@ -362,7 +363,10 @@ describe("Repository design grammar", () => {
     expect(finalStage).toContain(".history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr);");
     expect(finalStage).toContain(".history-graph-gutter { width: 14px; overflow: hidden; }");
     // SVG 자체는 축소하지 않는다 — 뷰포트 축소는 viewBox 종횡비로 그림을 세로로 눌러 레인 선을 끊는다.
+    // lane>0 행의 노드는 왼쪽 고정 클립으로 잃어버리므로, compact 모드의 음수 margin이 현재
+    // 레인을 14px 창 안으로 민다(graph.tsx GraphGutter).
     expect(finalStage).not.toMatch(/\.history-graph-gutter svg \{[^}]*(^|[^-])width:/);
+    expect(graphSource).toContain("compact && node.lane > 0 ? { marginLeft: `-${node.lane * LANE_WIDTH}px` }");
     // 본문 마커도 양보해야 hasBody 커밋에서 최종 단계가 성립한다.
     expect(finalStage).toContain(".history-commit-body-mark { display: none; }");
     // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -371,11 +371,11 @@ describe("Repository design grammar", () => {
     expect(finalStage).toContain(".history-graph-gutter-compact { margin-left: calc(-1 * var(--gutter-lane, 1) * 14px); }");
     expect(graphSource).toContain('"--gutter-lane": String(node.lane)');
     // compact 모드에서도 잘림 인디케이터(⋯)가 창 안에 남아야 한다 — 사라지면 허위 완결이다.
-    // 좌표·앵커 분기는 CSS가 브레이크포인트 안에서만 처리한다 — prop은 폭을 모르므로
-    // 전 폭 분기면 정상 그래프의 표식 위치가 어긋난다(2026-08-21 리뷰 정정).
-    expect(graphSource).toContain("x={lanes * LANE_WIDTH + 2}");
+    // 창은 로컬 [lane*14, lane*14+14]를 노출하므로 좌표는 활성 노드 기준(--gutter-indicator-x)
+    // 이고 CSS가 브레이크포인트 안에서만 적용한다 — prop은 폭을 모른다.
+    expect(graphSource).toContain('"--gutter-indicator-x": `${cx + NODE_R + 3}px`');
     expect(graphSource).toContain('textAnchor={compact && node.lane > 0 ? "end" : undefined}');
-    expect(finalStage).toContain('.history-graph-gutter-compact text[text-anchor="end"] { x: 13px; }');
+    expect(finalStage).toContain('.history-graph-gutter-compact text[text-anchor="end"] { x: var(--gutter-indicator-x, 13px); }');
     // 커밋 행 목록이 compact 문법의 컨테이너다 — CSS만으로 브레이크포인트를 판정한다.
     // .history-list-pane은 규칙 3개(공용 min-width·스택 재선언·본체)라 본체 규칙을 직접 찾는다.
     expect(blocksOf(".history-list-pane").some((body) => body.includes("container-type: inline-size"))).toBe(true);

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -64,9 +64,14 @@ function blockOf(selector: string): string {
 // prefers-reduced-motion 블록들의 본문만 모은다 — 파일 뒤쪽에 같은 선언이 있으면 통과해 버리는
 // slice(indexOf(...)) 방식은 "미디어 블록 안에 있음"을 증명하지 못한다.
 function reducedMotionBodies(): string {
+  return atRuleBodies("@media (prefers-reduced-motion: reduce)");
+}
+
+// 임의 at-rule(@media/@container) prelude에 속한 규칙 본문들을 정규화해 모은다 —
+// 컨테이너 쿼리 단계 계약이 "블록 안에 있음"을 증명하는 데 같은 파서를 쓴다.
+function atRuleBodies(prelude: string): string {
   const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
   const bodies: string[] = [];
-  const prelude = "@media (prefers-reduced-motion: reduce)";
   let from = 0;
   for (;;) {
     const start = stripped.indexOf(prelude, from);
@@ -85,8 +90,9 @@ function reducedMotionBodies(): string {
     bodies.push(stripped.slice(open + 1, index));
     from = index + 1;
   }
-  if (bodies.length === 0) throw new Error("Missing prefers-reduced-motion block");
-  return bodies.join("\n");
+  if (bodies.length === 0) throw new Error(`Missing at-rule block: ${prelude}`);
+  // 본문 규칙 사이 공백을 한 칸으로 정규화해 부분 문자열 단언이 안정적으로 붙게 한다.
+  return bodies.join("\n").replace(/\s+/g, " ");
 }
 
 describe("Repository design grammar", () => {
@@ -168,8 +174,8 @@ describe("Repository design grammar", () => {
     expect(css).toContain(".repository-sync-button:focus-visible .repository-sync-hint");
     // 동작 줄이기에서는 전이 연출만 걷고 상태는 남긴다 — opacity/transform 규칙을 지우면 안 된다.
     const reduced = reducedMotionBodies();
-    expect(reduced).toContain(".repository-identity .repository-sync-glyph { transition-duration: 1ms; }");
-    expect(reduced).toContain(".repository-identity .repository-sync-hint { transition-duration: 1ms; }");
+    expect(reduced).toContain(".repository-identity .repository-sync-glyph { transition-duration: 1ms; }".replace(/\s+/g, " "));
+    expect(reduced).toContain(".repository-identity .repository-sync-hint { transition-duration: 1ms; }".replace(/\s+/g, " "));
     expect(glyph).toContain("transition:");
   });
 
@@ -327,5 +333,34 @@ describe("Repository design grammar", () => {
         expect(blockOf(`.repository-line-${row} .repository-token-${token}`), `${row}/${token}`).toContain("inherit");
       }
     }
+  });
+
+  // 2026-08-21 재가 — 축소 순서 계약(identity 축). 패널이 좁아지면 동사 라벨이 먼저 양보하고
+  // 글리프+계수(ahead/behind 실질)가 남는다. 라벨 span은 표현만 숨겨지므로 DOM 상주가 계약이다.
+  it("collapses verb labels before glyphs under the shrink-order contract", () => {
+    const label = blockOf(".repository-verb-label");
+    expect(label).toContain("white-space: nowrap");
+    expect(label).toContain("text-overflow: ellipsis");
+    const collapsed = rules
+      .filter((rule) => rule.selectors.includes(".repository-verb-label") && rule.body.includes("display: none"));
+    expect(collapsed).toHaveLength(1);
+    // Sync 버튼은 수납에서 제외 — 글리프만으로 이미 최소형이다.
+    expect(css).not.toMatch(/\.repository-sync-button\s+\.repository-verb-label/);
+  });
+
+  // 2026-08-21 재가 — 축소 순서 계약(history 축). 최종 단계에서 gutter+subject만 남고,
+  // subject 보장폭(minmax 96px)은 어느 단계에서도 유지된다.
+  it("keeps a final commit-row stage where only gutter and subject survive", () => {
+    const finalStage = atRuleBodies("(max-width: 320px)");
+    expect(finalStage).toContain(".history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr) auto;");
+    // 이전 단계(420px)의 badges 소멸과 공존한다 — 사다리를 대체하지 않는다.
+    const badgeStage = atRuleBodies("(max-width: 420px)");
+    expect(badgeStage).toContain(".history-commit-badges { display: none; }");
+  });
+
+  // 체크아웃 탭 라벨도 identity 축의 2단으로 양보한다.
+  it("shortens checkout tab labels as the identity axis yields", () => {
+    const tabStage = atRuleBodies("(max-width: 380px)");
+    expect(tabStage).toContain(".repository-checkout-tab-label { max-width: 10ch; }");
   });
 });


### PR DESCRIPTION
## Summary
- 저장소 패널의 축소 순서를 계약으로 고정합니다: 레일이 좁아지면 툴바 동사(Pull/Push/Stash)가 먼저 텍스트 라벨을 내놓고 글리프+ahead/behind 계수를 유지하며(460px), 체크아웃 탭 라벨은 380px에서 짧아지고, 커밋 행은 320px 아래에서 gutter+subject만 남기되 subject 96px 읽기 폭을 보장합니다.
- 기존에는 정체 신호(refs 뱃지)가 위치·행동보다 먼저 사라졌고 identity 줄의 동사 묶음(≈300px)에 오버플로 규칙이 없었습니다. 이제 부수 메타(author→time→sha→badges 순)가 양보하고 최후 단계가 문법으로 남습니다. 스크린 리더 낭독은 어느 단계에서도 유지됩니다(라벨 span DOM 상주 + aria-label).
- 제안 배경: product-proposal 아티팩트 (실측·폭 시뮬레이터·옵션 평가 포함).

## Test Plan
- [x] `pnpm vitest run` (repository 플러그인 40파일 422테스트 통과 — design-grammar 계약에 수납 단계 3건 추가)
- [x] `pnpm typecheck` (tsc 클린)
- [x] 실브라우저 QA (격리 콘솔): 240px 패널에서 동사 라벨 display:none · 커밋 행 3트랙 · subject 96px 보장, 719px에서 라벨 복귀, 페이지 에러 0
- [x] `node scripts/compile-changelog-fragments.mjs --check`