### PR TITLE
refactor(console): rebuild the control grammar on form instead of one accent

### DIFF
--- a/.changelog.d/design-modern-sweep.md
+++ b/.changelog.d/design-modern-sweep.md
@@ -1,0 +1,14 @@
+---
+branch: design-modern-sweep
+---
+
+### fleet-console
+#### Changed
+- Selected segments, tabs and toggles now sit on a raised thumb that slides between choices instead of taking an accent wash, so the current choice reads the same in every theme; in the light theme the highlight used to fall darker than its surroundings.
+  ko: 세그먼트·탭·토글의 선택 상태가 강조색 채움 대신 트랙 위를 미끄러지는 썸으로 바뀌어, 어느 테마에서든 지금 고른 것이 같은 세기로 읽힙니다. 라이트 테마에서는 강조가 주변보다 어두워지던 문제가 함께 사라집니다.
+- Keyboard focus draws one ring everywhere. It used to borrow the state colours - the same tone that means waiting or failing - and varied in weight from surface to surface.
+  ko: 키보드 포커스가 제품 전체에서 같은 링 하나로 그려집니다. 예전에는 대기·실패를 뜻하는 상태색을 빌려 쓰거나 표면마다 굵기가 달랐습니다.
+- Hover, selection, current location and focus are now told apart by form rather than by one colour at four strengths, so a pointed row no longer looks like a chosen one.
+  ko: 가리킨 것·고른 것·지금 있는 곳·키보드 자리가 색 농도가 아니라 형태로 갈립니다. 마우스를 올린 줄이 선택된 줄처럼 보이지 않습니다.
+- Menus rise into place with a contact shadow, roomier corners and sentence-case labels, and control labels across the product read in the interface typeface instead of small monospaced capitals.
+  ko: 메뉴가 접지 그림자와 함께 떠오르고 모서리와 여백이 넉넉해졌으며, 항목과 컨트롤 라벨이 작은 모노 대문자 대신 인터페이스 서체로 읽힙니다.

--- a/runtime/fleet-console/CLAUDE.md
+++ b/runtime/fleet-console/CLAUDE.md
@@ -42,7 +42,8 @@
 
 ## Design invariants
 
-- Every color speaks on exactly one channel: signal tokens (`aurora`/`warn`/`coral`/`positive`) carry state only, `brass` carries location/focus/hover only, and user or agent identity uses the `--id-*` tones painted exclusively as marks (caption nameplate, rail-chip spine, minimap dot) — borders stay state-owned and identity never repaints signal surfaces or the unfocused caption fill.
+- Every color speaks on exactly one channel: signal tokens (`aurora`/`warn`/`coral`/`positive`) carry state only, `brass` carries location and focus only, and user or agent identity uses the `--id-*` tones painted exclusively as marks (caption nameplate, rail-chip spine, minimap dot) — borders stay state-owned and identity never repaints signal surfaces or the unfocused caption fill.
+- Interaction state is carried by form, not by one colour at four strengths: hover is a neutral surface (`--surface-hover`), selection is a raised surface (`--surface-select` + `--elev-select`), current location is a spine, and keyboard focus is the single ring (`--ring-shadow`). No surface reinvents a focus outline or paints selection as a brass fill; the segmented control has exactly one implementation, the SDK `Segmented`.
 - Core and built-in plugin CSS consume colors only as theme tokens via `var()`/`color-mix`; chromatic raw literals live solely in `theme.css` token definitions so all three themes retune together. Near-achromatic shadow, scrim, and sheen literals that carry depth rather than hue are the sanctioned exception.
 - `tests/instrument-design-contract.test.ts` pins the design grammar: a legitimate grammar change updates the contract together with the change, and intentional exceptions are recorded as doctrine comments beside the exempted CSS rule.
 

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -748,7 +748,7 @@ kbd {
 }
 
 .manifest-link:hover {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-hover);
   border-color: color-mix(in oklch, var(--brass) 50%, transparent);
   transform: translateY(-1px);
   color: var(--brass-bright);
@@ -829,8 +829,7 @@ kbd {
 }
 
 .command-card:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 70%, transparent);
-  outline-offset: 4px;
+  box-shadow: var(--ring-shadow);
 }
 
 .command-search {
@@ -865,6 +864,7 @@ kbd {
 
 #command-input:focus-visible {
   outline: 0;
+  box-shadow: none;
   text-shadow: 0 0 18px var(--brass-glow);
 }
 
@@ -896,9 +896,7 @@ kbd {
 }
 
 .command-result:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 68%, transparent);
