### PR TITLE
feat(fleet-console): give a Shell its own mark instead of an activity aura

### DIFF
--- a/.changelog.d/shell-kind-mark.md
+++ b/.changelog.d/shell-kind-mark.md
@@ -1,0 +1,8 @@
+---
+branch: shell-kind-mark
+---
+
+### fleet-console
+#### Changed
+- Show a Shell operation as its own kind glyph instead of an activity status mark, since a shell never reports a running or awaiting turn. The sidebar chip, command band, mobile list, and War Room map dot all drop the glow for shells, and status sections still list them where they were.
+  ko: Shell Operation은 실행·대기 턴을 보고하지 않으므로, 활동 상태 마크 대신 Shell 종류 글리프로 표시합니다. 사이드바 칩·커맨드 밴드·모바일 목록·War Room 지도 점에서 발광이 사라지고, 상태 섹션의 위치는 그대로입니다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent } from "react";
 import type { OperationRuntimeState } from "@fleet-console/sdk/plugin";
+import { ShellGlyph } from "@fleet-console/sdk/components/shell-glyph";
 import type { OperationActivityVisual } from "../operation-activity.js";
 
 import { useT } from "../i18n/index.js";
@@ -1207,6 +1208,9 @@ function renderTriageMapDots(
       operationId: operation.id,
       idleArrivalIds: getIdleArrivalIds(),
     }));
+    // Shell은 활동 축을 발행하지 않는다 — 활동 is-* 를 아예 달지 않아 채움·발광·링이 사라지고,
+    // 그 자리를 종류 글리프가 채운다. 점 자체가 마크라 글리프는 버튼의 자식으로 직접 선다.
+    const shell = operation.type === "shell";
     // 미룬(deferred) 마커는 대기 링 맥동에서 제외한다 — 사용자가 이미 보고 미룬 신호를 다시 흔들지 않는다.
     const deferred = isTriageOperationDeferred(operation.id);
     const dragging = draggingMarkerId === operation.id;
@@ -1232,7 +1236,7 @@ function renderTriageMapDots(
       ) : null}
       <button
         type="button"
-        className={`canvas-triage-map-dot is-${visual}${deferred ? " is-deferred" : ""}${dragging ? " is-dragging" : ""}`}
+        className={`canvas-triage-map-dot ${shell ? "is-shell" : `is-${visual}`}${deferred ? " is-deferred" : ""}${dragging ? " is-dragging" : ""}`}
         data-triage-map-dot={marker.operationId}
         style={style}
         aria-label={t("canvas.triage.deckCardAria", { title: operation.title })}
@@ -1259,6 +1263,7 @@ function renderTriageMapDots(
           pick(operation.id, event.currentTarget);
         }}
       >
+        {shell ? <ShellGlyph /> : null}
         <span className="canvas-triage-map-dot-label">{operation.title}</span>
       </button>
       </Fragment>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -11,7 +11,7 @@ import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCent
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
 import { ViewModeToggle } from "./view-mode-toggle.js";
-import { OperationStatusIcon } from "./operation-status-icon.js";
+import { OperationNameMark } from "./operation-name-mark.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { useUpdateProgress } from "../update-progress-store.js";
 import { resolveOperationActivity, resolveOperationMarkVisual } from "../operation-activity.js";
@@ -132,12 +132,14 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const activeLaunchModel = typeof activeOperation?.payload.launchModel === "string" ? activeOperation.payload.launchModel : null;
   // 사이드바 칩과 같은 규율: 이름 왼쪽 슬롯은 활동 상태가 가져간다. 무엇으로 띄웠는지가 아니라
   // 지금 무엇을 하고 있는지가 먼저 읽혀야 한다. 모델 이름은 스위처 메뉴 메타로만 남긴다.
+  // Shell만은 예외다 — 활동 축을 발행하지 않으므로 그 자리를 종류 글리프가 가져간다.
   // 마크는 사이드바 칩·지도 점과 같은 마크 축을 읽는다 — 미확인 도착은 AWAITING이 아니라 "unseen"
   // 이므로 초록 느린 점등으로 그려진다. raw 활동만 보면 목록은 도착이라는 그 패널을 밴드만 유휴라
   // 부르고(War Room 무대 승격은 acknowledged: false라 도착 표식이 살아남는다), 표시 활동을 그대로
   // 쓰면 이번엔 안 본 채 끝난 것이 사람을 기다리는 중과 같은 파랑으로 서 버린다.
   const activeOperationStatusMark = activeOperation
