### PR TITLE
fix(fleet-admiral): restore session resume through the Console PTY and CLI passthrough

### DIFF
--- a/packages/fleet-admiral/src/agent-cli/builders/claude.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/claude.ts
@@ -52,6 +52,9 @@ function buildSettingsArgs(
  */
 function buildSessionArgs(coordinate: AgentCliInjectionContext["sessionCoordinate"]): string[] {
   switch (coordinate.kind) {
+    // 호출자의 인자가 이미 좌표를 들고 있다. 여기서 `--session-id`를 더하면 자식이 거부한다.
+    case "external":
+      return [];
     case "resume":
       return ["--resume", coordinate.sessionId];
     case "fork":

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -130,7 +130,11 @@ export async function injectAgentCliProfile(
       cliId: profile.id,
       cwd: profile.cwd,
       dataDir: options.dataDir,
-      origin: options.origin ?? { kind: "new" },
+      // 이 프로필의 인자가 이미 세션 좌표를 들고 있으면 우리 것을 얹지 않는다 — 호스트가
+      // 무엇을 의도했든 자식은 두 좌표를 함께 받으면 거부한다(`fleet --resume <id>` 등).
+      origin: profileCarriesSessionCoordinate(profile.args)
+        ? { kind: "external" }
+        : options.origin ?? { kind: "new" },
       ...(options.claudeCodeSystemPrompt ? { claudeCodeSystemPrompt: options.claudeCodeSystemPrompt } : {}),
       captureSessionHookExec: options.captureSessionHookExec,
       turnStartHookExec: options.turnStartHookExec,
@@ -217,6 +221,27 @@ export async function injectAgentCliProfile(
   }
 }
 
+
+/**
+ * 이 argv가 이미 Claude 세션 좌표를 정하고 있는가.
+ *
+ * `fleet <passthrough>`는 사용자의 인자를 그대로 이어 붙이므로 여기에 `--resume`·`-c`가
+ * 들어올 수 있다. 그 위에 `--session-id`를 더하면 자식이 곧바로 거부한다(실측:
+ * `--session-id can only be used with --continue or --resume if --fork-session is also
+ * specified`). 좌표를 싣는 쪽이 그 규칙도 알아야 하므로 판정을 여기에 둔다.
+ */
+function profileCarriesSessionCoordinate(args: readonly string[]): boolean {
+  return args.some((arg) => SESSION_COORDINATE_FLAGS.has(arg) || arg.startsWith("--resume=") || arg.startsWith("--session-id="));
+}
+
+const SESSION_COORDINATE_FLAGS = new Set([
+  "--resume",
+  "-r",
+  "--continue",
+  "-c",
+  "--session-id",
+  "--fork-session",
+]);
 
 function buildAgentCliMcpServerConfigs(
   endpoints: readonly ExecutorServerEndpoint[],

--- a/packages/fleet-admiral/src/agent-cli/session.ts
+++ b/packages/fleet-admiral/src/agent-cli/session.ts
@@ -22,7 +22,9 @@ import type { ClaudeSessionCoordinate, CreateAgentCliPluginOptions } from "./typ
 export type ClaudeSessionOrigin =
   | { readonly kind: "new"; readonly preferredSessionId?: string }
   | { readonly kind: "resume"; readonly sessionId: string }
-  | { readonly kind: "fork"; readonly from: string; readonly preferredSessionId?: string };
+  | { readonly kind: "fork"; readonly from: string; readonly preferredSessionId?: string }
+  /** 좌표를 호출자의 argv가 이미 들고 있다. Fleet은 세션 플래그를 싣지 않는다. */
+  | { readonly kind: "external" };
 
 export type { ClaudeSessionCoordinate } from "./types.js";
 
@@ -122,6 +124,8 @@ export async function prepareClaudeSession(
  * 어긋날 방법이 없다.
  */
 function resolveSessionCoordinate(origin: ClaudeSessionOrigin): ClaudeSessionCoordinate {
+  // 자식이 어떤 세션을 열지 우리는 모른다 — 트리 이름은 이 런치의 것이지 세션 id가 아니다.
+  if (origin.kind === "external") return { kind: "external", sessionId: randomUUID() };
   if (origin.kind === "resume") {
     // 이어 붙이는 세션의 id는 트랜스크립트가 이미 정해 놓은 값이다 — 고를 수 없으므로
     // 형태를 요구하지도 않는다. 디렉터리 이름으로 안전한지는 저장소가 판정한다.
@@ -144,6 +148,8 @@ function toSdkSessionCoordinate(
   coordinate: ClaudeSessionCoordinate,
 ): Pick<ClaudeSessionSdkRequest, "sessionId" | "resume" | "forkSession"> {
   switch (coordinate.kind) {
+    case "external":
+      return {};
     case "resume":
       return { resume: coordinate.sessionId };
     case "fork":

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -73,7 +73,13 @@ export interface AgentCliMcpServerArg {
 export type ClaudeSessionCoordinate =
   | { readonly kind: "new"; readonly sessionId: string }
   | { readonly kind: "resume"; readonly sessionId: string }
-  | { readonly kind: "fork"; readonly sessionId: string; readonly from: string };
+  | { readonly kind: "fork"; readonly sessionId: string; readonly from: string }
+  /**
+   * 좌표를 호출자의 인자가 이미 들고 있다. Fleet은 세션 플래그를 하나도 싣지 않는다 —
+   * `fleet --resume <id>`·`fleet -c`처럼 사용자가 직접 넘긴 경우다. `sessionId`는 이 런치의
+   * 플러그인 트리 이름일 뿐 Claude 세션 id가 아니다: 자식이 어떤 세션을 열지 우리는 모른다.
+   */
+  | { readonly kind: "external"; readonly sessionId: string };
 
 export interface AgentCliInjectionContext {
   readonly cliId: AgentCliId;

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -53,6 +53,23 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(injected.session.sessionId).toBe(resumeSessionId);
   });
 
+  // 회귀: 호스트가 이미 좌표를 들고 오는 argv(`fleet --resume <id>`·`fleet -c`)에 `--session-id`를
+  // 얹으면 자식이 곧바로 거부한다. 좌표를 싣는 쪽이 그 규칙을 알아야 한다.
+  it("adds no session flag when the profile's own args already carry a coordinate", async () => {
+    const root = createTempRoot("fleet-admiral-claude-passthrough-");
+    for (const passthrough of [["--resume", "sid-from-user"], ["-c"], ["--continue"], ["--resume=sid-inline"]]) {
+      const profile = baseProfile("claude-gateway", { args: passthrough, cwd: root, env: { HOME: root } });
+      const injected = await injectAgentCliProfile(profile, baseInjectOptions(root));
+
+      expect(injected.args).not.toContain("--session-id");
+      expect(injected.args).not.toContain("--fork-session");
+      // 사용자의 좌표는 그대로 남고, 우리는 플러그인만 싣는다.
+      expect(injected.args.slice(0, passthrough.length)).toEqual(passthrough);
+      expect(injected.args).toContain("--plugin-dir");
+      injected.cleanup?.();
+    }
+  });
+
   it("pins a Fleet-issued session id for a new session, and forks with a fresh one", async () => {
     const root = createTempRoot("fleet-admiral-claude-pin-");
     const profile = baseProfile("claude-gateway", { args: [], cwd: root, env: { HOME: root } });

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -111,7 +111,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(events).toEqual([]);
   });
 
-  it("passes resumeSessionId and capture hook exec to fleet-admiral injection", async () => {
+  it("passes the resume coordinate and capture hook exec to fleet-admiral injection", async () => {
     const runtime = createFakeRuntime(() => undefined);
     const injectedOptions: InjectAgentCliProfileOptions[] = [];
     const resolveProfile = vi.fn(async (env: NodeJS.ProcessEnv, cwd: string) => ({ ...baseProfile, id: "claude-gateway" as const, label: "Claude", cwd, env: { ...env } }));
@@ -136,7 +136,9 @@ describe("createDefaultTerminalLaunchResolver", () => {
       cliId: "claude-gateway",
       resumeSessionId: "provider-session-a",
     }));
-    expect(injectedOptions[0]).toMatchObject({ resumeSessionId: "provider-session-a" });
+    // 재개는 좌표로 넘어간다. 대역이 아니라 실제 주입이 읽는 필드여야 한다 — 예전 이름을
+    // 그대로 두면 주입이 그것을 무시한 채 매번 새 세션을 열고, 대화가 조용히 끊긴다.
+    expect(injectedOptions[0]?.origin).toEqual({ kind: "resume", sessionId: "provider-session-a" });
     expect(injectedOptions[0]?.captureSessionHookExec).toEqual({
       command: "/node",
       args: ["--import", pathToFileURL("/loader/tsx.mjs").href, "/console/cli.ts", "hook", "capture-session", "claude"],
@@ -338,6 +340,60 @@ describe("createDefaultTerminalLaunchResolver", () => {
       name: "GatewayLaunchOptionError",
       code: "invalid_effort",
     });
+  });
+
+  // 회귀 가드: 재개 런치는 그 세션을 이어 붙여야 한다. 좌표가 주입에 닿지 않으면 매번 새
+  // 세션이 열려 대화가 조용히 끊기는데, 인자를 실제로 보지 않으면 그 사실이 드러나지 않는다.
+  it("resumes the given session instead of opening a new one", async () => {
+    const root = makeTempDir("fleet-gateway-admiral-resume-");
+    const releasedLabels: string[] = [];
+    const resolve = createDefaultTerminalLaunchResolver({
+      agentRuntime: {
+        dedicatedMcpSession: {
+          async getEndpoint() {
+            return { servers: [{ name: "fleet", url: "http://127.0.0.1:48123/mcp" }] };
+          },
+          issueSessionToken() {
+            return [{ name: "fleet", token: "gateway-token" }];
+          },
+          releaseSessionToken(label: string) {
+            releasedLabels.push(label);
+          },
+        },
+        mcpRegistry: { getAllAgentTools: () => [] },
+        async cleanup() {},
+      } as never,
+      aiGateway: {
+        routePath: "/plugins/terminal/ai-gateway",
+        origin: () => "http://127.0.0.1:43210",
+      },
+      createSessionIdentityResolver: (() => ({ resolve: async () => null })) as never,
+      cwd: root,
+      dataDir: root,
+      entryPath: "/console/cli.mjs",
+      env: {
+        CLAUDE_BIN: process.execPath,
+        CLAUDE_CONFIG_DIR: path.join(root, "claude-config"),
+        PATH: process.env.PATH,
+      },
+      execPath: process.execPath,
+      infraServices: createFakeInfraServices() as never,
+    });
+
+    const resumeSessionId = "11111111-2222-4333-8444-555555555555";
+    const spec = await resolve(root, {
+      cliId: "claude-gateway",
+      sessionId: "gateway-resumed",
+      resumeSessionId,
+    });
+
+    expect(spec.args[spec.args.indexOf("--resume") + 1]).toBe(resumeSessionId);
+    // 이어 붙이는 세션은 id를 고를 수 없다 — 둘을 함께 실으면 자식이 거부한다.
+    expect(spec.args).not.toContain("--session-id");
+    // 트리도 그 세션의 자리에 앉는다.
+    expect(path.basename(spec.args[spec.args.indexOf("--plugin-dir") + 1]!)).toBe(resumeSessionId);
+
+    await spec.cleanup?.();
   });
 
   it("launches claude-gateway through the real shared Admiral package", async () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -324,7 +324,10 @@ async function createAgentCliLaunchSpec(options: {
       onCleanup: (cleanup) => cleanupStack.push(cleanup),
       // 사용자가 고른 값이며 새 세션에만 적용된다 — 실행 중인 세션은 자기 런치 구성을 유지한다.
       claudeCodeSystemPrompt: resolveClaudeCodeSystemPrompt(options.infraServices.globalOptionsService.load()),
-      resumeSessionId: options.resumeSessionId,
+      // 이어 붙일 세션이 있으면 그 좌표로 연다. 없으면 admiral이 새 id를 발급해 못박는다.
+      origin: options.resumeSessionId
+        ? { kind: "resume", sessionId: options.resumeSessionId }
+        : { kind: "new" },
       mcpSessionLabel: options.sessionId,
       ...(gatewaySelection
         ? {
@@ -333,7 +336,7 @@ async function createAgentCliLaunchSpec(options: {
           gatewayEffortExposure: gatewaySelection.effortExposure,
         }
         : {}),
-    } as Parameters<typeof injectAgentCliProfile>[1] & { readonly mcpSessionLabel: string });
+    });
     options.onRuntimeSessionStart?.({
       cliId: injectedProfile.id,
       cliLabel: injectedProfile.label,


### PR DESCRIPTION
## Summary

#869이 낸 회귀 둘을 고칩니다. 둘 다 세션 좌표를 못박는 변경에서 나왔습니다.

### 1. Console 터미널의 재개가 끊겼습니다

재개는 `InjectAgentCliProfileOptions.resumeSessionId` **하나가** 옮기고 있었습니다 — Claude 프로필 팩토리는 `--resume`을 만들지 않습니다. #869이 그 필드를 `origin`으로 바꿨는데 Console PTY 호출부는 계속 `resumeSessionId`를 넘겼고, 그 객체에 걸린 캐스트가 초과 속성 오류를 삼켰습니다.

```ts
} as Parameters<typeof injectAgentCliProfile>[1] & { readonly mcpSessionLabel: string });
```

결과: `origin`이 `{ kind: "new" }` 기본값을 타서 **터미널 런치마다 새 세션이 발급되고 대화가 끊겼습니다.** Chat Mode에서 CLI로 돌아올 때마다 이전 대화가 사라집니다.

캐스트를 걷어 초과 속성 검사를 되살리고, 호출부가 `resumeSessionId`를 재개 좌표로 사상합니다.

### 2. `fleet --resume <id>` / `fleet -c` 가 거부됩니다

`fleet`은 사용자의 패스스루 인자를 그대로 이어 붙인 뒤 주입이 `--session-id`를 덧붙입니다. 자식은 그 조합을 받지 않습니다.

```
--session-id can only be used with --continue or --resume if --fork-session is also specified.
```

좌표를 싣는 쪽이 그 규칙도 알아야 하므로, 주입이 프로필 인자에 이미 좌표가 있는지 보고(`--resume`·`-r`·`--continue`·`-c`·`--session-id`·`--fork-session`, `=` 형태 포함) 있으면 아무 세션 플래그도 얹지 않습니다. 그때 플러그인 트리는 런치 단위 id로 이름 붙습니다 — 자식이 어떤 세션을 열지 우리가 모르기 때문입니다.

## 왜 안 잡혔는지

타입이 못 잡은 건 위의 캐스트 때문이고, 테스트가 못 잡은 건 **재개 계약을 대역으로만 검증**하고 있었기 때문입니다.

```ts
const injectProfile = vi.fn(async (profile, options) => { injectedOptions.push(options); ... });
expect(injectedOptions[0]).toMatchObject({ resumeSessionId: "provider-session-a" });
```

가짜 주입에 넘어간 옵션 이름을 단언하므로, 실제 함수가 그 이름을 더는 읽지 않아도 통과합니다. 그 단언을 `origin` 좌표로 바로잡고, **실제 Admiral을 통과시켜 argv를 보는** 재개 테스트를 따로 세웠습니다. 수정을 되돌리면 두 테스트 모두 레드입니다(확인함).

## Test Plan

- [x] `pnpm typecheck` (전 리포) — 0 오류
- [x] `pnpm build` (전 리포) — 통과
- [x] `pnpm -C packages/fleet-admiral test` — 192/192 (패스스루 좌표 4종에 세션 플래그를 얹지 않음)
- [x] `pnpm -C packages/core-agent test` — 133/133
- [x] `pnpm -C packages/core-infra test` — 60/60
- [x] `pnpm -C runtime/fleet-plugins/terminal exec vitest run` — 970/970
- [x] `pnpm -C runtime/fleet-console exec vitest run` — 2361/2361 (24 skip)
- [x] 수정을 되돌린 상태에서 신규 테스트 2건이 레드가 되는 것을 확인
- [x] `pnpm check:core-boundary` · `check:claude-agent-sdk-boundary` · `check:core-unified-agent-absent` — 통과

## Notes for Reviewers

- changelog 프래그먼트를 두지 않았습니다. #869의 `plugin-snapshot-store.md`가 아직 `.changelog.d/`에 미릴리스로 있어, 이 정정은 사용자가 소비할 수 없던 동작에 대한 것입니다(Release Baseline). 기존 프래그먼트의 서술도 수정 후 그대로 유효해 amend가 필요 없습니다.
- CLI→Chat 전환에서 플러그인 트리가 지워지는 것은 설계대로입니다 — `terminate`가 launch cleanup을 돌리고, Chat이 첫 턴에 같은 세션 id로 다시 렌더합니다. 회귀 1 때문에 그 id가 매번 갈려서 트리가 사라진 것처럼 보였습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
