### PR TITLE
fix(fleet-admiral): reclaim a session's plugin tree when its panel closes

### DIFF
--- a/packages/fleet-admiral/src/agent-cli/plugin/index.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/index.ts
@@ -1,11 +1,11 @@
 import path from "node:path";
 
-import { ensureWorkspaceDirectory, withDirectoryLock } from "@dotobokuri/core-infra";
+import { ensureWorkspaceDirectory, resolveWorkspaceDirectory, withDirectoryLock } from "@dotobokuri/core-infra";
 import { getFleetDataDir } from "@dotobokuri/core-infra/data-dir";
 
 import { assetBundle, buildAssetPluginFiles } from "./fleet.js";
 import { reclaimLegacyMarketplace } from "./legacy-marketplace.js";
-import { acquirePluginSession, PLUGIN_SESSIONS_DIR_NAME } from "./session-store.js";
+import { acquirePluginSession, PLUGIN_SESSIONS_DIR_NAME, removePluginSessionTree } from "./session-store.js";
 import type { AgentCliPlugin, CreateAgentCliPluginOptions } from "../types.js";
 
 export type {
@@ -22,6 +22,30 @@ const SESSIONS_LOCK_SUFFIX = ".lock";
  */
 export function pluginSessionsRoot(dataDir: string, cwd: string): string {
   return path.join(ensureWorkspaceDirectory(dataDir, cwd).path, PLUGIN_SESSIONS_DIR_NAME);
+}
+
+/**
+ * 이 세션의 플러그인 트리를 걷는다. Operation이 사라질 때 호스트가 부른다 — 트리는 세션의
+ * 것이라 런치가 끝나도 남지만, 세션 자체가 없어지면 그것을 읽을 주체도 없다.
+ *
+ * 없는 워크스페이스를 만들지 않는다: 회수는 자리를 세우는 일이 아니다. 어떤 실패도 호출자의
+ * 삭제 흐름을 막지 않는다.
+ */
+export function removePluginSession(options: {
+  readonly cwd: string;
+  readonly dataDir?: string;
+  readonly sessionId: string;
+}): void {
+  try {
+    const fleetRoot = options.dataDir ?? getFleetDataDir();
+    const sessionsRoot = path.join(resolveWorkspaceDirectory(fleetRoot, options.cwd).path, PLUGIN_SESSIONS_DIR_NAME);
+    withDirectoryLock(
+      { lockDir: `${sessionsRoot}${SESSIONS_LOCK_SUFFIX}` },
+      () => removePluginSessionTree(sessionsRoot, options.sessionId),
+    );
+  } catch {
+    return;
+  }
 }
 
 /**

--- a/packages/fleet-admiral/src/agent-cli/plugin/session-store.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/session-store.ts
@@ -37,6 +37,17 @@ export function isPluginSessionId(value: string): boolean {
 }
 
 /**
+ * 세션이 사라졌을 때 그 트리를 걷는다. 호출자는 저장소 락을 이미 쥐고 있어야 한다.
+ *
+ * 트리는 세션의 것이므로 런치가 끝나도 남지만, 세션 자체가 없어지면 그것을 읽을 것도 없다.
+ * 이 트리를 읽던 자식이 이미 접힌 뒤에 부른다 — 훅은 이벤트 시점에 디스크를 다시 읽는다.
+ */
+export function removePluginSessionTree(sessionsRoot: string, sessionId: string): void {
+  if (!isPluginSessionId(sessionId)) return;
+  removePrivatePath(path.join(sessionsRoot, sessionId), sessionsRoot);
+}
+
+/**
  * 이 세션의 플러그인 트리를 확보한다. 호출자는 저장소 락을 이미 쥐고 있어야 한다.
  *
  * **한 세션의 트리는 언제나 런치 하나가 독점한다.** 같은 Claude 세션을 PTY와 SDK가 함께 여는

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -118,6 +118,7 @@ export {
 export {
   createAgentCliPlugin,
   pluginSessionsRoot,
+  removePluginSession,
   type AgentCliPlugin,
   type CreateAgentCliPluginOptions,
 } from "./agent-cli/plugin/index.js";

--- a/packages/fleet-admiral/tests/agent-cli-plugin-sessions.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-sessions.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { findGatewayModel, type GatewayModel } from "@dotobokuri/core-ai-gateway";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createAgentCliPlugin, pluginSessionsRoot } from "../src/agent-cli/plugin/index.js";
+import { createAgentCliPlugin, pluginSessionsRoot, removePluginSession } from "../src/agent-cli/plugin/index.js";
 import type { CreateAgentCliPluginOptions } from "../src/agent-cli/types.js";
 
 const tempDirs: string[] = [];
@@ -133,6 +133,32 @@ describe("agent CLI plugin session store", () => {
     expect(second.pluginRoot).toBe(first.pluginRoot);
     expect(existsSync(guardPath)).toBe(true);
     expect(readdirSync(pluginSessionsRoot(dataDir, cwd))).toEqual([sessionId]);
+  });
+
+  // 트리는 런치가 끝나도 남지만 세션 자체가 사라지면 읽을 주체도 없다 — 그때 호스트가 걷는다.
+  it("removes only the named session's tree when the host reclaims it", async () => {
+    const { dataDir, cwd } = createRoots("fleet-admiral-session-reclaim-");
+    const goneId = randomUUID();
+    const keptId = randomUUID();
+
+    const gone = await createAgentCliPlugin(options({ cwd, dataDir, sessionId: goneId }));
+    const kept = await createAgentCliPlugin(options({ cwd, dataDir, sessionId: keptId }));
+
+    removePluginSession({ cwd, dataDir, sessionId: goneId });
+
+    expect(existsSync(gone.pluginRoot)).toBe(false);
+    expect(existsSync(kept.pluginRoot)).toBe(true);
+    expect(readdirSync(pluginSessionsRoot(dataDir, cwd))).toEqual([keptId]);
+  });
+
+  it("survives a reclaim for a session, workspace, or data dir that is not there", async () => {
+    const { dataDir, cwd } = createRoots("fleet-admiral-session-reclaim-absent-");
+
+    // 어느 쪽도 던지지 않고, 없는 워크스페이스를 만들지도 않는다 — 회수는 자리를 세우지 않는다.
+    expect(() => removePluginSession({ cwd, dataDir, sessionId: randomUUID() })).not.toThrow();
+    expect(() => removePluginSession({ cwd, dataDir, sessionId: "../escape" })).not.toThrow();
+    expect(() => removePluginSession({ cwd: path.join(cwd, "absent"), dataDir, sessionId: randomUUID() })).not.toThrow();
+    expect(existsSync(path.join(dataDir, "workspaces"))).toBe(false);
   });
 
   describe("legacy marketplace tree", () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -70,6 +70,11 @@ export interface ConsoleRuntimeSessionInfo {
   readonly label: string;
   readonly mcpToolCount: number;
   readonly sessionId: string;
+  /**
+   * 이 런치가 연 Claude 세션의 id. Fleet이 못박은 값이라 자식의 첫 프롬프트를 기다리지 않고
+   * 여기서 이미 확정이다 — capture hook이 오기 전에도 호스트가 그 세션의 좌표를 안다.
+   */
+  readonly claudeSessionId?: string;
 }
 
 export type GatewayLaunchOptionErrorCode = "gateway_model_not_enabled" | "invalid_effort";
