### PR TITLE
fix(ai-gateway): floor message_start input usage when the provider reports none

### DIFF
--- a/.changelog.d/gateway-usage-stream.md
+++ b/.changelog.d/gateway-usage-stream.md
@@ -1,0 +1,8 @@
+---
+branch: gateway-usage-stream
+---
+
+### fleet-console
+#### Fixed
+- Report a running turn's token count for gateway models whose provider withholds usage until the turn ends, instead of showing zero for the whole run.
+  ko: 턴이 끝나야 사용량을 주는 공급자의 게이트웨이 모델도 실행 중 토큰 수를 보여줍니다. 더 이상 실행 내내 0으로 남지 않습니다.

--- a/packages/core-ai-gateway/src/anthropic/gateway.ts
+++ b/packages/core-ai-gateway/src/anthropic/gateway.ts
@@ -77,7 +77,14 @@ export class AnthropicMessagesGateway {
       reasoning: canonical.reasoning,
       tools: canonical.tools,
     });
-    guardModelContextWindow(canonical, options.modelContextWindow, this.adapter);
+    // One estimate serves both the overflow guard and the usage floor below: the guard refuses
+    // a turn that cannot fit, and the floor keeps `message_start` from claiming zero input on
+    // providers whose `response.created` carries no usage.
+    const estimatedInputTokens = estimateCanonicalRequestTokens(
+      canonical,
+      this.adapter.wireTools?.(canonical) ?? canonical.tools ?? [],
+    );
+    guardModelContextWindow(canonical, options.modelContextWindow, estimatedInputTokens);
     const upstream = await this.adapter.stream(canonical, {
       apiKey: options.apiKey,
       ...(options.modelContextWindow === undefined
@@ -126,6 +133,7 @@ export class AnthropicMessagesGateway {
           contextWindow: options.contextWindow,
           compactCeiling: options.compactCeiling,
           model: request.model,
+          estimatedInputTokens,
         }))
       };
     }