-  outline-offset: -2px;
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass-bright) 30%, transparent);
+  box-shadow: var(--ring-shadow-inset);
 }
 
 .command-result-text {
@@ -1421,7 +1419,7 @@ kbd {
 }
 
 .queue-row:hover {
-  background: color-mix(in oklch, var(--brass) 6%, transparent);
+  background: var(--surface-hover);
   border-color: color-mix(in oklch, var(--brass) 22%, transparent);
 }
 
@@ -1756,7 +1754,7 @@ kbd {
 }
 
 .queue-raw-link:hover {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-hover);
   border-color: color-mix(in oklch, var(--brass) 50%, transparent);
   transform: translateY(-1px);
   color: var(--brass-bright);
@@ -1942,7 +1940,7 @@ kbd {
 .queue-reject-textarea:focus {
   outline: none;
   border-color: var(--brass);
-  box-shadow: 0 0 0 2px var(--brass-glow);
+  box-shadow: var(--ring-shadow);
 }
 
 .queue-action-error {
@@ -2150,8 +2148,23 @@ kbd {
 /* ─── Codex Navigator ─────────────────────────────────────────────────────── */
 
 .codex-nav-modes { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; padding: 8px 10px 0; }
-.codex-nav-modes button { border: 0; border-bottom: 2px solid transparent; padding: 8px; background: transparent; color: var(--text-tertiary); cursor: pointer; }
-.codex-nav-modes button[aria-selected="true"] { border-bottom-color: var(--brass); color: var(--text-primary); }
+/* ── 언더라인 탭 문법(C8) ── 인디케이터는 열이 아니라 라벨의 폭을 잰다. 열 전폭 바는 열이
+   넓어질수록 길어져서 탭이 아니라 구획선처럼 읽히고, 무엇이 선택됐는지를 폭으로 말하지 못한다. */
+.codex-nav-modes button { position: relative; border: 0; padding: 8px 8px 10px; background: transparent; color: var(--text-tertiary); cursor: pointer; }
+.codex-nav-modes button[aria-selected="true"] { color: var(--text-primary); }
+.codex-nav-modes button[aria-selected="true"]::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: max-content;
+  min-width: 24px;
+  max-width: calc(100% - 16px);
+  height: 2px;
+  transform: translateX(-50%);
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+}
 
 .codex-nav-search {
   display: flex;
@@ -2274,12 +2287,11 @@ kbd {
 .codex-nav-health-detail:hover,
 .codex-nav-health-detail:focus-visible,
 .codex-nav-health-detail[aria-expanded="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-hover);
 }
 
 .codex-nav-health-detail:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 68%, transparent);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .codex-nav-health-popover {
@@ -2386,7 +2398,7 @@ kbd {
 }
 
 .codex-nav-active-filter:hover {
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  background: var(--surface-hover);
 }
 
 .codex-nav-entry {
@@ -2405,7 +2417,7 @@ kbd {
 
 .codex-nav-entry:hover,
 .codex-nav-entry:focus-within {
-  background: color-mix(in oklch, var(--brass) 6%, transparent);
+  background: var(--surface-hover);
 }
 
 .codex-nav-entry.is-current {
@@ -2488,8 +2500,7 @@ kbd {
 .codex-nav-tag:focus-visible,
 .codex-nav-sort button:focus-visible,
 .codex-nav-active-filter:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 68%, transparent);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .codex-nav-loading,
@@ -2548,8 +2559,7 @@ kbd {
 .cowork-x:hover { color: var(--text-primary); }
 .cowork-pill:focus-visible, .cowork-ghost:focus-visible, .cowork-solid:focus-visible, .cowork-x:focus-visible, .cowork-chip:focus-visible, .cowork-send:focus-visible,
 .cowork-dock-input:focus-visible, .cowork-composer textarea:focus-visible, .cowork-card textarea:focus-visible {
-  outline: 2px solid var(--brass-bright);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 /* 선택 앵커 레이어 — 문서 스크롤을 따라가는 절대 배치 오버레이 */
@@ -2750,7 +2760,11 @@ kbd {
 }
 .cowork-chip span { color: var(--brass-bright); }
 .cowork-chip:hover { background: color-mix(in oklch, var(--ink-pearl) 8%, transparent); color: var(--text-primary); }
-.cowork-chip.is-active { background: color-mix(in oklch, var(--brass) 16%, transparent); color: var(--brass-bright); }
+.cowork-chip.is-active {
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
+  color: var(--brass-ink);
+}
 .cowork-chip--config { max-width: 16ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .cowork-dock-input {
@@ -2878,7 +2892,11 @@ kbd {
   transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
 .cowork-agent-row:hover { background: color-mix(in oklch, var(--ink-pearl) 8%, transparent); }
-.cowork-agent-row[aria-pressed="true"] { background: color-mix(in oklch, var(--brass) 16%, transparent); color: var(--brass-bright); }
+.cowork-agent-row[aria-pressed="true"] {
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
+  color: var(--brass-ink);
+}
 .cowork-agent-row-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cowork-agent-check { color: var(--brass-bright); font-size: var(--font-size-xs); inline-size: 12px; flex: none; }
 /* 손잡이는 실행 메뉴의 어휘 그대로다 — 행을 짚으면 윤곽이 먼저 서고, 짚거나 열면 brass 워시. */
@@ -2896,7 +2914,7 @@ kbd {
 .cowork-agent-row:hover .cowork-agent-effort-handle,
 .cowork-agent-row:focus-visible .cowork-agent-effort-handle { border-color: color-mix(in oklch, var(--surface-rim) 85%, transparent); }
 .cowork-agent-effort-handle:hover,
-.cowork-agent-effort-handle[data-open="true"] { border-color: color-mix(in oklch, var(--brass) 40%, transparent); background: color-mix(in oklch, var(--brass) 14%, transparent); }
+.cowork-agent-effort-handle[data-open="true"] { border-color: color-mix(in oklch, var(--brass) 40%, transparent); background: var(--surface-hover); }
 .cowork-effort-flyout {
   position: absolute;
   z-index: 9;

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -25,6 +25,7 @@ import { useInlineRename } from "../use-inline-rename.js";
 import { useT, type CoreMessageKey } from "../i18n/index.js";
 import { useViewMode } from "../view-mode-store.js";
 import { useFullscreenCommandBand } from "./use-fullscreen-command-band.js";
+import { Segmented } from "@fleet-console/sdk/components/segmented";
 
 interface NavigatorWithUserAgentData extends Navigator {
   readonly userAgentData?: {
@@ -549,24 +550,20 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       </div>
       {operationsViewVisible ? <div ref={mapControlsRef} className={`command-band-map-controls${sideBar.collapsed ? " is-docked" : ""}`}>
         <span className="command-band-dock-divider" aria-hidden="true" />
-        <div className="command-band-mode-switch" role="group" aria-label={t("chrome.commandBand.canvasMode")}>
-          {CANVAS_MODES.map((mode) => (
-            <button
-              key={mode.id}
-              type="button"
-              className="command-band-mode-seg"
-              data-canvas-mode={mode.id}
-              disabled={mode.id === "tactical" ? state.activeTheaterId === null : state.theaters.length === 0}
-              aria-pressed={canvasMode === mode.id}
-              aria-label={t(mode.titleKey)}
-              title={t(mode.titleKey)}
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() => selectCanvasMode(mode.id)}
-            >
-              {mode.label}
-            </button>
-          ))}
-        </div>
+        <Segmented
+          className="command-band-mode-switch"
+          ariaLabel={t("chrome.commandBand.canvasMode")}
+          value={canvasMode}
+          onChange={(next) => selectCanvasMode(next)}
+          options={CANVAS_MODES.map((mode) => ({
+            value: mode.id,
+            label: mode.label,
+            title: t(mode.titleKey),
+            ariaLabel: t(mode.titleKey),
+            disabled: mode.id === "tactical" ? state.activeTheaterId === null : state.theaters.length === 0,
+            data: { "data-canvas-mode": mode.id },
+          }))}
+        />
         {canvasMode === "cruise" ? <div className="command-band-mode-tray" role="group" aria-label={t("chrome.commandBand.cruiseTools")}>
           <span className="command-band-mode-tray-divider" aria-hidden="true" />
           <button type="button" className="command-band-mode-tool" onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })} disabled={state.activeTheaterId === null} aria-label={t("chrome.commandBand.resetCanvasView")} title={t("chrome.commandBand.resetCanvasView")}><ResetViewIcon /></button>

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -42,6 +42,7 @@ import {
   type SideBarStatus,
 } from "./operations-side-bar-store.js";
 import { SideBarResizeHandle, useSideBarResize } from "./side-bar-resize.js";
+import { Segmented } from "@fleet-console/sdk/components/segmented";
 
 interface OperationsSideBarProps {
   readonly theaters: readonly TheaterInfo[];
@@ -918,28 +919,17 @@ export function OperationsSideBar({
           한 번만 서고, 눌림이 아니라 낱말로 현재 축을 말한다. Theater가 없으면 정리할
           목록도 없으므로 스트립도 서지 않는다. */}
       {theaters.length > 0 ? (
-        <div className="operations-side-bar-axis" role="group" aria-label={t("sidebar.axis.aria")}>
-          <button
-            type="button"
-            className="operations-side-bar-axis-seg"
-            data-axis="group"
-            aria-pressed={!statusAxis}
-            title={t("sidebar.axis.groupTitle")}
-            onClick={() => setSideBarStatusAxis(false)}
-          >
-            {t("sidebar.axis.group")}
-          </button>
-          <button
-            type="button"
-            className="operations-side-bar-axis-seg"
-            data-axis="status"
-            aria-pressed={statusAxis}
-            title={t("sidebar.theater.sortByStatusTitle")}
-            onClick={() => setSideBarStatusAxis(true)}
-          >
-            {t("sidebar.axis.status")}
-          </button>
-        </div>
+        <Segmented
+          className="operations-side-bar-axis"
+          stretch
+          ariaLabel={t("sidebar.axis.aria")}
+          value={statusAxis ? "status" : "group"}
+          onChange={(next) => setSideBarStatusAxis(next === "status")}
+          options={[
+            { value: "group", label: t("sidebar.axis.group"), title: t("sidebar.axis.groupTitle"), data: { "data-axis": "group" } },
+            { value: "status", label: t("sidebar.axis.status"), title: t("sidebar.theater.sortByStatusTitle"), data: { "data-axis": "status" } },
+          ]}
+        />
       ) : null}
 
       <ol className="operations-side-bar-chips" ref={chipsRef} aria-label={t("sidebar.list.aria")}>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -108,11 +108,11 @@
 
 .fc-btn--secondary:hover:not(:disabled) {
   border-color: color-mix(in oklch, var(--brass) 45%, var(--hairline-strong));
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  background: var(--surface-hover);
 }
 
 .fc-btn--ghost:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  background: var(--surface-hover);
   color: var(--text-primary);
 }
 
@@ -122,8 +122,7 @@
 }
 
 .fc-btn:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 /* ===== Global Settings — 전역 옵션(시스템 프롬프트 주입 + 메타포) 표면 ===== */
 .global-settings-page {
@@ -455,7 +454,7 @@
 }
 
 .global-settings-toggle:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  background: var(--surface-hover);
   color: var(--text-primary);
 }
 
@@ -550,7 +549,7 @@
 .console-port-input:focus {
   outline: none;
   border-color: var(--brass);
-  box-shadow: 0 0 0 3px var(--brass-glow);
+  box-shadow: var(--ring-shadow);
 }
 
 .console-port-input.is-invalid {
@@ -764,7 +763,6 @@
   border-color: color-mix(in oklch, var(--ink-fog) 30%, transparent);
   background: color-mix(in oklch, var(--ink-spectral) 10%, transparent);
   color: var(--text-secondary);
-  outline: none;
 }
 
 .host-switcher-chip .host-switcher-name { color: inherit; }
@@ -956,8 +954,8 @@
 .add-host-close {
   display: grid;
   flex: none;
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   place-items: center;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
@@ -1078,8 +1076,8 @@
 .pair-close {
   display: grid;
   flex: none;
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   place-items: center;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
@@ -1496,7 +1494,7 @@
   font-size: var(--t-base);
 }
 
-.remote-host-name:focus { outline: 1px solid color-mix(in oklch, var(--brass) 55%, transparent); outline-offset: 3px; }
+.remote-host-name:focus { outline: none; box-shadow: var(--ring-shadow); }
 .remote-host-text small { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }
 
 .remote-host-open {
@@ -1602,10 +1600,11 @@
 .theme-mode-seg {
   display: inline-flex;
   flex: none;
-  overflow: hidden;
-  border: 1px solid var(--surface-rim);
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--surface-glass-strong) 55%, transparent);
+  background: var(--surface-track);
 }
 
 .theme-mode-seg button {
@@ -1643,9 +1642,9 @@
 }
 
 .theme-mode-seg button.is-active {
-  color: var(--text-primary);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent);
+  color: var(--brass-ink);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
 }
 
 .theme-dark-tray {
@@ -1783,7 +1782,7 @@
 
 .typography-reset:hover:not(:disabled) {
   border-color: color-mix(in oklch, var(--brass) 56%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  background: var(--surface-hover);
   color: var(--text-primary);
 }
 
@@ -1982,7 +1981,7 @@
 
 .font-field:focus-within {
   border-color: var(--brass);
-  box-shadow: 0 0 0 1px var(--brass-glow);
+  box-shadow: var(--ring-shadow);
 }
 
 .font-field input {
@@ -2085,9 +2084,9 @@
   border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-tertiary);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-size: var(--t-sm);
-  font-weight: var(--weight-bold);
+  font-weight: var(--weight-medium);
   white-space: nowrap;
   cursor: pointer;
   transition:
@@ -2100,7 +2099,8 @@
 }
 
 .segmented-option.is-active {
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
   color: var(--brass-ink);
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 38%, transparent);
 }
@@ -2225,7 +2225,7 @@
 }
 
 .model-auth-button:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  background: var(--surface-hover);
   color: var(--text-primary);
 }
 
@@ -2235,7 +2235,7 @@
 }
 
 .model-auth-button.is-primary:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  background: var(--surface-hover);
   color: var(--text-primary);
 }
 
@@ -2328,8 +2328,7 @@
 
 .backend-api-core-toggle:focus-visible,
 .backend-api-plugin-toggle:focus-visible {
-  outline: 1px solid var(--brass);
-  outline-offset: 5px;
+  box-shadow: var(--ring-shadow);
 }
 
 .backend-api-core-group {
@@ -2499,7 +2498,7 @@
 }
 
 .settings-disclosure-toggle:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  background: var(--surface-hover);
   color: var(--text-primary);
 }
 
@@ -3500,7 +3499,12 @@
 .canvas-triage-map-dot:focus-visible {
   border-color: var(--brass);
   box-shadow: 0 0 0 3px var(--brass-glow);
-  outline: none;
+}
+
+/* hover 글로우가 전역 포커스 링을 덮으므로 키보드 자리는 링으로 되돌린다 — 마우스 hover에는
+   글로우가, 키보드 포커스에는 링이 남는다. */
+.canvas-triage-map-dot:focus-visible {
+  box-shadow: var(--ring-shadow);
 }
 
 /* 무대 복귀 착지 확인 — 카드와 같은 positive 플래시 문법을 지도 점에도 준다(지도 모드에서는
@@ -3728,8 +3732,7 @@
 }
 
 .canvas-triage-deck-pick:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 65%, transparent);
-  outline-offset: -2px;
+  box-shadow: var(--ring-shadow-inset);
 }
 
 /* 검토 전 대기·도착·착지 신호는 칸이 받아 그 안의 패널 테두리로 말한다 — 신호가 칸이 아니라
@@ -3910,6 +3913,7 @@
      읽힌다. 절단 신호와 포인터 항해는 방향 스트립이, 위치 표시는 스크롤 게이지가 잇는다.
      휠·키보드 스크롤과 강도 플라이아웃의 scroll-follow는 스크롤 포트 그대로라 영향이 없다. */
   scrollbar-width: none;
+  animation: fleet-menu-in var(--duration-fast) var(--ease-spring);
 }
 
 .canvas-context-menu::-webkit-scrollbar {
@@ -4054,9 +4058,9 @@
 /* 항목은 tabIndex=-1이라 방향키로만 포커스가 옮겨온다. 프로그래매틱 포커스에서도 자리가
    보이도록 :focus-visible뿐 아니라 :focus에도 같은 brass 강조를 준다. */
 .canvas-context-menu-item:focus {
-  outline: none;
   color: var(--text-primary);
   background: color-mix(in oklch, var(--brass) 12%, transparent);
+  box-shadow: var(--ring-shadow);
 }
 
 .canvas-context-menu-help {
@@ -4734,6 +4738,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
 ═══════════════════════════════════════════════════════════════════════════════════ */
 
 .operations-side-bar {
+  --ring-backdrop: var(--surface-chrome);
+  --ring-shadow: 0 0 0 2px var(--ring-backdrop), 0 0 0 4px var(--ring);
   position: relative;
   display: flex;
   flex-direction: column;
@@ -4838,6 +4844,92 @@ body[data-side-bar-animating="true"] .canvas-operation {
 /* 축 스트립은 스크롤 목록 바깥에 고정된 하나짜리 뷰 스위치다 — 커맨드 밴드의
    .command-band-mode-switch와 같은 세그먼트 문법을 사이드바 폭에 맞춰 좁힌 것이고,
    새 어휘가 아니다. 눌림 채움은 brass(위치 채널)를 oklab에서 섞는다. */
+/* ══ 세그먼티드 컨트롤(SDK `Segmented`) ══════════════════════════════════════════
+   제품에 하나뿐인 세그먼티드 구현의 표면 규칙이다. 선택은 강조색 채움이 아니라 트랙 위에서
+   미끄러지는 썸이 말한다 — 실측에서 기존 brass 채움은 Whites에서 방향이 뒤집혀 있었고
+   (ΔL −4.8: 강조가 주변보다 어두웠다) 나머지 테마에서도 농도가 스물여덟 갈래로 갈려 있었다.
+   썸의 면·트랙의 면·고도는 전부 테마 토큰이 지므로 여기서는 형상과 운동만 적는다. */
+.fc-segmented {
+  position: relative;
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: var(--radius-md);
+  background: var(--surface-track);
+}
+
+.fc-segmented.is-stretch {
+  display: flex;
+  width: 100%;
+}
+
+.fc-segmented.is-stretch .fc-segmented__option {
+  flex: 1;
+  min-width: 0;
+}
+
+.fc-segmented__thumb {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  left: 0;
+  border-radius: var(--radius-xs);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
+  pointer-events: none;
+}
+
+/* 첫 배치는 정지 상태로 선다 — 열자마자 썸이 왼쪽에서 날아오면 이동이 뜻을 잃는다.
+   이후 전환만 스프링으로 움직인다. */
+.fc-segmented.is-armed .fc-segmented__thumb {
+  transition:
+    transform var(--duration-base) var(--ease-spring),
+    width var(--duration-base) var(--ease-spring);
+}
+
+.fc-segmented__option {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 0 10px;
+  border: none;
+  border-radius: var(--radius-xs);
+  background: none;
+  color: var(--text-tertiary);
+  /* 컨트롤 라벨은 사람이 누르는 낱말이지 수치가 아니다 — 텔레메트리 활자(모노)를 쓰지 않는다. */
+  font-family: var(--font-body);
+  font-size: var(--t-sm);
+  font-weight: var(--weight-medium);
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-glide);
+}
+
+.fc-segmented__option:hover:not(:disabled) {
+  color: var(--text-secondary);
+}
+
+.fc-segmented__option[aria-pressed="true"] {
+  color: var(--brass-ink);
+}
+
+.fc-segmented__option:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fc-segmented.is-armed .fc-segmented__thumb { transition: none; }
+}
+
+
 .operations-side-bar-axis {
   display: flex;
   flex: none;
@@ -4845,7 +4937,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: 2px;
   margin: var(--space-1) var(--space-1) 2px;
   padding: 2px;
-  border: 1px solid var(--surface-rim);
+  background: var(--surface-track);
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
 }
 
@@ -4865,9 +4958,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: transparent;
   color: var(--text-tertiary);
   cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: var(--t-xs);
-  font-weight: var(--weight-bold);
+  font-family: var(--font-body);
+  font-size: var(--t-sm);
+  font-weight: var(--weight-medium);
   white-space: nowrap;
   transition:
     background var(--duration-fast) var(--ease-spring),
@@ -4881,13 +4974,13 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .operations-side-bar-axis-seg[aria-pressed="true"] {
-  background: color-mix(in oklab, var(--brass) 12%, transparent);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
   color: var(--brass-ink);
 }
 
 .operations-side-bar-axis-seg:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .operations-side-bar-chips {
@@ -4944,8 +5037,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .side-bar-theater-activate:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .side-bar-theater-header {
@@ -4979,7 +5071,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: var(--ink-deep);
   border-color: var(--surface-rim);
   color: var(--text-secondary);
-  outline: none;
 }
 
 .side-bar-theater-header:focus-visible {
@@ -5053,13 +5144,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-ghost-theater-row:focus-visible .side-bar-ghost-theater-anchor {
   border-style: solid;
   border-color: var(--brass);
-  background: var(--brass-glow);
+  background: var(--surface-hover);
   color: var(--brass-ink);
 }
 
 .side-bar-ghost-theater-row:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: -2px;
+  box-shadow: var(--ring-shadow-inset);
 }
 
 .side-bar-ghost-theater-row:disabled {
@@ -5141,8 +5231,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .side-bar-theater-row-btn svg {
-  width: 13px;
-  height: 13px;
+  width: 14px;
+  height: 14px;
 }
 
 .side-bar-theater-row-btn:hover,
@@ -5152,8 +5242,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .side-bar-theater-row-btn:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: -2px;
+  box-shadow: var(--ring-shadow-inset);
 }
 
 .side-bar-theater-groups {
@@ -5194,7 +5283,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-chip:hover,
 .side-bar-chip:focus-visible {
   background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
-  outline: none;
 }
 
 .side-bar-chip:focus-visible {
@@ -5295,9 +5383,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .side-bar-chip-rename-input:focus {
   border-color: color-mix(in oklch, var(--brass) 68%, var(--surface-rim));
-  box-shadow:
-    inset 0 0 0 1px color-mix(in oklch, var(--brass) 20%, transparent),
-    0 0 0 2px color-mix(in oklch, var(--brass) 18%, transparent);
+  box-shadow: var(--ring-shadow);
 }
 
 /* 그룹 mark와 STATUS 축 pill은 identity 채널만 사용한다. 그룹의 resolveAccentColor(--id-*) 값은
@@ -5410,7 +5496,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: color-mix(in oklch, var(--ink-spectral) 10%, transparent);
   border-color: color-mix(in oklch, var(--ink-fog) 30%, transparent);
   color: var(--text-secondary);
-  outline: none;
 }
 
 .side-bar-chip-close svg {
@@ -5444,7 +5529,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-chip .side-bar-chip-close.is-armed:hover,
 .side-bar-chip .side-bar-chip-close.is-armed:focus-visible {
   background: color-mix(in oklch, var(--coral) 32%, transparent);
-  outline: none;
 }
 
 @keyframes chip-close-arm {
@@ -5513,8 +5597,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-status-header__toggle:hover,
 .side-bar-status-header__toggle:focus-visible {
   color: var(--text-secondary);
-  outline: 1px solid color-mix(in oklch, var(--brass) 55%, transparent);
-  outline-offset: -1px;
 }
 
 .side-bar-status-header__label {
@@ -5670,7 +5752,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-group-header__toggle:hover,
 .side-bar-group-header__toggle:focus-visible {
   color: var(--text-secondary);
-  outline: none;
 }
 
 .side-bar-group-header__arrow {
@@ -6037,8 +6118,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .canvas-operation-identity-name:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 65%, transparent);
-  outline-offset: -2px;
+  box-shadow: var(--ring-shadow-inset);
 }
 
 .canvas-operation-identity-input {
@@ -6054,7 +6134,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .canvas-operation-identity-input:focus {
   border-color: var(--brass);
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 32%, transparent);
+  box-shadow: var(--ring-shadow);
 }
 
 /* 캡션 More 버튼 — 사이드바 우클릭과 같은 Operation 메뉴를 여는 문.
@@ -6090,7 +6170,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-color: color-mix(in oklch, var(--ink-fog) 32%, transparent);
   background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
   color: var(--text-secondary);
-  outline: none;
 }
 
 /* accent 설정 팝업 — 패널/Dock 좌측 인디케이터 클릭으로 열린다. 트리거에 앵커되는 오버레이 팝업.
@@ -6113,7 +6192,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: 2px;
   padding: 6px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-raised);
   /* 팝업 판독성 계약: glass 믹스 아래 불투명 --ink-deep 언더레이 — maritime/carbon의 반투명
      glass 토큰에서도 뒤 콘텐츠가 비치지 않는다(whatsnew-card의 canonical 주석 참조). */
   background:
@@ -6123,6 +6202,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
     ),
     var(--ink-deep);
   box-shadow: var(--shadow-anchor);
+  animation: fleet-menu-in var(--duration-fast) var(--ease-spring);
 }
 
 .group-context-menu-section-label {
@@ -6158,7 +6238,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .group-context-menu-item:focus-visible {
   background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
   border-color: color-mix(in oklch, var(--ink-fog) 20%, transparent);
-  outline: none;
 }
 
 .group-context-menu-item:focus-visible {
@@ -6229,7 +6308,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .group-context-menu-new-input:focus {
   border-color: color-mix(in oklch, var(--brass) 60%, transparent);
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 30%, transparent);
+  box-shadow: var(--ring-shadow);
 }
 
 .group-context-menu-divider {
@@ -6256,7 +6335,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .accent-tone-row:focus-visible {
   border-color: color-mix(in oklch, var(--ink-fog) 20%, transparent);
   background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
-  outline: none;
 }
 
 .accent-tone-row:focus-visible {
@@ -6265,8 +6343,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .accent-tone-row[aria-pressed="true"] {
-  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
-  background: var(--brass-glow);
+  border-color: transparent;
+  box-shadow: var(--elev-select);
+  background: var(--surface-select);
 }
 
 .accent-tone-flag {
@@ -6361,8 +6440,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
   color: var(--brass-bright);
   border-color: color-mix(in oklab, var(--brass) 45%, var(--surface-rim));
   background: color-mix(in oklab, var(--brass) 12%, var(--surface-glass));
-  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
-  outline-offset: 2px;
 }
 
 .canvas-operation-icon-button.is-active,
@@ -6517,7 +6594,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .canvas-operation .canvas-operation-window-controls .canvas-operation-icon-button.is-armed-close:focus-visible {
   background: color-mix(in oklch, var(--coral) 32%, transparent);
   color: var(--coral-ink);
-  outline: none;
 }
 
 /* 캡션은 name → More → 상시 컨트롤 순서다. 창 컨트롤은 패널 속성이라 호버 전개하지 않는다. */
@@ -7056,8 +7132,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .operations-canvas-empty-standby-chip:focus-visible,
 .operations-canvas-empty-new:focus-visible,
 .operations-canvas-empty-open-all:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 58%, transparent);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .operations-canvas-empty-new:disabled {
@@ -7689,7 +7764,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   z-index: 40;
   padding: var(--space-2);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-raised);
   /* 팝업 판독성 계약: glass/pillar 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의
      canonical 주석 참조) — operation-launch·캔버스 컨텍스트 메뉴가 이 규칙을 상속한다. */
   background:
@@ -7699,6 +7774,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
     ),
     var(--ink-deep);
   box-shadow: var(--shadow-floating);
+  animation: fleet-menu-in var(--duration-fast) var(--ease-spring);
 }
 
 .theater-menu-list {
@@ -7729,7 +7805,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .theater-menu-item:hover:not(:disabled),
 .theater-menu-item:focus-visible {
   color: var(--text-primary);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-hover);
 }
 
 .theater-menu-item.is-active {
@@ -8005,9 +8081,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .operation-launch-variant-row:hover,
 .operation-launch-variant-row:focus-visible,
 .operation-launch-variant-row[aria-expanded="true"] {
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  background: var(--surface-hover);
   color: var(--text-primary);
-  outline: none;
 }
 
 /* 캔버스 메뉴는 실행 종류 행과 모델 밴드를 한 목록에 세운다. 그 목록의 왼쪽 홈통은 표식 자리다 —
@@ -8074,7 +8149,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .operation-launch-variant-effort-handle:hover,
 .operation-launch-variant-effort-handle[data-open="true"] {
   border-color: color-mix(in oklch, var(--brass) 40%, transparent);
-  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  background: var(--surface-hover);
 }
 
 .operation-launch-variant-effort-gauge {
@@ -8201,8 +8276,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .effort-track:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 /* 자동은 사다리 위의 한 단이 아니라 사다리를 쓰지 않는 상태다. 파선 테두리는 이 앱에서 "아직
@@ -8392,8 +8466,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .effort-track-apex-toggle:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .effort-track-apex-toggle[data-open="true"] {
@@ -8886,8 +8959,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .terminal-viewer-badge-action:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 /* 줌 보정 레이어: position:relative 기준 박스를 제공해 .terminal-canvas의 역스케일(%-기반)이
@@ -8943,7 +9015,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .terminal-job-line:hover {
-  background: color-mix(in oklch, var(--brass) 7%, transparent);
+  background: var(--surface-hover);
   transform: translateX(1px);
 }
 
@@ -9217,7 +9289,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .commissioning-secondary-link:hover,
 .commissioning-skip:hover {
   border-color: color-mix(in oklch, var(--brass) 52%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  background: var(--surface-hover);
 }
 
 .commissioning-error {
@@ -9388,7 +9460,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .app-toast-action:hover {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-hover);
 }
 
 .app-toast-close {
@@ -9440,8 +9512,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .operation-search-card:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 70%, transparent);
-  outline-offset: 4px;
+  box-shadow: var(--ring-shadow);
 }
 
 .operation-search-field {
@@ -9587,9 +9658,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .operation-search-result:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 68%, transparent);
-  outline-offset: -2px;
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass-bright) 30%, transparent);
+  box-shadow: var(--ring-shadow-inset);
 }
 
 .operation-search-result-text {
@@ -9892,9 +9961,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .directory-browser-root-chip.is-active {
-  border-color: color-mix(in oklch, var(--brass) 54%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
-  color: var(--brass-bright);
+  border-color: transparent;
+  box-shadow: var(--elev-select);
+  background: var(--surface-select);
+  color: var(--brass-ink);
 }
 
 .directory-browser-root-chip:disabled {
@@ -9943,7 +10013,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .directory-browser-crumb:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  background: var(--surface-hover);
   color: var(--brass-bright);
 }
 
@@ -9975,7 +10045,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .directory-browser-filter:focus-within {
   border-color: color-mix(in oklch, var(--brass) 50%, var(--surface-rim));
-  box-shadow: 0 0 0 3px var(--brass-glow);
+  box-shadow: var(--ring-shadow);
 }
 
 .directory-browser-filter-glyph {
@@ -10065,7 +10135,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .directory-browser-jump-input:focus {
   border-color: color-mix(in oklch, var(--brass) 50%, var(--surface-rim));
-  box-shadow: 0 0 0 3px var(--brass-glow);
+  box-shadow: var(--ring-shadow);
   outline: none;
 }
 
@@ -10554,7 +10624,6 @@ body:has([aria-modal="true"]:not([hidden])) .codex-edge-handle {
   transform: translateY(-50%) translateX(-3px);
   color: var(--brass-ink);
   background: color-mix(in oklch, var(--surface-glass) 94%, var(--ink-deep));
-  outline: none;
 }
 
 .codex-edge-handle-chevron {
@@ -10608,7 +10677,6 @@ body:has([aria-modal="true"]:not([hidden])) .codex-edge-handle {
   color: var(--text-primary);
   background: var(--surface-glass);
   border-color: var(--surface-rim);
-  outline: none;
 }
 
 /* 접힌 상태 = pane 숨김. brass로 '활성 토글'을 강조(focus-adjacent emphasis). */
@@ -10768,7 +10836,7 @@ body[data-codex-side="true"] .command-card {
 .whatsnew-close:hover,
 .whatsnew-close:focus-visible {
   border-color: color-mix(in oklch, var(--brass) 45%, transparent);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-hover);
   color: var(--brass-bright);
 }
 
@@ -10827,8 +10895,9 @@ body[data-codex-side="true"] .command-card {
 }
 
 .whatsnew-language-picker button.is-active {
-  background: color-mix(in oklch, var(--brass) 18%, transparent);
-  color: var(--brass-bright);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
+  color: var(--brass-ink);
 }
 
 .whatsnew-language-picker button:disabled {
@@ -10857,7 +10926,7 @@ body[data-codex-side="true"] .command-card {
 .whatsnew-refresh:hover,
 .whatsnew-refresh:focus-visible {
   border-color: color-mix(in oklch, var(--brass) 42%, transparent);
-  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  background: var(--surface-hover);
 }
 
 .whatsnew-refresh:disabled {
@@ -10965,7 +11034,7 @@ body[data-codex-side="true"] .command-card {
 .whatsnew-page-button:hover:not(:disabled),
 .whatsnew-page-button:focus-visible {
   border-color: color-mix(in oklch, var(--brass) 42%, transparent);
-  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  background: var(--surface-hover);
 }
 
 .whatsnew-page-button:disabled {
@@ -11231,8 +11300,8 @@ body[data-codex-side="true"] .command-card {
 
 .fc-settings-toggle:focus-within .fc-settings-toggle__control,
 .fc-settings-field__control:focus {
-  outline: 2px solid color-mix(in oklch, var(--brass) 70%, transparent);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--ring-shadow);
 }
 
 .fc-settings-select,
@@ -11434,7 +11503,7 @@ body[data-codex-side="true"] .command-card {
 .codex-reader-history-btn:focus-visible {
   color: var(--brass-bright);
   border-color: var(--brass-deep);
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  background: var(--surface-hover);
 }
 
 .codex-reader-history-btn:disabled {
@@ -11455,7 +11524,7 @@ body[data-codex-side="true"] .command-card {
   border: 1px solid var(--surface-rim);
   background: transparent;
   color: var(--text-tertiary);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xs);
   width: 24px;
   height: 24px;
   display: grid;
@@ -11682,7 +11751,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .codex-doc-outline-toggle:hover,
 .codex-doc-outline-toggle:focus-visible {
   color: var(--brass-bright);
-  background: color-mix(in oklch, var(--brass) 6%, transparent);
+  background: var(--surface-hover);
 }
 
 .codex-doc-outline-chevron {
@@ -11933,7 +12002,10 @@ body[data-codex-reading="true"] .operations-side-bar {
   transition: border-color var(--duration-fast) var(--ease-glide);
 }
 .fc-select__trigger:hover { border-color: var(--surface-rim-strong); }
-.fc-select__trigger:focus-visible { outline: none; border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); }
+.fc-select__trigger:focus-visible {
+ border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));
+ box-shadow: var(--ring-shadow);
+}
 .fc-select__trigger[aria-expanded="true"] { border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); }
 .fc-select__trigger:disabled { opacity: 0.45; cursor: default; }
 .fc-select__caret { color: var(--text-tertiary); font-size: var(--t-xs); transition: transform var(--duration-fast) var(--ease-glide); }
@@ -12340,9 +12412,8 @@ body[data-codex-reading="true"] .operations-side-bar {
 }
 
 .quick-launch-start-view-undo:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
   border-radius: var(--radius-xs);
+  box-shadow: var(--ring-shadow);
 }
 
 /* ── 고정(도킹) ────────────────────────────────────────────────────────
@@ -12631,9 +12702,8 @@ body[data-codex-reading="true"] .operations-side-bar {
 }
 
 .quick-launch-attachment-thumb-button:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
   border-radius: var(--radius-xs);
+  box-shadow: var(--ring-shadow);
 }
 
 .quick-launch-attachment-thumb {
@@ -12688,8 +12758,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 }
 
 .quick-launch-attachment-remove:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 /* 확대 보기 — 카드 위에 뜨는 단일 레이어. 클릭·Escape로 닫힌다(팝오버와 같은 소유). */
@@ -12739,8 +12808,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 }
 
 .quick-launch-attach:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .quick-launch-attach svg {
@@ -13658,8 +13726,6 @@ body[data-codex-reading="true"] .operations-side-bar {
 .control-bar button:hover:not(:disabled),
 .control-bar button:focus-visible {
   border-color: var(--brass-bright);
-  outline: 1px solid var(--brass);
-  outline-offset: 2px;
 }
 
 .control-curtain-actions button:disabled,
@@ -13822,7 +13888,9 @@ body[data-codex-reading="true"] .operations-side-bar {
   transition: border-color var(--duration-fast) var(--ease-glide);
 }
 .fc-failure__action:hover { border-color: var(--brass); }
-.fc-failure__action:focus-visible { outline: none; border-color: var(--brass); box-shadow: 0 0 0 2px var(--brass-glow); }
+.fc-failure__action:focus-visible {
+  box-shadow: var(--ring-shadow);
+}
 .fc-failure__action--primary {
   background: var(--brass);
   border-color: var(--brass);

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1984,6 +1984,14 @@
   box-shadow: var(--ring-shadow);
 }
 
+/* 프레임이 포커스를 대신 그리는 컨트롤 — 안쪽 입력에는 링을 그리지 않는다. 입력이 자기 outline만
+   끄면 전역 :focus-visible의 box-shadow는 그대로 남아 링이 두 겹으로 겹친다(실측: 사용자가
+   타이핑을 시작하는 순간 입력과 프레임에 같은 링이 동시에 그려졌다). 자손 선택자는 특이도
+   (0,2,0)이라 전역 규칙(0,1,0)을 이긴다. */
+.font-field:focus-within input:focus-visible {
+  box-shadow: none;
+}
+
 .font-field input {
   flex: 1;
   min-width: 0;
@@ -10046,6 +10054,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .directory-browser-filter:focus-within {
   border-color: color-mix(in oklch, var(--brass) 50%, var(--surface-rim));
   box-shadow: var(--ring-shadow);
+}
+
+.directory-browser-filter:focus-within .directory-browser-filter-input:focus-visible {
+  box-shadow: none;
 }
 
 .directory-browser-filter-glyph {

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -65,8 +65,6 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
 .right-rail-stale-veil button:hover,
 .right-rail-stale-veil button:focus-visible {
   border-color: var(--brass);
-  outline: 1px solid var(--brass);
-  outline-offset: 1px;
 }
 
 /* ---------------------------------------------------------------------------
@@ -191,8 +189,6 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
 .update-outcome-dismiss:hover,
 .update-outcome-dismiss:focus-visible {
   border-color: var(--brass);
-  outline: 1px solid var(--brass);
-  outline-offset: 1px;
 }
 
 .console-body,
@@ -207,6 +203,10 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
    좌우 여백 트랙은 동일 하한 + 동일 1fr이라 하한이 물려도 중심이 유지된다. 하한은 좌측 캡과
    맵 컨트롤 실측 폭에서 계산해 밴드에 주입한다(--command-band-center-gutter). */
 .command-band {
+  /* 포커스 링 안쪽 겹은 이 컨트롤들이 실제로 놓인 밴드 면이다(기본값은 패널 면).
+     --ring-shadow를 여기서 다시 조립하는 이유는 theme.css 주석 참조 — 치환은 선언 지점에서 일어난다. */
+  --ring-backdrop: var(--surface-band);
+  --ring-shadow: 0 0 0 2px var(--ring-backdrop), 0 0 0 4px var(--ring);
   --command-band-center-gutter: 44px;
   --command-band-stage-left: var(--command-band-left-width, 280px);
   --command-band-stage-right: 0px;
@@ -358,7 +358,6 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-local-chip:focus-visible {
   border-color: color-mix(in oklch, var(--ink-fog) 55%, var(--surface-rim));
   background: var(--surface-glass-strong);
-  outline: none;
 }
 
 .command-band-local-chip-label {
@@ -448,7 +447,9 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-environment-row code { color: var(--text-primary); font-family: var(--font-mono); overflow-wrap: anywhere; word-break: break-all; }
 .command-band-environment-row button { padding: 2px 5px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--surface-glass); color: var(--text-secondary); font-weight: var(--weight-regular); font-size: inherit; line-height: inherit; font-family: inherit; cursor: pointer; }
 .command-band-environment-row button:hover,
-.command-band-environment-row button:focus-visible { border-color: color-mix(in oklch, var(--ink-fog) 55%, var(--surface-rim)); outline: none; }
+.command-band-environment-row button:focus-visible {
+ border-color: color-mix(in oklch, var(--ink-fog) 55%, var(--surface-rim));
+}
 .command-band-environment-footer { margin-top: var(--space-2); color: var(--text-tertiary); font-size: var(--t-2xs); }
 
 /* 좁은 뷰에서는 칩 앵커(x≈80~160) + 520px 폭이 우측을 벗어나 Copy 버튼이 잘린다 —
@@ -504,7 +505,6 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   border-color: color-mix(in oklch, var(--ink-fog) 30%, transparent);
   background: color-mix(in oklch, var(--ink-spectral) 10%, transparent);
   color: var(--text-secondary);
-  outline: none;
 }
 
 /* 눌린 아이콘 버튼은 밴드의 다른 토글과 같은 문법으로 말한다 — .command-band-mode-seg·
@@ -512,7 +512,8 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
    이미 이 문법을 입고 있다. 이 규칙이 없던 동안 aria-pressed는 접근성 트리에만 존재하고
    화면에는 아무 흔적도 남기지 않았다. */
 .command-band-button[aria-pressed="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
   color: var(--brass-ink);
 }
 
@@ -561,8 +562,10 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   align-items: center;
   gap: 2px;
   padding: 2px;
-  border: 1px solid var(--surface-rim);
+  /* 테두리 대신 움푹한 트랙 — 선 하나로 묶는 대신 면을 내려 썸이 올라설 자리를 만든다. */
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
+  background: var(--surface-track);
 }
 
 .command-band-mode-seg {
@@ -575,9 +578,9 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   border-radius: 6px;
   color: var(--text-tertiary);
   white-space: nowrap;
-  font-family: var(--font-mono);
-  font-size: var(--t-xs);
-  font-weight: var(--weight-bold);
+  font-family: var(--font-body);
+  font-size: var(--t-sm);
+  font-weight: var(--weight-medium);
 }
 
 /* hover는 이웃 command-band-button과 동일한 링 문법 — brass 채움은 활성(pressed) 상태 전용. */
@@ -587,8 +590,16 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   color: var(--text-primary);
 }
 
+/* ── 선택 문법(C2) ── 제품의 모든 세그먼티드·토글이 공유하는 정본이다.
+   선택된 컨트롤은 강조색으로 칠하지 않고 면을 들어 올린다. 기존 레시피
+   color-mix(brass 12%)는 실측에서 뒤 면 대비 1.16~1.22:1로 사실상 보이지 않았고, 농도를 22%로
+   올려도 Whites는 1.30에 머물렀다 — brass가 L 56%라 L 95.5% 종이에 섞이면 거의 움직이지 않는다.
+   그래서 면은 --surface-select(다크는 한 단 밝은 잉크, 라이트는 순백 카드)와 --elev-select가
+   지고, brass는 라벨(--brass-ink)에만 남는다. 새 토글은 이 세 줄을 그대로 쓰고 자기 농도를
+   발명하지 않는다 — 계약 테스트가 정본 소비처 목록을 함께 고정한다. */
 .command-band-mode-seg[aria-pressed="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
   color: var(--brass-ink);
 }
 
@@ -646,7 +657,8 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 }
 
 .command-band-mode-tool[aria-pressed="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
   color: var(--brass-ink);
 }
 
@@ -732,8 +744,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 .command-band-segment-trigger:hover,
 .command-band-segment-trigger:focus-visible,
 .command-band-segment-trigger.is-open {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  outline: none;
+  background: var(--surface-hover);
 }
 
 .command-band-segment-label {
@@ -771,9 +782,13 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   max-width: min(340px, calc(100vw - 24px));
   max-height: min(60vh, 420px);
   overflow-y: auto;
-  padding: var(--space-2);
-  border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-md);
+  /* ── 드롭다운 문법(C4) ── 떠 있는 면은 라운드 한 단 위(md+4)와 안쪽 여백을 쓴다. 여백이 있어야
+     항목 호버가 면 가장자리에 닿지 않고 캡슐로 떠서, 목록이 아니라 고를 수 있는 것들로 읽힌다.
+     구분선도 그 여백 안으로 들여쓴다 — 전폭 선은 메뉴를 두 개의 상자로 갈라 놓는다. */
+  padding: 6px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-raised);
+  animation: fleet-menu-in var(--duration-fast) var(--ease-spring);
   /* 팝업 판독성 계약: pillar 믹스 아래 불투명 --ink-deep 언더레이(components.css whatsnew-card의 canonical 주석 참조). */
   background:
     linear-gradient(
@@ -789,12 +804,17 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   align-items: center;
   gap: var(--space-2);
   width: 100%;
-  padding: var(--space-2);
+  min-height: 32px;
+  padding: 0 var(--space-2);
   border-radius: var(--radius-xs);
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--t-xs);
-  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  /* 메뉴 항목은 수치가 아니라 문장이다 — 텔레메트리 활자(모노 11px)에서 본문 티어로 내려온다.
+     한국어에는 대문자가 없어 uppercase가 라틴 라벨만 대문자로 세우고 있었고, 그 결과 같은 줄에
+     두 개의 활자 체계가 섞여 있었다. */
+  font-family: var(--font-body);
+  font-size: var(--t-md);
+  font-weight: var(--weight-medium);
+  letter-spacing: -0.005em;
   text-align: left;
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -804,8 +824,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 .command-band-menu-item:hover:not(:disabled),
 .command-band-menu-item:focus-visible {
   color: var(--text-primary);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  outline: none;
+  background: var(--surface-hover);
 }
 
 .command-band-menu-item.is-active {
@@ -858,7 +877,8 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 
 .command-band-menu-divider {
   height: 1px;
-  margin: var(--space-2) var(--space-1);
+  /* 안쪽 여백보다 더 들여쓴다 — 전폭 선은 한 메뉴를 두 개의 상자로 갈라 놓는다. */
+  margin: var(--space-1) var(--space-3);
   background: var(--surface-rim);
 }
 

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -124,8 +124,7 @@
 
 .mobile-session-close:focus-visible {
   color: var(--text-primary);
-  outline: 2px solid color-mix(in srgb, var(--brass) 55%, transparent);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 /* chip-close-arm lives in components.css — same 1.5s coral arm as the desktop frame. */
@@ -142,7 +141,6 @@
 .mobile-session-close.is-armed:focus-visible {
   background: color-mix(in oklch, var(--coral) 32%, transparent);
   color: var(--coral-ink);
-  outline: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -219,7 +217,6 @@
 .mobile-header-icon-button[aria-pressed="true"] {
   color: var(--text-primary);
   border-color: color-mix(in srgb, var(--brass) 55%, var(--hairline));
-  outline: none;
 }
 
 .mobile-total-count {
@@ -249,7 +246,6 @@
 .mobile-new-operation:focus-visible,
 .mobile-new-operation:active {
   border-color: var(--brass);
-  outline: none;
 }
 
 .mobile-status-sections {
@@ -306,7 +302,6 @@
 .mobile-operation-card:focus-visible,
 .mobile-operation-card:active {
   border-color: color-mix(in srgb, var(--brass) 65%, var(--hairline));
-  outline: none;
 }
 
 .mobile-operation-card-copy {
@@ -384,7 +379,7 @@
 
 .mobile-theater-row:focus-visible {
   border-color: color-mix(in srgb, var(--brass) 55%, var(--hairline));
-  outline: none;
+  box-shadow: var(--ring-shadow);
 }
 
 .mobile-theater-copy {
@@ -471,8 +466,9 @@
 }
 
 .mobile-tab.is-active {
-  color: var(--text-primary);
-  background: color-mix(in srgb, var(--brass) 12%, transparent);
+  color: var(--brass-ink);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
 }
 
 .mobile-tab-icon {
@@ -566,8 +562,7 @@
 
 .mobile-settings-back:focus-visible {
   color: var(--text-primary);
-  outline: 2px solid color-mix(in srgb, var(--brass) 55%, transparent);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 /* 헤더는 뒤로가기·제목·저장 표시 세 자리다. 제목이 가운데 자리를 다 쓰도록 남은 둘은 늘어나지 않는다. */
@@ -648,7 +643,6 @@
 .mobile-settings-row:focus-visible,
 .mobile-settings-row:active {
   background: var(--ink-mid);
-  outline: none;
 }
 
 .mobile-settings-row-icon {

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -7,6 +7,8 @@
 }
 
 .right-rail {
+  --ring-backdrop: var(--surface-chrome);
+  --ring-shadow: 0 0 0 2px var(--ring-backdrop), 0 0 0 4px var(--ring);
   display: flex;
   flex-direction: row;
   width: calc(44px + var(--right-rail-panel-width, 0px));
@@ -197,15 +199,18 @@
 
 .right-rail-float-toggle.is-active {
   color: var(--brass-ink);
-  background: var(--brass-glow);
-  border-color: color-mix(in oklch, var(--brass) 45%, transparent);
+  box-shadow: var(--elev-select);
+  background: var(--surface-select);
+  border-color: transparent;
 }
 
-/* 활성 hover는 brass 채널을 유지한 채 테두리만 강화한다(비활성 hover의 veil 덮기 방지). */
+/* 활성 항목의 hover는 선택 면을 덮지 않는다 — 썸은 그대로 두고 라벨만 한 단 올린다.
+   여기서 배경을 다시 칠하면 마우스를 올린 순간 선택 상태가 사라진 것처럼 읽힌다. */
 .right-rail-float-toggle.is-active:hover {
-  color: var(--brass-ink);
-  background: var(--brass-glow);
-  border-color: color-mix(in oklch, var(--brass) 70%, transparent);
+  color: var(--brass-bright);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
+  border-color: transparent;
 }
 
 .right-rail-alpha {
@@ -274,11 +279,11 @@
 }
 
 .right-rail-alpha-slider:focus-visible::-webkit-slider-thumb {
-  box-shadow: 0 0 0 2px var(--brass);
+  box-shadow: 0 0 0 2px var(--ring);
 }
 
 .right-rail-alpha-slider:focus-visible::-moz-range-thumb {
-  box-shadow: 0 0 0 2px var(--brass);
+  box-shadow: 0 0 0 2px var(--ring);
 }
 
 /* forced-colors 모드는 box-shadow 포커스 링을 제거하므로 outline으로 병기한다. */
@@ -300,8 +305,8 @@
 
 .right-rail-close-btn {
   margin-left: auto;
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   flex: none;
   display: inline-grid;
   place-items: center;
@@ -314,8 +319,8 @@
 }
 
 .right-rail-close-btn svg {
-  width: 12px;
-  height: 12px;
+  width: 14px;
+  height: 14px;
   display: block;
 }
 
@@ -324,8 +329,6 @@
   color: var(--brass-bright);
   border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
   background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
-  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
-  outline-offset: 2px;
 }
 
 .right-rail-panel-body {
@@ -415,7 +418,6 @@
 .right-rail-ico:focus-visible {
   color: var(--text-secondary);
   background: var(--surface-glass);
-  outline: none;
 }
 
 .right-rail-ico.is-active {
@@ -454,9 +456,8 @@
 }
 
 .right-rail-resize-handle:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: -2px;
   background: color-mix(in oklch, var(--brass) 50%, transparent);
+  box-shadow: var(--ring-shadow-inset);
 }
 
 .right-rail.is-dragging .right-rail-resize-handle {

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -635,11 +635,16 @@ html:focus-visible {
 }
 
 /* forced-colors 모드는 box-shadow를 지운다 — 포커스 표시가 통째로 사라지지 않도록 outline으로 병기한다.
-   시스템 색(Highlight)을 쓰는 것이 이 모드의 계약이므로 여기서만 brass를 떠난다. */
+   시스템 색(Highlight)을 쓰는 것이 이 모드의 계약이므로 여기서만 brass를 떠난다.
+   !important인 이유는 특이도다: 미디어 쿼리는 특이도를 더하지 않으므로 이 규칙은 (0,1,0)이고,
+   자기 outline을 끈 컴포넌트 규칙(예: .directory-browser-filter-input:focus, (0,2,0))에 진다.
+   그 자리에서는 box-shadow도 이 모드에서 함께 지워지므로 포커스가 통째로 보이지 않는다
+   (실측: 같은 선택자를 문서 끝에 주입해도 outline-style이 none으로 계산됐다).
+   접근성 오버라이드 모드에서 !important는 이 상황의 관용구이며, 여기 말고는 쓰지 않는다. */
 @media (forced-colors: active) {
   :focus-visible {
-    outline: 2px solid Highlight;
-    outline-offset: 2px;
+    outline: 2px solid Highlight !important;
+    outline-offset: 2px !important;
   }
 }
 

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -148,8 +148,53 @@
   --identity-small-tag: var(--aurora);
 
   --shadow-soft: 0 1px 0 0 oklch(96% 0.01 90 / 6%) inset, 0 18px 38px -22px oklch(0% 0 0 / 70%);
-  --shadow-floating: 0 1px 0 0 oklch(96% 0.01 90 / 8%) inset, 0 32px 60px -28px oklch(0% 0 0 / 80%);
+  /* 떠 있는 면의 고도는 두 겹이다 — 면이 어디에 닿아 있는지 말하는 접지 그림자와, 얼마나 떠
+     있는지 말하는 확산 그림자. 한 겹 확산만으로는 메뉴가 배경 위에 인쇄된 것처럼 읽힌다. */
+  --shadow-floating: 0 1px 0 0 oklch(96% 0.01 90 / 8%) inset, 0 1px 2px oklch(0% 0 0 / 44%), 0 24px 52px -20px oklch(0% 0 0 / 78%);
   --shadow-anchor: 0 0 0 1px color-mix(in oklch, var(--brass) 16%, transparent), 0 12px 32px -16px color-mix(in oklch, var(--brass) 30%, transparent);
+
+  /* 포커스 링은 제품 전체에서 하나다. 색은 brass(위치·포커스 채널)만 쓴다 — 신호색
+     (aurora/warn/coral/positive)을 링으로 빌리면 "이 항목이 대기 중"과 "여기에 키보드가 있다"가
+     같은 색으로 말해져 구분이 사라진다(실측: 링이 다섯 채널로 흩어져 있었다).
+     outline이 아니라 2겹 box-shadow인 이유는 두 가지다 — outline은 일부 렌더 경로에서
+     border-radius를 따라가지 않고, overflow:hidden 조상 안에서 잘린다. 안쪽 겹은 컨트롤이
+     실제로 놓인 면색이라 링이 배경에서 떠 보인다. 그 면은 표면마다 다르므로 소비처 컨테이너가
+     --ring-backdrop을 자기 면으로 좁힌다(기본은 패널 면).
+     주의 — 사용자 정의 속성은 "선언된 요소"에서 치환된다. --ring-shadow를 :root에서만 조립하면
+     그 안의 var(--ring-backdrop)은 :root 값으로 굳어 내려오고, 자손이 --ring-backdrop을 아무리
+     좁혀도 반영되지 않는다(실측: Whites 크롬 열에서 96%를 좁혔는데 링 간격은 98.2%로 나왔다).
+     그래서 면을 좁히는 컨테이너는 --ring-shadow도 같은 자리에서 다시 조립한다. */
+  --ring: var(--brass);
+  --ring-backdrop: var(--surface-panel);
+  --ring-shadow: 0 0 0 2px var(--ring-backdrop), 0 0 0 4px var(--ring);
+  /* 바깥 링이 잘리거나 이웃과 부딪히는 자리(스크롤 목록의 전폭 행, 분할선, 덱 칸 안쪽)를 위한
+     안쪽 변종. 예전에 outline-offset을 음수로 주던 13곳이 이 토큰으로 모인다 — 색과 굵기는
+     바깥 링과 같고 그리는 위치만 다르다. */
+  --ring-shadow-inset: inset 0 0 0 2px var(--ring);
+
+  /* 선택된 상태의 면 — 강조색 채움이 아니라 "들어 올린 표면"이다. 실측에서 기존 레시피
+     color-mix(brass 12%)는 뒤 면 대비 1.16~1.22:1로 사실상 보이지 않았고, 농도를 22%로 올려도
+     Whites는 1.30에 머물렀다(brass가 L 56%라 L 95.5% 종이에 섞이면 거의 움직이지 않는다).
+     그래서 선택은 색이 아니라 고도로 말한다. --surface-panel-raised와 이름이 비슷하지만 방향이
+     반대다 — 얹히는 면은 라이트에서 뒤로 물러나고(ink-deep), 선택 썸은 라이트에서도 앞으로
+     나와야 한다(순백 카드). 값은 밴드 면 기준 OKLab ΔL ≈ +11을 목표로 테마마다 실측해 잡았다.
+     면 분리를 WCAG 대비비로 재면 안 된다 — 그 지표는 텍스트 판독용이라 어두운 두 면 사이에서
+     +0.05 오프셋에 눌려 1.1~1.2로 붙어 버린다(같은 두 면의 ΔL은 7~10인데도). 실측은 ΔL로 한다. */
+  /* 세그먼티드 그룹이 앉는 움푹한 트랙 — 썸을 들어 올리려면 그 아래가 한 단 내려가 있어야 한다.
+     라이트에서 특히 중요하다: 썸이 순백(L 100%)에서 천장을 치므로 분리를 벌리는 유일한 방향이
+     트랙을 낮추는 쪽이다(종이 95.5% → 트랙 91% → 썸 100%). 값은 밴드·패널·크롬 어느 면 위에
+     놓여도 그보다 어둡도록 잡았다. */
+  /* 포인터가 겨눈 자리 — 색이 아니라 면으로 말한다. C3 이전에는 hover·선택·현재 위치·포커스가
+     전부 brass 채움이고 농도만 8/12/12/12%로 갈려 있어, 사람 눈이 구별할 수 없는 차이로 서로
+     다른 네 가지 뜻을 나르고 있었다. 이제 각 단은 다른 물리를 쓴다 — hover는 중성 표면,
+     선택은 들어 올린 썸, 현재 위치는 스파인, 포커스는 링. brass는 hover 채널에서 물러난다.
+     값이 --text-primary 믹스인 이유는 테마를 따라 방향이 뒤집혀야 하기 때문이다(다크는 밝게,
+     라이트는 어둡게). 고정 리터럴로는 네 테마 중 둘에서 반대로 움직인다. */
+  --surface-hover: color-mix(in oklab, var(--text-primary) 7%, transparent);
+  --surface-track: oklch(10% 0.016 245);
+  --surface-select: oklch(24% 0.018 245);
+  --surface-select-edge: oklch(100% 0 0 / 8%);
+  --elev-select: inset 0 1px 0 var(--surface-select-edge), 0 1px 2px oklch(0% 0 0 / 40%);
 
   --scrollbar-thumb: oklch(50% 0.04 248 / 30%);
   --scrollbar-thumb-hover: oklch(70% 0.05 248 / 50%);
@@ -160,6 +205,10 @@
      할 때 어느 이름을 움직여야 하는지도 알 수 없다(구 sm=xs, lg=xl=md 중복은 그렇게 생겼다). */
   --radius-xs: 6px;
   --radius-md: 10px;
+  /* 떠 있는 면(메뉴·팝오버·컨텍스트 메뉴)은 붙어 있는 면보다 한 단 둥글다 — 라운드가 고도를
+     함께 말한다. 어휘를 넷으로 늘린 이유는 md 하나로는 "판에 붙은 카드"와 "판 위에 뜬 메뉴"가
+     같은 모서리를 갖게 되어 둘의 층위가 형상에서 지워지기 때문이다. 여기서 더 늘리지 말 것. */
+  --radius-raised: 14px;
   /* 999px는 도트·비콘·상태 캡슐 전용 — 컨트롤(버튼/칩)에는 쓰지 않는다. */
   --radius-pill: 999px;
 
@@ -301,6 +350,11 @@
   --id-indigo: oklch(73% 0.09 278);
   --id-plum: oklch(74% 0.09 318);
   --id-rose: oklch(75% 0.085 350);
+
+  --surface-track: oklch(16% 0.04 248);
+  --surface-select: oklch(32% 0.045 248);
+  --surface-select-edge: oklch(100% 0 0 / 11%);
+  --elev-select: inset 0 1px 0 var(--surface-select-edge), 0 1px 2px oklch(0% 0 0 / 42%);
 }
 
 :root[data-theme="carbon"] {
@@ -361,6 +415,11 @@
   --id-indigo: oklch(71% 0.052 278);
   --id-plum: oklch(72% 0.052 318);
   --id-rose: oklch(73% 0.05 350);
+
+  --surface-track: oklch(14% 0.006 255);
+  --surface-select: oklch(29% 0.007 252);
+  --surface-select-edge: oklch(100% 0 0 / 9%);
+  --elev-select: inset 0 1px 0 var(--surface-select-edge), 0 1px 2px oklch(0% 0 0 / 44%);
 }
 
 /* Light 테마 단일종(Whites) — 잉크 스케일을 역할째 반전한 오트밀(warm-neutral) 주간 변주.
@@ -470,8 +529,13 @@
   --hairline-strong: oklch(76% 0.014 100);
 
   --shadow-soft: 0 1px 0 0 oklch(99.5% 0.004 100 / 70%) inset, 0 18px 38px -22px oklch(30% 0.015 95 / 26%);
-  --shadow-floating: 0 1px 0 0 oklch(99.5% 0.004 100 / 80%) inset, 0 32px 60px -28px oklch(28% 0.015 95 / 30%);
+  --shadow-floating: 0 1px 0 0 oklch(99.5% 0.004 100 / 80%) inset, 0 1px 2px oklch(28% 0.015 95 / 16%), 0 24px 48px -20px oklch(28% 0.015 95 / 28%);
   --shadow-anchor: 0 0 0 1px color-mix(in oklch, var(--brass) 22%, transparent), 0 12px 32px -16px color-mix(in oklch, var(--brass) 26%, transparent);
+
+  --surface-track: oklch(91% 0.008 100);
+  --surface-select: oklch(100% 0 0);
+  --surface-select-edge: oklch(20% 0.012 95 / 10%);
+  --elev-select: inset 0 0 0 1px var(--surface-select-edge), 0 1px 2px oklch(30% 0.015 95 / 22%), 0 2px 6px -2px oklch(30% 0.015 95 / 16%);
 
   --scrollbar-thumb: oklch(44% 0.015 95 / 35%);
   --scrollbar-thumb-hover: oklch(37% 0.018 95 / 55%);
@@ -550,10 +614,15 @@ a {
   text-decoration: none;
 }
 
+/* 제품 전체의 포커스 표시는 이 규칙 하나가 전담한다. 컴포넌트는 자기 hover·선택 페인트만 지고
+   키보드 위치는 여기서 그린다. 예전처럼 컴포넌트마다 outline을 다시 적으면 색·굵기·offset이
+   다시 흩어지므로, 링을 따로 적어야 하는 경우는 자기 box-shadow가 있어 이 규칙이 덮이는
+   표면뿐이고 그때도 값은 var(--ring-shadow) 하나다.
+   border-radius를 여기서 지정하지 않는 이유는 box-shadow가 요소 자신의 라운드를 그대로 따라가기
+   때문이다 — 예전 규칙은 포커스 순간에만 캡슐 컨트롤을 6px로 깎고 있었다. */
 :focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
-  border-radius: var(--radius-xs);
+  outline: none;
+  box-shadow: var(--ring-shadow);
 }
 
 /* Map <main>은 키보드 정거장이 아니다. 채팅 로그처럼 포커스 불가한 본문을 누르면
@@ -562,6 +631,16 @@ a {
 body:focus-visible,
 html:focus-visible {
   outline: none;
+  box-shadow: none;
+}
+
+/* forced-colors 모드는 box-shadow를 지운다 — 포커스 표시가 통째로 사라지지 않도록 outline으로 병기한다.
+   시스템 색(Highlight)을 쓰는 것이 이 모드의 계약이므로 여기서만 brass를 떠난다. */
+@media (forced-colors: active) {
+  :focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
 }
 
 ::-webkit-scrollbar {
@@ -604,6 +683,19 @@ html:focus-visible {
     opacity: 1;
     transform: translateY(0) scale(1);
     filter: blur(0);
+  }
+}
+
+/* 떠 있는 면의 진입 — 4px 올라오며 페이드. 메뉴가 아무 예고 없이 나타나면 그 자리에 원래
+   있었는지 방금 열렸는지 구분이 안 된다. reduced-motion에서는 전역 규칙이 0.01ms로 축약한다. */
+@keyframes fleet-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/runtime/fleet-console/font-picker/styles.css
+++ b/runtime/fleet-console/font-picker/styles.css
@@ -56,8 +56,7 @@
 .fc-font-browser__row:focus-visible,
 .fc-font-browser__stepper:focus-visible,
 .fc-font-browser__range:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .fc-font-browser__listbox { max-height: 18rem; overflow: auto; }

--- a/runtime/fleet-console/markdown/styles.css
+++ b/runtime/fleet-console/markdown/styles.css
@@ -541,9 +541,7 @@ code.hljs {
 }
 
 .diagram-block:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 4px;
-  box-shadow: var(--shadow-soft), 0 0 0 4px var(--brass-glow);
+  box-shadow: var(--ring-shadow), var(--shadow-soft);
 }
 
 .diagram-block svg {

--- a/runtime/fleet-console/sdk/components/segmented.tsx
+++ b/runtime/fleet-console/sdk/components/segmented.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+/**
+ * 세그먼티드 컨트롤 — 제품에 하나뿐인 구현.
+ *
+ * 이 모듈이 존재하는 이유는 실측이다: 활성 상태를 그리는 레시피가 스물여덟 갈래로 갈려 있었고
+ * (채움 4종·테두리 6농도·글자색 4종), 같은 컨트롤이 표면마다 조금씩 다르게 생겨 있었다.
+ * CSS 문법만 통일하면 다음 표면이 또 자기 버전을 발명하므로, 선택을 그리는 일 자체를 여기로 옮긴다.
+ *
+ * 선택은 **색이 아니라 고도**로 말한다. 강조색으로 칠하는 대신 트랙 위에서 썸이 미끄러진다 —
+ * 그 방향이 아니면 라이트 테마가 구조적으로 무너진다(brass가 L 56%라 L 95.5% 종이에 섞으면
+ * 강조가 주변보다 *어두워진다*: 실측 ΔL −4.8). 썸 면·트랙 면·고도는 전부 테마 토큰이 진다.
+ *
+ * 썸은 절대 위치 엘리먼트 하나이고, 라벨은 그 위에 색만 바꿔 얹힌다. 폭·위치는 레이아웃에서
+ * 읽어 transform으로 옮기므로, 라벨 길이가 언어마다 달라져도 계산이 따로 필요 없다.
+ */
+
+export type SegmentedOption<T extends string> = {
+  readonly value: T;
+  readonly label: ReactNode;
+  readonly title?: string;
+  readonly ariaLabel?: string;
+  readonly disabled?: boolean;
+  /** 호출부가 세그먼트를 지목할 수 있게 하는 data-* 한 벌(동작 테스트·자동화가 쓴다). */
+  readonly data?: Readonly<Record<string, string>>;
+};
+
+export type SegmentedProps<T extends string> = {
+  readonly options: readonly SegmentedOption<T>[];
+  readonly value: T;
+  readonly onChange: (value: T) => void;
+  /** 그룹 자체의 접근성 이름. role="group"에 붙는다. */
+  readonly ariaLabel: string;
+  /** 호출부가 배치를 위해 얹는 클래스. 컨트롤 문법은 이 모듈과 코어 CSS가 진다. */
+  readonly className?: string;
+  /** 열을 가득 채우는 변종(사이드바 축 전환처럼 폭이 정해진 자리). */
+  readonly stretch?: boolean;
+};
+
+type ThumbGeometry = { readonly left: number; readonly width: number } | null;
+
+export function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className,
+  stretch = false,
+}: SegmentedProps<T>) {
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const buttonsRef = useRef(new Map<string, HTMLButtonElement>());
+  const [thumb, setThumb] = useState<ThumbGeometry>(null);
+  // 첫 배치는 애니메이션하지 않는다 — 열자마자 썸이 왼쪽에서 날아오면 이동이 뜻을 잃는다.
+  const [armed, setArmed] = useState(false);
+
+  const measure = useCallback(() => {
+    const track = trackRef.current;
+    const active = buttonsRef.current.get(value);
+    if (!track || !active) {
+      setThumb(null);
+      return;
+    }
+    const trackBox = track.getBoundingClientRect();
+    const activeBox = active.getBoundingClientRect();
+    if (trackBox.width === 0 || activeBox.width === 0) {
+      // 숨은 탭(display:none)에서는 0이 나온다 — 그 값을 쓰면 다시 보일 때 썸이 접힌 채로 선다.
+      setThumb(null);
+      return;
+    }
+    setThumb({ left: activeBox.left - trackBox.left, width: activeBox.width });
+  }, [value]);
+
+  useLayoutEffect(() => {
+    measure();
+  }, [measure, options]);
+
+  useEffect(() => {
+    if (thumb && !armed) {
+      const id = requestAnimationFrame(() => setArmed(true));
+      return () => cancelAnimationFrame(id);
+    }
+    return undefined;
+  }, [thumb, armed]);
+
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track || typeof ResizeObserver === "undefined") return undefined;
+    // 폭은 레일 드래그·창 크기·서체 로드로 바뀐다. 그때마다 다시 재지 않으면 썸이 라벨에서 어긋난다.
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(track);
+    for (const button of buttonsRef.current.values()) observer.observe(button);
+    return () => observer.disconnect();
+  }, [measure, options]);
+
+  useEffect(() => {
+    if (typeof document === "undefined" || !document.fonts?.ready) return;
+    let cancelled = false;
+    void document.fonts.ready.then(() => {
+      if (!cancelled) measure();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [measure]);
+
+  const focusAt = (index: number) => {
+    const target = options[((index % options.length) + options.length) % options.length];
+    if (!target) return;
+    buttonsRef.current.get(target.value)?.focus();
+    if (!target.disabled) onChange(target.value);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    // 세그먼티드는 라디오 그룹처럼 방향키로 옮긴다 — 탭 하나로 그룹을 지나가고 안에서는 화살표다.
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      focusAt(index + 1);
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      focusAt(index - 1);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      focusAt(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      focusAt(options.length - 1);
+    }
+  };
+
+  return (
+    <div
+      ref={trackRef}
+      className={["fc-segmented", stretch ? "is-stretch" : "", armed ? "is-armed" : "", className ?? ""]
+        .filter(Boolean)
+        .join(" ")}
+      role="group"
+      aria-label={ariaLabel}
+    >
+      {thumb ? (
+        <span
+          className="fc-segmented__thumb"
+          aria-hidden="true"
+          style={{ transform: `translateX(${thumb.left}px)`, width: `${thumb.width}px` }}
+        />
+      ) : null}
+      {options.map((option, index) => (
+        <button
+          key={option.value}
+          ref={(node) => {
+            if (node) buttonsRef.current.set(option.value, node);
+            else buttonsRef.current.delete(option.value);
+          }}
+          type="button"
+          className="fc-segmented__option"
+          aria-pressed={option.value === value}
+          aria-label={option.ariaLabel}
+          title={option.title}
+          disabled={option.disabled}
+          tabIndex={option.value === value ? 0 : -1}
+          {...option.data}
+          onKeyDown={(event) => onKeyDown(event, index)}
+          onClick={() => {
+            if (!option.disabled) onChange(option.value);
+          }}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/runtime/fleet-console/sdk/package.json
+++ b/runtime/fleet-console/sdk/package.json
@@ -107,6 +107,12 @@
       "import": "./components/effort-track.tsx",
       "default": "./components/effort-track.tsx"
     },
+    "./components/segmented": {
+      "types": "./components/segmented.tsx",
+      "browser": "./components/segmented.tsx",
+      "import": "./components/segmented.tsx",
+      "default": "./components/segmented.tsx"
+    },
     "./components/caption-actions": {
       "types": "./components/caption-actions.tsx",
       "browser": "./components/caption-actions.tsx",

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -801,6 +801,90 @@ describe("Instrument core design contract", () => {
   // 깊이를 나르는 근사 무채색(그림자·스크림·시트)은 console CLAUDE.md가 명시한 예외라 통과시킨다.
   // 문법은 oklch 하나가 아니다 — hex·rgb·hsl로 적은 유채색도 같은 두 규칙을 깨므로 함께 막고,
   // 채널을 해석할 수 없는 함수형(color()/lab()/lch())은 통과시키지 않는다.
+  // 포커스 표시는 제품 전체에서 하나다. 이 핀이 막는 회귀는 두 가지이며 둘 다 실측으로 확인됐다:
+  //  (1) 채널 침범 — 링이 brass·aurora·warn·positive·coral 다섯 색으로 흩어져 "대기 중"과
+  //      "키보드가 여기"가 같은 색으로 말해지고 있었다(플러그인에만 aurora 링 8곳).
+  //  (2) 표현 분산 — 같은 brass가 48/55/58/65/68/70% 여섯 농도와 offset 1·2·3px으로 갈렸고,
+  //      outline:none으로 끈 뒤 자기 글로우를 다시 그린 표면이 11곳이었다(인풋의 이중 링).
+  // 그래서 표면은 자기 hover·상태 페인트만 지고, 링은 전역 규칙 하나와 두 토큰만 쓴다.
+  it("pins the single focus-ring grammar — one brass ring, no signal channel, no per-surface outline", () => {
+    const theme = source("styles/theme.css");
+    expect(theme).toContain("--ring: var(--brass);");
+    expect(theme.match(/^ {2}--ring:/gm)).toHaveLength(1);
+    expect(theme).toContain("--ring-shadow: 0 0 0 2px var(--ring-backdrop), 0 0 0 4px var(--ring);");
+    expect(theme).toContain("--ring-shadow-inset: inset 0 0 0 2px var(--ring);");
+    expect(theme).toMatch(/^:focus-visible \{\n {2}outline: none;\n {2}box-shadow: var\(--ring-shadow\);\n\}/m);
+    // box-shadow는 forced-colors에서 지워진다 — 그 모드에서만 outline으로 병기하고 시스템 색을 쓴다.
+    expect(theme).toMatch(/@media \(forced-colors: active\) \{\s*:focus-visible \{\s*outline: 2px solid Highlight;/);
+
+    const outlineViolations: string[] = [];
+    const shadowViolations: string[] = [];
+    for (const file of listProductCssFiles()) {
+      const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+      const masked = maskCssCommentsAndStrings(css);
+      const forcedColors = [...masked.matchAll(/@media \(forced-colors: active\)\s*\{/g)].map((match) => ({
+        start: match.index,
+        end: masked.indexOf("\n}", match.index),
+      }));
+      const insideForcedColors = (index: number) =>
+        forcedColors.some((range) => index >= range.start && (range.end === -1 || index <= range.end));
+      for (const declaration of cssDeclarations(masked, "outline")) {
+        if (declaration.value === "none" || declaration.value === "0") continue;
+        if (insideForcedColors(declaration.index)) continue;
+        const selector = selectorAt(masked, declaration.index);
+        if (!selector.includes(":focus")) continue;
+        outlineViolations.push(`${consoleRelativePath(file)}:${lineAt(css, declaration.index)} ${selector}`);
+      }
+      // 포커스 전용 규칙의 box-shadow는 링 토큰이거나, 쉬는 상태의 그림자를 함께 실은 합성이어야 한다.
+      // 자기 글로우를 링 대신 그리면 굵기·농도가 다시 갈린다.
+      for (const declaration of cssDeclarations(masked, "box-shadow")) {
+        const selector = selectorAt(masked, declaration.index);
+        if (!selector.includes(":focus")) continue;
+        if (selector.includes(":hover") || selector.includes("::-")) continue;
+        if (declaration.value === "none") continue;
+        if (declaration.value.includes("var(--ring-shadow")) continue;
+        shadowViolations.push(`${consoleRelativePath(file)}:${lineAt(css, declaration.index)} ${selector}`);
+      }
+    }
+    expect(outlineViolations).toEqual([]);
+    expect(shadowViolations).toEqual([]);
+  });
+
+  // 선택 문법(C2). 이 핀이 막는 회귀는 "활성 상태를 강조색 채움으로 그리기"다 — 실측에서 그 면은
+  // 네 테마 모두 뒤 면 대비 1.16~1.22:1이었고 Whites는 농도를 올려도 회복되지 않았다(brass L 56%가
+  // L 95.5% 종이에 섞이면 거의 움직이지 않는다). 선택은 색이 아니라 고도로 말한다.
+  it("pins the selection grammar — one raised surface, no brass fill on pressed toggles", () => {
+    const theme = source("styles/theme.css");
+    // 값은 밴드 면 기준 OKLab ΔL ≈ +11로 테마마다 실측해 잡았다 — 면 분리는 WCAG 대비비가 아니라
+    // ΔL로 잰다(대비비는 어두운 두 면 사이에서 +0.05 오프셋에 눌려 1.1~1.2로 붙는다).
+    expect(theme).toContain("--surface-select: oklch(24% 0.018 245);");
+    expect(theme).toContain("--surface-select: oklch(32% 0.045 248);");
+    expect(theme).toContain("--surface-select: oklch(29% 0.007 252);");
+    expect(theme).toContain("--surface-select-edge: oklch(100% 0 0 / 8%);");
+    expect(theme).toContain("--elev-select: inset 0 1px 0 var(--surface-select-edge), 0 1px 2px oklch(0% 0 0 / 40%);");
+    // 라이트는 방향이 반대다 — 종이 위에서 "선택됨"은 더 밝게 칠하는 것이 아니라 들어 올리는 것이다.
+    const whites = theme.slice(theme.indexOf(':root[data-theme="whites"]'));
+    expect(whites).toContain("--surface-select: oklch(100% 0 0);");
+    expect(whites).toMatch(/--elev-select: inset 0 0 0 1px var\(--surface-select-edge\)/);
+
+    const canonical: Array<[string, string]> = [
+      ["styles/layout.css", '.command-band-mode-seg[aria-pressed="true"]'],
+      ["styles/layout.css", '.command-band-mode-tool[aria-pressed="true"]'],
+      ["styles/layout.css", '.command-band-button[aria-pressed="true"]'],
+      ["styles/components.css", '.operations-side-bar-axis-seg[aria-pressed="true"]'],
+      ["styles/components.css", ".theme-mode-seg button.is-active"],
+      ["styles/components.css", ".segmented-option.is-active"],
+      ["styles/mobile.css", ".mobile-tab.is-active"],
+    ];
+    for (const [file, selector] of canonical) {
+      const css = source(file);
+      const block = css.match(new RegExp(`^${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\{[^}]*\\}`, "m"))?.[0] ?? "";
+      expect(block, `${file} ${selector}`).toContain("background: var(--surface-select);");
+      expect(block, `${file} ${selector}`).toContain("box-shadow: var(--elev-select);");
+      expect(block, `${file} ${selector}`).not.toMatch(/background:[^;]*--brass/);
+    }
+  });
+
   it("keeps chromatic color literals inside theme.css", () => {
     const violations: string[] = [];
     for (const file of listProductCssFiles()) {
@@ -1096,11 +1180,13 @@ describe("Instrument core design contract", () => {
     expect(shell).not.toContain("overflow: hidden;");
 
     // 켜진 단계는 사다리 위의 위치이지 Operation 상태가 아니다 — 신호색을 빌리면 같은 카드의
-    // 활동 축과 충돌하므로, 코어 segmented와 같은 brass 워시+brass ink+inset 링만 쓴다.
+    // 활동 축과 충돌한다. 코어 segmented와 같은 문법을 쓰되, C2 이후 그 문법은 brass 워시가 아니라
+    // 들어 올린 면(--surface-select + --elev-select)이고 brass는 라벨에만 남는다.
     const on = css.match(/\.ai-gateway-effort-level\.is-on \{[^}]*\}/)?.[0] ?? "";
-    expect(on).toContain("background: color-mix(in oklch, var(--brass) 16%, transparent);");
+    expect(on).toContain("background: var(--surface-select);");
+    expect(on).toContain("box-shadow: var(--elev-select);");
     expect(on).toContain("color: var(--brass-ink);");
-    expect(on).toContain("box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 38%, transparent);");
+    expect(on).not.toMatch(/background:[^;]*--brass/);
     for (const [, , body] of css.matchAll(/([^{}]*\.ai-gateway-effort[^{}]*)\{([^}]*)\}/g)) {
       expect(body).not.toMatch(/var\(--(aurora|warn|coral|positive)[a-z-]*\)/);
     }
@@ -1340,7 +1426,12 @@ describe("Instrument core design contract", () => {
     expect(sidebar).not.toContain('className="side-bar-status-axis-toggle"');
     expect(sidebar).toContain('className="operations-side-bar-axis"');
     expect(sidebar).toContain('data-sidebar-axis={statusAxis ? "status" : "group"}');
-    expect(sidebar).toContain('title={t("sidebar.theater.sortByStatusTitle")}');
+    // 축 스위치는 제품에 하나뿐인 세그먼티드 구현을 쓴다 — 인라인 버튼 두 개로 되돌리면
+    // 선택 페인트가 다시 이 표면만의 것이 된다(C 이전 스물여덟 갈래가 그렇게 생겼다).
+    expect(sidebar).toContain('from "@fleet-console/sdk/components/segmented"');
+    expect(sidebar).toContain("<Segmented");
+    expect(sidebar).toContain('title: t("sidebar.theater.sortByStatusTitle")');
+    expect(sidebar).not.toContain('className="operations-side-bar-axis-seg"');
     expect(sidebar).toContain("groupTheaterStatusEntries(");
     expect(sidebar).toContain("minimizedIds.has(entry.operation.id) && !dormantIds.has(entry.operation.id)");
     expect(sidebar).toContain("<StatusRecoveryShelves");
@@ -1559,7 +1650,9 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain("onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })}");
     // 캔버스 모드는 세그먼트 스위치 하나가 단독으로 소유한다 — 모드별 도구를 밴드에 상시
     // 늘어놓으면 다른 모드의 도구를 눌러 무경고로 모드를 이탈시킬 수 있다(2026-08 격자 클릭 사고).
-    expect(commandBand).toContain('className="command-band-mode-switch" role="group" aria-label={t("chrome.commandBand.canvasMode")}');
+    expect(commandBand).toContain('from "@fleet-console/sdk/components/segmented"');
+    expect(commandBand).toContain('className="command-band-mode-switch"');
+    expect(commandBand).toContain('ariaLabel={t("chrome.commandBand.canvasMode")}');
     // 모드는 낱말로, 모드 전용 도구는 아이콘으로 말한다 — 세그먼트에 아이콘을 더하면 클러스터가
     // 375px까지 벌어져 1280px 밴드에서 중앙 브레드크럼이 사라진다(2026-08 실측).
     expect(commandBand).toContain('{ id: "cruise", label: "Cruise", titleKey: "chrome.commandBand.modeCruise" },');
@@ -1567,7 +1660,7 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain('{ id: "warRoom", label: "War Room", titleKey: "chrome.commandBand.modeWarRoom" },');
     expect(commandBand).not.toMatch(/<mode\.Icon \/>/);
     expect(commandBand).toContain('const canvasMode: CanvasMode = triageActive ? "warRoom" : formationView ? "tactical" : "cruise";');
-    expect(commandBand).toContain('aria-pressed={canvasMode === mode.id}');
+    expect(commandBand).toContain("value={canvasMode}");
     // 트레이는 활성 모드의 도구만 마운트한다 — 비활성 모드 도구는 disabled가 아니라 부재다.
     expect(commandBand).toContain('{canvasMode === "cruise" ? <div className="command-band-mode-tray"');
     expect(commandBand).toContain('{canvasMode === "tactical" ? <div className="command-band-mode-tray"');
@@ -1582,7 +1675,7 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain("onClick={() => { if (formationLayout !== layout.id) selectFormationLayout(layout.id); }}");
     expect(commandBand).toContain("aria-pressed={formationLayout === layout.id}");
     // Tactical은 Theater별 상태라 활성 Theater로, War Room은 전역 모드라 등록된 Theater 존재로 게이트한다.
-    expect(commandBand).toContain('disabled={mode.id === "tactical" ? state.activeTheaterId === null : state.theaters.length === 0}');
+    expect(commandBand).toContain('disabled: mode.id === "tactical" ? state.activeTheaterId === null : state.theaters.length === 0,');
     // 모드 이름은 번역하지 않는 제품 고유 명칭이다 — 로케일 메시지에 이름을 넣으면 두 벌이 생긴다.
     expect(commandBand).not.toMatch(/t\("chrome\.commandBand\.(triage|formationView)"\)/);
     const sidebar = source("sidebar/operations-side-bar.tsx");
@@ -1755,9 +1848,11 @@ describe("Instrument core design contract", () => {
     expect(whatsNewOverlayBlock).toContain("z-index: 35;");
     // 모달 뒤로 물러나는 것은 떠 있는 밴드뿐이다 — 도킹된 밴드에 걸면 44px 빈 띠만 남는다.
     expect(layout).toContain('body:has([aria-modal="true"]:not([hidden])) .command-band.is-fullscreen:not(.is-docked),');
-    // aria-pressed가 화면에 흔적을 남기지 않던 회귀를 막는다 — 밴드 토글의 눌림은 brass 채움이다.
+    // aria-pressed가 화면에 흔적을 남기지 않던 회귀를 막는다 — C2 이후 밴드 토글의 눌림은
+    // brass 채움이 아니라 들어 올린 면이다(실측: 채움은 뒤 면 대비 1.19:1로 보이지 않았다).
     const pressedBandButtonBlock = layout.match(/\.command-band-button\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(pressedBandButtonBlock).toContain("background: color-mix(in oklch, var(--brass) 12%, transparent);");
+    expect(pressedBandButtonBlock).toContain("background: var(--surface-select);");
+    expect(pressedBandButtonBlock).toContain("box-shadow: var(--elev-select);");
     expect(pressedBandButtonBlock).toContain("color: var(--brass-ink);");
   });
 
@@ -1865,13 +1960,16 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--ink-abyss: oklch(97% 0.003 100);");
     expect(theme.match(/^:root \{/gm)).toHaveLength(1);
     // Legacy dark 테마는 팔레트 토큰만 — 광학·color-scheme과 형상·타이포 오버라이드는 진입 불가.
+    // ring·elev는 팔레트와 같은 층이다: 포커스 링 색과 고도 레시피는 테마의 대기(잉크 스케일·
+    // 대비)에 묶여 있어 테마가 재조율해야 하고, 라운드·간격·서체 같은 형상은 아니다.
+    // 이 목록을 늘릴 때는 "테마가 색으로 답해야 하는가"만 기준으로 삼을 것.
     const darkVariantBlocks = theme.match(/^:root\[data-theme="(?:maritime|carbon)"\][^{]*\{[^}]*\}/gm) ?? [];
     expect(darkVariantBlocks).toHaveLength(3);
     for (const block of darkVariantBlocks) {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id)[a-z-]*:$/);
+        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|ring|elev)[a-z-]*:$/);
       }
     }
     // Light 테마만 팔레트 + 광학(color-scheme/shadow/scrollbar/신호 ink·halo/본문 regular 굵기 보정)을 허용한다.
@@ -1883,7 +1981,7 @@ describe("Instrument core design contract", () => {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|provider|shadow|scrollbar)[a-z-]*|--weight-regular|color-scheme):$/);
+        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|provider|shadow|scrollbar|ring|elev)[a-z-]*|--weight-regular|color-scheme):$/);
       }
     }
     // 신호 ink 티어는 base에서 별칭으로 존재해 다크 3종이 var 간접으로 base 신호색을 상속한다.
@@ -2095,7 +2193,9 @@ describe("Instrument core design contract", () => {
     }
     const chatFollowHoverBlock = chat.match(/^\.agent-chat-follow:hover,\n\.agent-chat-follow:focus-visible \{[^}]*\}/m)?.[0] ?? "";
     expect(chatFollowHoverBlock).toContain("border-color: var(--brass);");
-    expect(chatFollowHoverBlock).toContain("outline: none;");
+    // 포커스 표시는 이 규칙의 몫이 아니다 — C1 이후 링은 전역 :focus-visible 하나가 그린다.
+    // 여기서 outline을 다시 적으면 그 단일성이 깨지므로 어떤 형태로도 등장하지 않아야 한다.
+    expect(chatFollowHoverBlock).not.toContain("outline");
     // 떠 있는 컨트롤은 자기 몫의 로그 여백을 함께 가진다 — 스크롤 컨테이너가 그만큼 비워 두지
     // 않으면 바닥까지 내린 마지막 줄이 컨트롤 뒤에 갇혀 스크롤로도 빠져나오지 못한다.
     // 위쪽 34px은 전환 칩 줄의 몫이었고, 그 줄이 캡션으로 떠난 지금 로그는 패널 상단에서 바로
@@ -2620,7 +2720,9 @@ describe("Instrument core design contract", () => {
     expect(armed).toContain("color: var(--coral-ink);");
     expect(armed).toContain("animation: chip-close-arm 1.5s linear forwards;");
     const focus = css.match(/^\.mobile-session-close:focus-visible \{[^}]*\}/m)?.[0] ?? "";
-    expect(focus).toContain("outline: 2px solid color-mix(in srgb, var(--brass) 55%, transparent);");
+    // brass 포커스는 유지하되 표현은 제품 공통 링이다 — 자기 농도·offset을 다시 발명하지 않는다.
+    expect(focus).toContain("box-shadow: var(--ring-shadow);");
+    expect(focus).not.toContain("outline:");
     expect(css).toMatch(/@media \(prefers-reduced-motion: reduce\) \{\s*\.mobile-session-close\.is-armed \{\s*animation: none;/);
   });
 });

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -815,7 +815,25 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--ring-shadow-inset: inset 0 0 0 2px var(--ring);");
     expect(theme).toMatch(/^:focus-visible \{\n {2}outline: none;\n {2}box-shadow: var\(--ring-shadow\);\n\}/m);
     // box-shadow는 forced-colors에서 지워진다 — 그 모드에서만 outline으로 병기하고 시스템 색을 쓴다.
-    expect(theme).toMatch(/@media \(forced-colors: active\) \{\s*:focus-visible \{\s*outline: 2px solid Highlight;/);
+    // 미디어 쿼리는 특이도를 더하지 않는다 — 자기 outline을 끈 컴포넌트 규칙((0,2,0))이
+    // 이 폴백((0,1,0))을 이기면 forced-colors에서 포커스가 통째로 보이지 않는다(box-shadow도 이
+    // 모드에서 지워지므로). 접근성 오버라이드 모드의 !important는 그 자리를 되찾기 위한 것이다.
+    expect(theme).toMatch(/@media \(forced-colors: active\) \{\s*:focus-visible \{\s*outline: 2px solid Highlight !important;/);
+
+    // 프레임이 포커스를 대신 그리는 컨트롤은 안쪽 입력의 링을 반드시 끈다. 입력이 자기 outline만
+    // 끄면 전역 규칙의 box-shadow가 남아 링이 두 겹이 된다(실측 확인). 링을 :focus-within으로
+    // 그리는 래퍼를 새로 만들면 이 목록에도 함께 올릴 것.
+    const delegated: Array<[string, string]> = [
+      ["styles/components.css", ".font-field:focus-within input:focus-visible"],
+      ["styles/components.css", ".directory-browser-filter:focus-within .directory-browser-filter-input:focus-visible"],
+    ];
+    for (const [file, selector] of delegated) {
+      const css = source(file);
+      const block = css.match(new RegExp(`^${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\{[^}]*\\}`, "m"))?.[0] ?? "";
+      expect(block, `${file} ${selector}`).toContain("box-shadow: none;");
+    }
+    const chatCss = externalSource(TERMINAL_CHAT_CSS_PATH);
+    expect(chatCss).toContain(".agent-chat-composer-frame:focus-within .agent-chat-composer-input:focus-visible");
 
     const outlineViolations: string[] = [];
     const shadowViolations: string[] = [];

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -91,8 +91,8 @@ describe("OperationsSideBar STATUS axis", () => {
     // 말하면서 전역 불리언 하나를 뒤집어, 한 번의 클릭이 모든 행을 함께 눌린 상태로 만든다.
     expect(container?.querySelectorAll(".side-bar-status-axis-toggle").length).toBe(0);
     expect(container?.querySelectorAll(".operations-side-bar-axis").length).toBe(1);
-    const groupSeg = required<HTMLButtonElement>('.operations-side-bar-axis-seg[data-axis="group"]');
-    const statusSeg = required<HTMLButtonElement>('.operations-side-bar-axis-seg[data-axis="status"]');
+    const groupSeg = required<HTMLButtonElement>('.fc-segmented__option[data-axis="group"]');
+    const statusSeg = required<HTMLButtonElement>('.fc-segmented__option[data-axis="status"]');
     expect(groupSeg.textContent).toBe("Groups");
     expect(statusSeg.textContent).toBe("Status");
     expect(groupSeg.getAttribute("aria-pressed")).toBe("true");
@@ -363,7 +363,7 @@ describe("OperationsSideBar STATUS axis", () => {
 
     expect(getSnapshot().operationOrder).toEqual(["first", "second"]);
 
-    act(() => required<HTMLButtonElement>('.operations-side-bar-axis-seg[data-axis="group"]').click());
+    act(() => required<HTMLButtonElement>('.fc-segmented__option[data-axis="group"]').click());
     const groupFirst = required<HTMLElement>('[data-side-bar-chip-id="first"]');
     act(() => groupFirst.dispatchEvent(new KeyboardEvent("keydown", {
       key: "ArrowDown",

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -111,9 +111,8 @@
 }
 
 .fexp-divider:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: -2px;
   background: color-mix(in oklab, var(--brass) 50%, transparent);
+  box-shadow: var(--ring-shadow-inset);
 }
 
 /* ── 파일 행 컨텍스트 메뉴 ── */
@@ -130,7 +129,7 @@
   overflow-y: auto;
   padding: 6px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-raised);
   /* 팝업 판독성 계약: glass 믹스 아래 불투명 ink 언더레이. */
   background:
     linear-gradient(
@@ -139,6 +138,7 @@
     ),
     var(--ink-deep);
   box-shadow: var(--shadow-anchor);
+  animation: fleet-menu-in var(--duration-fast) var(--ease-spring);
 }
 
 .fexp-context-menu-item {
@@ -162,9 +162,9 @@
 }
 
 .fexp-context-menu-item:focus-visible {
-  outline: none;
   border-color: color-mix(in oklab, var(--brass) 55%, var(--surface-rim));
   background: var(--brass-glow);
+  box-shadow: var(--ring-shadow);
 }
 
 .fexp-context-menu-separator {
@@ -291,8 +291,9 @@
 }
 
 .fexp-chip.is-active {
-  border-color: color-mix(in oklab, var(--brass) 55%, var(--surface-rim));
-  background: var(--brass-glow);
+  border-color: transparent;
+  box-shadow: var(--elev-select);
+  background: var(--surface-select);
 }
 
 .fexp-chip-open {
@@ -326,8 +327,7 @@
 .fexp-viewer-stale:focus-visible,
 .fexp-viewer-wrap:focus-visible,
 .fexp-tree-error-retry:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: -2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .fexp-chip-icon {
@@ -666,8 +666,7 @@
 }
 
 .fexp-tree-row:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: -2px;
+  box-shadow: var(--ring-shadow-inset);
 }
 
 .fexp-tree-row.is-cur {

--- a/runtime/fleet-plugins/ledger/client/ledger.css
+++ b/runtime/fleet-plugins/ledger/client/ledger.css
@@ -17,8 +17,9 @@
   grid-auto-columns: 1fr;
   gap: 2px;
   padding: 2px;
-  border: 1px solid var(--hairline);
-  border-radius: var(--radius-xs);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: var(--surface-track);
   background: var(--surface-glass);
 }
 
@@ -41,16 +42,16 @@
 }
 
 .ledger-segment button[aria-pressed="true"] {
-  border-color: color-mix(in oklch, var(--brass) 35%, transparent);
-  background: var(--brass-glow);
-  color: var(--text-primary);
+  border-color: transparent;
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
+  color: var(--brass-ink);
 }
 
 .ledger-segment button:focus-visible,
 .ledger-button:focus-visible,
 .ledger-trend-bar:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .ledger-summary {
@@ -493,12 +494,11 @@
 
 .ledger-backend-head:hover {
   border-color: color-mix(in oklch, var(--brass) 40%, var(--hairline));
-  background: var(--brass-glow);
+  background: var(--surface-hover);
 }
 
 .ledger-backend-head:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .ledger-backend-copy {

--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -193,8 +193,7 @@
 }
 
 .quota-grip:focus-visible {
-  outline: 1px solid var(--brass);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .quota-grip:active {

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -169,7 +169,7 @@
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-xs);
   transition: color 0.14s, background 0.14s;
 }
 
@@ -179,7 +179,8 @@
 
 .repository-toggle-btn.is-active {
   color: var(--brass-ink);
-  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
 }
 
 /* ── 섹션 스크롤 컨테이너 ── */
@@ -765,8 +766,7 @@
 }
 
 .history-order-toggle:focus-visible {
-  outline: 1px solid var(--brass);
-  outline-offset: -1px;
+  box-shadow: var(--ring-shadow-inset);
 }
 
 .history-order-icon {
@@ -1040,8 +1040,7 @@
 }
 
 .repository-reload-state:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .history-pagination {
@@ -1122,9 +1121,9 @@
 .history-commit-sha { grid-column: 6; grid-row: 1; }
 .history-commit-time { grid-column: 7; grid-row: 1; }
 .history-inspector { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
-.history-segmented { display: flex; gap: 4px; padding: 8px 12px; border-bottom: 1px solid var(--surface-rim); }
-.history-segmented button { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; border: 1px solid transparent; border-radius: var(--radius-xs); background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .01em; padding: 6px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
-.history-segmented button[aria-pressed="true"] { border-color: color-mix(in oklch, var(--brass) 40%, transparent); background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--text-secondary); }
+.history-segmented { display: flex; gap: 2px; margin: 8px 12px; padding: 2px; border-radius: var(--radius-md); background: var(--surface-track); }
+.history-segmented button { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; border: 1px solid transparent; border-radius: var(--radius-xs); background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-body); font-size: var(--t-sm); font-weight: var(--weight-medium); letter-spacing: -.005em; padding: 6px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
+.history-segmented button[aria-pressed="true"] { border-color: transparent; background: var(--surface-select); box-shadow: var(--elev-select); color: var(--brass-ink); }
 .history-segmented span { color: var(--text-tertiary); font-size: var(--t-2xs); }
 .history-segmented .history-inspector-close { flex: 0 0 auto; width: 24px; min-width: 24px; height: 24px; padding: 0; border-color: transparent; }
 .history-details-tab { display: grid; min-height: 0; overflow: hidden; }
@@ -1299,8 +1298,7 @@
 }
 
 .repository-ws-section-head:focus-visible {
-  outline: 1px solid var(--brass);
-  outline-offset: -1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .repository-ws-section.is-collapsed .repository-folder-chevron {
@@ -1404,8 +1402,8 @@
 
 .repository-tree-action {
   display: none;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   margin-left: auto;
   padding: 0;
   border: 1px solid transparent;
@@ -1424,7 +1422,6 @@
   border-color: var(--surface-rim);
   background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
   color: var(--text-primary);
-  outline: none;
 }
 
 @media (hover: hover) {
@@ -1455,7 +1452,7 @@
   overflow-y: auto;
   padding: 6px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-raised);
   background:
     linear-gradient(
       color-mix(in oklch, var(--surface-glass-strong) 88%, var(--ink-deep)),
@@ -1463,6 +1460,7 @@
     ),
     var(--ink-deep);
   box-shadow: var(--shadow-anchor);
+  animation: fleet-menu-in var(--duration-fast) var(--ease-spring);
 }
 
 .repository-context-menu-item {
@@ -1486,9 +1484,9 @@
 }
 
 .repository-context-menu-item:focus-visible {
-  outline: none;
   border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
   background: var(--brass-glow);
+  box-shadow: var(--ring-shadow);
 }
 
 .repository-context-menu-item:disabled {
@@ -1670,7 +1668,9 @@
 .history-commit-row:hover .history-row-compare,
 .history-commit-row:focus-within .history-row-compare { display: inline-flex; }
 .history-row-compare:hover,
-.history-row-compare:focus-visible { border-color: var(--aurora); background: color-mix(in oklch, var(--aurora) 12%, var(--ink-mid)); color: var(--text-primary); outline: none; }
+.history-row-compare:focus-visible {
+ border-color: var(--aurora); background: color-mix(in oklch, var(--aurora) 12%, var(--ink-mid)); color: var(--text-primary);
+}
 .history-commit-row.is-picked { background: color-mix(in oklch, var(--aurora) 9%, transparent); box-shadow: inset 2px 0 0 var(--aurora); }
 .history-commit-row.is-picked .history-commit-sha { color: var(--aurora); }
 .repository-pin-chip { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 42%, transparent); border-radius: var(--radius-xs); color: var(--aurora); cursor: pointer; }

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -101,12 +101,13 @@ describe("Repository honesty grammar", () => {
     }
   });
 
-  // 로컬 상태를 다시 읽는 컨트롤은 쉬는 상태에서 위치 채널을 켜지 않는다 — brass는 hover/focus에만.
-  it("rests the reload control on neutral ink and takes brass only on focus", () => {
+  // 로컬 상태를 다시 읽는 컨트롤은 쉬는 상태에서 위치 채널을 켜지 않는다. 포커스 표시는 C1 이후
+  // 이 표면의 몫이 아니라 제품 공통 링(--ring-shadow)이며, 링의 색은 brass 하나다.
+  it("rests the reload control on neutral ink and takes the shared ring only on focus", () => {
     const rest = blockOf(".repository-reload-state");
     expect(rest).toContain("var(--text-tertiary)");
     expect(rest).not.toContain("var(--brass)");
-    expect(blockOf(".repository-reload-state:focus-visible")).toContain("var(--brass)");
+    expect(blockOf(".repository-reload-state:focus-visible")).toContain("var(--ring-shadow)");
   });
 
   // 목록 220 + 디바이더 4 + diff 140 = 364px. 그 아래에서 좌우 분할을 유지하면 목록이 82px까지
@@ -277,8 +278,9 @@ describe("Repository design grammar", () => {
     expect(sectionHeadHover).toContain("color: var(--text-secondary)");
 
     const sectionHeadFocus = blockOf(".repository-ws-section-head:focus-visible");
-    expect(sectionHeadFocus).toContain("outline: 1px solid var(--brass)");
-    expect(sectionHeadFocus).toContain("outline-offset: -1px");
+    // 자기 outline 대신 공통 링을 쓴다 — 농도·offset을 표면마다 다시 정하지 않는다.
+    expect(sectionHeadFocus).toContain("var(--ring-shadow)");
+    expect(sectionHeadFocus).not.toContain("outline:");
 
     const chevrons = blocksOf(".repository-folder-chevron");
     expect(chevrons[0]).toContain("width: 11px");

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -22,9 +22,8 @@
 }
 
 .scuttlebutt-bird:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
   border-radius: var(--radius-md);
+  box-shadow: var(--ring-shadow);
 }
 
 .scuttlebutt-bird-tag {
@@ -620,8 +619,7 @@
 
 .scuttlebutt-arrival-open:focus-visible,
 .scuttlebutt-arrival-dismiss:focus-visible {
-  outline: 2px solid var(--positive);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .scuttlebutt-departure-bubble {
@@ -727,8 +725,7 @@
 
 .scuttlebutt-departure-open:focus-visible,
 .scuttlebutt-departure-dismiss:focus-visible {
-  outline: 2px solid var(--warn);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 /* 부유 레이어는 클릭을 통과시키므로 실제로 그린 표면만 스스로 되살린다. */
@@ -803,8 +800,7 @@
 }
 
 .scuttlebutt-chat-moor:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }
 
 .scuttlebutt-chat-moor-track {
@@ -863,7 +859,7 @@
 }
 
 .scuttlebutt-chat-tuck:focus-visible {
-  outline: 2px solid var(--brass);
+  box-shadow: var(--ring-shadow);
 }
 
 .scuttlebutt-chat-log {
@@ -981,7 +977,7 @@
 .scuttlebutt-composer input:focus {
   border-color: var(--brass);
   outline: none;
-  box-shadow: 0 0 0 3px var(--brass-glow);
+  box-shadow: var(--ring-shadow);
 }
 
 .scuttlebutt-send {
@@ -997,7 +993,7 @@
 }
 
 .scuttlebutt-send:focus-visible {
-  outline: 2px solid var(--text-primary);
+  box-shadow: var(--ring-shadow);
 }
 
 .scuttlebutt-send:disabled {

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-design-tokens.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-design-tokens.test.ts
@@ -27,8 +27,11 @@ describe("Scuttlebutt design tokens", () => {
     expect(bubble).toMatch(/\),\s*var\(--ink-deep\);/);
     expect(label).toContain("color: var(--warn-ink);");
     expect(label).not.toContain("72%");
-    expect(focus).toContain("outline: 2px solid var(--warn);");
-    // 닫기 액션도 같은 신호 채널의 포커스 규칙을 공유한다.
+    // 포커스는 신호 채널이 아니다 — warn 링은 "이 알림이 경고"인지 "여기에 키보드가 있는지"를
+    // 같은 색으로 말하고 있었다. C1 이후 링은 brass 하나이며 표현은 --ring-shadow 하나다.
+    expect(focus).toContain("var(--ring-shadow)");
+    expect(focus).not.toContain("var(--warn)");
+    // 닫기 액션도 같은 포커스 규칙을 공유한다.
     expect(focus).toContain(".scuttlebutt-departure-dismiss:focus-visible");
   });
 

--- a/runtime/fleet-plugins/skills/client/skills.css
+++ b/runtime/fleet-plugins/skills/client/skills.css
@@ -24,9 +24,9 @@
   border-bottom: 2px solid transparent;
   color: var(--text-tertiary);
   cursor: pointer;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-size: var(--t-sm);
-  font-weight: var(--weight-bold);
+  font-weight: var(--weight-medium);
   letter-spacing: 0.01em;
   line-height: 1;
   padding: var(--space-2) var(--space-3);
@@ -35,9 +35,22 @@
 
 .skills-tab-btn:hover { color: var(--text-secondary); }
 
+/* 인디케이터는 라벨 폭을 잰다 — 전폭 바 문법은 코어 C8에서 물러났다. */
+.skills-tab-btn { position: relative; border-bottom-color: transparent; }
+
 .skills-tab-btn.is-active {
-  border-bottom-color: var(--brass);
   color: var(--brass-ink);
+}
+
+.skills-tab-btn.is-active::after {
+  content: "";
+  position: absolute;
+  left: var(--space-3);
+  right: var(--space-3);
+  bottom: -1px;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -84,9 +97,9 @@
   color: var(--text-tertiary);
   cursor: pointer;
   flex: 1;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-size: var(--t-sm);
-  font-weight: var(--weight-bold);
+  font-weight: var(--weight-medium);
   letter-spacing: 0.01em;
   padding: 4px var(--space-2);
   transition: background var(--duration-base), color var(--duration-base);
@@ -95,7 +108,8 @@
 .skills-scope-btn:hover:not(:disabled) { color: var(--text-secondary); }
 
 .skills-scope-btn.is-active {
-  background: color-mix(in srgb, var(--brass) 20%, transparent);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
   color: var(--brass-ink);
 }
 
@@ -126,8 +140,8 @@
 .skills-filter-input::placeholder { color: var(--text-tertiary); }
 
 .skills-filter-input:focus {
-  outline: 2px solid var(--brass);
-  outline-offset: -1px;
+  outline: none;
+  box-shadow: var(--ring-shadow);
 }
 
 /* ─── empty state ───────────────────────────────────────────────────────────── */
@@ -362,8 +376,7 @@
 }
 
 .skills-dock-toggle:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .skills-dock-dot {
@@ -428,8 +441,7 @@
 .skills-dock-dismiss:hover { color: var(--text-secondary); }
 
 .skills-dock-dismiss:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .skills-dock-retry {
@@ -444,8 +456,7 @@
 }
 
 .skills-dock-retry:focus-visible {
-  outline: 2px solid var(--coral);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .skills-dock-chevron {
@@ -494,8 +505,9 @@
 .skills-agent-chip:hover:not(:disabled) { color: var(--text-secondary); }
 
 .skills-agent-chip.is-active {
-  background: color-mix(in srgb, var(--brass) 15%, transparent);
-  border-color: color-mix(in srgb, var(--brass) 40%, transparent);
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
+  border-color: transparent;
   color: var(--brass-ink);
 }
 

--- a/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
+++ b/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
@@ -113,7 +113,8 @@
 
 .agent-cli-path-input:focus {
   border-color: var(--brass);
-  outline: 1px solid var(--brass);
+  outline: none;
+  box-shadow: var(--ring-shadow);
 }
 
 .agent-cli-path-actions {
@@ -476,8 +477,9 @@
 }
 
 .ai-gateway-host-only.is-on {
-  border-color: color-mix(in oklch, var(--brass) 40%, transparent);
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  border-color: transparent;
+  box-shadow: var(--elev-select);
+  background: var(--surface-select);
   color: var(--brass-ink);
 }
 
@@ -585,9 +587,9 @@
 }
 
 .ai-gateway-effort-level.is-on {
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  background: var(--surface-select);
   color: var(--brass-ink);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 38%, transparent);
+  box-shadow: var(--elev-select);
 }
 
 /* 마지막 한 단계는 끌 수 없다. 켜진 채로 잠긴 상태이므로 흐리게 만들지 않는다 —

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -28,10 +28,10 @@ button.session-analyst__chip { cursor: pointer; }
 button.session-analyst__chip:hover:not(:disabled) { border-color: var(--brass); color: var(--brass-ink); box-shadow: 0 0 14px var(--brass-glow); }
 button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: default; }
 /* 모드 세그먼트 — [Chat | Artifacts·n]. 선택 표시는 brass(위치 채널)만 쓴다. */
-.session-analyst__modechip { display: inline-flex; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: var(--radius-xs); background: var(--ink-mid); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .06em; }
+.session-analyst__modechip { display: inline-flex; gap: 2px; padding: 2px; border: 1px solid transparent; border-radius: var(--radius-md); background: var(--surface-track); font-family: var(--font-body); font-size: var(--t-sm); font-weight: var(--weight-medium); letter-spacing: -.005em; }
 .session-analyst__modechip button { display: inline-flex; align-items: center; gap: 6px; border: 0; background: transparent; color: var(--text-tertiary); padding: 5px 9px; font: inherit; letter-spacing: inherit; line-height: 1; cursor: pointer; }
-.session-analyst__modechip button + button { border-left: 1px solid var(--hairline); }
-.session-analyst__modechip button[aria-pressed="true"] { background: var(--brass-glow); color: var(--brass-ink); }
+.session-analyst__modechip button { border-radius: var(--radius-xs); }
+.session-analyst__modechip button[aria-pressed="true"] { background: var(--surface-select); box-shadow: var(--elev-select); color: var(--brass-ink); }
 .session-analyst__modechip button:disabled { color: var(--text-tertiary); opacity: .5; cursor: default; }
 /* 카운트 배지 — 기존 세로 핸들의 aurora 배지 톤을 승계한다. */
 .session-analyst__chip-count { display: grid; place-items: center; min-width: 15px; min-height: 15px; border-radius: var(--radius-pill); background: color-mix(in oklch, var(--aurora) 16%, transparent); color: var(--aurora-ink); font-weight: var(--weight-bold); font-size: var(--t-2xs); line-height: 1; }
@@ -168,7 +168,7 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
    컴포저에 근거 질문을 프리필해 분석가의 session_read 경로로 맥락을 보여준다. */
 .session-analyst__ev { display: inline-grid; place-items: center; min-width: 20px; height: 15px; padding: 0 4px; margin: 0 1px; vertical-align: 2px; border: 1px solid color-mix(in oklch, var(--aurora) 40%, var(--hairline)); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--aurora) 8%, transparent); color: var(--aurora-ink); font-family: var(--font-mono); font-weight: var(--weight-medium); font-size: 9px; line-height: 1; cursor: pointer; transition: border-color var(--duration-fast), background var(--duration-fast); }
 /* 호버 델타는 위치/호버 채널(brass) — 칩의 바탕 aurora는 인용 표식으로 남는다. */
-.session-analyst__ev:hover { border-color: var(--brass); color: var(--brass-ink); background: color-mix(in oklch, var(--brass) 10%, transparent); }
+.session-analyst__ev:hover { border-color: var(--brass); color: var(--brass-ink); background: var(--surface-hover); }
 
 /* 아티팩트 저작/발행 카드 — 스파인 열에 맞춘 인라인 카드. */
 .session-analyst__author-card { min-width: 0; flex: none; margin: var(--space-4) 0 0 26px; overflow: hidden; border: 1px solid var(--hairline); border-radius: var(--radius-md); background: var(--surface-panel-raised); padding: var(--space-3); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -325,9 +325,8 @@
 }
 
 .agent-chat-tally-fold > summary:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 2px;
   border-radius: var(--radius-xs);
+  box-shadow: var(--ring-shadow);
 }
 
 /* 어포던스는 오직 이 꺾쇠가 진다. 이전에는 9px에 --hairline-strong이라, 쉬는 상태에서 눌리는
@@ -554,7 +553,6 @@
 .agent-chat-ask-option:focus-visible {
   border-color: var(--brass);
   background: color-mix(in oklch, var(--brass) 7%, var(--surface-panel));
-  outline: none;
 }
 
 .agent-chat-ask-option:hover:not(:disabled) .agent-chat-ask-option-label,
@@ -563,8 +561,9 @@
 }
 
 .agent-chat-ask-option[aria-pressed="true"] {
-  border-color: var(--brass);
-  background: color-mix(in oklch, var(--brass) 12%, var(--surface-panel));
+  border-color: transparent;
+  box-shadow: var(--elev-select);
+  background: var(--surface-select);
 }
 
 .agent-chat-ask-option:disabled { opacity: 0.55; cursor: default; }
@@ -609,9 +608,9 @@
 .agent-chat-ask-input::placeholder { color: var(--text-tertiary); }
 
 .agent-chat-ask-input:focus {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
+  outline: none;
   border-style: solid;
+  box-shadow: var(--ring-shadow);
 }
 
 .agent-chat-ask-foot {
@@ -632,7 +631,9 @@
   cursor: pointer;
 }
 
-.agent-chat-ask-send:focus-visible { outline: 2px solid var(--brass); outline-offset: 2px; }
+.agent-chat-ask-send:focus-visible {
+ box-shadow: var(--ring-shadow);
+}
 .agent-chat-ask-send:disabled { opacity: 0.45; cursor: default; }
 
 /* 보조 동작 — 승인이 주 동작이므로 채움을 양보한다. */
@@ -664,7 +665,6 @@
 .agent-chat-ask-mini:focus-visible {
   color: var(--brass-ink);
   border-color: var(--brass);
-  outline: none;
 }
 
 .agent-chat-ask-hint {
@@ -747,9 +747,8 @@
 .agent-chat-fold > summary:hover { color: var(--text-secondary); }
 
 .agent-chat-fold > summary:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 3px;
   border-radius: var(--radius-xs);
+  box-shadow: var(--ring-shadow);
 }
 
 .agent-chat-fold > summary::-webkit-details-marker { display: none; }
@@ -851,7 +850,7 @@
 
 .agent-chat-composer-frame:focus-within {
   border-color: var(--brass);
-  box-shadow: 0 0 0 1px var(--brass-glow);
+  box-shadow: var(--ring-shadow);
 }
 
 /* 파일을 끌어온 동안 — 어디에 놓이는지 프레임이 스스로 말한다(포커스와 같은 brass 채널). */
@@ -1009,7 +1008,7 @@
 
 .agent-chat-composer-attach:hover {
   color: var(--brass-ink);
-  background: var(--brass-glow);
+  background: var(--surface-hover);
 }
 
 .agent-chat-composer-send {
@@ -1053,7 +1052,6 @@
 .agent-chat-composer-send.is-stopping:focus-visible {
   border-color: var(--brass);
   color: var(--brass-ink);
-  outline: none;
 }
 
 .agent-chat-composer-send.is-stopping:disabled {
@@ -1165,7 +1163,11 @@
   border-color: var(--brass);
   color: var(--brass-ink);
   box-shadow: var(--brass-halo);
-  outline: none;
+}
+
+/* hover halo가 전역 포커스 링을 덮으므로 키보드 자리는 링으로 되돌린다. */
+.agent-chat-follow:focus-visible {
+  box-shadow: var(--ring-shadow);
 }
 
 /* War Room 카드의 본문은 읽는 자리다 — 승격 면이 클릭을 가로채고 본문은 inert라
@@ -1570,8 +1572,7 @@
 .agent-chat-job:hover { border-color: var(--hairline-strong); }
 
 .agent-chat-job:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .agent-chat-job.is-open { border-color: color-mix(in oklch, var(--aurora) 32%, var(--hairline)); }
@@ -1693,8 +1694,7 @@
 .agent-chat-strip:hover { border-color: color-mix(in oklch, var(--aurora) 55%, var(--hairline)); }
 
 .agent-chat-strip:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 3px;
+  box-shadow: var(--ring-shadow);
 }
 
 .agent-chat-strip-orbit {
@@ -1789,9 +1789,8 @@
 .agent-chat-work-cap:hover { color: var(--text-secondary); }
 
 .agent-chat-work-cap:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 2px;
   border-radius: var(--radius-xs);
+  box-shadow: var(--ring-shadow);
 }
 
 .agent-chat-work-cap-chev {
@@ -1848,8 +1847,7 @@
 }
 
 .agent-chat-detail-back:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 /* 중단은 되돌릴 수 없는 문이라 돌아가기와 같은 무게로 두지 않는다 — 평소에는 조용하고,
@@ -1875,8 +1873,7 @@
 }
 
 .agent-chat-detail-stop:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 2px;
+  box-shadow: var(--ring-shadow);
 }
 
 .agent-chat-detail-stop:disabled {
@@ -2115,7 +2112,6 @@
 .agent-chat-ctx-chip:focus-visible {
   border-color: var(--brass);
   color: var(--brass-ink);
-  outline: none;
 }
 
 .agent-chat-ctx-pct { color: var(--agent-chat-ctx-ink); }
@@ -2291,9 +2287,8 @@
 .agent-chat-ctx-detail > summary:hover .agent-chat-ctx-name { color: var(--text-secondary); }
 
 .agent-chat-ctx-detail > summary:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 2px;
   border-radius: var(--radius-xs);
+  box-shadow: var(--ring-shadow);
 }
 
 /* 값이 언제 잰 것인지 말하지 않으면 이 표면은 조용한 거짓말이 된다 — 자식은 턴이 끝나기 전에

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -853,6 +853,11 @@
   box-shadow: var(--ring-shadow);
 }
 
+/* 프레임이 포커스를 대신 그리므로 안쪽 입력에는 링을 그리지 않는다(코어 .font-field와 같은 문법). */
+.agent-chat-composer-frame:focus-within .agent-chat-composer-input:focus-visible {
+  box-shadow: none;
+}
+
 /* 파일을 끌어온 동안 — 어디에 놓이는지 프레임이 스스로 말한다(포커스와 같은 brass 채널). */
 .agent-chat-composer-frame.is-drag-over {
   border-color: var(--brass);

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
@@ -67,12 +67,12 @@
 /* A latched Ctrl or Alt, and the open panel, speak the same brass fill every other pressed toggle
    in the product uses. */
 .terminal-key[aria-pressed="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  background: var(--surface-select);
+  box-shadow: var(--elev-select);
+  border-color: transparent;
   color: var(--brass-ink);
 }
 
 .terminal-key:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
+  box-shadow: var(--ring-shadow);
 }


### PR DESCRIPTION
## Summary

컨트롤이 자기 상태를 말하는 방식을 색 농도에서 **형태**로 옮깁니다. 격리 콘솔 실측에서 hover·선택·현재 위치·포커스가 전부 brass 채움이고 농도만 8/12/12/12%로 갈려 있어, 사람 눈이 구별할 수 없는 차이로 서로 다른 네 가지 뜻을 나르고 있었습니다.

- **포커스** — 191개 선언이 다섯 색 채널(brass·aurora·warn·positive·coral)에 흩어져 있었고 brass만 여섯 농도·세 offset이었습니다. 링 하나(`--ring-shadow`)로 통일하고 신호색을 상태 채널로 회수했습니다. `outline` 대신 `box-shadow`라 라운드를 따라가고 `overflow` 안에서 잘리지 않으며, forced-colors 폴백을 함께 답니다.
- **선택** — 활성 페인트가 28가지로 갈려 있었고, 라이트 테마에서는 강조가 주변보다 **OKLab ΔL −4.8만큼 어두웠습니다**(강조가 아니라 얼룩). 움푹한 트랙(`--surface-track`) 위를 미끄러지는 썸(`--surface-select` + `--elev-select`)으로 바꿔 네 테마 모두 ΔL +9~16으로 맞췄습니다.
- **hover** — 중성 표면(`--surface-hover`)으로 분리해 brass가 hover 채널에서 물러납니다.
- **메뉴·탭·아이콘 버튼·컨트롤 라벨** — 떠 있는 면에 접지 그림자(2겹 `--shadow-floating`)와 `--radius-raised`, 들여쓴 구분선, 진입 모션, 본문 티어 항목 활자. 언더라인 탭은 열이 아니라 라벨 폭을 재고, 아이콘 버튼은 문서화된 24/32px 티어로 되돌립니다.
- **SDK `Segmented`** — 세그먼티드 구현을 하나로 합치고 커맨드 밴드와 사이드바 축 전환이 채택합니다. 썸이 스프링으로 미끄러지며, `prefers-reduced-motion`에서는 즉시 전환입니다.

계약 테스트에 포커스 링·선택 문법 단언 2개를 추가하고, 옛 문법을 못 박던 핀 6개(코어 4·플러그인 2)를 문법과 함께 옮겼습니다. 테마 팔레트 값은 바뀌지 않습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console build` (tsc + vite) — green
- [x] `vitest run` (서버 기동 스위트 제외) — 2243 passed / 6 skipped
- [x] 플러그인 자체 러너 7종 — terminal 970 · repository 439 · ledger 125 · skills 126 · file-explorer 209 · scuttlebutt 145 · quota 34 전부 green
- [x] `instrument-design-contract` 77 passed (신규 단언 2 포함)
- [x] `compile-changelog-fragments --check` — 14 entries validated
- [x] 격리 콘솔 헤디드 검증 — instrument/maritime/carbon/whites 4테마에서 세그먼티드·포커스 링·메뉴 스크린샷 확인, 썸 슬라이드 실측(translateX 3 → 140.5)
- [x] 선택 면 분리 실측(OKLab ΔL, 캔버스 합성) — 썸 vs 트랙: instrument 13.7 · maritime 16.1 · carbon 15.1 · whites 9.1