-    ? <OperationStatusIcon
+    ? <OperationNameMark
+        operation={activeOperation}
         status={resolveOperationMarkVisual({
           activity: resolveOperationActivity(activeOperation, state.operationRuntime),
           operationId: activeOperation.id,

--- a/runtime/fleet-console/core/client/src/components/operation-name-mark.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-name-mark.tsx
@@ -1,0 +1,40 @@
+import { ShellGlyph } from "@fleet-console/sdk/components/shell-glyph";
+
+import { getT } from "../i18n/index.js";
+import { resolveActiveLocale } from "../operation-activity.js";
+import { isShellOperation } from "../theater-shell.js";
+import type { OperationMarkVisual } from "../operation-activity.js";
+import type { OperationNode } from "../types.js";
+
+import { OperationStatusIcon } from "./operation-status-icon.js";
+
+/**
+ * 목록의 이름 왼쪽 칸에 서는 마크. 두 종류뿐이다.
+ *
+ * - 에이전트 Operation: 활동 비콘(OperationStatusIcon) — 지금 무엇을 하고 있는지.
+ * - Shell Operation: 종류 글리프 — Shell은 활동 축을 발행하지 않아 비콘이 늘 "초록 유휴"
+ *   또는 "중공 종료"로 굳는다. 그건 상태가 아니라 상태가 없다는 사실이므로, 발광·맥동을
+ *   띄우는 대신 그 자리를 정체성이 가져간다. 살아있는 Shell과 종료된 Shell은 같은 그림이다.
+ *
+ * 칸(섹션 분류)은 이 마크와 무관하게 그대로다 — Shell은 여전히 유휴/휴면 칸에 선다.
+ */
+export function ShellKindMark({ decorative = false, className }: {
+  readonly decorative?: boolean;
+  readonly className?: string;
+}) {
+  const label = getT(resolveActiveLocale())("operation.kind.shell");
+  const classes = ["shell-kind-mark", className].filter(Boolean).join(" ");
+  if (decorative) return <span className={classes} aria-hidden="true" title={label}><ShellGlyph /></span>;
+  return <span className={classes} role="img" aria-label={label} title={label}><ShellGlyph /></span>;
+}
+
+export function OperationNameMark({ operation, status, decorative = false, className }: {
+  readonly operation: Pick<OperationNode, "type">;
+  readonly status: OperationMarkVisual | undefined;
+  /** 감싼 요소가 이미 그 사실을 접근성 이름으로 말하는 자리 — 중복 낭독을 막는다. */
+  readonly decorative?: boolean;
+  readonly className?: string;
+}) {
+  if (isShellOperation(operation)) return <ShellKindMark decorative={decorative} className={className} />;
+  return <OperationStatusIcon status={status} decorative={decorative} className={className} />;
+}

--- a/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
@@ -336,6 +336,9 @@ export const pagesEn = {
   // 패널도 이 마크를 단다 — "아직 열지 않음"은 그 자리에서 거짓이 된다. 확인 여부로만 말한다.
   "activity.unseen": "Finished, unacknowledged",
 
+  // Operation 종류 마크 — Shell은 활동 축을 발행하지 않으므로 그 자리를 종류가 채운다.
+  "operation.kind.shell": "Shell",
+
   // codex — cowork
   "codex.cowork.requestFailed": "Cowork request failed.",
   "codex.cowork.draftChangesAria": "Draft changes",
@@ -822,6 +825,8 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "activity.ended": "종료됨",
   "activity.idle": "유휴",
   "activity.unseen": "종료됨 — 확인 전",
+
+  "operation.kind.shell": "Shell",
 
   "codex.cowork.requestFailed": "Cowork 요청에 실패했습니다.",
   "codex.cowork.draftChangesAria": "초안 변경",

--- a/runtime/fleet-console/core/client/src/main.tsx
+++ b/runtime/fleet-console/core/client/src/main.tsx
@@ -8,6 +8,7 @@ import * as sdkReactBrowser from "@fleet-console/sdk/react/browser";
 import * as sdkComponentsFailureNotice from "@fleet-console/sdk/components/failure-notice";
 import * as sdkComponentsEffortTrack from "@fleet-console/sdk/components/effort-track";
 import * as sdkComponentsLaunchProviderGlyphs from "@fleet-console/sdk/components/launch-provider-glyphs";
+import * as sdkComponentsShellGlyph from "@fleet-console/sdk/components/shell-glyph";
 import "@fontsource-variable/fraunces";
 import "@fontsource-variable/fraunces/standard-italic.css";
 import "@fontsource-variable/manrope";
@@ -44,6 +45,7 @@ interface FleetConsoleRuntime {
   readonly "@fleet-console/sdk/components/failure-notice": typeof sdkComponentsFailureNotice;
   readonly "@fleet-console/sdk/components/effort-track": typeof sdkComponentsEffortTrack;
   readonly "@fleet-console/sdk/components/launch-provider-glyphs": typeof sdkComponentsLaunchProviderGlyphs;
+  readonly "@fleet-console/sdk/components/shell-glyph": typeof sdkComponentsShellGlyph;
 }
 
 declare global {
@@ -63,6 +65,7 @@ globalThis.__fleetConsoleRuntime__ = {
   "@fleet-console/sdk/components/failure-notice": sdkComponentsFailureNotice,
   "@fleet-console/sdk/components/effort-track": sdkComponentsEffortTrack,
   "@fleet-console/sdk/components/launch-provider-glyphs": sdkComponentsLaunchProviderGlyphs,
+  "@fleet-console/sdk/components/shell-glyph": sdkComponentsShellGlyph,
 };
 
 // 서버 주입이 첫 페인트의 권위값이며 theme-hint는 미주입 서빙 경로의 폴백이다.

--- a/runtime/fleet-console/core/client/src/mobile/mobile-operation-list.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/mobile-operation-list.tsx
@@ -1,6 +1,7 @@
 import type { OperationActivityVisual } from "../operation-activity.js";
 import type { OperationRuntimeState } from "@fleet-console/sdk/plugin";
 
+import { ShellKindMark } from "../components/operation-name-mark.js";
 import { ViewModeToggle } from "../components/view-mode-toggle.js";
 import { useT } from "../i18n/index.js";
 import { operationActivityVisual, resolveOperationActivity } from "../operation-activity.js";
@@ -62,7 +63,11 @@ export function MobileOperationList({ operations, operationRuntime, notification
                   : null;
                 return (
                   <button type="button" className="mobile-operation-card" key={operation.id} onClick={() => onOpen(operation.id)}>
-                    <span className={beaconClass(status)} aria-hidden="true" />
+                    {/* Shell은 활동 축을 발행하지 않는다 — 늘 같은 값으로 굳는 비콘 대신 종류 글리프가 선다.
+                        칸(섹션)은 그대로이고, 유휴/종료라는 사실은 섹션 머리글이 이미 말한다. */}
+                    {operation.type === "shell"
+                      ? <ShellKindMark decorative />
+                      : <span className={beaconClass(status)} aria-hidden="true" />}
                     <span className="mobile-operation-card-copy">
                       <strong>{operation.title}</strong>
                       {cliLabel ? <span>{cliLabel}</span> : null}

--- a/runtime/fleet-console/core/client/src/operation-activity.ts
+++ b/runtime/fleet-console/core/client/src/operation-activity.ts
@@ -97,7 +97,9 @@ export function operationActivityVisual(status: OperationActivityVisual | undefi
   return "idle";
 }
 
-function resolveActiveLocale() {
+// 마크 라벨을 그리는 다른 조형(종류 글리프)도 같은 로케일 해석을 쓴다 — 한 화면의 두 마크가
+// 서로 다른 언어로 낭독되면 안 된다.
+export function resolveActiveLocale() {
   const preference = getGlobalSettingsStoreState().state?.language ?? "auto";
   const navigatorLanguage =
     typeof navigator !== "undefined" && typeof navigator.language === "string"

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, type CSSProperties, type PointerEvent as ReactPointerEvent, type SyntheticEvent } from "react";
 
 
-import { OperationStatusIcon } from "../components/operation-status-icon.js";
+import { OperationNameMark } from "../components/operation-name-mark.js";
 import { useT } from "../i18n/index.js";
 import { type OperationActivityVisual, type OperationMarkVisual } from "../operation-activity.js";
 import { useInlineRename } from "../use-inline-rename.js";
@@ -230,9 +230,10 @@ export function OperationsSideBarChip({
     >
       {/* 이름 왼쪽 슬롯은 활동 상태가 소유한다 — 목록에서 먼저 읽혀야 하는 것은 무엇으로
           띄웠는지가 아니라 지금 무엇을 하고 있는지다. 칩 자체가 상태를 접근성 이름으로
-          말하지 않으므로 마크가 그 이름을 진다. */}
+          말하지 않으므로 마크가 그 이름을 진다. 예외는 Shell 하나다: Shell은 활동 축을
+          발행하지 않아 비콘이 늘 같은 값으로 굳으므로, 그 자리를 종류 글리프가 가져간다. */}
       <span className="side-bar-chip-beacon-button">
-        <OperationStatusIcon status={markVisual} className="side-bar-chip-status" />
+        <OperationNameMark operation={operation} status={markVisual} className="side-bar-chip-status" />
       </span>
       {rename.renaming ? (
         <input

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2667,6 +2667,26 @@
   }
 }
 
+/* 종류 마크 — 신호가 아니라 잉크다. Shell은 활동 축을 발행하지 않아 활동 비콘이 늘 같은 값으로
+   굳는다(초록 유휴 / 중공 종료). 그 자리를 이 마크가 대신하며, 살아있든 종료됐든 같은 그림이다:
+   상태 채널(aurora·warn·positive·coral)도, 위치 채널(brass)도 빌리지 않는다.
+   목록 슬롯의 표준 치수는 14px 하나다 — 표면마다 다른 크기를 두면 같은 사실이 표면 수만큼의
+   무게로 읽힌다. 지도 점은 점 자체가 마크라 여기가 아니라 .canvas-triage-map-dot.is-shell이 맡는다. */
+.shell-kind-mark {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  color: var(--text-secondary);
+}
+
+.shell-kind-mark svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+
 .status-dot--lg {
   width: 10px;
   height: 10px;
@@ -3336,6 +3356,23 @@
     border-color var(--duration-fast) var(--ease-glide),
     box-shadow var(--duration-fast) var(--ease-glide),
     opacity var(--duration-fast) var(--ease-glide);
+}
+
+/* Shell 점 — 활동 is-* 를 아예 달지 않으므로 --activity-color 채움과 발광·링이 성립하지 않는다.
+   남는 것은 기본 규칙의 채움과 유휴 감쇠뿐이라 여기서 그 둘만 되돌린다. box-shadow는 건드리지
+   않는다: hover/focus의 brass 링(.canvas-triage-map-dot:hover, 0,2,1)이 계속 이겨야 한다. */
+.canvas-triage-map-dot.is-shell {
+  display: grid;
+  place-items: center;
+  background: none;
+  opacity: 1;
+  color: var(--text-secondary);
+}
+
+.canvas-triage-map-dot.is-shell svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .canvas-triage-map-dot.is-awaiting {

--- a/runtime/fleet-console/core/client/src/theater-shell.ts
+++ b/runtime/fleet-console/core/client/src/theater-shell.ts
@@ -13,6 +13,15 @@ export function isTheaterShellLaunch(kind: Pick<OperationLaunchKind, "type">): b
   return kind.type === SHELL_OPERATION_TYPE;
 }
 
+/**
+ * 이미 존재하는 Operation이 Shell인가 — 크롬이 종류 마크를 그릴지 정하는 유일한 판정.
+ * pluginId는 보지 않는다: 재사용 대상 Shell을 "찾는" 일(findTheaterShellId)과 달리, 무엇으로
+ * 그릴지는 제품 정체성(type)만의 문제다.
+ */
+export function isShellOperation(operation: Pick<OperationNode, "type">): boolean {
+  return operation.type === SHELL_OPERATION_TYPE;
+}
+
 /** 목록이 비어 있는 부트 구간을 "Shell 없음"으로 읽으면 복원분 옆에 하나를 더 만든다. */
 export function theaterShellDecisionRequiresHydration(
   kind: Pick<OperationLaunchKind, "type">,

--- a/runtime/fleet-console/core/host/plugin-host/plugin-host.ts
+++ b/runtime/fleet-console/core/host/plugin-host/plugin-host.ts
@@ -236,6 +236,7 @@ const SHIM_DEFINITIONS: readonly ShimDefinition[] = [
   { name: "sdk-components-failure-notice", specifier: "@fleet-console/sdk/components/failure-notice", globalKey: "@fleet-console/sdk/components/failure-notice", namedExports: SHIM_NAMED_EXPORTS["@fleet-console/sdk/components/failure-notice"] ?? [] },
   { name: "sdk-components-effort-track", specifier: "@fleet-console/sdk/components/effort-track", globalKey: "@fleet-console/sdk/components/effort-track", namedExports: SHIM_NAMED_EXPORTS["@fleet-console/sdk/components/effort-track"] ?? [] },
   { name: "sdk-components-launch-provider-glyphs", specifier: "@fleet-console/sdk/components/launch-provider-glyphs", globalKey: "@fleet-console/sdk/components/launch-provider-glyphs", namedExports: SHIM_NAMED_EXPORTS["@fleet-console/sdk/components/launch-provider-glyphs"] ?? [] },
+  { name: "sdk-components-shell-glyph", specifier: "@fleet-console/sdk/components/shell-glyph", globalKey: "@fleet-console/sdk/components/shell-glyph", namedExports: SHIM_NAMED_EXPORTS["@fleet-console/sdk/components/shell-glyph"] ?? [] },
 ];
 const SHIM_URL_BY_SPECIFIER = new Map(SHIM_DEFINITIONS.map((definition) => [definition.specifier, `/plugin-runtime/shim/${definition.name}.mjs`]));
 const SHIM_BY_NAME = new Map(SHIM_DEFINITIONS.map((definition) => [definition.name, definition]));

--- a/runtime/fleet-console/sdk/components/shell-glyph.tsx
+++ b/runtime/fleet-console/sdk/components/shell-glyph.tsx
@@ -1,0 +1,19 @@
+/**
+ * Shell 종류 마크 — 화면 + 프롬프트 stroke 글리프 하나.
+ *
+ * Shell Operation은 에이전트 턴 축을 발행하지 않는다. 그래서 호스트 크롬이 Shell 자리에
+ * 활동 비콘(초록 유휴 발광 / 중공 종료 사각)을 그리면 그건 없는 상태를 있는 것처럼 말하는
+ * 것이다. 그 자리를 이 글리프가 대신한다 — 상태가 아니라 정체성이므로 살아있든 종료됐든
+ * 같은 그림이다.
+ *
+ * 크기·색은 소비처가 CSS로 정한다(글리프에는 width/height·색 속성이 없다). 터미널 플러그인의
+ * 실행 아이콘과 Console 크롬의 종류 마크가 같은 획을 쓰도록 SDK가 유일한 원본을 갖는다.
+ */
+export function ShellGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <rect x="2.8" y="3.4" width="10.4" height="9.2" rx="1.4" fill="none" stroke="currentColor" strokeWidth="1.15" />
+      <path d="M5 6.6 6.8 8.4 5 10.2M8.4 10.2h2.8" fill="none" stroke="currentColor" strokeWidth="1.15" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/sdk/package.json
+++ b/runtime/fleet-console/sdk/package.json
@@ -119,6 +119,12 @@
       "import": "./components/launch-provider-glyphs.tsx",
       "default": "./components/launch-provider-glyphs.tsx"
     },
+    "./components/shell-glyph": {
+      "types": "./components/shell-glyph.tsx",
+      "browser": "./components/shell-glyph.tsx",
+      "import": "./components/shell-glyph.tsx",
+      "default": "./components/shell-glyph.tsx"
+    },
     "./composer": {
       "types": "./composer/index.ts",
       "browser": "./composer/index.ts",

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -89,6 +89,11 @@ describe("Command Band switcher disclosure", () => {
     expect(source).toContain("activity: resolveOperationActivity(activeOperation, state.operationRuntime),");
     expect(source).toContain("idleArrivalIds,");
     expect(source).toContain("{activeOperationStatusMark}");
+    // Shell만 예외다 — 활동 축을 발행하지 않으므로 그 칸을 종류 글리프가 가져간다. 분기는 밴드가
+    // 직접 적지 않고 칩·모바일과 같은 한 문(OperationNameMark)을 지난다.
+    expect(source).toContain("<OperationNameMark");
+    expect(source).toContain("operation={activeOperation}");
+    expect(source).not.toMatch(/command-band[^\n]*type === "shell"/);
     expect(source).not.toContain("operation-provider-mark");
     expect(source).not.toContain("command-band-operation-attribute");
     expect(styles).not.toContain(".command-band-operation-attribute");

--- a/runtime/fleet-console/tests/i18n.test.ts
+++ b/runtime/fleet-console/tests/i18n.test.ts
@@ -35,6 +35,8 @@ const IDENTICAL_LOCALE_VALUE_ALLOWLIST = new Set([
   // Remote access Desktop 설치 링크 라벨 — GitHub 제품 표면 명칭을 그대로 둔다.
   "GitHub releases",
   "Backend API",
+  // Operation 종류 명칭 — 플러그인 카탈로그(terminal.kind.shell)도 두 로케일 모두 "Shell"이다.
+  "Shell",
   // 캔버스 모드 3종은 번역하지 않는 제품 고유 명칭이다.
   "Cruise",
   "Tactical",

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2305,6 +2305,7 @@ describe("Instrument core design contract", () => {
     const sidebar = source("sidebar/operations-side-bar.tsx");
     const chip = source("sidebar/operations-side-bar-chip.tsx");
     const statusIcon = source("components/operation-status-icon.tsx");
+    const nameMark = source("components/operation-name-mark.tsx");
     const minimap = source("canvas/canvas-minimap.tsx");
     const commandBand = source("components/command-band.tsx");
     const components = source("styles/components.css");
@@ -2321,10 +2322,22 @@ describe("Instrument core design contract", () => {
     expect(sidebar).toContain("hasCustomGroups && section.entries.length > 0");
     expect(sidebar).toContain("theaterInitials(theater.label)");
     expect(chip).toContain("side-bar-chip-status");
-    // 상태 마크 해석은 한 모듈이 소유한다 — 표면마다 매핑을 다시 적으면 같은 상태가 두 조형으로 갈라진다.
-    expect(chip).toContain('import { OperationStatusIcon } from "../components/operation-status-icon.js"');
+    // 이름 왼쪽 칸의 조형 선택은 한 모듈이 소유한다 — 표면마다 "Shell이면 글리프" 분기를 다시 적으면
+    // 같은 사실이 표면 수만큼의 조형으로 갈라진다. 칩·밴드·모바일이 모두 이 문을 지난다.
+    expect(chip).toContain('import { OperationNameMark } from "../components/operation-name-mark.js"');
+    expect(nameMark).toContain('import { ShellGlyph } from "@fleet-console/sdk/components/shell-glyph"');
+    expect(nameMark).toContain("if (isShellOperation(operation)) return <ShellKindMark");
+    expect(nameMark).toContain('return <OperationStatusIcon status={status}');
+    // 상태 마크 해석은 여전히 상태 아이콘 하나가 소유한다 — 종류 분기는 그 위층의 다른 질문이다.
     expect(statusIcon).toContain('if (visual === "background") return "tenant-beacon is-background"');
     expect(statusIcon).toContain('if (visual === "awaiting") return "tenant-beacon is-awaiting"');
+    // 종류 마크는 신호 채널도 위치 채널도 빌리지 않는다 — 활동 토큰 묶음 밖에 선다.
+    expect(components).toMatch(/\.shell-kind-mark \{[^}]*width:\s*14px;[^}]*height:\s*14px;[^}]*color:\s*var\(--text-secondary\)/);
+    expect(components).not.toMatch(/\.shell-kind-mark \{[^}]*(box-shadow|animation)/);
+    expect(components).toMatch(/\.canvas-triage-map-dot\.is-shell \{[^}]*background:\s*none;[^}]*opacity:\s*1;[^}]*color:\s*var\(--text-secondary\)/);
+    // 활동 토큰 묶음에 종류를 끼워 넣으면 Shell이 다시 상태 축의 한 값으로 읽힌다.
+    expect(components).not.toContain(".canvas-triage-map-dot.is-shell,");
+    expect(components).not.toContain(".tenant-beacon.is-shell");
     expect(chip).not.toContain("is-attention");
     expect(components).toContain(".side-bar-chip:focus-within .side-bar-chip-close");
     expect(components).toContain(".side-bar-chip--minimized .side-bar-chip-name {\n  color: var(--ink-muted);");

--- a/runtime/fleet-console/tests/mobile-operation-kind-mark.test.tsx
+++ b/runtime/fleet-console/tests/mobile-operation-kind-mark.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MobileOperationList } from "../core/client/src/mobile/mobile-operation-list.js";
+import type { OperationNode } from "../core/client/src/types.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+function operation(id: string, type: string): OperationNode {
+  return {
+    id,
+    theaterId: "theater-1",
+    type,
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    ts: { createdAt: 1, updatedAt: 1 },
+  } as OperationNode;
+}
+
+function render(operations: readonly OperationNode[]) {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(createElement(MobileOperationList, {
+    operations,
+    operationRuntime: {},
+    notificationIds: new Set<string>(),
+    theaterLabel: "Alpha",
+    onOpen: () => {},
+  })));
+  return container;
+}
+
+/**
+ * 모바일 목록도 데스크톱 칩·커맨드 밴드·지도 점과 같은 판단을 쓴다 — Shell은 활동 축을 발행하지
+ * 않으므로 비콘 자리를 종류 글리프가 가져간다. 표면마다 다르게 그리면 같은 사실이 표면 수만큼의
+ * 이야기로 갈라진다.
+ */
+describe("mobile operation list kind mark", () => {
+  it("draws a shell as the kind glyph and an agent as the activity beacon", () => {
+    const view = render([operation("shell-row", "shell"), operation("agent-row", "agent")]);
+
+    const cards = [...view.querySelectorAll(".mobile-operation-card")];
+    expect(cards).toHaveLength(2);
+    const shellCard = cards.find((card) => card.textContent?.includes("shell-row"));
+    const agentCard = cards.find((card) => card.textContent?.includes("agent-row"));
+
+    expect(shellCard?.querySelector(".shell-kind-mark svg")).not.toBeNull();
+    expect(shellCard?.querySelector(".tenant-beacon")).toBeNull();
+    // 목록 카드는 이미 자기 제목을 읽어 주고, 유휴/종료라는 사실은 섹션 머리글이 진다.
+    expect(shellCard?.querySelector(".shell-kind-mark")?.getAttribute("aria-hidden")).toBe("true");
+
+    expect(agentCard?.querySelector(".tenant-beacon.is-idle")).not.toBeNull();
+    expect(agentCard?.querySelector(".shell-kind-mark")).toBeNull();
+  });
+
+  it("keeps a shell inside the same status section as an agent with the same activity", () => {
+    const view = render([operation("shell-row", "shell"), operation("agent-row", "agent")]);
+
+    const sections = [...view.querySelectorAll(".mobile-status-section")];
+    const idle = sections.find((section) => section.querySelector("h2")?.textContent === "Idle");
+    expect(idle?.querySelectorAll(".mobile-operation-card")).toHaveLength(2);
+  });
+});

--- a/runtime/fleet-console/tests/operations-side-bar-chip-status.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-chip-status.test.ts
@@ -31,6 +31,23 @@ describe("OperationsSideBarChip activity status", () => {
     expect(statusDot.className).toContain(expectedClass);
     expect(statusDot.getAttribute("aria-label")).toBe(expectedLabel);
   });
+
+  // Shell은 활동 축을 발행하지 않는다 — 비콘을 그리면 활동값이 무엇이든 "초록 유휴" 또는
+  // "중공 종료"로 굳어, 없는 상태를 있는 것처럼 말하게 된다. 그 자리는 종류가 가져간다.
+  it.each(["idle", "ended", "running", undefined] as const)(
+    "draws a shell as the kind glyph regardless of the %s activity value",
+    (status) => {
+      const mark = renderChip(status, "shell");
+
+      expect(mark.className).toContain("shell-kind-mark");
+      expect(mark.className).toContain("side-bar-chip-status");
+      expect(mark.className).not.toContain("tenant-beacon");
+      expect(mark.getAttribute("aria-label")).toBe("Shell");
+      // 발광·맥동을 붙일 자리가 없도록 활동 클래스는 하나도 실리지 않는다.
+      expect(mark.className).not.toMatch(/\bis-(idle|ended|awaiting|unseen|turn-running|background)\b/);
+      expect(mark.querySelector("svg")).not.toBeNull();
+    },
+  );
 });
 
 // degraded 는 "모른다"는 뜻이다 — 마지막으로 알던 값을 지금의 사실처럼 패널에 넘기면,
@@ -67,7 +84,7 @@ describe("Operation runtime contract", () => {
   });
 });
 
-function renderChip(status: OperationActivityVisual | undefined): HTMLSpanElement {
+function renderChip(status: OperationActivityVisual | undefined, type = "agent"): HTMLSpanElement {
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
@@ -76,7 +93,7 @@ function renderChip(status: OperationActivityVisual | undefined): HTMLSpanElemen
       operation: {
         id: "operation-1",
         theaterId: "theater-1",
-        type: "shell",
+        type,
         pluginId: "terminal",
         title: "Bridge",
         payload: {},

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -136,6 +136,25 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').dataset.reorderEnabled).toBe("false");
   });
 
+  it("keeps a shell in its status bucket while drawing the kind glyph instead of the activity beacon", () => {
+    setConsoleState({ operationRuntime: { agent: { lifecycle: "live", activity: "running" } } });
+    setSideBarStatusAxis(true);
+    renderSideBar([makeOperation("agent", null), makeOperation("shell", null, undefined, THEATER.id, "shell")]);
+
+    // 칸은 그대로다 — 마크가 바뀐다고 Shell이 목록에서 사라지거나 다른 칸으로 옮겨 가면 안 된다.
+    const idle = required<HTMLElement>(".side-bar-status-section--idle");
+    expect(idle.querySelector(".side-bar-status-header__count")?.textContent).toBe("1");
+    expect(idle.querySelector('[data-side-bar-chip-id="shell"]')).not.toBeNull();
+
+    const shellMark = required<HTMLElement>('[data-side-bar-chip-id="shell"] .side-bar-chip-status');
+    expect(shellMark.className).toContain("shell-kind-mark");
+    expect(shellMark.className).not.toContain("tenant-beacon");
+    expect(shellMark.getAttribute("aria-label")).toBe("Shell");
+    // 같은 목록의 에이전트 행은 활동 축을 그대로 쓴다 — 이 변경은 Shell 하나에만 닿는다.
+    expect(required<HTMLElement>('[data-side-bar-chip-id="agent"] .side-bar-chip-status').className)
+      .toContain("tenant-beacon is-turn-running");
+  });
+
   it("pins three live sections plus both recovery shelves, defaults empty sections collapsed, and toggles empty and occupied sections independently", () => {
     setConsoleState({ operationRuntime: { only: { lifecycle: "live", activity: "running" } } });
     setSideBarStatusAxis(true);
@@ -762,11 +781,13 @@ function required<T extends Element>(selector: string): T {
   return element;
 }
 
-function makeOperation(id: string, groupId: string | null, accent?: string, theaterId: string = THEATER.id): OperationNode {
+// 이 파일의 기본 픽스처는 활동 축의 대역이다 — Shell은 활동 축을 발행하지 않아 마크가 종류
+// 글리프로 갈리므로, 상태 칸·마크를 재는 픽스처는 에이전트여야 한다(Shell 사례는 아래 전용 테스트).
+function makeOperation(id: string, groupId: string | null, accent?: string, theaterId: string = THEATER.id, type = "agent"): OperationNode {
   return {
     id,
     theaterId,
-    type: "shell",
+    type,
     pluginId: "terminal",
     title: id,
     payload: {},

--- a/runtime/fleet-console/tests/plugin-client-assets.test.ts
+++ b/runtime/fleet-console/tests/plugin-client-assets.test.ts
@@ -54,8 +54,9 @@ describe("plugin client assets", () => {
       'import { FailureNotice } from "@fleet-console/sdk/components/failure-notice";',
       'import { EffortTrack } from "@fleet-console/sdk/components/effort-track";',
       'import { launchProviderFromModelId } from "@fleet-console/sdk/components/launch-provider-glyphs";',
+      'import { ShellGlyph } from "@fleet-console/sdk/components/shell-glyph";',
       'const row = { id: "m", label: "M", launch: { model: "m" }, chips: [{ id: "low", label: "LOW", launch: { model: "m", effort: "low" } }] };',
-      'export default { id: "notice", railPanels: [{ id: "n", title: "N", render: () => <><FailureNotice title="t" /><EffortTrack row={row} value="low" onChange={() => {}} autoLabel="AUTO" ariaLabel="effort" autoValueText="auto" /><span>{launchProviderFromModelId("sonnet")}</span></> }] };',
+      'export default { id: "notice", railPanels: [{ id: "n", title: "N", render: () => <><FailureNotice title="t" /><EffortTrack row={row} value="low" onChange={() => {}} autoLabel="AUTO" ariaLabel="effort" autoValueText="auto" /><span>{launchProviderFromModelId("sonnet")}</span><ShellGlyph /></> }] };',
     ].join("\n"));
     const assets = createPluginClientAssets({ plugins: [plugin] });
 
@@ -65,6 +66,7 @@ describe("plugin client assets", () => {
     expect(source).toContain("/plugin-runtime/shim/sdk-components-failure-notice.mjs");
     expect(source).toContain("/plugin-runtime/shim/sdk-components-effort-track.mjs");
     expect(source).toContain("/plugin-runtime/shim/sdk-components-launch-provider-glyphs.mjs");
+    expect(source).toContain("/plugin-runtime/shim/sdk-components-shell-glyph.mjs");
     expect(assets.manifest().skipped ?? []).toEqual([]);
   });
 

--- a/runtime/fleet-console/tests/plugin-shim-registry.test.ts
+++ b/runtime/fleet-console/tests/plugin-shim-registry.test.ts
@@ -35,6 +35,7 @@ describe("plugin shim registry", () => {
     expect(defined).toContain("@fleet-console/sdk/components/failure-notice");
     expect(defined).toContain("@fleet-console/sdk/components/effort-track");
     expect(defined).toContain("@fleet-console/sdk/components/launch-provider-glyphs");
+    expect(defined).toContain("@fleet-console/sdk/components/shell-glyph");
   });
 
   it("serves every defined shim from the browser runtime namespace", () => {

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -2265,6 +2265,41 @@ describe("triage fleet map markers", () => {
     expect(dot?.classList.contains("is-idle")).toBe(false);
   });
 
+  it("draws a shell dot as the kind glyph with no activity class, even on an idle arrival", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    triagePlateRoot = createRoot(container);
+    const shell = operation("shell-map", 1, THEATER_ID, "shell");
+    // 도착 표식까지 걸어 둔다 — 미확인 점등(is-unseen)마저 Shell에는 실리지 않아야 한다.
+    markIdleArrival(shell.id);
+
+    act(() => {
+      triagePlateRoot?.render(createElement(TriageWatchDeck, {
+        active: true,
+        entering: false,
+        theaters: THEATERS,
+        operations: [shell],
+        operationRuntime: {},
+        operationAccent: {},
+      }));
+    });
+    act(() => {
+      setTriageDeckMapModeLive(true);
+    });
+
+    // Shell은 활동 축을 발행하지 않는다 — 활동 is-*를 아예 달지 않아야 채움·발광·링이 성립하지 않고,
+    // 그 자리를 종류 글리프가 채운다. CSS override로 끄는 방식이면 새 상태가 늘 때마다 다시 꺼야 한다.
+    const dot = container.querySelector<HTMLElement>('[data-triage-map-dot="shell-map"]');
+    expect(dot?.classList.contains("is-shell")).toBe(true);
+    expect(dot?.classList.contains("is-unseen")).toBe(false);
+    expect(dot?.classList.contains("is-idle")).toBe(false);
+    expect(dot?.classList.contains("is-awaiting")).toBe(false);
+    expect(dot?.querySelector("svg")).not.toBeNull();
+    // 점의 나머지 문법(유영·집기·이름표)은 그대로다 — 바뀐 것은 마크뿐이다.
+    expect(dot?.style.getPropertyValue("--triage-drift-mult")).not.toBe("");
+    expect(dot?.querySelector(".canvas-triage-map-dot-label")?.textContent).toBe("shell-map");
+  });
+
   it("resets the card grid scroll when the deck enters map mode", () => {
     const container = document.createElement("div");
     document.body.append(container);
@@ -2293,11 +2328,13 @@ describe("triage fleet map markers", () => {
   });
 });
 
-function operation(id: string, createdAt: number, theaterId = THEATER_ID): OperationNode {
+// 기본 픽스처는 활동 축의 대역이다 — Shell 점은 활동 is-*를 아예 달지 않으므로, 상태 색·링을
+// 재는 픽스처는 에이전트여야 한다(Shell 점 사례는 전용 테스트가 따로 있다).
+function operation(id: string, createdAt: number, theaterId = THEATER_ID, type = "agent"): OperationNode {
   return {
     id,
     theaterId,
-    type: "shell",
+    type,
     pluginId: "terminal",
     title: id,
     payload: {},

--- a/runtime/fleet-plugins/terminal/client/shell/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/shell/index.tsx
@@ -2,6 +2,7 @@ import { defineOperationKind } from "@fleet-console/sdk/plugin/browser";
 import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
 import { definePlugin, React } from "@fleet-console/sdk/plugin/browser";
 import { FailureNotice } from "@fleet-console/sdk/components/failure-notice";
+import { ShellGlyph } from "@fleet-console/sdk/components/shell-glyph";
 import { getT } from "../i18n/index.js";
 import { TerminalSurface } from "../shared/index.js";
 
@@ -92,15 +93,5 @@ function ShellOperationView({ context }: { readonly context: OperationRenderCont
       onStatusDetail={(detail) => context.statusDetail.set(context.operationId, detail)}
       onExit={context.onClose}
     />
-  );
-}
-
-function ShellGlyph() {
-  // 순정 셸 — 화면+프롬프트 stroke 마크. 셸 플러그인이 자기 드롭다운 아이콘을 소유한다.
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <rect x="2.8" y="3.4" width="10.4" height="9.2" rx="1.4" fill="none" stroke="currentColor" strokeWidth="1.15" />
-      <path d="M5 6.6 6.8 8.4 5 10.2M8.4 10.2h2.8" fill="none" stroke="currentColor" strokeWidth="1.15" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
   );
 }

--- a/scripts/generate-fleet-console-shim-keys.mjs
+++ b/scripts/generate-fleet-console-shim-keys.mjs
@@ -36,6 +36,7 @@ const SPECIFIER_ENTRIES = [
   ["@fleet-console/sdk/components/failure-notice", path.join(sdkRoot, "components", "failure-notice.tsx")],
   ["@fleet-console/sdk/components/effort-track", path.join(sdkRoot, "components", "effort-track.tsx")],
   ["@fleet-console/sdk/components/launch-provider-glyphs", path.join(sdkRoot, "components", "launch-provider-glyphs.tsx")],
+  ["@fleet-console/sdk/components/shell-glyph", path.join(sdkRoot, "components", "shell-glyph.tsx")],
 ];
 
 const tmpDir = mkdtempSync(path.join(os.tmpdir(), "fleet-console-shim-keys-"));


### PR DESCRIPTION
## Summary

- Shell Operation은 런타임 활동을 발행하지 않는다. 그래서 이름 왼쪽의 활동 마크는 늘 같은 그림이었다 — 살아 있으면 초록 유휴 발광, 프로세스가 없으면 중공 종료 사각. 없는 상태를 있는 것처럼 말하는 aura였고, 한눈에 Shell이 살아 있는 에이전트처럼 읽혔다. 그 칸을 종류가 가져간다: 살아 있든 휴면이든 같은 글리프 하나, 신호색이 아니라 잉크로.
- 터미널 플러그인이 사유하던 셸 글리프를 `@fleet-console/sdk/components/shell-glyph`로 승격해 호스트 크롬과 플러그인 실행 아이콘이 같은 획을 쓰게 하고, 플러그인 shim 4곳을 함께 배선했다.
- 사이드바 칩·커맨드 밴드·모바일 목록은 `OperationNameMark` 한 문을 지난다(표면마다 `type === "shell"` 분기를 다시 적지 않는다). War Room 지도 점은 활동 클래스 대신 `.is-shell`을 달아, 채움·발광·링을 CSS로 끄는 게 아니라 **애초에 성립하지 않게** 했다 — 상태가 늘어도 다시 끌 일이 없다.
- 상태 칸·카운트·섹션 스트라이프, 그리고 에이전트 Operation의 활동 축 전체는 손대지 않았다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @fleet-console/sdk typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run` — 186 files / 2311 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/check-localized-attributes.mjs`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 격리 콘솔 수동 확인 — 한 Theater에 Agent 1 + Shell(live) 1 + Shell(dormant) 1을 시드해 사이드바 칩·커맨드 밴드·War Room 지도 점을 대조

### 새/변경된 테스트

- `operations-side-bar-chip-status` — Shell 칩은 활동값과 무관하게 종류 글리프, 활동 클래스는 하나도 실리지 않음
- `operations-side-bar-status-axis` — Shell이 같은 상태 칸에 남으면서 마크만 갈리고, 같은 목록의 Agent는 비콘 유지
- `triage-store` — 도착 표식(`markIdleArrival`)을 걸어도 Shell 점에 `is-unseen`이 실리지 않고, 유영·이름표 문법은 그대로
- `mobile-operation-kind-mark` (신규) — 모바일 목록의 Shell/Agent 대조와 섹션 유지
- `instrument-design-contract` — `.shell-kind-mark`가 활동 토큰 묶음 밖에 서고 발광·애니메이션을 갖지 않음을 못 박음
- 공유 픽스처 2곳이 `type: "shell"`을 활동 축 대역으로 쓰고 있었다 — 활동을 재는 픽스처는 `agent`로 되돌리고, Shell은 전용 케이스를 따로 세웠다