### PR TITLE
refactor(fleet-admiral): drop the plugin session holder bookkeeping

### DIFF
--- a/packages/core-infra/src/fs-store/directory-lock.ts
+++ b/packages/core-infra/src/fs-store/directory-lock.ts
@@ -167,10 +167,9 @@ function restoreQuarantinedLock(quarantineDir: string, lockDir: string): void {
 
 /**
  * 같은 호스트의 pid 생존 프로브. ESRCH만 죽음으로 판정하고 EPERM 등 그 외 오류는
- * 살아 있음으로 취급한다 — 소유자 판별이 불확실할 때 자원을 회수하지 않는 보수적 계약이며,
- * lock 복구와 plugin snapshot lease 회수가 같은 판정을 공유한다.
+ * 살아 있음으로 취급한다 — 소유자 판별이 불확실할 때 락을 회수하지 않는 보수적 계약이다.
  */
-export function isProcessAlive(pid: number): boolean {
+function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;

--- a/packages/core-infra/src/fs-store/index.ts
+++ b/packages/core-infra/src/fs-store/index.ts
@@ -10,7 +10,7 @@ export type {
 } from "./types.js";
 
 export { createDurableJsonStore } from "./json-store.js";
-export { isProcessAlive, withDirectoryLock } from "./directory-lock.js";
+export { withDirectoryLock } from "./directory-lock.js";
 export {
   NOFOLLOW_FLAG,
   safeLstat,

--- a/packages/fleet-admiral/src/agent-cli/plugin/index.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/index.ts
@@ -5,7 +5,7 @@ import { getFleetDataDir } from "@dotobokuri/core-infra/data-dir";
 
 import { assetBundle, buildAssetPluginFiles } from "./fleet.js";
 import { reclaimLegacyMarketplace } from "./legacy-marketplace.js";
-import { acquirePluginSession, PLUGIN_SESSIONS_DIR_NAME, type PluginSessionReclaimDeps } from "./session-store.js";
+import { acquirePluginSession, PLUGIN_SESSIONS_DIR_NAME } from "./session-store.js";
 import type { AgentCliPlugin, CreateAgentCliPluginOptions } from "../types.js";
 
 export type {
@@ -41,10 +41,9 @@ export async function createAgentCliPlugin(
   const fleetRoot = options.dataDir ?? getFleetDataDir();
   const sessionsRoot = pluginSessionsRoot(fleetRoot, options.cwd);
   const files = buildAssetPluginFiles(assetBundle, options);
-  const reclaimDeps: PluginSessionReclaimDeps = options.reclaimDeps ?? {};
   const lease = withDirectoryLock(
     { lockDir: `${sessionsRoot}${SESSIONS_LOCK_SUFFIX}` },
-    () => acquirePluginSession(sessionsRoot, options.sessionId, files, reclaimDeps),
+    () => acquirePluginSession(sessionsRoot, options.sessionId, files),
   );
   // 레거시 트리는 이 코드가 읽지도 쓰지도 않지만, 남겨 두면 한 호스트에 Fleet 플러그인
   // 트리가 둘이 된다. 렌더 경로에 붙여 두어 구버전 런치가 끊긴 뒤 자연히 걷히게 한다.
@@ -52,7 +51,6 @@ export async function createAgentCliPlugin(
   const cleanup = createOnceCleanup(() => lease.release());
   options.onCleanup?.(cleanup);
   return {
-    attach: lease.attach,
     cleanup,
     pluginRoot: lease.pluginRoot,
     pluginRoots: [lease.pluginRoot],

--- a/packages/fleet-admiral/src/agent-cli/plugin/session-store.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/session-store.ts
@@ -1,12 +1,7 @@
-import { createHash, randomUUID } from "node:crypto";
-import { existsSync, lstatSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
-
-import { isProcessAlive } from "@dotobokuri/core-infra";
 
 import { ensurePrivateDir, removePrivatePath, writePrivateFile, writePrivateJson } from "./fs.js";
 import type { AssetPluginFile } from "./fleet.js";
-import type { PluginSessionReclaimDeps } from "../types.js";
 
 /**
  * 세션 플러그인 트리가 앉는 자리는 그 세션의 워크스페이스 안이다:
@@ -21,107 +16,73 @@ import type { PluginSessionReclaimDeps } from "../types.js";
  */
 export const PLUGIN_SESSIONS_DIR_NAME = "sessions";
 
+/** 이 트리가 무엇인지 사람이 알아볼 수 있게 남기는 기록. 코드는 읽지 않는다. */
 const SESSION_MANIFEST_NAME = ".fleet-session.json";
-const HOLDERS_DIR_NAME = ".holders";
-/**
- * 홀더 pid가 죽어 보여도 이 유예 안에서는 트리를 지우지 않는다.
- *
- * 유예가 필요한 창은 하나다 — 트리를 발행하고 홀더를 세운 뒤, 호스트가 실제 자식 pid를
- * 붙이기(`attach`)까지의 사이. 그동안 홀더는 런처의 pid를 들고 있으므로, 런처가 먼저 죽으면
- * 아직 살아날 자식이 죽은 것처럼 보인다. `attach`가 끝난 뒤에는 홀더가 그 트리를 실제로 읽는
- * 프로세스를 직접 가리키므로 pid 생사 판정이 정확해지고, 유예는 더 이상 필요하지 않다.
- */
-const RECLAIM_GRACE_MS = 10 * 60 * 1000;
 /**
  * 디렉터리 이름으로 쓸 수 있는 세션 id.
  *
  * UUID보다 넓다. 새 세션과 갈래의 id는 Claude가 UUID를 요구하므로 그쪽에서 따로 좁히지만,
  * 이어 붙이는 세션의 id는 이미 존재하는 트랜스크립트가 주는 값이라 우리가 고를 수 없다 —
- * 여기서 요구할 수 있는 것은 그 값이 경로를 벗어나지 않는다는 것뿐이다. 점으로 시작하는
- * 이름을 막아 두면 운영용 항목(`.holders`)과도 섞이지 않는다.
+ * 여기서 요구할 수 있는 것은 그 값이 경로를 벗어나지 않는다는 것뿐이다.
  */
 const SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 export interface PluginSessionLease {
-  readonly contentHash: string;
   readonly pluginRoot: string;
   readonly sessionId: string;
-  /**
-   * 이 트리를 실제로 읽는 자식의 pid를 홀더에 옮겨 적는다. 호스트가 spawn 직후 부른다 —
-   * 자식 pid는 프로세스를 세운 호스트만 알고, 그것을 알기 전까지 홀더는 런처를 가리킨다.
-   * 자식 pid를 모르는 표면(SDK 경로)은 부르지 않아도 되며, 그때 홀더는 런처를 계속 가리킨다.
-   */
-  readonly attach: (childPid: number) => void;
   readonly release: () => void;
 }
-
-export type { PluginSessionReclaimDeps } from "../types.js";
 
 export function isPluginSessionId(value: string): boolean {
   return SESSION_ID_PATTERN.test(value);
 }
 
-/** 파일 집합의 내용 해시. 재렌더가 필요한지 판정하는 유일한 근거다. 매니페스트 자신은 입력이 아니다(순환). */
-export function hashPluginFiles(files: readonly AssetPluginFile[]): string {
-  const hash = createHash("sha256");
-  for (const file of [...files].sort((a, b) => a.relativePath.localeCompare(b.relativePath))) {
-    hash.update(file.relativePath, "utf8");
-    hash.update("\0");
-    hash.update(file.content, "utf8");
-    hash.update("\0");
-  }
-  return hash.digest("hex");
-}
-
 /**
  * 이 세션의 플러그인 트리를 확보한다. 호출자는 저장소 락을 이미 쥐고 있어야 한다.
  *
- * 새 세션과 fork 재개는 매번 새 id를 받으므로 여기서 기존 트리를 만날 일이 없다. 만나는 경우는
- * 하나뿐이다 — 같은 세션을 다시 재개하는 런치. 그때 내용이 같으면 그대로 쓰고, 갈렸는데 아직
- * 그 트리를 쥔 런치가 살아 있으면 고쳐 쓰지 않고 이 런치를 시끄럽게 실패시킨다.
+ * **한 세션의 트리는 언제나 런치 하나가 독점한다.** 같은 Claude 세션을 PTY와 SDK가 함께 여는
+ * 상태는 Console이 상위에서 거부하고(전환은 유휴 세션만 허용하며 PTY를 먼저 접는다), 새 세션과
+ * 갈래는 매번 새 id를 받는다. 그래서 여기서 만나는 기존 트리는 **반드시 끝난 런치의 잔해**다 —
+ * 검증하거나 살릴 이유가 없으므로 그대로 걷고 다시 쓴다.
+ *
+ * 이 독점 전제가 점유 표식(홀더)과 회수 기계를 통째로 불필요하게 만든다. 잔해는 그 세션이 다시
+ * 뜰 때 이 자리에서 정리되고, 정상 종료한 세션은 `release`가 자기 트리를 걷고 간다.
  */
 export function acquirePluginSession(
   sessionsRoot: string,
   sessionId: string,
   files: readonly AssetPluginFile[],
-  deps: PluginSessionReclaimDeps = {},
 ): PluginSessionLease {
   if (!isPluginSessionId(sessionId)) {
     throw new Error(`Fleet plugin session id cannot name a directory: ${sessionId}`);
   }
   ensurePrivateDir(sessionsRoot, sessionsRoot);
-  const contentHash = hashPluginFiles(files);
   const pluginRoot = path.join(sessionsRoot, sessionId);
-  if (existsSync(pluginRoot)) {
-    if (!verifyPluginSession(pluginRoot, contentHash, files)) {
-      if (hasLiveHolder(sessionsRoot, sessionId, deps.isPidAlive) || hasRecentHolderTrace(sessionsRoot, sessionId, deps.now)) {
-        throw new Error(
-          `Fleet plugin session tree is in use by another launch and its content differs: ${pluginRoot}`,
-        );
+  removePrivatePath(pluginRoot, sessionsRoot);
+  publishPluginSession(sessionsRoot, sessionId, files);
+  return {
+    pluginRoot,
+    sessionId,
+    release: () => {
+      try {
+        removePrivatePath(pluginRoot, sessionsRoot);
+      } catch {
+        // 반납 실패는 세션 종료를 막지 않는다. 남은 트리는 이 세션이 다시 뜰 때 걷힌다.
       }
-      removePrivatePath(pluginRoot, sessionsRoot);
-      publishPluginSession(sessionsRoot, sessionId, contentHash, files);
-    }
-  } else {
-    publishPluginSession(sessionsRoot, sessionId, contentHash, files);
-  }
-  const holder = holdPluginSession(sessionsRoot, sessionId);
-  reclaimPluginSessions(sessionsRoot, sessionId, deps);
-  return { contentHash, pluginRoot, sessionId, attach: holder.attach, release: holder.release };
+    },
+  };
 }
 
 /**
  * 세션 트리를 제자리에 쓴다. 스테이징도 rename도 없다.
  *
- * 발행·홀더·회수가 모두 저장소 락 안에서 돌므로 반쯤 쓰인 트리를 볼 프로세스가 없고, 이
- * 트리를 읽을 자식은 발행이 끝난 뒤에야 선다. 중단된 발행이 남기는 것은 매니페스트가 없거나
- * 해시가 맞지 않는 트리이고, 그것은 다음 런치의 손상 판정이 그대로 걸러 낸다 — 그래서
- * 매니페스트를 **맨 마지막에** 쓴다. 이 순서가 이 함수의 유일한 원자성 장치다.
+ * 이 트리를 읽을 자식은 발행이 끝난 뒤에야 서고, 발행은 저장소 락 안에서 돈다 — 반쯤 쓰인
+ * 트리를 볼 프로세스가 없다. 중단된 발행이 남기는 잔해도 다음 런치가 무조건 걷어 내므로,
+ * 중간 상태를 판정할 장치가 필요하지 않다.
  */
 function publishPluginSession(
   sessionsRoot: string,
   sessionId: string,
-  contentHash: string,
   files: readonly AssetPluginFile[],
 ): void {
   const pluginRoot = path.join(sessionsRoot, sessionId);
@@ -134,149 +95,6 @@ function publishPluginSession(
   writePrivateJson(path.join(pluginRoot, SESSION_MANIFEST_NAME), {
     version: 1,
     sessionId,
-    contentHash,
     renderedAt: Date.now(),
   }, sessionsRoot);
-}
-
-/**
- * 기대 파일 전량을 바이트 비교로 검증한다. 여분 파일은 실패 사유가 아니다 — 실패는
- * 매니페스트 해시 불일치, 기대 파일의 부재·변조, 또는 필수 디렉터리의 부재다.
- */
-function verifyPluginSession(
-  pluginRoot: string,
-  contentHash: string,
-  files: readonly AssetPluginFile[],
-): boolean {
-  try {
-    const manifestRaw = readFileSync(path.join(pluginRoot, SESSION_MANIFEST_NAME), "utf8");
-    const manifest = JSON.parse(manifestRaw) as { readonly contentHash?: unknown };
-    if (manifest.contentHash !== contentHash) return false;
-    // agents/는 빈 로스터에서도 소비자가 요구하는 필수 디렉터리인데 파일 목록에는 빈 디렉터리가
-    // 실리지 않으므로, 존재를 명시적으로 검증해야 복구 경로가 발동한다. lstat(no-follow)이어야
-    // 한다 — 심링크로 바꿔치기된 디렉터리는 이 패키지 fs 규약대로 손상으로 판정한다.
-    if (!lstatSync(path.join(pluginRoot, "agents")).isDirectory()) return false;
-    for (const file of files) {
-      const onDisk = readFileSync(path.join(pluginRoot, ...file.relativePath.split("/")), "utf8");
-      if (onDisk !== file.content) return false;
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function holdersRootFor(sessionsRoot: string, sessionId: string): string {
-  return path.join(sessionsRoot, HOLDERS_DIR_NAME, sessionId);
-}
-
-/**
- * 이 런치가 트리를 쥐고 있다는 표식. 홀더는 플러그인 루트 **바깥**에 앉는다 — 자식이 읽는
- * 트리에 Fleet의 운영 파일을 섞으면 플러그인 내용이 런치마다 달라진다.
- */
-function holdPluginSession(
-  sessionsRoot: string,
-  sessionId: string,
-): { readonly attach: (childPid: number) => void; readonly release: () => void } {
-  // Console 데몬은 여러 세션이 한 pid를 공유하므로 홀더 정체성은 pid가 아니라 pid+nonce다.
-  const holderPath = path.join(holdersRootFor(sessionsRoot, sessionId), `${process.pid}-${randomUUID()}.json`);
-  const startedAt = Date.now();
-  writePrivateJson(holderPath, { pid: process.pid, startedAt }, sessionsRoot);
-  let released = false;
-  return {
-    attach: (childPid: number) => {
-      if (released || !Number.isInteger(childPid) || childPid <= 0) return;
-      try {
-        writePrivateJson(holderPath, { pid: childPid, launcherPid: process.pid, startedAt }, sessionsRoot);
-      } catch {
-        // 옮겨 적지 못해도 런처 pid를 가리키는 홀더가 남는다 — 유예가 그 부정확을 흡수한다.
-      }
-    },
-    release: () => {
-      if (released) return;
-      released = true;
-      try {
-        removePrivatePath(holderPath, sessionsRoot);
-        // 마지막 홀더가 나가면 트리도 함께 걷는다. 세션이 다시 재개되면 그때 다시 렌더한다 —
-        // 정상 종료한 세션의 트리를 남겨 둘 이유가 없다.
-        if (!hasAnyHolderTrace(sessionsRoot, sessionId)) {
-          removePrivatePath(path.join(sessionsRoot, sessionId), sessionsRoot);
-          removePrivatePath(holdersRootFor(sessionsRoot, sessionId), sessionsRoot);
-        }
-      } catch {
-        // 홀더 해제 실패는 세션 종료를 막지 않는다. 남은 트리는 pid 사망 후 회수가 걷는다.
-      }
-    },
-  };
-}
-
-function hasLiveHolder(
-  sessionsRoot: string,
-  sessionId: string,
-  isPidAlive: (pid: number) => boolean = isProcessAlive,
-): boolean {
-  const holdersRoot = holdersRootFor(sessionsRoot, sessionId);
-  if (!existsSync(holdersRoot)) return false;
-  for (const entry of readdirSync(holdersRoot)) {
-    try {
-      const holder = JSON.parse(readFileSync(path.join(holdersRoot, entry), "utf8")) as { readonly pid?: unknown };
-      if (typeof holder.pid !== "number") return true;
-      if (isPidAlive(holder.pid)) return true;
-    } catch {
-      // 읽을 수 없는 홀더는 살아 있는 것으로 취급한다 — 불확실을 삭제로 해소하지 않는다.
-      return true;
-    }
-  }
-  return false;
-}
-
-/** 홀더 파일이 하나라도 남아 있는가 — pid 생사와 무관한 흔적 판정. 정상 반납한 런치는 파일을 지우고 간다. */
-function hasAnyHolderTrace(sessionsRoot: string, sessionId: string): boolean {
-  const holdersRoot = holdersRootFor(sessionsRoot, sessionId);
-  if (!existsSync(holdersRoot)) return false;
-  return readdirSync(holdersRoot).length > 0;
-}
-
-/** 유예 안의 홀더 흔적이 있는가 — 죽은 pid라도 재시작 고아 자식의 가능성으로 취급한다. */
-function hasRecentHolderTrace(sessionsRoot: string, sessionId: string, now: () => number = Date.now): boolean {
-  const holdersRoot = holdersRootFor(sessionsRoot, sessionId);
-  if (!existsSync(holdersRoot)) return false;
-  for (const entry of readdirSync(holdersRoot)) {
-    try {
-      if (now() - statSync(path.join(holdersRoot, entry)).mtimeMs <= RECLAIM_GRACE_MS) return true;
-    } catch {
-      // 확인할 수 없는 흔적은 최근 것으로 취급한다 — 불확실을 삭제로 해소하지 않는다.
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * best-effort 회수. 정상 종료한 세션은 이미 자기 트리를 걷고 갔으므로, 여기 남는 것은
- * 홀더를 반납하지 못하고 죽은 런치의 잔해뿐이다. 살아 있는 홀더가 있거나 유예 안의 흔적이
- * 남은 트리는 건드리지 않는다. 어떤 실패도 런치를 막지 않는다.
- */
-export function reclaimPluginSessions(
-  sessionsRoot: string,
-  keepSessionId: string,
-  deps: PluginSessionReclaimDeps = {},
-): void {
-  const now = deps.now ?? Date.now;
-  const isPidAlive = deps.isPidAlive ?? isProcessAlive;
-  try {
-    for (const entry of readdirSync(sessionsRoot)) {
-      try {
-        if (entry === keepSessionId || !isPluginSessionId(entry)) continue;
-        if (hasLiveHolder(sessionsRoot, entry, isPidAlive)) continue;
-        if (hasRecentHolderTrace(sessionsRoot, entry, now)) continue;
-        removePrivatePath(path.join(sessionsRoot, entry), sessionsRoot);
-        removePrivatePath(holdersRootFor(sessionsRoot, entry), sessionsRoot);
-      } catch {
-        continue;
-      }
-    }
-  } catch {
-    return;
-  }
 }

--- a/packages/fleet-admiral/src/agent-cli/session.ts
+++ b/packages/fleet-admiral/src/agent-cli/session.ts
@@ -57,8 +57,6 @@ export interface ClaudeSessionHandle {
   readonly claudeCodeSystemPrompt: "on" | "off";
   /** Chat Mode처럼 SDK로 자식을 세우는 표면이 그대로 펼쳐 쓰는 투영. */
   readonly sdk: ClaudeSessionSdkProjection;
-  /** 이 트리를 읽는 자식의 pid를 홀더에 옮겨 적는다. spawn 직후 호스트가 부른다. */
-  readonly attach: (childPid: number) => void;
   readonly release: () => void;
 }
 
@@ -111,7 +109,6 @@ export async function prepareClaudeSession(
         ...(claudeCodeSystemPrompt === "on" ? { systemPrompt: { mode: "preset" } as const } : {}),
       },
     },
-    attach: plugin.attach,
     release: plugin.cleanup,
   };
 }

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -130,15 +130,8 @@ export interface CreateAgentCliPluginOptions {
   readonly onCleanup?: (cleanup: () => void) => void;
   /** 이 트리를 읽을 Claude 세션의 id. 곧 디렉터리 이름이므로 UUID여야 한다. */
   readonly sessionId: string;
-  /** 테스트가 회수 판정의 시계와 pid 프로브를 갈아 끼우는 자리. 프로덕션은 비워 둔다. */
-  readonly reclaimDeps?: PluginSessionReclaimDeps;
   /** 테스트가 레거시 트리 회수의 시계와 나이 창을 갈아 끼우는 자리. 프로덕션은 비워 둔다. */
   readonly legacyReclaimDeps?: LegacyMarketplaceReclaimDeps;
-}
-
-export interface PluginSessionReclaimDeps {
-  readonly now?: () => number;
-  readonly isPidAlive?: (pid: number) => boolean;
 }
 
 export interface LegacyMarketplaceReclaimDeps {
@@ -147,7 +140,6 @@ export interface LegacyMarketplaceReclaimDeps {
 }
 
 export interface AgentCliPlugin {
-  readonly attach: (childPid: number) => void;
   readonly cleanup: () => void;
   readonly pluginRoot: string;
   readonly pluginRoots: readonly string[];

--- a/packages/fleet-admiral/tests/agent-cli-plugin-sessions.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-sessions.test.ts
@@ -1,6 +1,5 @@
-import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -8,7 +7,6 @@ import { findGatewayModel, type GatewayModel } from "@dotobokuri/core-ai-gateway
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createAgentCliPlugin, pluginSessionsRoot } from "../src/agent-cli/plugin/index.js";
-import { reclaimPluginSessions } from "../src/agent-cli/plugin/session-store.js";
 import type { CreateAgentCliPluginOptions } from "../src/agent-cli/types.js";
 
 const tempDirs: string[] = [];
@@ -37,8 +35,8 @@ describe("agent CLI plugin session store", () => {
     expect(existsSync(path.join(plugin.pluginRoot, "hooks", "hooks.json"))).toBe(true);
     expect(existsSync(path.join(plugin.pluginRoot, "hooks", "fleet-gateway-model-guard.mjs"))).toBe(true);
     expect(existsSync(path.join(plugin.pluginRoot, "agents"))).toBe(true);
-    // sessions/ 아래에는 세션 트리와 홀더 말고는 아무것도 살지 않는다 — 발행은 제자리에 쓴다.
-    expect(readdirSync(sessionsRoot).sort()).toEqual([".holders", sessionId]);
+    // sessions/ 아래에는 세션 트리 말고 아무것도 살지 않는다.
+    expect(readdirSync(sessionsRoot)).toEqual([sessionId]);
   });
 
   it("rejects a session id that cannot name a directory", async () => {
@@ -73,82 +71,38 @@ describe("agent CLI plugin session store", () => {
     expect(readdirSync(path.join(first.pluginRoot, "agents"))).toEqual([]);
   });
 
-  it("reuses the same tree when the same session relaunches with identical content", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-reuse-");
-    const sessionId = randomUUID();
-
-    const first = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    const manifestBefore = readSessionManifest(first.pluginRoot);
-    first.cleanup();
-    // 정상 종료한 세션은 자기 트리를 걷고 간다 — 재개가 그때 다시 렌더한다.
-    expect(existsSync(first.pluginRoot)).toBe(false);
-
-    const second = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-
-    expect(second.pluginRoot).toBe(first.pluginRoot);
-    expect(readSessionManifest(second.pluginRoot).contentHash).toBe(manifestBefore.contentHash);
-  });
-
-  // 제자리에 쓰므로 발행 중 죽으면 반쯤 쓰인 트리가 남는다. 매니페스트를 맨 마지막에 쓰는
-  // 순서가 그것을 다음 런치에서 손상으로 드러나게 하는 유일한 장치다.
-  it("repairs a tree whose publish was interrupted before the manifest landed", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-partial-");
-    const sessionId = randomUUID();
-
-    const first = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    dropHolders(dataDir, cwd, sessionId);
-    // 중단된 발행의 흔적: 파일은 일부 있고 매니페스트가 없다.
-    rmSync(path.join(first.pluginRoot, ".fleet-session.json"), { force: true });
-    rmSync(path.join(first.pluginRoot, "hooks"), { recursive: true, force: true });
-
-    const second = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-
-    expect(second.pluginRoot).toBe(first.pluginRoot);
-    expect(existsSync(path.join(second.pluginRoot, ".fleet-session.json"))).toBe(true);
-    expect(existsSync(path.join(second.pluginRoot, "hooks", "fleet-gateway-model-guard.mjs"))).toBe(true);
-  });
-
-  it("repairs a corrupt tree when no launch holds it", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-repair-");
+  // 한 세션의 트리는 런치 하나가 독점한다 — 같은 Claude 세션을 두 표면이 함께 여는 상태를
+  // Console이 상위에서 거부하므로, 여기서 만나는 기존 트리는 반드시 끝난 런치의 잔해다.
+  // 살리거나 검증할 이유가 없으므로 무조건 걷고 다시 쓴다.
+  it("replaces whatever the previous launch left behind", async () => {
+    const { dataDir, cwd } = createRoots("fleet-admiral-session-replace-");
     const sessionId = randomUUID();
 
     const first = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
     const guardPath = path.join(first.pluginRoot, "hooks", "fleet-gateway-model-guard.mjs");
     const original = readFileSync(guardPath, "utf8");
-    // 홀더만 지우고 트리는 남긴다 — 홀더를 반납하지 못하고 죽은 런치의 잔해다.
-    dropHolders(dataDir, cwd, sessionId);
+    // 잔해의 모든 모습: 변조된 파일, 사라진 필수 디렉터리, 발행 중 끊긴 흔적, 낯선 여분 파일.
     writeFileSync(guardPath, "// tampered\n");
+    rmSync(path.join(first.pluginRoot, "agents"), { recursive: true, force: true });
+    rmSync(path.join(first.pluginRoot, ".fleet-session.json"), { force: true });
+    writeFileSync(path.join(first.pluginRoot, "stray.txt"), "left over\n");
 
     const second = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
 
     expect(second.pluginRoot).toBe(first.pluginRoot);
     expect(readFileSync(guardPath, "utf8")).toBe(original);
-  });
-
-  // 빈 로스터 트리의 agents/는 파일이 없는 필수 디렉터리다 — 파일 바이트 검증만으로는 그
-  // 부재를 못 잡으므로, 디렉터리 소실도 손상으로 판정되어 복구 경로가 발동해야 한다.
-  it("repairs a tree whose required empty agents directory was lost", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-agents-dir-");
-    const sessionId = randomUUID();
-
-    const first = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    dropHolders(dataDir, cwd, sessionId);
-    rmSync(path.join(first.pluginRoot, "agents"), { recursive: true, force: true });
-
-    const second = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-
-    expect(second.pluginRoot).toBe(first.pluginRoot);
     expect(existsSync(path.join(second.pluginRoot, "agents"))).toBe(true);
+    expect(existsSync(path.join(second.pluginRoot, ".fleet-session.json"))).toBe(true);
+    // 이전 런치의 여분 파일까지 남지 않는다 — 트리는 통째로 새것이다.
+    expect(existsSync(path.join(second.pluginRoot, "stray.txt"))).toBe(false);
   });
 
-  // 심링크로 바꿔치기된 agents/는 실디렉터리가 아니다 — no-follow 판정으로 손상 처리되어
-  // 복구 경로가 실디렉터리를 되살린다.
-  it("treats a symlinked agents directory as corruption and repairs it", async () => {
+  // 심링크로 바꿔치기된 agents/도 잔해의 한 형태다. no-follow 규약대로 실디렉터리로 되돌아온다.
+  it("replaces a tree whose agents directory was swapped for a symlink", async () => {
     const { dataDir, cwd } = createRoots("fleet-admiral-session-agents-link-");
     const sessionId = randomUUID();
 
     const first = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    dropHolders(dataDir, cwd, sessionId);
     const agentsPath = path.join(first.pluginRoot, "agents");
     const outside = path.join(dataDir, "outside-agents");
     mkdirSync(outside, { recursive: true });
@@ -158,106 +112,24 @@ describe("agent CLI plugin session store", () => {
 
     const second = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
 
-    expect(second.pluginRoot).toBe(first.pluginRoot);
     const restored = readdirSync(second.pluginRoot, { withFileTypes: true }).find((entry) => entry.name === "agents");
     expect(restored?.isDirectory()).toBe(true);
     expect(restored?.isSymbolicLink()).toBe(false);
   });
 
-  it("refuses to relaunch onto a differing tree that a live launch still holds", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-held-");
-    const sessionId = randomUUID();
-
-    const first = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    writeFileSync(path.join(first.pluginRoot, "hooks", "fleet-gateway-model-guard.mjs"), "// tampered\n");
-
-    // 홀더는 아직 살아 있다(이 테스트 프로세스의 pid). 실행 중 런치가 읽는 트리는 고쳐 쓰지
-    // 않고 새 런치를 시끄럽게 실패시킨다.
-    await expect(
-      createAgentCliPlugin(options({ cwd, dataDir, sessionId })),
-    ).rejects.toThrow(/in use by another launch/);
-  });
-
-  // 트리를 발행하고 자식 pid를 붙이기 전에 런처가 죽으면, 홀더 pid는 죽어 보이지만 자식은
-  // 살아날 수 있다. 그 창 안의 흔적은 살아 있는 것으로 취급한다.
-  it("refuses to repair a differing tree that carries a recent dead-pid holder trace", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-orphan-");
-    const sessionId = randomUUID();
-
-    const first = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    dropHolders(dataDir, cwd, sessionId);
-    const guardPath = path.join(first.pluginRoot, "hooks", "fleet-gateway-model-guard.mjs");
-    writeFileSync(guardPath, "// tampered\n");
-    writeDeadHolder(dataDir, cwd, sessionId);
-
-    await expect(
-      createAgentCliPlugin(options({ cwd, dataDir, sessionId })),
-    ).rejects.toThrow(/in use by another launch/);
-    expect(readFileSync(guardPath, "utf8")).toBe("// tampered\n");
-  });
-
-  it("moves the holder onto the child pid that actually reads the tree", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-attach-");
-    const sessionId = randomUUID();
-
-    const plugin = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    expect(readHolders(dataDir, cwd, sessionId).map((holder) => holder.pid)).toEqual([process.pid]);
-
-    plugin.attach(424242);
-
-    const [holder] = readHolders(dataDir, cwd, sessionId);
-    expect(holder?.pid).toBe(424242);
-    expect(holder?.launcherPid).toBe(process.pid);
-  });
-
-  it("removes the tree and its holders on cleanup, and cleanup is idempotent", async () => {
+  it("removes the tree on cleanup, and cleanup is idempotent", async () => {
     const { dataDir, cwd } = createRoots("fleet-admiral-session-cleanup-");
     const sessionId = randomUUID();
 
     const plugin = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    expect(readHolders(dataDir, cwd, sessionId)).toHaveLength(1);
+    expect(existsSync(plugin.pluginRoot)).toBe(true);
 
     plugin.cleanup();
     plugin.cleanup();
 
     expect(existsSync(plugin.pluginRoot)).toBe(false);
-    expect(readHolders(dataDir, cwd, sessionId)).toEqual([]);
-  });
-
-  it("reclaims a crashed launch's tree past the grace window and keeps a held one", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-reclaim-");
-    const heldId = randomUUID();
-    const orphanId = randomUUID();
-
-    const held = await createAgentCliPlugin(options({ cwd, dataDir, sessionId: heldId }));
-    const orphan = await createAgentCliPlugin(options({ cwd, dataDir, sessionId: orphanId }));
-    dropHolders(dataDir, cwd, orphanId);
-    writeDeadHolder(dataDir, cwd, orphanId);
-    const sessionsRoot = pluginSessionsRoot(dataDir, cwd);
-
-    // 유예 안에서는 죽은 pid 흔적도 살아 있는 것으로 취급한다.
-    reclaimPluginSessions(sessionsRoot, heldId);
-    expect(existsSync(orphan.pluginRoot)).toBe(true);
-
-    // 유예 밖으로 나가면 회수한다. 홀더가 살아 있는 트리는 그대로 둔다.
-    reclaimPluginSessions(sessionsRoot, heldId, { now: () => Date.now() + 11 * 60 * 1000 });
-
-    expect(existsSync(orphan.pluginRoot)).toBe(false);
-    expect(existsSync(held.pluginRoot)).toBe(true);
-  });
-
-  it("serializes concurrent renders of the same session and leaves no staging behind", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-race-");
-    const sessionId = randomUUID();
-
-    const [first, second] = await Promise.all([
-      createAgentCliPlugin(options({ cwd, dataDir, sessionId })),
-      createAgentCliPlugin(options({ cwd, dataDir, sessionId })),
-    ]);
-
-    expect(first.pluginRoot).toBe(second.pluginRoot);
-    expect(readHolders(dataDir, cwd, sessionId)).toHaveLength(2);
-    expect(readdirSync(pluginSessionsRoot(dataDir, cwd)).sort()).toEqual([".holders", sessionId]);
+    // 정상 종료한 세션은 아무것도 남기지 않는다 — 걷어야 할 잔해가 애초에 없다.
+    expect(readdirSync(pluginSessionsRoot(dataDir, cwd))).toEqual([]);
   });
 
   describe("legacy marketplace tree", () => {
@@ -405,33 +277,6 @@ function readSessionManifest(pluginRoot: string): { readonly contentHash: string
     readonly contentHash: string;
     readonly renderedAt: number;
   };
-}
-
-function holdersDir(dataDir: string, cwd: string, sessionId: string): string {
-  return path.join(pluginSessionsRoot(dataDir, cwd), ".holders", sessionId);
-}
-
-function readHolders(
-  dataDir: string,
-  cwd: string,
-  sessionId: string,
-): Array<{ readonly pid?: number; readonly launcherPid?: number }> {
-  const dir = holdersDir(dataDir, cwd, sessionId);
-  if (!existsSync(dir)) return [];
-  return readdirSync(dir).map((entry) => JSON.parse(readFileSync(path.join(dir, entry), "utf8")) as { pid?: number });
-}
-
-/** 홀더만 지운다 — 트리는 남기고 "반납하지 못하고 죽은 런치"의 잔해를 만든다. */
-function dropHolders(dataDir: string, cwd: string, sessionId: string): void {
-  rmSync(holdersDir(dataDir, cwd, sessionId), { recursive: true, force: true });
-}
-
-/** 방금 종료된 프로세스의 pid로 죽은 홀더 흔적을 남긴다 — 런처만 죽은 상태의 재현. */
-function writeDeadHolder(dataDir: string, cwd: string, sessionId: string): void {
-  const deadPid = spawnSync(process.execPath, ["-e", ""]).pid!;
-  const dir = holdersDir(dataDir, cwd, sessionId);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(path.join(dir, `${deadPid}-orphan.json`), `${JSON.stringify({ pid: deadPid, startedAt: Date.now() })}\n`);
 }
 
 function seedLegacyMarketplace(dataDir: string): string {

--- a/runtime/fleet-console/cli/gateway/launch.ts
+++ b/runtime/fleet-console/cli/gateway/launch.ts
@@ -52,9 +52,6 @@ export async function launchClaudeGateway(options: LaunchClaudeGatewayOptions): 
       env: launchProfile.env,
       stdio: "inherit",
     });
-    // 플러그인 트리를 실제로 읽는 것은 이 자식이다. 홀더를 자식 pid로 옮겨 적어야 런처가
-    // 먼저 죽어도 회수가 살아 있는 트리를 걷지 않는다.
-    if (child.pid !== undefined) injected.session.attach(child.pid);
 
     // stdio inherit + 동일 포그라운드 프로세스 그룹: Ctrl+C의 SIGINT는 커널이 자식에게도
     // 직접 전달한다. 부모가 SIGINT를 재전달하면 자식이 이중 수신해 Claude Code의

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -356,15 +356,11 @@ async function createAgentCliLaunchSpec(options: {
       });
     }
     const sessionIdentityResolver = options.createSessionIdentityResolver({ cwd: launchProfile.cwd });
-    return {
-      ...toLaunchSpec(launchProfile, createOnceCleanup(async () => {
-        for (const cleanup of [...cleanupStack].reverse()) {
-          await cleanup();
-        }
-      }), sessionIdentityResolver),
-      // 플러그인 트리를 실제로 읽는 것은 이 자식이다.
-      onChildSpawned: (pid: number) => injectedProfile.session.attach(pid),
-    };
+    return toLaunchSpec(launchProfile, createOnceCleanup(async () => {
+      for (const cleanup of [...cleanupStack].reverse()) {
+        await cleanup();
+      }
+    }), sessionIdentityResolver);
   } catch (error) {
     for (const cleanup of [...cleanupStack].reverse()) {
       try {

--- a/runtime/fleet-plugins/terminal/server/shared/pty.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/pty.ts
@@ -52,7 +52,7 @@ export function startTerminalShell(launch: TerminalLaunchSpec, size: { readonly 
   if (testStartShell) return testStartShell(launch, size);
   const { spawn: spawnPty } = loadNodePty();
   const useConptyDll = resolveUseConptyDll(process.platform, process.env);
-  const pty = spawnPty(launch.bin, [...launch.args], {
+  return spawnPty(launch.bin, [...launch.args], {
     cols: size.cols,
     rows: size.rows,
     cwd: launch.cwd,
@@ -60,8 +60,6 @@ export function startTerminalShell(launch: TerminalLaunchSpec, size: { readonly 
     name: launch.terminalName ?? TERMINAL_TERM,
     ...(useConptyDll ? { useConptyDll: true } : {}),
   });
-  if (typeof pty.pid === "number") launch.onChildSpawned?.(pty.pid);
-  return pty;
 }
 
 export function resolveNodePtyModulePath(currentFile: string = fileURLToPath(import.meta.url)): string {

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -9,11 +9,6 @@ export interface TerminalLaunchSpec {
   readonly env: NodeJS.ProcessEnv;
   readonly messagePolicy?: CliMessagePolicy;
   readonly renameCommand?: string;
-  /**
-   * spawn된 자식의 pid를 런치를 만든 쪽으로 되돌린다. 플러그인 트리 홀더가 이 pid로 옮겨
-   * 앉아야, 런처가 먼저 죽어도 회수가 살아 있는 트리를 걷지 않는다.
-   */
-  readonly onChildSpawned?: (pid: number) => void;
   /** Spawn-time selected opaque provider identity reader; never browser-visible. */
   readonly sessionIdentityResolver?: SessionIdentityResolver;
   readonly terminalName?: string;
@@ -89,8 +84,6 @@ export interface TerminalPtyDataDisposable {
 
 export interface TerminalPtyHandle {
   readonly fd?: number;
-  /** spawn된 자식의 pid. node-pty가 채우며, 테스트 대역은 비워 둘 수 있다. */
-  readonly pid?: number;
   onData(callback: (data: string) => void): TerminalPtyDataDisposable;
   onExit(callback: () => void): TerminalPtyDataDisposable;
   write(data: string): void;

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-ask.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-ask.test.ts
@@ -111,7 +111,6 @@ function seedFor(awaitingLog: boolean[]): AgentChatSessionSeed {
           options: { plugins: [{ path: pluginRoot }], settingSources: ["user", "project", "local"], allowAmbientMcpServers: true },
           request: { sessionId, permissionMode: "bypassPermissions" },
         },
-        attach: () => {},
         release: () => {},
       };
     },

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -229,7 +229,6 @@ function fakeClaudeSession(
         ...(claudeCodeSystemPrompt === "on" ? { systemPrompt: { mode: "preset" } as const } : {}),
       },
     },
-    attach: () => {},
     release: overrides.release ?? (() => {}),
   };
 }


### PR DESCRIPTION
## Summary

#869이 플러그인 트리를 세션 단위로 격리하면서 점유 표식(`.holders/`)과 회수 기계를 함께 들여왔습니다. 그런데 **한 세션의 트리는 언제나 런치 하나가 독점**합니다 — 그 기계가 막던 상태는 애초에 발생할 수 없습니다.

### 독점은 제품이 이미 강제합니다

`handleChatConvert`(`agent.ts:1141-1167`):

```
if (info?.status === "starting") → 409 chat_convert_busy
  // "이때 전환하면 launch가 완주해 PTY와 SDK가 같은 provider 세션의 이중 필자가 된다"
if (live && (awaiting|turn|background)) → 409 chat_convert_busy
...
terminalRuntime.terminate(sessionId)   // → removeSession → killSession + launch cleanup → release()
```

이중 필자를 거부하는 가드가 이미 있고, 전환은 유휴 세션만 허용하며, `terminate`가 PTY와 launch cleanup을 먼저 돌립니다. Chat의 트리 렌더는 `ensureSdk` 안에서 **첫 턴에 지연 실행**되므로 사용자가 다음 행동을 하기 전까지 시작도 하지 않습니다. 새 세션과 갈래는 매번 새 id를 받으므로 기존 트리를 만날 일 자체가 없습니다.

### 그래서 홀더가 하던 일이 전부 비어 있었습니다

| 홀더 용도 | 실제 |
|---|---|
| 살아 있는 런치가 읽는 트리 거부 | 그런 런치가 공존할 수 없음 → 도달 불가 분기 |
| 다른 홀더가 없을 때만 트리 삭제 | 다른 홀더가 있을 수 없음 → 무조건 삭제면 충분 |
| 회수 스윕이 살아 있는 트리를 건너뜀 | 회수 대상은 크래시 잔해뿐이고, 그건 그 세션이 다시 뜰 때 이 자리에서 정리됨 |

### 남은 계약

```
acquire: 이전 런치가 남긴 것을 무조건 걷고 다시 쓴다
release: 자기 트리를 지운다
```

여기서 만나는 기존 트리는 정의상 끝난 런치의 잔해이므로, 살리거나 검증할 이유가 없습니다. 내용 해시·바이트 검증·손상 판정·홀더 디렉터리·유예 창·회수 스윕이 함께 사라집니다.

`.fleet-session.json`은 남기되 **코드가 읽지 않는 기록**입니다 — UUID로만 이름 붙은 디렉터리가 무엇인지 사람이 알아볼 수 있게 하는 용도입니다.

### 호스트 표면도 줄어듭니다

홀더가 없으면 트리를 읽는 자식의 pid를 알 이유가 없습니다. #869이 그 때문에 추가했던 것들이 되돌아갑니다.

- `ClaudeSessionHandle.attach(childPid)`
- `TerminalLaunchSpec.onChildSpawned`
- `TerminalPtyHandle.pid`
- CLI의 spawn 직후 `attach` 호출, PTY의 `onChildSpawned` 발화
- `core-infra`의 `isProcessAlive` public export — #869이 스냅숏 저장소를 위해 열었던 것으로, 이제 디렉터리 락 내부로 되돌립니다

**순 -369줄**(13 files changed, 56 insertions, 425 deletions).

## Test Plan

- [x] `pnpm typecheck` (전 리포) — 0 오류
- [x] `pnpm build` (전 리포) — 통과
- [x] `pnpm -C packages/fleet-admiral test` — 191/191. 세션 저장소 스위트를 새 계약으로 교체: 이전 런치의 잔해(변조 파일·사라진 `agents/`·끊긴 발행·여분 파일)를 무조건 대체, 심링크 `agents/`도 같은 경로로 복구, cleanup이 트리를 지우고 `sessions/`를 비움
- [x] `pnpm -C packages/core-infra test` — 60/60
- [x] `pnpm -C packages/core-agent test` — 통과
- [x] `pnpm -C runtime/fleet-plugins/terminal exec vitest run` — 970/970
- [x] `pnpm -C runtime/fleet-console exec vitest run` — 2360/2360 (24 skip)
- [x] `pnpm check:core-boundary` · `check:claude-agent-sdk-boundary` · `check:core-unified-agent-absent` — 통과

## Notes for Reviewers

- 사용자가 관찰하는 동작은 바뀌지 않으므로 changelog 프래그먼트를 두지 않았습니다.
- 독점 전제가 깨지는 유일한 경로는 Fleet 밖에서 같은 세션 id로 `claude --resume`을 직접 두 번 띄우는 경우입니다. 그때는 나중 런치가 앞선 트리를 대체하며, 이는 한 트랜스크립트에 두 필자가 붙는 이미 잘못된 상태입니다.
- 잔해가 남는 경우: 크래시로 `release()`를 못 돌린 트리는 그 세션이 다시 뜰 때 정리됩니다. 다시 뜨지 않으면 워크스페이스가 지워질 때까지 하나에 104K로 남습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