@@ -343,6 +348,7 @@ async function createAgentCliLaunchSpec(options: {
       label: injectedProfile.label,
       mcpToolCount: countMcpTools(agentRuntime),
       sessionId: options.sessionId,
+      claudeSessionId: injectedProfile.session.sessionId,
     });
     let launchProfile: AgentCliProfile = injectedProfile;
     if (injectedProfile.id === "claude-gateway") {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 
-import { buildDisabledSkillOverrides, buildGatewayModelsToolSpec, createDelayedPtyWriter, createFleetGatewayAgentRuntimeLifecycle, formatPtyMessage, GATEWAY_DISABLED_CLAUDE_SKILLS, getAgentCliIds, getAgentCliMetadata, isHostSessionToolAllowed, LaunchPromptError, MAX_LAUNCH_PROMPT_CHARS, NATIVE_CLAUDE_EFFORTS, parseAgentCliId, resolveNativeClaudeModelAlias, sanitizeLaunchPrompt, sanitizePtyMessageText, writeGatewayModelCacheForHome, type AgentCliId, type PtyInputChunk } from "@dotobokuri/fleet-admiral";
+import { buildDisabledSkillOverrides, buildGatewayModelsToolSpec, createDelayedPtyWriter, createFleetGatewayAgentRuntimeLifecycle, formatPtyMessage, GATEWAY_DISABLED_CLAUDE_SKILLS, getAgentCliIds, getAgentCliMetadata, isHostSessionToolAllowed, LaunchPromptError, MAX_LAUNCH_PROMPT_CHARS, NATIVE_CLAUDE_EFFORTS, parseAgentCliId, removePluginSession, resolveNativeClaudeModelAlias, sanitizeLaunchPrompt, sanitizePtyMessageText, writeGatewayModelCacheForHome, type AgentCliId, type PtyInputChunk } from "@dotobokuri/fleet-admiral";
 import type { AgentToolSpec } from "@dotobokuri/core-agent";
 import { ensureWorkspaceDirectory, withDirectoryLock, type GlobalOptionsService } from "@dotobokuri/core-infra";
 import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
@@ -786,7 +786,20 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         ? observability.registerTerminalRuntimeSession(runtimeSession) ?? namedSession
         : observability.updateTerminalSessionStatus(sessionId, "terminal-only") ?? namedSession;
       observability.notifySessionUpdated(created);
-      ctx.host.operations.patch(sessionId, { payload: toOperationPayload(ctx.host.operations.get(sessionId)?.payload, cwd, created, undefined, observability.getDurableOperation(sessionId)?.providerTitle) });
+      // 세션 좌표는 런치 시점에 이미 확정이다 — Fleet이 못박은 id이므로 capture hook을 기다리지
+      // 않는다. 첫 프롬프트 없이 닫히는 패널도 자기 플러그인 트리를 걷을 수 있어야 한다.
+      // 이미 좌표가 있으면 그것을 남긴다 — 재개 런치의 기존 기록이 트랜스크립트 경로까지 들고
+      // 있고, 못박은 id는 그 기록과 같은 값이라 덮어써서 얻을 것이 없다.
+      const launchedProviderSession = readProviderSession(ctx.host.operations.get(sessionId)?.payload)
+        ?? (runtimeSession?.claudeSessionId
+          ? {
+            provider: "claude" as const,
+            sessionId: runtimeSession.claudeSessionId,
+            capturedAt: new Date().toISOString(),
+            source: "launch",
+          }
+          : undefined);
+      ctx.host.operations.patch(sessionId, { payload: toOperationPayload(ctx.host.operations.get(sessionId)?.payload, cwd, created, launchedProviderSession, observability.getDurableOperation(sessionId)?.providerTitle) });
       ctx.host.http.writeJson(res, 200, created);
     } catch (error) {
       // 실패한 스폰은 첨부 예약을 되돌린다 — 재시도가 같은 id를 다시 실을 수 있고,
@@ -1676,13 +1689,36 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
   function removeSession(sessionId: string): void {
     reminderWriter.cancel(sessionId);
     resetOscActivity(sessionId);
-    void chatRegistry.dispose(sessionId);
+    // 트리 회수를 이 teardown 뒤로 붙인다 — 훅은 이벤트 시점에 트리를 다시 읽으므로,
+    // 자식이 아직 접히는 중일 때 지우면 종료 경로의 훅이 빈 자리를 읽는다.
+    const disposed = chatRegistry.dispose(sessionId);
     terminalRuntime.terminate(sessionId);
     pendingRuntimeSessions.delete(sessionId);
     observability.removeTerminalSession(sessionId);
     // 첨부 파일의 수명은 Operation을 따른다 — dormant·재개를 지나도 남고, 삭제와 함께 거둔다.
     launchAttachments.releaseSession(sessionId);
+    // Operation이 지워지기 전에 좌표를 읽어 둔다 — 지운 뒤에는 어느 트리였는지 알 수 없다.
+    const reclaimTree = buildSessionTreeReclaim(sessionId);
     ctx.host.operations.delete(sessionId);
+    void disposed.catch(() => undefined).finally(reclaimTree);
+  }
+
+  /**
+   * 이 Operation의 세션 플러그인 트리를 걷는 일감을 만든다.
+   *
+   * 트리는 세션의 것이라 런치가 끝나도 남지만, 세션 자체가 사라지면 그것을 읽을 주체도 없다.
+   * 좌표(cwd·세션 id)는 Operation이 durable하게 아는 값이고, 삭제 뒤에는 되찾을 수 없으므로
+   * 지우기 전에 붙든다. 회수 실패가 패널 닫기를 막지는 않는다.
+   */
+  function buildSessionTreeReclaim(sessionId: string): () => void {
+    const operation = ctx.host.operations.get(sessionId);
+    if (!operation) return () => undefined;
+    const providerSessionId = readProviderSession(operation.payload)?.sessionId;
+    const cwd = readPayloadString(operation.payload, "cwd") || ctx.host.paths.resolveTheaterPath(operation.theaterId) || "";
+    if (!providerSessionId || !cwd) return () => undefined;
+    return () => {
+      removePluginSession({ cwd, dataDir: ctx.host.paths.fleetDataDir, sessionId: providerSessionId });
+    };
   }
 
   async function cleanup(): Promise<void> {

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -1,5 +1,5 @@
 import http from "node:http";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -7,6 +7,8 @@ import type { OperationCreateInput, OperationNode, OperationPatchInput } from "@
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import type { RouteHandler } from "@fleet-console/sdk/routing";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentCliPlugin } from "@dotobokuri/fleet-admiral";
 
 import { registerAgentRoutes } from "../server/agent.js";
 import type { TerminalRuntime } from "../server/shared/index.js";
@@ -197,6 +199,45 @@ describe("agent provider capture grace", () => {
     });
 
     expect(harness.operations[0]!.payload.providerSession).toEqual(providerSession);
+  });
+
+  // 패널을 닫으면 그 세션의 플러그인 트리도 함께 걷힌다 — 세션이 사라지면 트리를 읽을 주체도 없다.
+  it("reclaims the session's plugin tree when the panel is closed", async () => {
+    const harness = await createHarness({ cliId: "claude-gateway" });
+    const cwd = path.join(harness.fleetDataDir, "✳ theater");
+    mkdirSync(cwd, { recursive: true });
+    const providerSessionId = "11111111-2222-4333-8444-555555555555";
+    const plugin = await createAgentCliPlugin({
+      cliId: "claude-gateway",
+      cwd,
+      dataDir: harness.fleetDataDir,
+      sessionId: providerSessionId,
+    });
+    expect(existsSync(plugin.pluginRoot)).toBe(true);
+
+    harness.operations.push({
+      id: "closing-operation",
+      theaterId: "theater-1",
+      type: "agent",
+      pluginId: "terminal",
+      title: "Closing",
+      payload: {
+        cliId: "claude-gateway",
+        cwd,
+        providerSession: {
+          provider: "claude",
+          sessionId: providerSessionId,
+          capturedAt: "2026-08-23T00:00:00.000Z",
+        },
+      },
+      geometry: null,
+      ts: { createdAt: 1, updatedAt: 1 },
+    });
+
+    await harness.deleteSession("closing-operation");
+    await vi.waitFor(() => {
+      expect(existsSync(plugin.pluginRoot)).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

#875가 `release()`를 걷어내면서 트리를 지우는 지점이 하나도 남지 않았습니다. 패널을 닫아도 그 세션의 플러그인이 영구히 남습니다. 닫기 경로에 회수를 겁니다.

### 1. 패널 닫기가 트리를 걷습니다

`launchAttachments`가 이미 같은 문제를 푼 방식을 따릅니다 — Operation이 아직 좌표를 들고 있을 때 읽어 두고, 자식이 접힌 뒤에 지웁니다.

```ts
const disposed = chatRegistry.dispose(sessionId);
terminalRuntime.terminate(sessionId);
...
const reclaimTree = buildSessionTreeReclaim(sessionId);  // 삭제 전에 좌표를 붙든다
ctx.host.operations.delete(sessionId);
void disposed.catch(() => undefined).finally(reclaimTree);
```

훅은 이벤트 시점에 트리를 다시 읽으므로, 종료 중인 자식이 빈 자리를 읽지 않도록 teardown 뒤로 붙입니다. 회수 실패는 패널 닫기를 막지 않습니다.

admiral은 `removePluginSession({ cwd, dataDir, sessionId })`를 냅니다 — 저장소 락 아래에서 그 트리만 지우고, 없는 워크스페이스를 만들지 않습니다(회수는 자리를 세우는 일이 아닙니다).

### 2. 좌표가 런치 시점에 기록됩니다

회수하려면 세션 id가 필요한데, 그 값은 **capture hook을 통해서만** payload에 닿았습니다. 훅은 첫 프롬프트(`UserPromptSubmit`)에 발화하므로, **패널을 띄우고 프롬프트 없이 닫으면 회수할 좌표 자체가 없었습니다** — 사용자가 겪은 그 경우입니다.

세션 id는 Fleet이 못박은 값이라 런치 시점에 이미 확정입니다. spawn 직후 Console이 그것을 `providerSession`으로 기록합니다. 재개 런치처럼 이미 더 풍부한 기록(트랜스크립트 경로 포함)이 있으면 그대로 둡니다 — 못박은 id는 그 기록과 같은 값이라 덮어써서 얻을 것이 없습니다.

## Test Plan

### 단위

- [x] `pnpm typecheck` · `pnpm build` (전 리포) — 통과
- [x] `pnpm -C packages/fleet-admiral test` — 194/194. 회수가 지정한 세션의 트리만 지우고 이웃은 남기는 것, 없는 세션·잘못된 id·없는 워크스페이스에 대해 던지지도 자리를 만들지도 않는 것
- [x] `pnpm -C runtime/fleet-plugins/terminal exec vitest run` — 971/971. 패널 닫기(DELETE 라우트)가 실제로 트리를 걷는 것. 회수 호출을 되돌리면 이 테스트가 레드가 되는 것을 확인
- [x] `pnpm -C runtime/fleet-console exec vitest run` — 2361/2361 (24 skip)
- [x] `pnpm -C packages/core-agent test` — 133/133
- [x] `pnpm check:core-boundary` · `check:claude-agent-sdk-boundary` — 통과

### 실제 브라우저 (격리 Console, headless)

빌드한 소스로 `FLEET_CONSOLE_DATA_DIR` 격리 Console을 띄우고 Theater를 시드한 뒤 실제 `claude-gateway` Operation을 실행했습니다.

| 단계 | 관측값 |
|---|---|
| 런치 | `sessions/c53dc265-…` 생성. `providerSession = { sessionId: "c53dc265-…", source: "launch" }` — **턴 없이도 기록됨** |
| 패널 닫기 (캔버스 닫기 버튼, 2단 arm) | 트리 `GONE`, `operations` 비었음 |
| 새 세션 런치 | `sessions/b1245bda-…` 생성 |
| Console 정지 (모든 런치 teardown) | 트리 `EXISTS`, Operation 유지 |
| 재기동 + 재개 | **같은 트리 재사용**, 디렉터리 1개 그대로 |
| 자식 프로세스 인자 | `--resume b1245bda-… --plugin-dir …/sessions/b1245bda-…`, `--session-id` 없음 |
| 재개된 패널 닫기 | 트리 `GONE`, `sessions/` 비었음 |

브라우저 진단: `errors: []`, `rejections: []`, 열린 소켓 0.

Chat Mode 전환은 트랜스크립트가 필요해(`chat_transcript_missing`) 실제 턴 없이는 진행되지 않았습니다. 대신 그 전환이 의존하는 성질 — 런치가 접혀도 트리가 남는다 — 을 Console 정지·재기동·재개로 확인했고, Chat dispose가 트리를 건드리지 않는 것은 단위 테스트가 덮습니다.

## Notes for Reviewers

- changelog 프래그먼트를 두지 않았습니다. #869의 `plugin-snapshot-store.md`가 아직 미릴리스라 사용자가 소비할 수 없던 동작의 정정입니다(Release Baseline).
- 호스트 주도 삭제(Theater 잊기)는 플러그인 DELETE 라우트를 지나지 않습니다. 그 경로의 트리는 그 세션이 다시 뜰 때 갈아 끼워지고, 안 뜨면 워크스페이스가 지워질 때까지 남습니다. `launchAttachments`가 `operation:purged`로 그 경로를 덮는 것과 달리 여기는 아직 걸지 않았습니다 — purge 이벤트에는 cwd·세션 id가 실리지 않아 좌표를 되찾을 수 없기 때문입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
