### PR TITLE
fix(fleet-console): paint every provider mark from one supplier tone table

### DIFF
--- a/.changelog.d/ai-gateway-glyphs.md
+++ b/.changelog.d/ai-gateway-glyphs.md
@@ -1,0 +1,8 @@
+---
+branch: ai-gateway-glyphs
+---
+
+### fleet-console
+#### Fixed
+- Every provider mark now carries its own supplier color: the xAI and OpenCode chips in AI Gateway settings no longer lose their frame and fall to grey, Kimi is painted in the same tone the Quota panel uses, and the Quota panel colors its xAI mark too.
+  ko: 공급자 마크가 저마다 고유한 공급자 색을 갖습니다. AI Gateway 설정의 xAI·OpenCode 칩이 테두리를 잃고 회색으로 떨어지지 않고, Kimi는 Quota 패널과 같은 색조로 칠해지며, Quota 패널도 xAI 마크에 색을 입힙니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7914,6 +7914,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
   text-transform: uppercase;
 }
 
+.operation-launch-variant-caption.is-antigravity,
+.quick-launch-pop-band.is-antigravity { --launch-provider-tone: var(--provider-antigravity); }
 .operation-launch-variant-caption.is-claude,
 .quick-launch-pop-band.is-claude { --launch-provider-tone: var(--provider-claude); }
 .operation-launch-variant-caption.is-codex,
@@ -7950,6 +7952,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 10px;
 }
 
+.quick-launch-kind-icon.is-antigravity,
 .quick-launch-kind-icon.is-claude,
 .quick-launch-kind-icon.is-codex,
 .quick-launch-kind-icon.is-cursor,
@@ -7958,6 +7961,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .quick-launch-kind-icon.is-xai {
   color: var(--launch-provider-tone);
 }
+.quick-launch-kind-icon.is-antigravity { --launch-provider-tone: var(--provider-antigravity); }
 .quick-launch-kind-icon.is-claude { --launch-provider-tone: var(--provider-claude); }
 .quick-launch-kind-icon.is-codex { --launch-provider-tone: var(--provider-codex); }
 .quick-launch-kind-icon.is-cursor { --launch-provider-tone: var(--provider-cursor); }
@@ -7969,6 +7973,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
    세는 크롬 표면(사이드바 칩·커맨드 밴드·팔레트·War Room 카드)이 하나의 캐리어 시그니처 톤을
    공유하므로 대조표는 여기 한 번만 적고, 각 표면은 자기 치수만 소유한다. 공급자는 정체성 축이라
    마크의 잉크에만 머문다 — 테두리·상태 표면을 덧칠하지 않고, 포커스나 활성으로 다시 칠하지도 않는다. */
+.operation-provider-mark.is-antigravity { color: var(--provider-antigravity); }
 .operation-provider-mark.is-claude { color: var(--provider-claude); }
 .operation-provider-mark.is-codex { color: var(--provider-codex); }
 .operation-provider-mark.is-cursor { color: var(--provider-cursor); }

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -79,6 +79,7 @@
   --provider-cursor: oklch(72% 0.13 238);
   --provider-opencode: oklch(72% 0.07 165);
   --provider-xai: oklch(76% 0.055 258);
+  --provider-antigravity: oklch(74% 0.115 288);
   /* 정체성 톤(--id-*) — Operation accent·그룹색·captain 식별이 공유하는 8톤.
      각 테마의 채도 봉투를 따라 재조율된다(Instrument C≈0.06). 신호색(brass/aurora/warn/coral)과
      hue가 이웃한 crimson/amber는 채도를 낮춰 상태 신호와 혼동되지 않게 한다. */
@@ -437,6 +438,7 @@
   --provider-cursor: oklch(50% 0.115 238);
   --provider-opencode: oklch(48% 0.08 165);
   --provider-xai: oklch(46% 0.06 258);
