### PR TITLE
fix(ai-gateway): read the Antigravity credential on Windows

### DIFF
--- a/packages/core-ai-gateway/src/antigravity/credentials.ts
+++ b/packages/core-ai-gateway/src/antigravity/credentials.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import path from "node:path";
 
 import {
   MAX_CREDENTIAL_BYTES,
@@ -71,6 +72,12 @@ export const ANTIGRAVITY_REFRESH_BUFFER_MS = 60_000;
 /** `agy models` is a network round trip; measured near 3s, bounded well above it. */
 const VENDOR_REFRESH_TIMEOUT_MS = 20_000;
 const KEYCHAIN_TIMEOUT_MS = 5_000;
+/**
+ * Windows pays for a PowerShell start and a C# compile the other stores do not.
+ * Measured near 450ms on this path (2026-08-22); bounded well above it because a
+ * cold .NET load makes that figure a floor, not a ceiling.
+ */
+const WINDOWS_CREDENTIAL_TIMEOUT_MS = 15_000;
 
 const vendorRefreshInFlight = new Map<string, Promise<void>>();
 
@@ -178,12 +185,74 @@ export function parseAntigravityKeychainValue(raw: string): StoredAntigravityTok
 }
 
 /**
+ * `go-keyring`'s Windows backend stores one Credential Manager generic item named
+ * `service:account`, so this names the same secret macOS and Linux reach through
+ * their own store's addressing.
+ */
+const WINDOWS_CREDENTIAL_TARGET = `${ANTIGRAVITY_KEYCHAIN_SERVICE}:${ANTIGRAVITY_KEYCHAIN_ACCOUNT}`;
+
+/**
+ * Read one Credential Manager item and print its blob as base64.
+ *
+ * Windows ships no shell tool that prints a generic credential's value, which is
+ * why this declares `CredReadW` and calls it rather than shelling out to one. Two
+ * choices here are deliberate: the blob is emitted base64 because the console code
+ * page would otherwise decide how `go-keyring`'s UTF-8 bytes come out, and base64
+ * is ASCII under every page; and an absent item prints nothing and exits 0, since
+ * "not signed in" is a fact to report, not a failure to raise.
+ */
+const WINDOWS_CREDENTIAL_READER = `$ErrorActionPreference = 'Stop'
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class FleetAntigravityCredential {
+  [DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode, EntryPoint="CredReadW")]
+  private static extern bool CredRead(string target, uint type, uint flags, out IntPtr credential);
+  [DllImport("advapi32.dll")]
+  private static extern void CredFree(IntPtr credential);
+  [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+  private struct CREDENTIAL {
+    public uint Flags; public uint Type; public IntPtr TargetName; public IntPtr Comment;
+    public long LastWritten; public uint CredentialBlobSize; public IntPtr CredentialBlob;
+    public uint Persist; public uint AttributeCount; public IntPtr Attributes;
+    public IntPtr TargetAlias; public IntPtr UserName;
+  }
+  public static string Read(string target) {
+    IntPtr handle;
+    if (!CredRead(target, 1, 0, out handle)) return "";
+    try {
+      CREDENTIAL cred = (CREDENTIAL)Marshal.PtrToStructure(handle, typeof(CREDENTIAL));
+      byte[] blob = new byte[cred.CredentialBlobSize];
+      Marshal.Copy(cred.CredentialBlob, blob, 0, (int)cred.CredentialBlobSize);
+      return Convert.ToBase64String(blob);
+    } finally { CredFree(handle); }
+  }
+}
+'@
+[Console]::Out.Write([FleetAntigravityCredential]::Read('${WINDOWS_CREDENTIAL_TARGET}'))
+`;
+
+/**
+ * PowerShell by absolute path, never by name.
+ *
+ * This runs with the caller's `PATH`, and a credential reader is the last place to
+ * let `PATH` order pick which binary sees the secret. The bare name stays only as
+ * the fallback for a host that hid `SystemRoot`.
+ */
+function windowsPowerShell(deps: CredentialResolverDeps): string {
+  const systemRoot = optionalTrimmedString(deps.env.SystemRoot);
+  return systemRoot === undefined
+    ? "powershell.exe"
+    : path.win32.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+/**
  * Read the OS credential store `go-keyring` wrote into.
  *
- * macOS is the keychain and Linux is libsecret through `secret-tool`, which is the
- * same backend `go-keyring` selects on each platform. Windows uses the Credential
- * Manager, which has no shell reader that returns a value on stdout, so it reports
- * absent rather than pretending to have looked.
+ * Each branch reads the store `go-keyring` itself selects for that platform: the
+ * keychain on macOS, libsecret through `secret-tool` on Linux, and the Credential
+ * Manager on Windows. Anything else has no store to read and reports absent rather
+ * than pretending to have looked.
  */
 async function readKeychainValue(deps: CredentialResolverDeps): Promise<string | null> {
   if (deps.platform === "darwin") {
@@ -213,6 +282,24 @@ async function readKeychainValue(deps: CredentialResolverDeps): Promise<string |
       ],
       { timeout: KEYCHAIN_TIMEOUT_MS },
     );
+    return raw.length > MAX_CREDENTIAL_BYTES ? null : raw;
+  }
+  if (deps.platform === "win32") {
+    const encoded = await deps.execFile(
+      windowsPowerShell(deps),
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        // `-EncodedCommand` takes UTF-16LE base64, which is what keeps a script
+        // full of quotes and `$` out of Windows command-line quoting entirely.
+        Buffer.from(WINDOWS_CREDENTIAL_READER, "utf16le").toString("base64"),
+      ],
+      { timeout: WINDOWS_CREDENTIAL_TIMEOUT_MS },
+    );
+    const blob = encoded.trim();
+    if (blob.length === 0) return null;
+    const raw = Buffer.from(blob, "base64").toString("utf8");
     return raw.length > MAX_CREDENTIAL_BYTES ? null : raw;
   }
   return null;

