### PR TITLE
fix(fleet-admiral): keep a session's plugin tree for the session's whole life

### DIFF
--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -147,7 +147,6 @@ export async function injectAgentCliProfile(
       gatewayEffortExposure: options.gatewayEffortExposure,
     });
     const cleanup = createOnceCleanup(() => {
-      session.release();
       for (const tempCleanup of tempCleanups) {
         tempCleanup();
       }

--- a/packages/fleet-admiral/src/agent-cli/plugin/index.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/index.ts
@@ -48,21 +48,9 @@ export async function createAgentCliPlugin(
   // 레거시 트리는 이 코드가 읽지도 쓰지도 않지만, 남겨 두면 한 호스트에 Fleet 플러그인
   // 트리가 둘이 된다. 렌더 경로에 붙여 두어 구버전 런치가 끊긴 뒤 자연히 걷히게 한다.
   reclaimLegacyMarketplace(fleetRoot, options.legacyReclaimDeps ?? {});
-  const cleanup = createOnceCleanup(() => lease.release());
-  options.onCleanup?.(cleanup);
   return {
-    cleanup,
     pluginRoot: lease.pluginRoot,
     pluginRoots: [lease.pluginRoot],
     sessionId: lease.sessionId,
-  };
-}
-
-function createOnceCleanup(cleanup: () => void): () => void {
-  let cleaned = false;
-  return () => {
-    if (cleaned) return;
-    cleaned = true;
-    cleanup();
   };
 }

--- a/packages/fleet-admiral/src/agent-cli/plugin/session-store.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/session-store.ts
@@ -30,7 +30,6 @@ const SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 export interface PluginSessionLease {
   readonly pluginRoot: string;
   readonly sessionId: string;
-  readonly release: () => void;
 }
 
 export function isPluginSessionId(value: string): boolean {
@@ -45,8 +44,10 @@ export function isPluginSessionId(value: string): boolean {
  * 갈래는 매번 새 id를 받는다. 그래서 여기서 만나는 기존 트리는 **반드시 끝난 런치의 잔해**다 —
  * 검증하거나 살릴 이유가 없으므로 그대로 걷고 다시 쓴다.
  *
- * 이 독점 전제가 점유 표식(홀더)과 회수 기계를 통째로 불필요하게 만든다. 잔해는 그 세션이 다시
- * 뜰 때 이 자리에서 정리되고, 정상 종료한 세션은 `release`가 자기 트리를 걷고 간다.
+ * 이 독점 전제가 점유 표식(홀더)과 회수 기계를 통째로 불필요하게 만든다. 그리고 런치가 끝날 때
+ * 걷을 것도 없다 — **트리는 세션의 것이지 런치의 것이 아니다**. 이름이 세션 id인 디렉터리를
+ * 런치마다 지우면, 살아 있는 세션의 플러그인이 CLI↔Chat 전환마다 사라졌다 다시 생긴다. 낡은
+ * 내용은 다음 런치가 이 자리에서 갈아 끼우므로, 지우는 쪽이 사는 것은 그 churn뿐이다.
  */
 export function acquirePluginSession(
   sessionsRoot: string,
@@ -60,17 +61,7 @@ export function acquirePluginSession(
   const pluginRoot = path.join(sessionsRoot, sessionId);
   removePrivatePath(pluginRoot, sessionsRoot);
   publishPluginSession(sessionsRoot, sessionId, files);
-  return {
-    pluginRoot,
-    sessionId,
-    release: () => {
-      try {
-        removePrivatePath(pluginRoot, sessionsRoot);
-      } catch {
-        // 반납 실패는 세션 종료를 막지 않는다. 남은 트리는 이 세션이 다시 뜰 때 걷힌다.
-      }
-    },
-  };
+  return { pluginRoot, sessionId };
 }
 
 /**

--- a/packages/fleet-admiral/src/agent-cli/session.ts
+++ b/packages/fleet-admiral/src/agent-cli/session.ts
@@ -59,7 +59,6 @@ export interface ClaudeSessionHandle {
   readonly claudeCodeSystemPrompt: "on" | "off";
   /** Chat Mode처럼 SDK로 자식을 세우는 표면이 그대로 펼쳐 쓰는 투영. */
   readonly sdk: ClaudeSessionSdkProjection;
-  readonly release: () => void;
 }
 
 export interface PrepareClaudeSessionOptions
@@ -111,7 +110,6 @@ export async function prepareClaudeSession(
         ...(claudeCodeSystemPrompt === "on" ? { systemPrompt: { mode: "preset" } as const } : {}),
       },
     },
-    release: plugin.cleanup,
   };
 }
 

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -133,7 +133,6 @@ export interface CreateAgentCliPluginOptions {
   // claude-gateway 렌더만 읽어 `agents/` 정의를 만든다.
   readonly gatewayDelegationModels?: readonly GatewayModel[];
   readonly gatewayEffortExposure?: GatewayEffortExposure;
-  readonly onCleanup?: (cleanup: () => void) => void;
   /** 이 트리를 읽을 Claude 세션의 id. 곧 디렉터리 이름이므로 UUID여야 한다. */
   readonly sessionId: string;
   /** 테스트가 레거시 트리 회수의 시계와 나이 창을 갈아 끼우는 자리. 프로덕션은 비워 둔다. */
@@ -146,7 +145,6 @@ export interface LegacyMarketplaceReclaimDeps {
 }
 
 export interface AgentCliPlugin {
-  readonly cleanup: () => void;
   readonly pluginRoot: string;
   readonly pluginRoots: readonly string[];
   readonly sessionId: string;

--- a/packages/fleet-admiral/tests/agent-cli-plugin-sessions.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-sessions.test.ts
@@ -117,19 +117,22 @@ describe("agent CLI plugin session store", () => {
     expect(restored?.isSymbolicLink()).toBe(false);
   });
 
-  it("removes the tree on cleanup, and cleanup is idempotent", async () => {
-    const { dataDir, cwd } = createRoots("fleet-admiral-session-cleanup-");
+  // 트리는 세션의 것이지 런치의 것이 아니다. 런치가 끝났다고 걷으면, 살아 있는 세션의
+  // 플러그인이 CLI↔Chat 전환마다 사라졌다 다시 생긴다.
+  it("keeps the tree in place for the session's whole life", async () => {
+    const { dataDir, cwd } = createRoots("fleet-admiral-session-persist-");
     const sessionId = randomUUID();
 
-    const plugin = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
-    expect(existsSync(plugin.pluginRoot)).toBe(true);
+    const first = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
+    const guardPath = path.join(first.pluginRoot, "hooks", "fleet-gateway-model-guard.mjs");
+    expect(existsSync(guardPath)).toBe(true);
 
-    plugin.cleanup();
-    plugin.cleanup();
+    // 한 런치가 끝나고 다음 런치가 서기 전에도 트리는 그 자리에 있다.
+    const second = await createAgentCliPlugin(options({ cwd, dataDir, sessionId }));
 
-    expect(existsSync(plugin.pluginRoot)).toBe(false);
-    // 정상 종료한 세션은 아무것도 남기지 않는다 — 걷어야 할 잔해가 애초에 없다.
-    expect(readdirSync(pluginSessionsRoot(dataDir, cwd))).toEqual([]);
+    expect(second.pluginRoot).toBe(first.pluginRoot);
+    expect(existsSync(guardPath)).toBe(true);
+    expect(readdirSync(pluginSessionsRoot(dataDir, cwd))).toEqual([sessionId]);
   });
 
   describe("legacy marketplace tree", () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -109,8 +109,7 @@ export interface AgentChatSessionSeed {
   /**
    * 이 세션의 Claude 좌표와 능력 표면을 admiral에서 확정해 온다. 세션 id, 플러그인 트리,
    * 스킬 억제, 설정 층, 시스템 프롬프트 정책이 한 핸들에 함께 실린다 — 터미널 세션이
-   * `--session-id`·`--plugin-dir`·`--settings`로 받는 것과 같은 값이다. `release`는 dispose가
-   * 부르고, 그래야 이 세션의 트리가 회수될 수 있다.
+   * `--session-id`·`--plugin-dir`·`--settings`로 받는 것과 같은 값이다.
    */
   readonly resolveClaudeSession?: () => Promise<ClaudeSessionHandle>;
   /** 위에서 발급한 토큰을 되돌린다. 세션 dispose에서만 불린다. */
@@ -674,10 +673,8 @@ class AgentChatSession {
     // 없이 남는다. 반납 자체는 라벨로 지우므로 발급된 적 없는 세션에서도 무해하다.
     if (this.fleetMcpFlight) await this.fleetMcpFlight.catch(() => undefined);
     this.seed.releaseFleetMcpServers?.();
-    // 발급이 아직 날고 있으면 착지시킨 뒤 반납한다 — 먼저 놓으면 뒤늦게 렌더된 트리가
-    // 주인 없이 남는다.
+    // 발급이 아직 날고 있으면 착지시킨다 — 트리 자체는 세션의 것이라 여기서 걷지 않는다.
     if (this.claudeSessionFlight) await this.claudeSessionFlight.catch(() => undefined);
-    this.claudeSession?.release();
     this.claudeSession = null;
     this.listeners.clear();
   }
@@ -1133,7 +1130,7 @@ class AgentChatSession {
           this.sdk = sdk;
           return sdk;
         } catch (error) {
-          claudeSession.release();
+          // 트리는 그대로 둔다 — 이 세션의 것이고, 다음 시도가 같은 자리를 다시 쓴다.
           this.claudeSession = null;
           throw error;
         }

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-ask.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-ask.test.ts
@@ -111,7 +111,6 @@ function seedFor(awaitingLog: boolean[]): AgentChatSessionSeed {
           options: { plugins: [{ path: pluginRoot }], settingSources: ["user", "project", "local"], allowAmbientMcpServers: true },
           request: { sessionId, permissionMode: "bypassPermissions" },
         },
-        release: () => {},
       };
     },
     onProviderSessionUpdate: () => {},

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -204,7 +204,6 @@ function fakeClaudeSession(
     readonly resumeOf?: string;
     readonly pluginRoot?: string;
     readonly claudeCodeSystemPrompt?: "on" | "off";
-    readonly release?: () => void;
   } = {},
 ): ClaudeSessionHandle {
   const sessionId = overrides.resumeOf ?? overrides.sessionId ?? "11111111-2222-4333-8444-555555555555";
@@ -229,7 +228,6 @@ function fakeClaudeSession(
         ...(claudeCodeSystemPrompt === "on" ? { systemPrompt: { mode: "preset" } as const } : {}),
       },
     },
-    release: overrides.release ?? (() => {}),
   };
 }
 
@@ -350,17 +348,17 @@ describe("AgentChatRegistry — chat-born sessions", () => {
 
   // 스킬·게이트웨이 정체성·정책 훅은 플러그인 한 벌로 실린다. 설정 층까지 같아야 같은 세션을
   // 터미널로 열었을 때와 능력이 갈리지 않는다.
-  it("loads the Fleet plugin, reads the terminal's setting layers, and releases the lease on dispose", async () => {
+  it("loads the Fleet plugin and reads the terminal's setting layers", async () => {
     const home = tempDir("chat-home-");
     const { factory } = createFakeSdkFactory([
       { messages: [{ type: "result", subtype: "success", is_error: false, duration_ms: 3 }] },
     ]);
     const registry = new AgentChatRegistry(factory);
-    const cleanup = vi.fn();
+    const resolveClaudeSession = vi.fn(async () => fakeClaudeSession());
     const pluginRoot = "/fleet/workspaces/tmp-workspace/sessions/11111111-2222-4333-8444-555555555555";
     const session = await registry.ensure("op-plugin", () => ({
       ...freshSeedFor(home),
-      resolveClaudeSession: async () => fakeClaudeSession({ release: cleanup }),
+      resolveClaudeSession,
     }));
     session.send("go");
     await drainTurn(registry, "op-plugin");
@@ -370,10 +368,11 @@ describe("AgentChatRegistry — chat-born sessions", () => {
       settingSources: ["user", "project", "local"],
       allowAmbientMcpServers: true,
     }));
-    // 트리는 세션이 접힐 때에야 반납된다 — 그 전에 놓으면 실행 중 세션의 트리가 회수 대상이 된다.
-    expect(cleanup).not.toHaveBeenCalled();
+    // 좌표는 세션당 한 번만 받는다 — 턴마다 다시 받으면 같은 트리를 매번 새로 렌더한다.
+    expect(resolveClaudeSession).toHaveBeenCalledTimes(1);
+    // dispose는 트리를 건드리지 않는다 — 트리는 이 세션의 것이고 런치가 접혀도 남는다.
     await registry.disposeAll();
-    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(resolveClaudeSession).toHaveBeenCalledTimes(1);
   });
 
   // Console 자신이 Fleet 터미널에서 떴다면 그 세션 id를 상속하고 있다. 자식에게 따라가면


### PR DESCRIPTION
## Summary

디렉터리 이름이 Claude 세션 id인데 `release()`가 **런치가 끝날 때** 그 트리를 지우고 있었습니다. 세션은 런치보다 오래 사는데 트리는 런치와 함께 죽으니, Operation을 터미널 ↔ Chat Mode로 전환할 때마다 **살아 있는 세션의 플러그인이 사라졌다가 다음 턴에 다시 생겼습니다.**

그 삭제에 기대는 것은 없었습니다 — `acquire`가 어차피 있는 것을 갈아 끼우므로, 지우는 쪽이 사는 것은 그 churn뿐입니다.

```
이전: acquire(렌더) → 런치 종료 → release(삭제) → 전환 → acquire(렌더) → ...
지금: acquire(렌더) → 런치 종료 → (그대로) → 전환 → acquire(갈아 끼움)
```

트리는 같은 세션이 다시 떠서 다시 쓸 때까지 그 자리에 있습니다.

## 함께 사라지는 것

`release`가 할 일이 없어지면서 그 배선이 전부 따라갑니다.

- `PluginSessionLease.release`
- `AgentCliPlugin.cleanup` · `CreateAgentCliPluginOptions.onCleanup`
- `ClaudeSessionHandle.release`
- Chat 세션의 dispose·실패 경로에서 부르던 반납

`injectAgentCliProfile`의 `cleanup`은 남습니다 — MCP 토큰 반납과 프롬프트 임시 파일 정리는 그것만 할 수 있는 일입니다.

**9 files changed, 27 insertions, 55 deletions.**

## Test Plan

- [x] `pnpm typecheck` (전 리포) — 0 오류
- [x] `pnpm build` (전 리포) — 통과
- [x] `pnpm -C packages/fleet-admiral test` — 192/192. `removes the tree on cleanup`을 `keeps the tree in place for the session's whole life`로 교체 — 런치가 끝난 뒤에도 트리가 그 자리에 있고, 다음 런치가 같은 자리를 쓰는 것을 확인
- [x] `pnpm -C packages/core-agent test` — 133/133
- [x] `pnpm -C runtime/fleet-plugins/terminal exec vitest run` — 970/970 (Chat 테스트는 dispose가 트리를 건드리지 않는 것으로 단언을 바꿈)
- [x] `pnpm -C runtime/fleet-console exec vitest run` — 2361/2361 (24 skip)
- [x] `pnpm check:core-boundary` · `check:claude-agent-sdk-boundary` — 통과

## Notes for Reviewers

- changelog 프래그먼트를 두지 않았습니다. #869의 `plugin-snapshot-store.md`가 아직 미릴리스라 사용자가 소비할 수 없던 동작의 정정입니다(Release Baseline).
- 트리가 남는 범위: 그 세션이 다시 뜨면 이 자리에서 갈아 끼웁니다. 다시 뜨지 않는 세션의 트리는 워크스페이스가 지워질 때까지 하나에 104K로 남습니다. 나중에 선제 정리가 필요해지면 Operation 삭제가 자연스러운 걸이 지점입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