+  --provider-antigravity: oklch(51% 0.1 288);
 
   --id-crimson: oklch(54% 0.1 25);
   --id-amber: oklch(56% 0.095 70);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1004,7 +1004,7 @@ describe("Instrument core design contract", () => {
     // 되고 같은 Operation이 두 색으로 보인다 — 대조표는 .operation-provider-mark 한 곳에만 있어야
     // 하고, 표면 클래스는 치수만 소유한다.
     const css = source("styles/components.css");
-    for (const provider of ["claude", "codex", "cursor", "kimi", "opencode", "xai"]) {
+    for (const provider of ["antigravity", "claude", "codex", "cursor", "kimi", "opencode", "xai"]) {
       expect(css).toContain(`.operation-provider-mark.is-${provider} { color: var(--provider-${provider}); }`);
     }
     // 공급자는 정체성 축이다 — 마크의 잉크에만 머물러야 하므로 배경·테두리로 번지지 않고,
@@ -1022,6 +1022,35 @@ describe("Instrument core design contract", () => {
     // 목록 표면은 공급자를 세지 않는다 — 그 자리는 활동 상태가 소유한다.
     expect(source("sidebar/operations-side-bar-chip.tsx")).not.toContain("operation-provider-mark");
     expect(source("components/command-band.tsx")).not.toContain("operation-provider-mark");
+  });
+
+  it("pins the provider tone table as one axis — every gateway provider named on both surfaces", () => {
+    // 공급자 색 대조표는 --provider-* 축 하나다. 표에서 빠진 공급자는 컴파일도 렌더도 실패하지
+    // 않고 조용히 회색으로 떨어지며, AI Gateway 칩의 경우 톤이 미정의라 color-mix()가 통째로
+    // 무효화되어 테두리·배경까지 사라진다 — 같은 공급자가 두 화면에서 다른 마크로 읽힌다.
+    const providers = ["antigravity", "codex", "cursor", "kimi", "opencode", "xai"] as const;
+    const theme = source("styles/theme.css");
+    for (const provider of providers) {
+      expect(theme).toMatch(new RegExp(`--provider-${provider}: oklch\\(`));
+    }
+
+    const gatewayCss = externalSource(TERMINAL_AGENT_CLI_CSS_PATH).replace(/\r\n/g, "\n");
+    for (const provider of providers) {
+      expect(gatewayCss).toContain(
+        `.ai-gateway-provider.is-${provider} { --ai-gateway-provider-tone: var(--provider-${provider}); }`,
+      );
+    }
+    // 톤은 --provider-* 말고 다른 축에서 빌려오지 않는다 — --id-*를 빌리면 같은 공급자가
+    // Quota 레일과 다른 색으로 불린다.
+    for (const [, body] of gatewayCss.matchAll(/\.ai-gateway-provider\.is-[a-z]+ \{([^}]*)\}/g)) {
+      expect(body).toMatch(/var\(--provider-[a-z]+\)/);
+    }
+
+    // Quota 레일은 Claude Code까지 세므로 한 공급자가 더 많다.
+    const quotaCss = externalSource(QUOTA_CSS_PATH).replace(/\r\n/g, "\n");
+    for (const provider of [...providers, "claude"]) {
+      expect(quotaCss).toContain(`.quota-provider__mark--${provider} {\n  color: var(--provider-${provider});\n}`);
+    }
   });
 
   it("pins the AI Gateway provider-priority toggle grammar — ink rank only, no signal colour, no brass", () => {

--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -308,6 +308,10 @@
   color: var(--text-tertiary);
 }
 
+.quota-provider__mark--antigravity {
+  color: var(--provider-antigravity);
+}
+
 .quota-provider__mark--claude {
   color: var(--provider-claude);
 }
@@ -326,6 +330,10 @@
 
 .quota-provider__mark--opencode {
   color: var(--provider-opencode);
+}
+
+.quota-provider__mark--xai {
+  color: var(--provider-xai);
 }
 
 .quota-plan {

--- a/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
+++ b/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
@@ -188,9 +188,15 @@
   background: color-mix(in oklch, var(--ink-abyss) 35%, transparent);
 }
 
+/* 공급자 마크의 색 대조표는 --provider-* 하나뿐이다 — 여기 빠진 공급자는 톤이 미정의가 되어
+   color-mix()가 통째로 무효화되고, 칩 테두리·배경만 사라진 채 마크가 회색으로 남는다. Quota
+   레일의 대조표(.quota-provider__mark--*)와 같은 축을 써야 두 화면이 같은 공급자를 같은 색으로 부른다. */
+.ai-gateway-provider.is-antigravity { --ai-gateway-provider-tone: var(--provider-antigravity); }
 .ai-gateway-provider.is-codex { --ai-gateway-provider-tone: var(--provider-codex); }
 .ai-gateway-provider.is-cursor { --ai-gateway-provider-tone: var(--provider-cursor); }
-.ai-gateway-provider.is-kimi { --ai-gateway-provider-tone: var(--id-plum); }
+.ai-gateway-provider.is-kimi { --ai-gateway-provider-tone: var(--provider-kimi); }
+.ai-gateway-provider.is-opencode { --ai-gateway-provider-tone: var(--provider-opencode); }
+.ai-gateway-provider.is-xai { --ai-gateway-provider-tone: var(--provider-xai); }
 
 /* 헤드는 말풍선의 기준 상자이기도 하다 — 기준을 토글로 두면 말풍선 폭이 토글 폭에서
    자라 좁은 화면에서 카드 밖으로 넘는다. 좁아지면 부제부터 다음 줄로 접어 글리프·이름·


### PR DESCRIPTION
## Summary
- Settings의 AI Gateway 공급자 칩 중 xAI·OpenCode·Antigravity는 `--ai-gateway-provider-tone`이 정의되지 않아 `color-mix()`가 통째로 무효화됐습니다. 테두리와 배경이 사라지고 마크만 상속색으로 남아, 같은 마크가 Quota 레일과 다른 것처럼 읽혔습니다. 여섯 공급자 모두 `--provider-*`에서 색조를 받도록 대조표를 채웠습니다.
- Kimi 칩만 `--id-plum`을 빌려 쓰고 있어 Quota 레일(`--provider-kimi`)과 다른 색으로 불렸습니다. 같은 축으로 통일했습니다.
- `--provider-antigravity` 토큰을 기본·라이트 팔레트에 신설하고, Quota 레일 마크·Operation 공급자 마크·실행 밴드까지 같은 축에 연결했습니다. Quota 레일이 빠뜨렸던 xAI 마크 색도 채웠습니다.
- 디자인 계약 테스트에 공급자 색 대조표를 고정해, 이후 추가되는 공급자가 어느 화면에서든 조용히 회색으로 떨어지지 않게 했습니다.

마크(SVG) 자체는 이미 SDK `launchProviderGlyph` 한 곳이 소유하고 있어 변경하지 않았습니다 — 실제 불일치는 색 축이었습니다.

## Test Plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (fleet-console 2360 passed, terminal 970, quota 34, desktop 302 — Wiki 스토리지 테스트 1건이 전체 병렬 실행에서 한 번 흔들렸으나 단독·재실행 모두 통과)
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts` — 새 대조표 픽스가 규칙 1줄 제거 시 실패하는 것까지 확인
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 격리 Console 실측(console-e2e, headless): 다크·라이트 두 테마에서 AI Gateway 6개 칩과 Quota 7개 마크의 computed color가 동일한 `--provider-*` 값으로 일치함을 확인