--- a/packages/core-ai-gateway/tests/antigravity.test.ts
+++ b/packages/core-ai-gateway/tests/antigravity.test.ts
@@ -204,11 +204,44 @@ describe("antigravity credentials", () => {
     expect(antigravityUserAgent("win32", "x64")).toContain("os_type=windows; arch=amd64");
   });
 
-  it("has no credential store to read on Windows rather than guessing at one", async () => {
-    const execFile = vi.fn(async (_file: string, _args: readonly string[]) => "unused");
+  it("reads the Windows Credential Manager item go-keyring wrote", async () => {
+    // The Windows store takes arbitrary bytes, so `agy` leaves plain JSON there
+    // with none of the `go-keyring-base64:` wrapping the other platforms need;
+    // the base64 here is this reader's own transport off PowerShell's stdout.
+    const payload = JSON.stringify({
+      token: {
+        access_token: ACCESS,
+        refresh_token: REFRESH,
+        expiry: new Date(Date.now() + 3_600_000).toISOString(),
+      },
+      auth_method: "consumer",
+    });
+    const execFile = vi.fn(
+      async (_file: string, _args: readonly string[]) =>
+        Buffer.from(payload, "utf8").toString("base64"),
+    );
+    const result = await resolveAntigravityAuth(credentialDeps({
+      platform: "win32",
+      env: { SystemRoot: "C:\\Windows" },
+      execFile,
+    }));
+    expect(result).toMatchObject({ status: "ok", credentials: { accessToken: ACCESS } });
+
+    const [file, args] = execFile.mock.calls[0]!;
+    // Absolute path: PATH order must not choose which binary sees the secret.
+    expect(file).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+    expect(args.slice(0, 3)).toEqual(["-NoProfile", "-NonInteractive", "-EncodedCommand"]);
+    const script = Buffer.from(args[3] ?? "", "base64").toString("utf16le");
+    expect(script).toContain("CredReadW");
+    expect(script).toContain("gemini:antigravity");
+  });
+
+  it("treats an empty Credential Manager read as signed out", async () => {
+    const execFile = vi.fn(async (_file: string, _args: readonly string[]) => "");
     const result = await resolveAntigravityAuth(credentialDeps({ platform: "win32", execFile }));
     expect(result).toEqual({ status: "signed_out" });
-    expect(execFile).not.toHaveBeenCalled();
+    // No SystemRoot to resolve against, so the bare name is the only fallback left.
+    expect(execFile.mock.calls[0]?.[0]).toBe("powershell.exe");
   });
 });
 


