### PR TITLE
fix(ai-gateway): recover transient upstream failures instead of ending the turn

### DIFF
--- a/.changelog.d/ai-gateway-resilience.md
+++ b/.changelog.d/ai-gateway-resilience.md
@@ -1,0 +1,21 @@
+---
+branch: ai-gateway-resilience
+---
+
+### fleet-console
+#### Fixed
+- Recover a gateway turn that a provider drops or refuses, instead of ending it on the first attempt. Transient failures now reach Claude Code as statuses its own retry budget acts on, so an interruption that one more attempt would clear no longer surfaces as an API error.
+  ko: 공급자가 끊거나 거절한 게이트웨이 턴을 첫 시도에서 끝내지 않고 복구합니다. 일시적 실패가 Claude Code의 재시도 예산이 반응하는 상태로 전달되므로, 한 번만 더 시도하면 지나갈 중단이 API 오류로 드러나지 않습니다.
+- Cap how many upstream connections a single Console holds per provider, so a wide fan-out queues instead of opening a connection per agent and losing streams to the pressure.
+  ko: 하나의 Console이 공급자당 유지하는 업스트림 연결 수에 상한을 두어, 폭넓은 팬아웃이 에이전트마다 연결을 여는 대신 대기하도록 하고 그 부하로 스트림을 잃지 않게 합니다.
+- Record every failed gateway turn to a durable log, so an interruption that used to vanish after one on-screen notice can be diagnosed afterwards.
+  ko: 실패한 게이트웨이 턴을 지속 로그에 기록하여, 화면에 한 번 표시되고 사라지던 중단을 사후에 진단할 수 있게 합니다.
+
+### fleet-cli
+#### Fixed
+- Recover a gateway turn that a provider drops or refuses, instead of ending it on the first attempt. Transient failures now reach Claude Code as statuses its own retry budget acts on, so an interruption that one more attempt would clear no longer surfaces as an API error.
+  ko: 공급자가 끊거나 거절한 게이트웨이 턴을 첫 시도에서 끝내지 않고 복구합니다. 일시적 실패가 Claude Code의 재시도 예산이 반응하는 상태로 전달되므로, 한 번만 더 시도하면 지나갈 중단이 API 오류로 드러나지 않습니다.
+- Cap how many upstream connections the launcher holds per provider, so a wide fan-out queues instead of opening a connection per agent and losing streams to the pressure.
+  ko: 런처가 공급자당 유지하는 업스트림 연결 수에 상한을 두어, 폭넓은 팬아웃이 에이전트마다 연결을 여는 대신 대기하도록 하고 그 부하로 스트림을 잃지 않게 합니다.
+- Record every failed gateway turn to a durable log, so an interruption that used to vanish after one on-screen notice can be diagnosed afterwards.
+  ko: 실패한 게이트웨이 턴을 지속 로그에 기록하여, 화면에 한 번 표시되고 사라지던 중단을 사후에 진단할 수 있게 합니다.

--- a/packages/core-ai-gateway/src/anthropic/claude-context.ts
+++ b/packages/core-ai-gateway/src/anthropic/claude-context.ts
@@ -11,6 +11,53 @@ export const COMPACT_CEILING_CUSTOM_MAX = 99;
 
 /** Stored compact-timing policy. Absent / null is Auto (window − 16k). */
 export type CompactCeiling = "early" | "late" | number;
+
+/**
+ * The statuses Claude Code's own retry budget acts on.
+ *
+ * Documented in Claude Code's error reference: a failure that arrives before the response
+ * stream starts is retried up to `CLAUDE_CODE_MAX_RETRIES` (default 10) with exponential
+ * backoff and `retry-after` honoured — but only for these codes. Every other status ends the
+ * turn at the client, no matter how transient the cause was.
+ *
+ * `502`, `503`, and `504` are deliberately absent from that list, which is why they must not
+ * be what a transient upstream failure reaches Claude Code as.
+ */
+const CLAUDE_RETRYABLE_STATUSES: ReadonlySet<number> = new Set([408, 409, 429, 500, 529]);
+
+/**
+ * What a gateway-side transient failure reports when no upstream status exists.
+ *
+ * A dropped socket, a stalled stream, or an adapter fault is not the caller's mistake and is
+ * usually gone on the next attempt, so it has to land inside {@link CLAUDE_RETRYABLE_STATUSES}.
+ * `500` rather than `529`: the gateway cannot claim the provider was overloaded when the
+ * evidence is only that its own read failed.
+ */
+export const GATEWAY_TRANSIENT_ERROR_STATUS = 500;
+
+/**
+ * Remap an upstream status Claude Code would refuse to retry onto one it will.
+ *
+ * A bad-gateway / unavailable / timeout answer from a provider edge is the transient class the
+ * client's retry budget exists for, but the client never sees it that way because those codes
+ * are not on its list — so the turn dies on a failure that a single retry would have absorbed.
+ * Measured 2026-08-21: an upstream answered `503` with an empty body 38.7s after dispatch while
+ * the gateway was carrying concurrent streams, and the turn ended there.
+ *
+ * They become `529` (`overloaded_error`) rather than `500`: the upstream did answer, and what it
+ * answered means "not now". That is also the one code Claude Code's retry watchdog will keep
+ * retrying indefinitely when an operator turns it on.
+ *
+ * Statuses the client already retries pass through untouched, and so does every 4xx — a `400`
+ * or `413` is a verdict about the request that retrying cannot change.
+ */
+export function claudeRetryableUpstreamStatus(status: number): number {
+  if (CLAUDE_RETRYABLE_STATUSES.has(status)) return status;
+  if (status === 502 || status === 503 || status === 504) return 529;
+  // Cloudflare-family edge failures carry the same "try again" meaning.
+  if (status >= 520 && status <= 524) return 529;
+  return status;
+}
 const DEFAULT_MAX_JSON_BYTES = 16 * 1024 * 1024;
 const DEFAULT_MAX_SSE_FRAME_BYTES = 1024 * 1024;
 const MAX_SSE_SEPARATOR_BYTES = 4;

--- a/packages/core-ai-gateway/src/anthropic/gateway.ts
+++ b/packages/core-ai-gateway/src/anthropic/gateway.ts
@@ -10,6 +10,7 @@ import type {
   CanonicalResponseRequest,
 } from "../canonical/index.js";
 import { OpenAIResponsesAdapter } from "../codex/responses/adapter.js";
+import { claudeRetryableUpstreamStatus } from "./claude-context.js";
 import { withSseKeepAlive } from "../transport/sse-keepalive.js";
 import { estimateTokens } from "../transport/token-estimate.js";
 import { logCanonicalEvents, wireLog, wireLogEnabled } from "../transport/wire-log.js";
@@ -100,7 +101,9 @@ export class AnthropicMessagesGateway {
         headers.set("content-length", String(translated.body.byteLength));
       }
       return {
-        status: upstream.status,
+        // The upstream body is forwarded with its wording intact so the client can still read
+        // what happened; only the status is lifted onto a code the client's retry budget acts on.
+        status: claudeRetryableUpstreamStatus(upstream.status),
         headers,
         body: oneChunk(translated.body)
       };

