### PR TITLE
feat(fleet-admiral): stop a delegated agent from spawning agents of its own

### DIFF
--- a/.changelog.d/block-nested-agent-spawn.md
+++ b/.changelog.d/block-nested-agent-spawn.md
@@ -1,0 +1,8 @@
+---
+branch: block-nested-agent-spawn
+---
+
+### fleet-console
+#### Changed
+- Keep delegation one level deep: an agent you delegate to can no longer spawn agents of its own.
+  ko: 위임은 한 단으로 끝납니다. 위임받은 에이전트가 다시 에이전트를 띄우지 못합니다.

--- a/packages/fleet-admiral/src/agent-cli/claude/factory.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/factory.ts
@@ -21,7 +21,19 @@ export function createClaudeFamilyCliDefinition(
       // 상한을 넘길 때만 주입 계층이 파일 포인터로 바꾸고, cmd shim이면 그 짧은 지시만
       // shim 안전 검사를 받는다.
       const commandLineLimit = resolveLaunchCommandLineLimit(prefixArgs);
-      const childEnv = createChildEnv(profileOptions.env, {});
+      const childEnv = createChildEnv(profileOptions.env, {
+        // 위임은 한 단으로 끝난다. 이 상한이 1이면 세션 자신(depth 0)만 Agent를 부를 수 있고,
+        // 그 아래 서브에이전트에게는 Agent 도구가 아예 실리지 않는다 — 호출 후 거절이 아니라
+        // 목록에서 사라진다. Fleet의 실행 에이전트 프롬프트가 산문으로 걸어 둔 "assignment
+        // 전체를 재위임하지 말라"를 기계적으로 만드는 유일한 레버다.
+        //
+        // 에이전트 frontmatter로는 못 한다: `tools:` 허용목록은 MCP·지연 도구까지 함께 얼려
+        // 게이트웨이 정체성에서 Fleet MCP를 떨어뜨리고, `disallowed-tools`는 스킬/명령 전용이라
+        // 에이전트 파일에서는 조용히 무시되며, `tools: ["*", "Agent(...)"]`의 allowedAgentTypes는
+        // 중첩 스폰을 실제로 막지 않는다(세 경로 모두 실측).
+        CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH:
+          profileOptions.env.CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH ?? "1",
+      });
       return {
         args: [...prefixArgs, ...buildModelArgs(profileOptions.model), ...buildEffortArgs(profileOptions.effort)],
         bin,

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -69,6 +69,24 @@ describe("claude-gateway profile", () => {
     });
   });
 
+  it("caps subagent spawn depth so a delegated worker cannot re-delegate", async () => {
+    const profile = await resolveAgentCliProfile({
+      CLAUDE_BIN: process.execPath,
+    }, "/tmp", { cliId: "claude-gateway" });
+
+    // 1이면 세션 자신만 Agent를 부를 수 있다 — 서브에이전트의 도구 목록에서 Agent가 사라진다.
+    expect(profile.env.CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH).toBe("1");
+  });
+
+  it("preserves an explicit operator subagent depth override", async () => {
+    const profile = await resolveAgentCliProfile({
+      CLAUDE_BIN: process.execPath,
+      CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH: "3",
+    }, "/tmp", { cliId: "claude-gateway" });
+
+    expect(profile.env.CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH).toBe("3");
+  });
+
   it("delivers ultra as Claude Code --effort ultracode", async () => {
     const profile = await resolveAgentCliProfile({
       CLAUDE_BIN: process.execPath,


### PR DESCRIPTION
## Summary
- Fleet이 띄우는 Claude Code 자식 프로세스에 `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1`을 얹어, 세션 자신(depth 0)만 Agent를 부를 수 있게 한다. 위임받은 서브에이전트에게는 Agent 도구가 목록에서 아예 빠진다 — 호출 후 거절이 아니다.
- 운영자가 값을 명시하면 그대로 존중한다(`CLAUDE_CODE_AUTO_COMPACT_WINDOW` 선례와 동일).
- 에이전트 frontmatter로는 불가능한 것을 실측으로 확인했다: `tools:` 허용목록은 MCP·지연 도구까지 얼려 게이트웨이 정체성에서 Fleet MCP를 떨어뜨리고, `disallowed-tools`는 스킬/명령 전용이라 에이전트 파일에서 조용히 무시되며, `tools: ["*", "Agent(...)"]`의 `allowedAgentTypes`는 중첩 스폰을 실제로 막지 않는다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` — 13 files / 175 tests pass
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck` — clean
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 32 entries validated
- [x] 실측: `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1`로 띄운 세션의 서브에이전트가 `Agent` 도구 부재를 보고, 미설정 세션에서는 중첩 스폰 성공