@@ -135,6 +143,7 @@ export class AnthropicMessagesGateway {
       contextWindow: options.contextWindow,
       compactCeiling: options.compactCeiling,
       model: request.model,
+      estimatedInputTokens,
     });
     return {
       status: upstream.status,
@@ -170,7 +179,7 @@ async function* oneChunk(body: Uint8Array): AsyncGenerator<Uint8Array> {
 function guardModelContextWindow(
   canonical: CanonicalResponseRequest,
   modelContextWindow: number | undefined,
-  adapter: AiGatewayAdapter,
+  requestTokens: number,
 ): void {
   if (
     typeof modelContextWindow !== "number"
@@ -179,8 +188,6 @@ function guardModelContextWindow(
   ) {
     return;
   }
-  const wireTools = adapter.wireTools?.(canonical) ?? canonical.tools ?? [];
-  const requestTokens = estimateCanonicalRequestTokens(canonical, wireTools);
   if (requestTokens > modelContextWindow) {
     throw new ContextWindowExceededError(requestTokens, modelContextWindow);
   }

--- a/packages/core-ai-gateway/src/anthropic/protocol.ts
+++ b/packages/core-ai-gateway/src/anthropic/protocol.ts
@@ -562,6 +562,21 @@ export interface ClaudeResponseCompatibilityOptions {
   readonly compactCeiling?: import("./claude-context.js").CompactCeiling | null;
   /** Rewrites the echoed response model to the client-requested id. */
   readonly model?: string;
+  /**
+   * Deterministic character-based estimate of this request's input tokens, used ONLY when the
+   * upstream envelope reports no input usage at all.
+   *
+   * Responses-backed providers (xAI, Codex, OpenCode) send `usage: null` on `response.created`,
+   * so the `message_start` frame they produce would otherwise claim zero input tokens for the
+   * whole turn — and Claude Code reads that frame to size the turn while it is still running,
+   * which is what leaves those models showing `0 tok` until the turn ends. Cursor never hits
+   * this branch: its adapter synthesizes a real per-segment usage before `response.created`.
+   *
+   * This is an estimate and is labelled as one — it is a floor for a frame that would otherwise
+   * be a definite lie (zero), never a substitute for the upstream count. The terminal
+   * `message_delta` still reports whatever upstream actually measured.
+   */
+  readonly estimatedInputTokens?: number;
 }
 
 interface AnthropicCacheAwareUsage {
@@ -657,14 +672,32 @@ function nonNegativeCacheValue(value: number | undefined): number {
   return value;
 }
 
+function estimatedFallbackInputTokens(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
 /** Build the shared usage shape directly from a canonical response snapshot's usage. */
 function anthropicUsageFromCanonical(
   usage: CanonicalUsage | null | undefined,
   advertisedContextWindow: number | undefined,
-  options: { forceOutputZero?: boolean; compactCeiling?: ClaudeResponseCompatibilityOptions["compactCeiling"] } = {},
+  options: {
+    forceOutputZero?: boolean;
+    compactCeiling?: ClaudeResponseCompatibilityOptions["compactCeiling"];
+    estimatedInputTokens?: number;
+  } = {},
 ): AnthropicCacheAwareUsage {
+  // The estimate only stands in for a missing count, never for a measured one: any positive
+  // upstream input total wins, and the cache breakdown is left untouched because an estimate
+  // cannot say which part of it was a cache hit.
+  const reportedInputTokens = usage?.input_tokens ?? 0;
+  const inputTokens = reportedInputTokens > 0
+    ? reportedInputTokens
+    : estimatedFallbackInputTokens(options.estimatedInputTokens);
   return toAnthropicCacheAwareUsage(
-    usage?.input_tokens ?? 0,
+    inputTokens,
     usage?.cached_input_tokens,
     usage?.cache_write_input_tokens,
     options.forceOutputZero ? 0 : usage?.output_tokens ?? 0,
@@ -797,7 +830,7 @@ export async function collectAnthropicMessage(
     stop_reason: stopReason,
     stop_sequence: null,
     usage: toAnthropicCacheAwareUsage(
-      inputTokens,
+      inputTokens > 0 ? inputTokens : estimatedFallbackInputTokens(options.estimatedInputTokens),
       cachedInputTokens,
       cacheWriteInputTokens,
       outputTokens,
@@ -901,6 +934,7 @@ export async function* encodeAnthropicSse(
               usage: anthropicUsageFromCanonical(event.response.usage, options.contextWindow, {
                 forceOutputZero: true,
                 compactCeiling: options.compactCeiling,
+                estimatedInputTokens: options.estimatedInputTokens,
               })
             }
           });
@@ -1087,6 +1121,7 @@ export async function* encodeAnthropicSse(
           // zero input usage even though Kimi's native Anthropic stream works.
           usage: anthropicUsageFromCanonical(event.response.usage, options.contextWindow, {
             compactCeiling: options.compactCeiling,
+            estimatedInputTokens: options.estimatedInputTokens,
           })
         });
         yield encode("message_stop", { type: "message_stop" });

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -3911,6 +3911,80 @@ describe("response model rewrite", () => {
   });
 });
 
+describe("message_start input usage floor", () => {
+  const usageAdapter = (
+    createdUsage: Record<string, number> | null,
+    completedUsage: Record<string, number> | null,
+  ): AiGatewayAdapter => ({
+    async stream() {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        events: iterable<CanonicalResponseEvent>([
+          {
+            type: "response.created",
+            response: { id: "resp_usage", model: "grok-4.6", usage: createdUsage as never },
+          },
+          { type: "response.output_text.delta", item_id: "m", output_index: 0, content_index: 0, delta: "hi" },
+          {
+            type: "response.completed",
+            response: { id: "resp_usage", model: "grok-4.6", usage: completedUsage as never },
+          },
+        ]),
+      };
+    },
+  });
+
+  const longRequest = (): AnthropicMessagesRequest => ({
+    ...baseRequest(),
+    system: [{ type: "text", text: "You are a assistant. ".repeat(200) }],
+    messages: [{ role: "user", content: "Summarize this. ".repeat(200) }],
+  });
+
+  it("reports an estimated input floor on message_start when response.created carries no usage", async () => {
+    const response = await new AnthropicMessagesGateway(usageAdapter(null, { input_tokens: 900, output_tokens: 4 }))
+      .stream(longRequest(), { apiKey: "k" });
+    const frames = parseSse(await collectBody(response.body));
+    const start = frames.find((item) => item.event === "message_start");
+    const usage = (start?.data as { message: { usage: { input_tokens: number; output_tokens: number } } }).message.usage;
+
+    // Without the floor this frame reports 0 and Claude Code sizes the whole running turn at
+    // zero tokens; the estimate is a floor, so it only has to be positive, never exact.
+    expect(usage.input_tokens).toBeGreaterThan(0);
+    expect(usage.output_tokens).toBe(0);
+  });
+
+  it("never lets the estimate override a measured upstream input count", async () => {
+    const response = await new AnthropicMessagesGateway(
+      usageAdapter({ input_tokens: 7, output_tokens: 0 }, { input_tokens: 11, output_tokens: 4 }),
+    ).stream(longRequest(), { apiKey: "k" });
+    const frames = parseSse(await collectBody(response.body));
+    const start = frames.find((item) => item.event === "message_start");
+    const delta = frames.find((item) => item.event === "message_delta");
+
+    expect((start?.data as { message: { usage: { input_tokens: number } } }).message.usage.input_tokens).toBe(7);
+    expect((delta?.data as { usage: { input_tokens: number } }).usage.input_tokens).toBe(11);
+  });
+
+  it("floors a terminal message_delta whose upstream usage is missing entirely", async () => {
+    const response = await new AnthropicMessagesGateway(usageAdapter(null, null))
+      .stream(longRequest(), { apiKey: "k" });
+    const frames = parseSse(await collectBody(response.body));
+    const delta = frames.find((item) => item.event === "message_delta");
+
+    expect((delta?.data as { usage: { input_tokens: number } }).usage.input_tokens).toBeGreaterThan(0);
+  });
+
+  it("applies the same floor to the non-streaming response body", async () => {
+    const response = await new AnthropicMessagesGateway(usageAdapter(null, null))
+      .stream({ ...longRequest(), stream: false }, { apiKey: "k" });
+    const body = JSON.parse(await collectBody(response.body)) as { usage: { input_tokens: number } };
+
+    expect(body.usage.input_tokens).toBeGreaterThan(0);
+  });
+});
+
 describe("upstream errors", () => {
   it("maps an OpenAI error to Anthropic shape while preserving its HTTP status", async () => {
     const adapter = new OpenAIResponsesAdapter({


### PR DESCRIPTION
## Summary
- Responses-backed providers (xAI, Codex, OpenCode) send `usage: null` on `response.created`, so the `message_start` frame the gateway builds from it claimed zero input tokens. Claude Code sizes a still-running turn from that frame, which is why a workflow agent on those models shows `0 tok` for its whole visible lifetime while Cursor — whose adapter synthesizes a real per-segment usage before `response.created` — shows a live count.
- Reuse the estimate the gateway already computes for the pre-flight overflow guard as a floor for any usage frame whose upstream input total is absent or zero. A measured upstream count always wins, the cache breakdown is never invented, and the terminal `message_delta` keeps reporting exactly what the provider measured. Streaming and non-streaming share the one path, so xAI, Codex, and OpenCode are fixed together.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 859 passed (4 new: estimated floor on `message_start`, measured count wins over the estimate, terminal `message_delta` floored when upstream usage is missing entirely, non-streaming body floored)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Live wire, isolated Console booted from this branch, real xai/grok-4.6: `message_start` `input_tokens` 0 -> 22 with `message_delta` unchanged at the provider's own 111/67+44
- [x] Live end-to-end, real Claude Code agent on `claude-gateway--xai--grok-4.6` against both gateways, comparing raw `stream_event` frames:
  - baseline `message_start #1 in=0` -> `message_delta in=4812 out=158`
  - patched  `message_start #1 in=4843` -> `message_delta in=23 cache_read=4789 out=150`