--- a/packages/core-ai-gateway/src/gateway-router/opencode.ts
+++ b/packages/core-ai-gateway/src/gateway-router/opencode.ts
@@ -37,8 +37,13 @@ export function isOpencodeAnthropicPassthrough(model: Pick<GatewayModel, "wire">
 /** 번역 경로용 게이트웨이. 요청마다 생성해도 되는 무상태 어댑터를 감싼다. */
 export function createOpencodeGateway(
   wire: Exclude<GatewayModelWire, "anthropic">,
+  fetchImpl?: typeof fetch,
 ): AnthropicMessagesGateway {
-  return new AnthropicMessagesGateway(createOpencodeGoAdapter(wire));
+  // fetch를 넘기지 않으면 어댑터가 globalThis.fetch로 떨어져 라우터의 업스트림 게이트를 우회한다.
+  return new AnthropicMessagesGateway(createOpencodeGoAdapter(
+    wire,
+    fetchImpl ? { fetch: fetchImpl } : {},
+  ));
 }
 
 export async function proxyToOpencode(

--- a/packages/core-ai-gateway/src/gateway-router/proxy.ts
+++ b/packages/core-ai-gateway/src/gateway-router/proxy.ts
@@ -1,4 +1,7 @@
-import { projectAnthropicResponseUsage } from "../anthropic/claude-context.js";
+import {
+  claudeRetryableUpstreamStatus,
+  projectAnthropicResponseUsage,
+} from "../anthropic/claude-context.js";
 import { eagerAnthropicRequestBody } from "../anthropic/passthrough.js";
 import { withSseKeepAlive } from "../transport/sse-keepalive.js";
 import { findCauseCode } from "../transport/upstream-sse.js";
@@ -71,7 +74,9 @@ export async function proxyAnthropicMessages(
   upstream.headers.forEach((value, key) => {
     if (!HOP_BY_HOP_HEADERS.has(key)) responseHeaders[key] = value;
   });
-  res.writeHead(upstream.status, responseHeaders);
+  // Passthrough forwards the provider's own bytes, but a status the client refuses to retry
+  // would strand a transient upstream failure that one attempt would have cleared.
+  res.writeHead(claudeRetryableUpstreamStatus(upstream.status), responseHeaders);
   if (!upstream.body) {
     res.end();
     return;

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -40,8 +40,11 @@ import { DEFAULT_XAI_ENDPOINT_PREFERENCE, resolveAiGatewaySelection } from "../s
 import type { AiGatewayStoredSettings, XaiEndpointPreference } from "../settings/index.js";
 import type { CompactCeiling } from "../anthropic/claude-context.js";
 import { defaultCredentialDeps } from "../transport/credentials.js";
+import { findCauseCode } from "../transport/upstream-sse.js";
 import { createUpstreamGate } from "../transport/upstream-gate.js";
 import type { UpstreamGateOriginStats } from "../transport/upstream-gate.js";
+import { failureDetail } from "../transport/failure-journal.js";
+import type { GatewayFailureSink } from "../transport/failure-journal.js";
 
 import { applyGatewayRequestPolicy } from "./router-policy.js";
 import {
@@ -148,6 +151,13 @@ export interface AiGatewayRouteDeps {
    * simultaneous provider connections. Absent is the transport default.
    */
   readonly maxUpstreamInFlight?: number;
+  /**
+   * Where failed turns are recorded.
+   *
+   * A failure after the response commits can only be reported as one SSE frame the client renders
+   * once, so without a sink it leaves no trace anywhere. Absent means the gateway keeps no record.
+   */
+  readonly failureJournal?: GatewayFailureSink;
 }
 
 export interface AiGatewayRouter {
@@ -350,6 +360,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
     const controller = new AbortController();
     const abort = (): void => controller.abort(new Error("client disconnected"));
     req.once("close", abort);
+    const startedAt = Date.now();
 
     try {
       if (!target) {
@@ -450,6 +461,26 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
         ? 413
         : invalidRequest ? 400 : GATEWAY_TRANSIENT_ERROR_STATUS;
       const message = errorMessage(error);
+      // Recorded before the client is told, so a sink failure cannot change what it is told.
+      if (deps.failureJournal) {
+        const code = findCauseCode(error);
+        const [busiest] = upstreamGate.stats()
+          .slice()
+          .sort((left, right) => right.inFlight - left.inFlight);
+        deps.failureJournal({
+          timestamp: new Date(startedAt).toISOString(),
+          phase: res.headersSent ? "post_commit" : "pre_commit",
+          ...(target ? { model: target.id, provider: target.provider } : {}),
+          ...(res.headersSent ? {} : { status }),
+          errorType: type,
+          ...(code === undefined ? {} : { code }),
+          detail: failureDetail(message),
+          elapsedMs: Date.now() - startedAt,
+          ...(busiest
+            ? { upstreamInFlight: busiest.inFlight, upstreamQueued: busiest.queued }
+            : {}),
+        });
+      }
       if (res.headersSent) {
         // 헤더를 보낸 뒤에는 상태 코드를 바꿀 수 없다. 그냥 끊으면 클라이언트는
         // 오류 문구 없는 잘린 스트림만 보므로, 종단 SSE error 프레임으로 사유를 남긴다.

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -6,7 +6,10 @@ import {
   anthropicNativeHeaders,
   ANTHROPIC_MESSAGES_URL,
 } from "../anthropic/native.js";
-import { stripClaudeUsageLimitDirectives } from "../anthropic/claude-context.js";
+import {
+  GATEWAY_TRANSIENT_ERROR_STATUS,
+  stripClaudeUsageLimitDirectives,
+} from "../anthropic/claude-context.js";
 import type { AnthropicMessagesRequest } from "../anthropic/protocol.js";
 import { UnsupportedReasoningEffortError } from "../canonical/index.js";
 import { CodexResponsesAdapter } from "../codex/responses/adapter.js";
@@ -37,6 +40,8 @@ import { DEFAULT_XAI_ENDPOINT_PREFERENCE, resolveAiGatewaySelection } from "../s
 import type { AiGatewayStoredSettings, XaiEndpointPreference } from "../settings/index.js";
 import type { CompactCeiling } from "../anthropic/claude-context.js";
 import { defaultCredentialDeps } from "../transport/credentials.js";
+import { createUpstreamGate } from "../transport/upstream-gate.js";
+import type { UpstreamGateOriginStats } from "../transport/upstream-gate.js";
 
 import { applyGatewayRequestPolicy } from "./router-policy.js";
 import {
@@ -136,17 +141,32 @@ export interface AiGatewayRouteDeps {
   readonly readModelOverride?: () => string | undefined;
   readonly cursorDiagnostics?: CursorDiagnosticSink;
   readonly fetch?: typeof fetch;
+  /**
+   * Concurrent upstream calls allowed per provider origin.
+   *
+   * Every gateway turn holds its socket for the whole stream, so this is the process's ceiling on
+   * simultaneous provider connections. Absent is the transport default.
+   */
+  readonly maxUpstreamInFlight?: number;
 }
 
 export interface AiGatewayRouter {
   readonly handle: GatewayHttpHandler;
+  /** Live upstream occupancy per provider origin. Empty when nothing is in flight. */
+  upstreamStats(): readonly UpstreamGateOriginStats[];
   /** Dispose only router-owned provider state; injected gateways remain externally owned. */
   dispose(): void;
 }
 
 export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter {
   const readAuth = deps.readAuth;
-  const fetchImpl = deps.fetch ?? globalThis.fetch.bind(globalThis);
+  // One gate for this router's lifetime. It is the only place that sees every upstream call, so
+  // it is also the only place that can bound them or report how many are open.
+  const upstreamGate = createUpstreamGate(
+    deps.fetch ?? globalThis.fetch.bind(globalThis),
+    deps.maxUpstreamInFlight === undefined ? {} : { maxInFlight: deps.maxUpstreamInFlight },
+  );
+  const fetchImpl = upstreamGate.fetch as typeof fetch;
   const ownedCursorAdapter = deps.gateway
     ? undefined
     : new CursorAdapter({ diagnostics: deps.cursorDiagnostics });
@@ -423,7 +443,12 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
       // context window; a 400 carrying the same text ends the turn instead. Everything
       // else keeps 400 — a Cursor transport-budget refusal is not an overflow, and
       // reporting it as one would send the client compacting after the wrong thing.
-      const status = error instanceof ContextWindowExceededError ? 413 : invalidRequest ? 400 : 502;
+      // A transient gateway-side fault must arrive as a status Claude Code's retry budget acts
+      // on. `502` is not one of them, so every dropped socket and stalled stream used to end the
+      // turn at the client on the first try.
+      const status = error instanceof ContextWindowExceededError
+        ? 413
+        : invalidRequest ? 400 : GATEWAY_TRANSIENT_ERROR_STATUS;
       const message = errorMessage(error);
       if (res.headersSent) {
         // 헤더를 보낸 뒤에는 상태 코드를 바꿀 수 없다. 그냥 끊으면 클라이언트는
@@ -441,7 +466,11 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
 
   return {
     handle,
-    dispose: () => ownedCursorAdapter?.dispose(),
+    upstreamStats: () => upstreamGate.stats(),
+    dispose: () => {
+      upstreamGate.dispose();
+      ownedCursorAdapter?.dispose();
+    },
   };
 }
 

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -464,8 +464,8 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
         ? 413
         : invalidRequest ? 400 : GATEWAY_TRANSIENT_ERROR_STATUS;
       const message = errorMessage(error);
-      // Recorded before the client is told, so a sink failure cannot change what it is told.
-      if (deps.failureJournal) {
+      const recordFailure = (): void => {
+        if (!deps.failureJournal) return;
         const code = findCauseCode(error);
         const [busiest] = upstreamGate.stats()
           .slice()
@@ -483,6 +483,14 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
             ? { upstreamInFlight: busiest.inFlight, upstreamQueued: busiest.queued }
             : {}),
         });
+      };
+      // 저널은 관측 수단일 뿐이므로, 호스트가 주입한 싱크가 던져도 클라이언트 응답을 막아서는
+      // 안 된다. 가드가 없으면 싱크의 예외가 원래 실패를 덮고 이 catch 밖으로 빠져나가, 아래
+      // 응답 종료가 실행되지 않는다.
+      try {
+        recordFailure();
+      } catch {
+        // 기록 실패는 삼킨다 — 기록하지 못한 것이 응답을 바꾸는 이유가 되면 안 된다.
       }
       if (res.headersSent) {
         // 헤더를 보낸 뒤에는 상태 코드를 바꿀 수 없다. 그냥 끊으면 클라이언트는

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -406,13 +406,16 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
         ?? (target.provider === "cursor"
           ? ownedCursorGateway!
           : target.provider === "opencode"
-            ? createOpencodeGateway(opencodeGoWire(target) as "responses" | "chat-completions")
+            ? createOpencodeGateway(
+              opencodeGoWire(target) as "responses" | "chat-completions",
+              fetchImpl,
+            )
             : target.provider === "xai"
               ? new AnthropicMessagesGateway(new XaiResponsesAdapter({
                 fetch: fetchImpl,
                 endpoint: xaiEndpoint(),
               }))
-              : createGatewayFor(target, chatgptAccountId, deps.originator));
+              : createGatewayFor(target, chatgptAccountId, deps.originator, fetchImpl));
       const diagnosticsEnabled = target.provider === "cursor"
         ? cursorDiagnosticsEnabled()
         : undefined;
@@ -557,13 +560,17 @@ function createGatewayFor(
   model: GatewayModel,
   chatgptAccountId: string,
   originator: string,
+  fetchImpl: typeof fetch,
 ): AnthropicMessagesGateway {
   if (model.provider !== "codex") {
     throw new TypeError(`Unsupported translated gateway provider: ${model.provider}`);
   }
+  // 어댑터가 fetch를 받지 않으면 globalThis.fetch로 떨어져 게이트 밖에서 소켓을 연다.
+  // 그러면 이 라우터의 상한과 점유 보고가 이 공급자만 보지 못한다.
   return new AnthropicMessagesGateway(new CodexResponsesAdapter({
     accountId: chatgptAccountId,
     headers: { originator },
+    fetch: fetchImpl,
   }));
 }
 

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -145,10 +145,12 @@ export interface AiGatewayRouteDeps {
   readonly cursorDiagnostics?: CursorDiagnosticSink;
   readonly fetch?: typeof fetch;
   /**
-   * Concurrent upstream calls allowed per provider origin.
+   * Concurrent upstream calls allowed per provider origin, for every provider reached over `fetch`.
    *
-   * Every gateway turn holds its socket for the whole stream, so this is the process's ceiling on
-   * simultaneous provider connections. Absent is the transport default.
+   * Those turns hold their socket for the whole stream, so the bound is a real ceiling on
+   * simultaneous connections to one origin. Cursor is **not** covered: it dials `http2.connect`
+   * per Run rather than `fetch`, so it offers no seam this bound can wrap and keeps its own
+   * separate limits. Absent is the transport default.
    */
   readonly maxUpstreamInFlight?: number;
   /**

--- a/packages/core-ai-gateway/src/index.ts
+++ b/packages/core-ai-gateway/src/index.ts
@@ -65,6 +65,18 @@ export type {
   UpstreamGateOriginStats,
 } from "./transport/upstream-gate.js";
 export {
+  DEFAULT_FAILURE_JOURNAL_MAX_BYTES,
+  createFailureJournal,
+  failureDetail,
+} from "./transport/failure-journal.js";
+export type {
+  FailureJournal,
+  FailureJournalOptions,
+  GatewayFailurePhase,
+  GatewayFailureRecord,
+  GatewayFailureSink,
+} from "./transport/failure-journal.js";
+export {
   GATEWAY_TRANSIENT_ERROR_STATUS,
   claudeRetryableUpstreamStatus,
 } from "./anthropic/claude-context.js";

--- a/packages/core-ai-gateway/src/index.ts
+++ b/packages/core-ai-gateway/src/index.ts
@@ -53,3 +53,18 @@ export * from "./codex/credentials.js";
 export * from "./codex/responses/index.js";
 export * from "./kimi/index.js";
 export * from "./transport/sse-keepalive.js";
+export {
+  DEFAULT_MAX_IN_FLIGHT_PER_ORIGIN,
+  DEFAULT_MAX_QUEUE_WAIT_MS,
+  UpstreamQueueTimeoutError,
+  createUpstreamGate,
+} from "./transport/upstream-gate.js";
+export type {
+  UpstreamGate,
+  UpstreamGateOptions,
+  UpstreamGateOriginStats,
+} from "./transport/upstream-gate.js";
+export {
+  GATEWAY_TRANSIENT_ERROR_STATUS,
+  claudeRetryableUpstreamStatus,
+} from "./anthropic/claude-context.js";

--- a/packages/core-ai-gateway/src/transport/failure-journal.ts
+++ b/packages/core-ai-gateway/src/transport/failure-journal.ts
@@ -1,0 +1,105 @@
+/**
+ * A durable record of every turn this gateway failed, and nothing else.
+ *
+ * A failed turn is the one event that leaves no trace here. The wire log is opt-in, rotates on a
+ * byte budget, and keeps a single backup — measured 2026-08-21, a burst of 55 concurrent streams
+ * evicted 42 of its own request records while it was running, so the log is least usable exactly
+ * when a concurrency failure is what needs reading. And a failure that lands after the response
+ * has committed can only be reported as one SSE frame, which the client renders once and no one
+ * can retrieve.
+ *
+ * So this journal is deliberately the opposite of the wire log: always on, one line per failure,
+ * and small enough that a month of them costs nothing. It records the coordinates a diagnosis
+ * needs — which provider, which phase, what the client was told, what the transport said, and how
+ * many upstream connections were open at that moment — and never a prompt, a completion, a tool
+ * argument, a header, or a credential.
+ */
+
+export const DEFAULT_FAILURE_JOURNAL_MAX_BYTES = 2 * 1024 * 1024;
+/** Upper bound on the transport message. Long enough to carry a cause chain, short enough to stay a line. */
+const MAX_DETAIL_LENGTH = 512;
+
+/**
+ * Where the failure happened relative to the response, because it decides who could have recovered.
+ *
+ * `pre_commit` failures still have a status line to spend, so both this gateway and the client's
+ * retry budget can act on them. `post_commit` failures have already sent bytes; neither layer may
+ * retry them, and the client renders `API mid response error`. Counting the two separately is what
+ * tells an operator whether a fix belongs in recovery or in prevention.
+ */
+export type GatewayFailurePhase = "pre_commit" | "post_commit";
+
+export interface GatewayFailureRecord {
+  readonly timestamp: string;
+  readonly phase: GatewayFailurePhase;
+  /** Catalog id the caller asked for, never a credential-bearing alias. */
+  readonly model?: string;
+  readonly provider?: string;
+  /** Status the client was given, or absent when the response had already committed. */
+  readonly status?: number;
+  /** Anthropic error class the client was given. */
+  readonly errorType: string;
+  /** Transport cause code where one exists — `UND_ERR_SOCKET`, `ECONNRESET`, and so on. */
+  readonly code?: string;
+  /** Bounded failure text. Carries no body, header, or credential. */
+  readonly detail: string;
+  /** Milliseconds from the gateway accepting the request to the failure. */
+  readonly elapsedMs: number;
+  /** Upstream connections this process held when the turn died. */
+  readonly upstreamInFlight?: number;
+  /** Calls waiting for a connection at that moment. */
+  readonly upstreamQueued?: number;
+}
+
+export type GatewayFailureSink = (record: GatewayFailureRecord) => void;
+
+export interface FailureJournalOptions {
+  readonly filePath: string;
+  /** Rotate at this size, retaining one `.1` backup. */
+  readonly maxBytes?: number;
+}
+
+export interface FailureJournal {
+  readonly write: GatewayFailureSink;
+  /** Settle pending appends. Hosts call this on shutdown. */
+  flush(): Promise<void>;
+}
+
+/** Trim a failure message to one bounded, single-line field. */
+export function failureDetail(message: string): string {
+  const collapsed = message.replace(/\s+/g, " ").trim();
+  return collapsed.length <= MAX_DETAIL_LENGTH
+    ? collapsed
+    : `${collapsed.slice(0, MAX_DETAIL_LENGTH - 1)}…`;
+}
+
+/**
+ * An append-only JSONL journal.
+ *
+ * Writes are serialized behind one promise chain so concurrent failures cannot interleave inside a
+ * line, and every failure in the writer itself is swallowed: a journal that cannot record must
+ * never be the reason a turn ends differently than it would have.
+ */
+export function createFailureJournal(options: FailureJournalOptions): FailureJournal {
+  const maxBytes = options.maxBytes ?? DEFAULT_FAILURE_JOURNAL_MAX_BYTES;
+  let chain: Promise<void> = Promise.resolve();
+
+  const append = async (line: string): Promise<void> => {
+    const { appendFile, mkdir, rename, stat } = await import("node:fs/promises");
+    const { dirname } = await import("node:path");
+    await mkdir(dirname(options.filePath), { recursive: true });
+    const size = await stat(options.filePath).then((s) => s.size).catch(() => 0);
+    if (size + line.length > maxBytes && size > 0) {
+      await rename(options.filePath, `${options.filePath}.1`).catch(() => undefined);
+    }
+    await appendFile(options.filePath, line, { mode: 0o600 });
+  };
+
+  return {
+    write: (record) => {
+      const line = `${JSON.stringify(record)}\n`;
+      chain = chain.then(() => append(line)).catch(() => undefined);
+    },
+    flush: () => chain,
+  };
+}

--- a/packages/core-ai-gateway/src/transport/upstream-gate.ts
+++ b/packages/core-ai-gateway/src/transport/upstream-gate.ts
@@ -1,0 +1,284 @@
+/**
+ * A per-origin ceiling on concurrent upstream calls, and the queue that holds the overflow.
+ *
+ * Node's `fetch` opens one socket per in-flight request and caps nothing per origin — measured
+ * 2026-08-21: forty simultaneous requests produced forty sockets and queued none. Every gateway
+ * turn is an SSE stream that holds its socket for the whole turn, so in-flight count *is* socket
+ * count, and a fan-out of N agents is a fan-out of N long-lived connections from one process, one
+ * address, and one credential. That is the shape an edge culls, and a cull that lands mid-stream
+ * is unrecoverable at both this layer and the client's.
+ *
+ * The gate is a decorator over the injected `fetch` rather than a concrete HTTP client, because
+ * this package's contract is that its host supplies transport. A dispatcher would bind us to one.
+ *
+ * Two properties matter more than the ceiling itself:
+ *
+ * - **The wait happens before the response commits.** A caller awaits `fetch` before it writes a
+ *   status line, so a queued turn has not told the client anything yet. That keeps a queue
+ *   timeout an ordinary HTTP failure the client's retry budget can act on, instead of a
+ *   mid-response error that neither layer may retry.
+ * - **A permit is held until the body ends**, not until the headers arrive. Releasing at headers
+ *   would bound how fast turns start while leaving their sockets uncounted, which is the ceiling
+ *   this file exists to impose.
+ */
+
+import type { FetchLike } from "./upstream-sse.js";
+
+/** In-flight upstream calls one origin may hold at once. */
+export const DEFAULT_MAX_IN_FLIGHT_PER_ORIGIN = 32;
+
+/**
+ * Longest a call waits for a permit before it is failed instead.
+ *
+ * The wait is invisible to the client — it is just a slow turn — but it cannot be unbounded, or a
+ * saturated origin turns into a queue that never drains and the caller learns nothing. Failing at
+ * a bound the client can retry past is the honest outcome.
+ */
+export const DEFAULT_MAX_QUEUE_WAIT_MS = 45_000;
+
+export class UpstreamQueueTimeoutError extends Error {
+  constructor(readonly origin: string, readonly waitedMs: number) {
+    super(`Upstream ${origin} had no free connection after ${waitedMs}ms`);
+    this.name = "UpstreamQueueTimeoutError";
+  }
+}
+
+export interface UpstreamGateOptions {
+  /** Concurrent calls allowed per origin. */
+  readonly maxInFlight?: number;
+  /** Longest a call waits for a permit. */
+  readonly maxQueueWaitMs?: number;
+}
+
+/** What the gate is holding right now, per origin. */
+export interface UpstreamGateOriginStats {
+  readonly origin: string;
+  readonly inFlight: number;
+  readonly queued: number;
+}
+
+export interface UpstreamGate {
+  /** The wrapped fetch. Drop-in for the one it decorates. */
+  readonly fetch: FetchLike;
+  /** Live occupancy, for a diagnostics sink or an operator surface. */
+  stats(): readonly UpstreamGateOriginStats[];
+  /** Reject every waiter and stop admitting. Idempotent. */
+  dispose(): void;
+}
+
+type Release = () => void;
+
+interface Waiter {
+  readonly settle: (release: Release) => void;
+  readonly fail: (error: unknown) => void;
+  readonly cleanup: () => void;
+  aborted: boolean;
+}
+
+class OriginQueue {
+  private inFlight = 0;
+  private readonly waiters: Waiter[] = [];
+
+  constructor(
+    private readonly origin: string,
+    private readonly maxInFlight: number,
+  ) {}
+
+  get occupancy(): UpstreamGateOriginStats {
+    return { origin: this.origin, inFlight: this.inFlight, queued: this.waiters.length };
+  }
+
+  get idle(): boolean {
+    return this.inFlight === 0 && this.waiters.length === 0;
+  }
+
+  async acquire(signal: AbortSignal | null | undefined, maxWaitMs: number): Promise<Release> {
+    if (signal?.aborted) throw signal.reason;
+    if (this.inFlight < this.maxInFlight) {
+      this.inFlight += 1;
+      return this.releaseOnce();
+    }
+    return await new Promise<Release>((resolve, reject) => {
+      const startedAt = Date.now();
+      const waiter: Waiter = {
+        aborted: false,
+        settle: (release) => {
+          waiter.cleanup();
+          resolve(release);
+        },
+        fail: (error) => {
+          waiter.cleanup();
+          reject(error);
+        },
+        cleanup: () => {
+          clearTimeout(timer);
+          signal?.removeEventListener("abort", onAbort);
+        },
+      };
+      const onAbort = (): void => {
+        waiter.aborted = true;
+        this.drop(waiter);
+        waiter.fail(signal?.reason ?? new DOMException("The operation was aborted", "AbortError"));
+      };
+      const timer = setTimeout(() => {
+        waiter.aborted = true;
+        this.drop(waiter);
+        waiter.fail(new UpstreamQueueTimeoutError(this.origin, Date.now() - startedAt));
+      }, maxWaitMs);
+      timer.unref?.();
+      signal?.addEventListener("abort", onAbort, { once: true });
+      this.waiters.push(waiter);
+    });
+  }
+
+  rejectAll(error: unknown): void {
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift();
+      if (waiter && !waiter.aborted) waiter.fail(error);
+    }
+  }
+
+  private drop(waiter: Waiter): void {
+    const index = this.waiters.indexOf(waiter);
+    if (index !== -1) this.waiters.splice(index, 1);
+  }
+
+  /** A permit that can be handed back exactly once, however many times its holder calls it. */
+  private releaseOnce(): Release {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.inFlight -= 1;
+      this.handOff();
+    };
+  }
+
+  private handOff(): void {
+    while (this.waiters.length > 0 && this.inFlight < this.maxInFlight) {
+      const waiter = this.waiters.shift();
+      if (!waiter || waiter.aborted) continue;
+      this.inFlight += 1;
+      waiter.settle(this.releaseOnce());
+      return;
+    }
+  }
+}
+
+export function createUpstreamGate(
+  fetchImpl: FetchLike,
+  options: UpstreamGateOptions = {},
+): UpstreamGate {
+  const maxInFlight = positiveInteger(options.maxInFlight ?? DEFAULT_MAX_IN_FLIGHT_PER_ORIGIN);
+  const maxQueueWaitMs = positiveInteger(options.maxQueueWaitMs ?? DEFAULT_MAX_QUEUE_WAIT_MS);
+  const queues = new Map<string, OriginQueue>();
+  let disposed = false;
+
+  const queueFor = (origin: string): OriginQueue => {
+    let queue = queues.get(origin);
+    if (!queue) {
+      queue = new OriginQueue(origin, maxInFlight);
+      queues.set(origin, queue);
+    }
+    return queue;
+  };
+
+  // An origin nobody is using must not keep a map entry alive for the process's lifetime.
+  const sweep = (origin: string): void => {
+    const queue = queues.get(origin);
+    if (queue?.idle) queues.delete(origin);
+  };
+
+  const gatedFetch: FetchLike = async (input, init) => {
+    if (disposed) throw new Error("Upstream gate is disposed");
+    const origin = originOf(input);
+    if (origin === undefined) return await fetchImpl(input, init);
+    const queue = queueFor(origin);
+    const release = await queue.acquire(init?.signal, maxQueueWaitMs);
+    let response: Response;
+    try {
+      response = await fetchImpl(input, init);
+    } catch (error) {
+      release();
+      sweep(origin);
+      throw error;
+    }
+    return holdUntilBodyEnds(response, () => {
+      release();
+      sweep(origin);
+    });
+  };
+
+  return {
+    fetch: gatedFetch,
+    stats: () => [...queues.values()].map((queue) => queue.occupancy),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      const error = new Error("Upstream gate is disposed");
+      for (const queue of queues.values()) queue.rejectAll(error);
+      queues.clear();
+    },
+  };
+}
+
+/**
+ * Keep the permit until the response body is finished, failed, or cancelled.
+ *
+ * The socket lives as long as the body does, so the permit has to as well. A response that cannot
+ * carry a body has already freed its socket by the time it reaches here.
+ */
+function holdUntilBodyEnds(response: Response, release: Release): Response {
+  if (!response.body || !canCarryBody(response.status)) {
+    release();
+    return response;
+  }
+  const reader = response.body.getReader();
+  const held = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          release();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        release();
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      release();
+      return reader.cancel(reason);
+    },
+  });
+  return new Response(held, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+function canCarryBody(status: number): boolean {
+  return status !== 204 && status !== 205 && status !== 304;
+}
+
+function originOf(input: string | URL | Request): string | undefined {
+  try {
+    const raw = typeof input === "string" || input instanceof URL ? input : input.url;
+    return new URL(raw).origin;
+  } catch {
+    // A caller the gate cannot key is passed through rather than refused; bounding is a
+    // safeguard, not an admission check.
+    return undefined;
+  }
+}
+
+function positiveInteger(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`Upstream gate bounds must be positive integers, received ${value}`);
+  }
+  return value;
+}

--- a/packages/core-ai-gateway/src/transport/upstream-gate.ts
+++ b/packages/core-ai-gateway/src/transport/upstream-gate.ts
@@ -194,7 +194,7 @@ export function createUpstreamGate(
     const origin = originOf(input);
     if (origin === undefined) return await fetchImpl(input, init);
     const queue = queueFor(origin);
-    const release = await queue.acquire(init?.signal, maxQueueWaitMs);
+    const release = await queue.acquire(signalOf(input, init), maxQueueWaitMs);
     let response: Response;
     try {
       response = await fetchImpl(input, init);
@@ -263,6 +263,21 @@ function holdUntilBodyEnds(response: Response, release: Release): Response {
 
 function canCarryBody(status: number): boolean {
   return status !== 204 && status !== 205 && status !== 304;
+}
+
+/**
+ * The signal that governs this call, wherever the caller put it.
+ *
+ * `fetch(new Request(url, { signal }))` carries no `init`, so reading `init.signal` alone leaves
+ * that caller queued until a permit or the wait bound even though it already gave up. The gate
+ * accepts a `Request` by its own signature, so it has to honour one.
+ */
+function signalOf(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+): AbortSignal | null | undefined {
+  if (init?.signal !== undefined) return init.signal;
+  return typeof input === "string" || input instanceof URL ? undefined : input.signal;
 }
 
 function originOf(input: string | URL | Request): string | undefined {

--- a/packages/core-ai-gateway/src/transport/upstream-gate.ts
+++ b/packages/core-ai-gateway/src/transport/upstream-gate.ts
@@ -194,7 +194,8 @@ export function createUpstreamGate(
     const origin = originOf(input);
     if (origin === undefined) return await fetchImpl(input, init);
     const queue = queueFor(origin);
-    const release = await queue.acquire(signalOf(input, init), maxQueueWaitMs);
+    const signal = signalOf(input, init);
+    const release = await queue.acquire(signal, maxQueueWaitMs);
     let response: Response;
     try {
       response = await fetchImpl(input, init);
@@ -203,7 +204,7 @@ export function createUpstreamGate(
       sweep(origin);
       throw error;
     }
-    return holdUntilBodyEnds(response, () => {
+    return holdUntilBodyEnds(response, signal, () => {
       release();
       sweep(origin);
     });
@@ -223,34 +224,57 @@ export function createUpstreamGate(
 }
 
 /**
- * Keep the permit until the response body is finished, failed, or cancelled.
+ * Keep the permit until the response body is finished, failed, cancelled, or aborted.
  *
  * The socket lives as long as the body does, so the permit has to as well. A response that cannot
  * carry a body has already freed its socket by the time it reaches here.
+ *
+ * The abort listener is not redundant with the read path. A consumer parked on backpressure — the
+ * gateway proxy waits on a `drain` event that a dead client socket never emits — has no read in
+ * flight, so an abort that kills the upstream body reaches nothing: `pull` is not running to catch
+ * it and `cancel` is never called. The permit would then be held for the process's lifetime, and
+ * enough abandoned streams retire the ceiling into a queue nothing ever leaves.
  */
-function holdUntilBodyEnds(response: Response, release: Release): Response {
+function holdUntilBodyEnds(
+  response: Response,
+  signal: AbortSignal | null | undefined,
+  release: Release,
+): Response {
   if (!response.body || !canCarryBody(response.status)) {
     release();
     return response;
   }
   const reader = response.body.getReader();
+  let onAbort: (() => void) | undefined;
+  const finish = (): void => {
+    if (onAbort && signal) signal.removeEventListener("abort", onAbort);
+    release();
+  };
+  if (signal) {
+    onAbort = () => {
+      finish();
+      void reader.cancel(signal.reason).catch(() => undefined);
+    };
+    if (signal.aborted) onAbort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  }
   const held = new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
         const { done, value } = await reader.read();
         if (done) {
-          release();
+          finish();
           controller.close();
           return;
         }
         controller.enqueue(value);
       } catch (error) {
-        release();
+        finish();
         controller.error(error);
       }
     },
     cancel(reason) {
-      release();
+      finish();
       return reader.cancel(reason);
     },
   });

--- a/packages/core-ai-gateway/src/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/xai/responses/adapter.ts
@@ -218,7 +218,19 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
      * reopen. Once dropped it stays dropped for this turn.
      */
     let replayAvailable = replaysXaiReasoning(request);
-    let retryAvailable = true;
+    /**
+     * Two budgets, deliberately not one.
+     *
+     * A socket that dies while the request is still being written and a stream that dies after
+     * the upstream accepted it are different faults with different causes — a stale pooled
+     * connection versus an upstream that gave up mid-turn. Sharing one budget meant the first
+     * one to fire disarmed the other, so a request that survived a stale socket on the second
+     * dial then had no attempt left when its stream dropped. Spending each where it belongs
+     * costs at most one extra dial per turn and is the difference between a recovered turn and
+     * an `API mid response error` at the client.
+     */
+    let fetchRetryAvailable = true;
+    let streamRetryAvailable = true;
     let response: AdapterResponse;
 
     // 엔드포인트는 설정이 정한 하나뿐이다. 턴 도중이든 턴 사이든 다른 쪽으로 넘어가지 않는다 —
@@ -230,11 +242,14 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
     try {
       response = await this.fetchResponse(options.apiKey, payload, controller, endpoint);
     } catch (error) {
-      if (!isRetryableXaiFetchSocket(error, controller.signal, this.isMarkedFetchFailure)) {
+      if (
+        !fetchRetryAvailable
+        || !isRetryableXaiFetchSocket(error, controller.signal, this.isMarkedFetchFailure)
+      ) {
         unlinkAbort();
         throw error;
       }
-      retryAvailable = false;
+      fetchRetryAvailable = false;
       wireLog("xai-responses.retry.discarded", {
         reason: "socket_termination",
         phase: "fetch",
@@ -282,7 +297,7 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
         reopen,
         controller,
         unlinkAbort,
-        retryAvailable,
+        streamRetryAvailable,
         () => replayAvailable,
       ),
     };

--- a/packages/core-ai-gateway/tests/anthropic/claude-retryable-status.test.ts
+++ b/packages/core-ai-gateway/tests/anthropic/claude-retryable-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GATEWAY_TRANSIENT_ERROR_STATUS,
+  claudeRetryableUpstreamStatus,
+} from "../../src/anthropic/claude-context.js";
+
+/**
+ * Claude Code retries 408/409/429/500/529 and nothing else. A transient upstream failure that
+ * reaches it as any other code ends the turn on the first attempt, so these mappings are the
+ * contract that keeps the client's retry budget reachable.
+ */
+describe("claudeRetryableUpstreamStatus", () => {
+  it("lifts the transient 5xx family onto overloaded_error", () => {
+    expect(claudeRetryableUpstreamStatus(502)).toBe(529);
+    expect(claudeRetryableUpstreamStatus(503)).toBe(529);
+    expect(claudeRetryableUpstreamStatus(504)).toBe(529);
+  });
+
+  it("lifts Cloudflare-family edge failures the same way", () => {
+    for (const status of [520, 521, 522, 523, 524]) {
+      expect(claudeRetryableUpstreamStatus(status)).toBe(529);
+    }
+  });
+
+  it("leaves statuses the client already retries untouched", () => {
+    for (const status of [408, 409, 429, 500, 529]) {
+      expect(claudeRetryableUpstreamStatus(status)).toBe(status);
+    }
+  });
+
+  it("never rewrites a verdict about the request itself", () => {
+    // Retrying cannot change a 400/401/403/413, and a rewrite would hide the real cause.
+    for (const status of [400, 401, 403, 404, 413, 422]) {
+      expect(claudeRetryableUpstreamStatus(status)).toBe(status);
+    }
+  });
+
+  it("leaves a success status alone", () => {
+    expect(claudeRetryableUpstreamStatus(200)).toBe(200);
+  });
+
+  it("reports a gateway-side transient fault as a status the client retries", () => {
+    expect(GATEWAY_TRANSIENT_ERROR_STATUS).toBe(500);
+    expect(claudeRetryableUpstreamStatus(GATEWAY_TRANSIENT_ERROR_STATUS))
+      .toBe(GATEWAY_TRANSIENT_ERROR_STATUS);
+  });
+});

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -11,6 +11,7 @@ import type {
   AnthropicMessagesRequest,
   CanonicalResponseRequest,
 } from "../../src/index.js";
+import type { GatewayFailureRecord } from "../../src/index.js";
 import type { GatewayHttpHandlerContext } from "../../src/gateway-router/types.js";
 import { describe, expect, it, vi } from "vitest";
 
@@ -611,6 +612,51 @@ describe("upstream credential", () => {
     await second;
     expect(fetchMock).toHaveBeenCalledTimes(2);
     router.dispose();
+  });
+
+  it("journals a failed turn with its phase, cause, and upstream occupancy", async () => {
+    const records: GatewayFailureRecord[] = [];
+    const gateway = {
+      stream: async () => {
+        const error = new TypeError("fetch failed");
+        Object.defineProperty(error, "cause", { value: { code: "UND_ERR_SOCKET" } });
+        throw error;
+      },
+    } as unknown as AnthropicMessagesGateway;
+    const router = createAiGatewayRouter({
+      gateway,
+      readAuth,
+      failureJournal: (entry) => records.push(entry),
+    });
+
+    await router.handle(ctx({ res: response(), token: ANTHROPIC_CRED }));
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      phase: "pre_commit",
+      status: 500,
+      errorType: "api_error",
+      code: "UND_ERR_SOCKET",
+      provider: "codex",
+    });
+    expect(records[0]!.detail).toContain("UND_ERR_SOCKET");
+    expect(typeof records[0]!.elapsedMs).toBe("number");
+  });
+
+  it("keeps a caller mistake out of the transient class it journals", async () => {
+    const records: GatewayFailureRecord[] = [];
+    const gateway = {
+      stream: async () => { throw new ContextWindowExceededError(300_000, 200_000); },
+    } as unknown as AnthropicMessagesGateway;
+    const router = createAiGatewayRouter({
+      gateway,
+      readAuth,
+      failureJournal: (entry) => records.push(entry),
+    });
+
+    await router.handle(ctx({ res: response(), token: ANTHROPIC_CRED }));
+
+    expect(records[0]).toMatchObject({ status: 413, errorType: "invalid_request_error" });
   });
 
   it("reports a transient gateway fault as a status Claude Code retries", async () => {

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -566,6 +566,109 @@ describe("upstream credential", () => {
     }));
   });
 
+  it("bounds concurrent upstream calls per origin and reports occupancy", async () => {
+    let open!: ReadableStreamDefaultController<Uint8Array>;
+    const held = new ReadableStream<Uint8Array>({ start(c) { open = c; } });
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(held, {
+        status: 200, headers: { "content-type": "text/event-stream" },
+      }))
+      .mockResolvedValue(new Response("event: message_stop\n\n", {
+        status: 200, headers: { "content-type": "text/event-stream" },
+      }));
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      readKimiApiKey: async () => "kimi-secret",
+      maxUpstreamInFlight: 1,
+    });
+
+    const settle = async (): Promise<void> => {
+      for (let tick = 0; tick < 50; tick += 1) await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    };
+
+    const first = router.handle(ctx({
+      res: response(), token: ANTHROPIC_CRED, model: "claude-gateway--kimi--k3[1m]",
+    }));
+    await settle();
+
+    // The first turn's stream is still open, so its socket is still counted.
+    expect(router.upstreamStats()).toEqual([
+      expect.objectContaining({ inFlight: 1, queued: 0 }),
+    ]);
+
+    const second = router.handle(ctx({
+      res: response(), token: ANTHROPIC_CRED, model: "claude-gateway--kimi--k3[1m]",
+    }));
+    await settle();
+
+    // Second turn waits for a permit rather than opening a second socket.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    open.close();
+    await first;
+    await second;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    router.dispose();
+  });
+
+  it("reports a transient gateway fault as a status Claude Code retries", async () => {
+    // 502 is absent from the client's retry list, so a dropped upstream socket used to end the
+    // turn on the first attempt instead of reaching the 10-attempt budget.
+    const gateway = {
+      stream: async () => {
+        const error = new TypeError("fetch failed");
+        Object.defineProperty(error, "cause", { value: { code: "UND_ERR_SOCKET" } });
+        throw error;
+      },
+    } as unknown as AnthropicMessagesGateway;
+    const router = createAiGatewayRouter({ gateway, readAuth });
+    const res = response();
+
+    await router.handle(ctx({ res, token: ANTHROPIC_CRED }));
+
+    expect(res.status).toBe(500);
+    expect(res.body).toContain("UND_ERR_SOCKET");
+  });
+
+  it("keeps a caller mistake on its own status", async () => {
+    const gateway = {
+      stream: async () => {
+        throw new ContextWindowExceededError(300_000, 200_000);
+      },
+    } as unknown as AnthropicMessagesGateway;
+    const router = createAiGatewayRouter({ gateway, readAuth });
+    const res = response();
+
+    await router.handle(ctx({ res, token: ANTHROPIC_CRED }));
+
+    expect(res.status).toBe(413);
+  });
+
+  it("lifts a passthrough upstream 503 onto overloaded_error with its body intact", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ type: "error", error: { type: "api_error", message: "upstream said no" } }),
+      { status: 503, headers: { "content-type": "application/json" } },
+    ));
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      readKimiApiKey: async () => "kimi-secret",
+    });
+    const res = response();
+
+    await router.handle(ctx({
+      res,
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--kimi--k3[1m]",
+    }));
+
+    expect(res.status).toBe(529);
+    // The wording has to survive: the client's retry detection reads the upstream's own text.
+    expect(res.body).toContain("upstream said no");
+  });
+
   it("rejects a removed Cursor model instead of forwarding it to Anthropic", async () => {
     const router = createAiGatewayRouter({
       readAuth,

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -567,6 +567,28 @@ describe("upstream credential", () => {
     }));
   });
 
+  it.each([
+    ["claude-gateway--codex--gpt-5.6-sol", "codex"],
+    ["claude-gateway--opencode--deepseek-v4-flash", "opencode responses"],
+  ])("routes the %s translated adapter through the upstream gate", async (model) => {
+    // An adapter built without a fetch falls back to globalThis.fetch, which opens sockets the
+    // router neither bounds nor counts — the provider escapes the ceiling this router imposes.
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(
+      "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"output\":[]}}\n\n",
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ));
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      readOpencodeApiKey: async () => "opencode-secret",
+    });
+
+    await router.handle(ctx({ res: response(), token: ANTHROPIC_CRED, model }));
+
+    expect(fetchMock).toHaveBeenCalled();
+    router.dispose();
+  });
+
   it("bounds concurrent upstream calls per origin and reports occupancy", async () => {
     let open!: ReadableStreamDefaultController<Uint8Array>;
     const held = new ReadableStream<Uint8Array>({ start(c) { open = c; } });

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -665,6 +665,24 @@ describe("upstream credential", () => {
     expect(typeof records[0]!.elapsedMs).toBe("number");
   });
 
+  it("completes the client response even when the journal sink throws", async () => {
+    // The journal is an observation surface. A host sink that throws must not replace the failure
+    // it was recording and leave the client with no response at all.
+    const gateway = {
+      stream: async () => { throw new Error("upstream died"); },
+    } as unknown as AnthropicMessagesGateway;
+    const router = createAiGatewayRouter({
+      gateway,
+      readAuth,
+      failureJournal: () => { throw new Error("sink exploded"); },
+    });
+    const res = response();
+
+    await expect(router.handle(ctx({ res, token: ANTHROPIC_CRED }))).resolves.toBe(true);
+    expect(res.status).toBe(500);
+    expect(res.body).toContain("upstream died");
+  });
+
   it("keeps a caller mistake out of the transient class it journals", async () => {
     const records: GatewayFailureRecord[] = [];
     const gateway = {

--- a/packages/core-ai-gateway/tests/transport/failure-journal.test.ts
+++ b/packages/core-ai-gateway/tests/transport/failure-journal.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createFailureJournal,
+  failureDetail,
+} from "../../src/transport/failure-journal.js";
+import type { GatewayFailureRecord } from "../../src/transport/failure-journal.js";
+
+function record(overrides: Partial<GatewayFailureRecord> = {}): GatewayFailureRecord {
+  return {
+    timestamp: "2026-08-21T11:44:05.746Z",
+    phase: "post_commit",
+    model: "xai--grok-4.6",
+    provider: "xai",
+    errorType: "api_error",
+    code: "UND_ERR_SOCKET",
+    detail: "fetch failed (UND_ERR_SOCKET)",
+    elapsedMs: 38_749,
+    upstreamInFlight: 42,
+    upstreamQueued: 6,
+    ...overrides,
+  };
+}
+
+describe("failureDetail", () => {
+  it("collapses a multi-line message onto one field", () => {
+    expect(failureDetail("upstream said\n  no\n\nagain")).toBe("upstream said no again");
+  });
+
+  it("bounds a long message", () => {
+    const detail = failureDetail("x".repeat(4000));
+    expect(detail.length).toBe(512);
+    expect(detail.endsWith("…")).toBe(true);
+  });
+});
+
+describe("failure journal", () => {
+  it("appends one JSON line per failure", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fleet-journal-"));
+    const filePath = join(dir, "nested", "failures.jsonl");
+    const journal = createFailureJournal({ filePath });
+
+    journal.write(record());
+    journal.write(record({ phase: "pre_commit", status: 500 }));
+    await journal.flush();
+
+    const lines = (await readFile(filePath, "utf8")).trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      phase: "post_commit",
+      code: "UND_ERR_SOCKET",
+      upstreamInFlight: 42,
+    });
+    expect(JSON.parse(lines[1]!)).toMatchObject({ phase: "pre_commit", status: 500 });
+  });
+
+  it("writes owner-only", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fleet-journal-"));
+    const filePath = join(dir, "failures.jsonl");
+    const journal = createFailureJournal({ filePath });
+    journal.write(record());
+    await journal.flush();
+
+    expect((await stat(filePath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("rotates at the byte budget and keeps one backup", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fleet-journal-"));
+    const filePath = join(dir, "failures.jsonl");
+    const journal = createFailureJournal({ filePath, maxBytes: 400 });
+
+    for (let i = 0; i < 6; i += 1) journal.write(record({ elapsedMs: i }));
+    await journal.flush();
+
+    await expect(stat(`${filePath}.1`)).resolves.toBeTruthy();
+    expect((await stat(filePath)).size).toBeLessThanOrEqual(400);
+  });
+
+  it("never throws at the caller when the target is unwritable", async () => {
+    const journal = createFailureJournal({ filePath: "/proc/definitely/not/writable.jsonl" });
+    expect(() => journal.write(record())).not.toThrow();
+    await expect(journal.flush()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core-ai-gateway/tests/transport/upstream-gate.test.ts
+++ b/packages/core-ai-gateway/tests/transport/upstream-gate.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  UpstreamQueueTimeoutError,
+  createUpstreamGate,
+} from "../../src/transport/upstream-gate.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+/** A response whose body stays open until the test closes it, like a live SSE turn. */
+function openStream(): { response: Response; close: () => void } {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const body = new ReadableStream<Uint8Array>({ start(c) { controller = c; } });
+  return {
+    response: new Response(body, { status: 200 }),
+    close: () => controller.close(),
+  };
+}
+
+async function drain(response: Response): Promise<void> {
+  const reader = response.body!.getReader();
+  for (;;) {
+    const { done } = await reader.read();
+    if (done) return;
+  }
+}
+
+describe("upstream gate", () => {
+  it("holds a permit until the body ends, not until the headers arrive", async () => {
+    const first = openStream();
+    const second = openStream();
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(first.response)
+      .mockResolvedValueOnce(second.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+
+    const a = await gate.fetch("https://up.example/v1");
+    // Headers are back, but the stream is still open — the socket is still in use.
+    expect(gate.stats()).toEqual([{ origin: "https://up.example", inFlight: 1, queued: 0 }]);
+
+    const bPending = gate.fetch("https://up.example/v1");
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(gate.stats()).toEqual([{ origin: "https://up.example", inFlight: 1, queued: 1 }]);
+
+    first.close();
+    await drain(a);
+    const b = await bPending;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    second.close();
+    await drain(b);
+    expect(gate.stats()).toEqual([]);
+  });
+
+  it("counts each origin separately", async () => {
+    const streams = [openStream(), openStream()];
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(streams[0]!.response)
+      .mockResolvedValueOnce(streams[1]!.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+
+    await gate.fetch("https://one.example/v1");
+    await gate.fetch("https://two.example/v1");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(gate.stats()).toHaveLength(2);
+  });
+
+  it("fails a wait that outlives its bound instead of queueing forever", async () => {
+    const held = openStream();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(held.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1, maxQueueWaitMs: 20 });
+
+    await gate.fetch("https://up.example/v1");
+    await expect(gate.fetch("https://up.example/v1")).rejects.toBeInstanceOf(UpstreamQueueTimeoutError);
+    // The timeout must not leak the slot it never took.
+    expect(gate.stats()).toEqual([{ origin: "https://up.example", inFlight: 1, queued: 0 }]);
+  });
+
+  it("drops a queued call when its caller aborts", async () => {
+    const held = openStream();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(held.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+    const caller = new AbortController();
+
+    await gate.fetch("https://up.example/v1");
+    const queued = gate.fetch("https://up.example/v1", { signal: caller.signal });
+    await Promise.resolve();
+    caller.abort(new Error("client disconnected"));
+
+    await expect(queued).rejects.toThrow("client disconnected");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the permit when the upstream call throws", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("socket died"))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+
+    await expect(gate.fetch("https://up.example/v1")).rejects.toThrow("socket died");
+    await expect(gate.fetch("https://up.example/v1")).resolves.toBeInstanceOf(Response);
+  });
+
+  it("releases the permit when the caller cancels the body", async () => {
+    const held = openStream();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(held.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+
+    const response = await gate.fetch("https://up.example/v1");
+    await response.body!.cancel("caller left");
+
+    expect(gate.stats()).toEqual([]);
+  });
+
+  it("passes through a target it cannot key", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response("ok", { status: 200 }));
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+
+    await expect(gate.fetch("not-a-url")).resolves.toBeInstanceOf(Response);
+    expect(gate.stats()).toEqual([]);
+  });
+
+  it("rejects waiters on dispose", async () => {
+    const held = openStream();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(held.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+
+    await gate.fetch("https://up.example/v1");
+    const queued = gate.fetch("https://up.example/v1");
+    await Promise.resolve();
+    gate.dispose();
+
+    await expect(queued).rejects.toThrow("disposed");
+  });
+
+  it("refuses a bound that is not a positive integer", () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    expect(() => createUpstreamGate(fetchMock, { maxInFlight: 0 })).toThrow(TypeError);
+    expect(() => createUpstreamGate(fetchMock, { maxQueueWaitMs: -1 })).toThrow(TypeError);
+  });
+});

--- a/packages/core-ai-gateway/tests/transport/upstream-gate.test.ts
+++ b/packages/core-ai-gateway/tests/transport/upstream-gate.test.ts
@@ -118,6 +118,22 @@ describe("upstream gate", () => {
     expect(gate.stats()).toEqual([]);
   });
 
+  it("honors a signal carried by a Request when no init is given", async () => {
+    const held = openStream();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(held.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+    const caller = new AbortController();
+
+    await gate.fetch("https://up.example/v1");
+    // The signal lives on the Request, not on an init the caller never passed.
+    const queued = gate.fetch(new Request("https://up.example/v1", { signal: caller.signal }));
+    await Promise.resolve();
+    caller.abort(new Error("client disconnected"));
+
+    await expect(queued).rejects.toThrow("client disconnected");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("passes through a target it cannot key", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response("ok", { status: 200 }));
     const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });

--- a/packages/core-ai-gateway/tests/transport/upstream-gate.test.ts
+++ b/packages/core-ai-gateway/tests/transport/upstream-gate.test.ts
@@ -134,6 +134,41 @@ describe("upstream gate", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("releases a permit whose consumer parked on backpressure and then aborted", async () => {
+    // The gateway proxy waits on a `drain` event a dead client socket never emits, so nothing is
+    // pulling when the abort lands. Without an abort listener the permit is held forever and the
+    // ceiling decays into a queue nothing leaves.
+    const held = openStream();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(held.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+    const caller = new AbortController();
+
+    const response = await gate.fetch("https://up.example/v1", { signal: caller.signal });
+    // Take the reader but never pull again — the consumer is parked.
+    response.body!.getReader();
+    expect(gate.stats()).toEqual([{ origin: "https://up.example", inFlight: 1, queued: 0 }]);
+
+    caller.abort(new Error("client disconnected"));
+    await Promise.resolve();
+
+    expect(gate.stats()).toEqual([]);
+  });
+
+  it("releases immediately when the signal was already aborted", async () => {
+    const held = openStream();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(held.response);
+    const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });
+    const caller = new AbortController();
+
+    // A fetch that resolves after the caller gave up must not strand its permit either.
+    const pending = gate.fetch("https://up.example/v1", { signal: caller.signal });
+    caller.abort(new Error("late"));
+    await pending.catch(() => undefined);
+    await Promise.resolve();
+
+    expect(gate.stats()).toEqual([]);
+  });
+
   it("passes through a target it cannot key", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response("ok", { status: 200 }));
     const gate = createUpstreamGate(fetchMock, { maxInFlight: 1 });

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -1368,14 +1368,32 @@ describe("Grok Responses retry", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("shares one two-call budget between fetch and stream retry", async () => {
+  it("keeps the stream budget after a dial spent the fetch budget", async () => {
+    // Two faults, two causes: a stale pooled socket on the dial and an upstream that gave up
+    // mid-turn. They used to share one budget, so surviving the first left nothing for the
+    // second and the turn died on a failure one more attempt would have absorbed.
     const fetchMock = vi.fn<typeof fetch>()
       .mockRejectedValueOnce(socketTermination())
-      .mockResolvedValueOnce(xaiResponse(xaiFrame(responseCreated()), xaiFrame(failed())));
+      .mockResolvedValueOnce(xaiResponse(xaiFrame(responseCreated()), xaiFrame(failed())))
+      .mockResolvedValueOnce(xaiResponse(xaiFrame(responseCreated()), xaiFrame(textDelta("recovered"))));
     const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" });
     if (!response.ok) throw new Error("expected ok");
 
-    await expect(collectXaiEvents(response.events)).resolves.toEqual([responseCreated(), failed()]);
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      responseCreated(),
+      textDelta("recovered"),
+    ]);
+    // dial, dial-retry, then the pre-commit stream retry the split preserved.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("spends the fetch budget only once", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(socketTermination())
+      .mockRejectedValueOnce(socketTermination());
+    await expect(
+      new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k" }),
+    ).rejects.toThrow();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/runtime/fleet-console/cli/gateway/server.ts
+++ b/runtime/fleet-console/cli/gateway/server.ts
@@ -5,6 +5,7 @@ import {
   AI_GATEWAY_MODEL_ENV,
   createAiGatewayRouter,
   createCursorDiagnosticLog,
+  createFailureJournal,
   readCodexSubscriptionAuth,
   readCursorSubscriptionToken,
   readXaiSubscriptionToken,
@@ -27,7 +28,11 @@ export async function startGatewayHttpServer(deps: {
   readonly authService: AuthService;
 }): Promise<FleetCliGatewayServer> {
   const diagnostics = createCursorDiagnosticLog(path.join(getFleetDataDir(), "fleet-cli", "ai-gateway"));
+  const failureJournal = createFailureJournal({
+    filePath: path.join(getFleetDataDir(), "fleet-cli", "ai-gateway", "failures.jsonl"),
+  });
   const router = createAiGatewayRouter({
+    failureJournal: failureJournal.write,
     readAiGatewaySettings: () => deps.store.read(),
     readKimiApiKey: () => deps.authService.getApiKey(KIMI_AUTH_PROVIDER_ID),
     readOpencodeApiKey: () => deps.authService.getApiKey(OPENCODE_AUTH_PROVIDER_ID),
@@ -69,6 +74,7 @@ export async function startGatewayHttpServer(deps: {
   } catch (error) {
     router.dispose();
     await diagnostics.flush();
+    await failureJournal.flush();
     throw error;
   }
 
@@ -86,6 +92,7 @@ export async function startGatewayHttpServer(deps: {
       closePromise ??= closeServer(server).finally(async () => {
         router.dispose();
         await diagnostics.flush();
+        await failureJournal.flush();
       });
       return closePromise;
     },

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -5,6 +5,7 @@ import {
   AI_GATEWAY_ROUTE_SEGMENT,
   createAiGatewayRouter,
   createCursorDiagnosticLog,
+  createFailureJournal,
   readCodexSubscriptionAuth,
   readCursorSubscriptionToken,
   readXaiSubscriptionToken,
@@ -46,9 +47,21 @@ export function registerAiGatewayRoutes(
         ctx.host.paths.pluginDataDir(ctx.pluginId),
         "ai-gateway",
       ));
+  // Always on, unlike the wire log: a failed turn is the one event that otherwise leaves no
+  // trace, and a post-commit failure reaches the user as a single SSE frame nobody can retrieve.
+  const ownedFailureJournal = deps.failureJournal
+    ? undefined
+    : createFailureJournal({
+        filePath: path.join(
+          ctx.host.paths.pluginDataDir(ctx.pluginId),
+          "ai-gateway",
+          "failures.jsonl",
+        ),
+      });
   const router = createAiGatewayRouter({
     ...deps,
     originator: "fleet-console",
+    failureJournal: deps.failureJournal ?? ownedFailureJournal?.write,
     // 자격증명 조달은 호스트 결정이다 — Console은 core-ai-gateway가 export한 기본 reader를 주입한다.
     readAuth: deps.readAuth ?? (() => readCodexSubscriptionAuth()),
     readCursorToken: deps.readCursorToken ?? (() => readCursorSubscriptionToken()),
@@ -56,9 +69,10 @@ export function registerAiGatewayRoutes(
     readModelOverride: () => process.env[AI_GATEWAY_MODEL_ENV],
     cursorDiagnostics: deps.cursorDiagnostics ?? ownedDiagnostics?.write,
   });
-  ctx.host.lifecycle.registerCleanup(() => {
+  ctx.host.lifecycle.registerCleanup(async () => {
     router.dispose();
-    return ownedDiagnostics?.flush();
+    await ownedDiagnostics?.flush();
+    await ownedFailureJournal?.flush();
   });
   registerRouter(ctx, AI_GATEWAY_ROUTE_SEGMENT, router.handle, [
     { method: "*", path: "/api/hello", summary: "Read the AI Gateway health response.", category: "Terminal Plugin", gate: "loopback", transport: "http" },


### PR DESCRIPTION
## Summary

- **클라이언트 재시도 예산에 닿게 합니다.** 전이적 실패가 `502`로 나가고 있었는데, Claude Code의 재시도 예산은 `408/409/429/500/529`에만 반응합니다(문서화된 계약). 그래서 끊긴 소켓이나 멈춘 스트림이 첫 시도에서 턴을 끝냈습니다. 게이트웨이 자체 실패는 `500`으로, 상류의 전이적 5xx는 `529`로 올리되 **상류 원문은 그대로 전달**합니다 — 재시도 판정이 상류 문구를 읽기 때문입니다.
- **xAI 재시도 예산을 분리합니다.** 다이얼 단계의 stale 소켓과 스트림 중도 절단은 원인이 다른 결함인데 예산 하나를 나눠 써서, 첫 번째가 터지면 두 번째가 무장 해제됐습니다.
- **업스트림 연결에 origin별 상한을 둡니다.** Node `fetch`는 in-flight당 소켓 하나를 열고 origin당 아무것도 제한하지 않습니다(실측: 동시 40 요청 → 소켓 40개, 큐잉 0). 모든 턴이 SSE라 소켓을 턴 내내 붙들므로, 에이전트 N개 팬아웃이 곧 장수명 연결 N개였습니다. 게이트가 이를 묶고 초과분을 **응답 커밋 이전에** 대기시키며 점유율을 보고합니다.
- **실패한 턴을 저널에 남깁니다.** 커밋 이후 실패는 클라이언트가 한 번 렌더하고 마는 SSE 프레임 하나로만 보고되고, 와이어 로그는 opt-in인 데다 진단이 필요한 그 동시성 상황에서 자기 레코드를 evict합니다(실측: 스트림 55개 중 요청 레코드 13개만 생존). 저널은 항상 켜져 있고 실패당 한 줄이며, 프롬프트·완성·헤더·자격증명을 담지 않습니다.

근거: 게이트웨이 동시성을 8회 실측(최대 동시 상류 스트림 78, 상류 요청 약 200건)하고, `ocx claude` 경로와 Claude Code 오류/재시도 문서를 대조했습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 849 passed (39 files, 신규 25건)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway exec tsc --noEmit` — clean
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build` — success
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 2301 passed / 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` — clean
- [x] `pnpm --filter @fleet-plugins/terminal test` — 968 passed
- [x] `node scripts/check-core-boundary.mjs` — clean
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 10 entries validated
- [ ] 실사용 재현은 미완: "동시 5개 이상 xAI 오류"는 8회 시도에도 재현되지 않았습니다. 저널이 다음 실제 발생을 포착하도록 하는 것이 이 PR의 관측 목표입니다.