### PR DESCRIPTION
## Summary

Windows에서 Antigravity 자격증명을 전혀 읽지 못하던 문제를 수정합니다. `readKeychainValue`에 `win32` 분기가 없어 `agy`로 로그인해 둔 상태와 무관하게 항상 `signed_out`으로 판정되었습니다. `go-keyring`이 Windows에 남기는 Credential Manager 항목(`gemini:antigravity`)을 PowerShell 경유 `CredReadW`로 읽습니다 — generic credential의 값을 돌려주는 리더가 이것뿐입니다.

- 리더 스크립트는 UTF-16LE `-EncodedCommand`로 전달해 Windows 커맨드라인 인용을 거치지 않게 하고, blob은 base64로 회수해 콘솔 코드페이지가 `go-keyring`의 UTF-8 바이트를 훼손하지 못하게 했습니다.
- `powershell.exe`는 `PATH`가 아니라 `SystemRoot` 기준 절대 경로로 실행합니다.
- Windows 읽기에는 전용 15초 상한을 둡니다. warm 450ms이지만 콜드 첫 호출이 5.2초로 측정되어, 공용 5초 keychain 상한을 그대로 썼다면 첫 호출이 실패했을 것입니다.

## Type of Change

- [x] fix — bug fix

## Test Plan

- [x] `vitest run tests/antigravity.test.ts` — 45 passed. Windows 동작을 고정하던 기존 테스트를 실제 읽기 검증 2건(평문 JSON 파싱 + 절대경로/인자 검증, 빈 읽기 → `signed_out` + 폴백)으로 교체
- [x] `tsc -p tsconfig.json --noEmit` — exit 0
- [x] `vitest run` (core-ai-gateway 전체) — 899 passed / 4 failed. 실패 4건은 모두 POSIX 파일 권한(`0o700`/`0o600`) 검사이며 clean canary 체크아웃에서도 동일하게 실패하는 Windows 베이스라인. 신규 실패 0
- [x] `check:core-boundary`, `check:claude-agent-sdk-boundary` — 통과
- [x] 실제 백엔드 end-to-end (Windows): 해석된 토큰으로 `retrieveUserQuotaSummary` `status=ok`, `loadCodeAssist` `projectId` 획득, `streamGenerateContent` HTTP 200 + 모델 응답 수신
- [x] 갱신 경로: `forceRefresh: true`로 `agy models` 경유 재발급 후 expiry 갱신 확인

## Changelog

- `readKeychainValue`에 Windows Credential Manager 분기 추가
- Windows 전용 자격증명 읽기 타임아웃(15초) 분리
- Windows 미지원을 고정하던 테스트를 실제 읽기 검증으로 교체

## Notes for Reviewers

- 릴리스 노트 fragment는 의도적으로 추가하지 않았습니다. Antigravity 자체가 아직 미출시이고(`.changelog.d/ai-gateway-antigravity.md`가 pending), 해당 fragment가 플랫폼 제한을 언급하지 않아 fold할 내용도 없습니다 — `.changelog.d/CLAUDE.md`의 Release Baseline 규칙에 해당합니다.
- `spawnVendorRefresh`의 `agy` 실행은 손대지 않았습니다. Windows에서 실측상 정상 동작합니다(`exit 0`, 143ms).