### PR TITLE
fix(fleet-console): correct gauge weight polarity in the light theme

### DIFF
--- a/.changelog.d/light-theme-oatmeal-fit.md
+++ b/.changelog.d/light-theme-oatmeal-fit.md
@@ -1,0 +1,14 @@
+---
+branch: light-theme-oatmeal-fit
+---
+
+### fleet-console
+#### Fixed
+- Order usage meters by severity in the light theme, so a routine bar no longer reads heavier than a bar that has run out.
+  ko: 라이트 테마의 사용량 막대를 심각도 순서로 읽히게 고쳐, 평상시 막대가 소진된 막대보다 무겁게 보이지 않습니다.
+- Lighten the reasoning-effort handle and its filled track in the light theme, so a setting no longer outweighs everything else on the page.
+  ko: 라이트 테마에서 추론강도 손잡이와 채워진 트랙의 무게를 낮춰, 설정 하나가 화면의 다른 모든 것을 눌러 앉히지 않습니다.
+- Restore the ring around the reasoning-effort handle at ULTRACODE and MAX in the light theme.
+  ko: 라이트 테마에서 ULTRACODE와 MAX 단의 추론강도 손잡이 링이 다시 보입니다.
+- Calm the gated ULTRACODE and MAX track in the light theme by dropping its metallic grain and drift.
+  ko: 라이트 테마에서 게이트 뒤 ULTRACODE·MAX 트랙의 금속 결과 흐름을 걷어 조용하게 만듭니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8237,7 +8237,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-radius: var(--radius-pill);
   /* 광택 스윕은 이 상자 안에서만 지나간다 — 가두지 않으면 트랙 밖 빈자리에 흰 띠로 남는다. */
   overflow: hidden;
-  background: var(--brass);
+  background: var(--gauge-fill);
   transition: width var(--duration-fast) var(--ease-spring);
   pointer-events: none;
 }
@@ -8250,7 +8250,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
       115deg,
       color-mix(in oklch, var(--text-on-brass) 7%, transparent) 0 1.5px,
       transparent 1.5px 10px),
-    var(--brass);
+    var(--gauge-fill);
 }
 
 .effort-track[data-at-max="true"] .effort-track-fill::after {
@@ -8261,7 +8261,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: linear-gradient(
     100deg,
     transparent 35%,
-    color-mix(in oklch, var(--text-primary) 26%, transparent) 50%,
+    color-mix(in oklch, var(--gauge-face) 26%, transparent) 50%,
     transparent 65%);
   animation: effort-track-sweep 2.6s var(--ease-spring) infinite;
 }
@@ -8281,7 +8281,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .effort-track[data-apex="true"][data-effort-level="max"] .effort-track-fill {
-  background: linear-gradient(90deg, var(--brass) 0%, var(--crest) 82%);
+  background: linear-gradient(90deg, var(--gauge-fill) 0%, var(--gauge-crest) 82%);
 }
 
 /* MAX의 결은 용융 금속처럼 손잡이 쪽으로 흐른다. 115° 스트라이프(주기 10px)의 수평 주기는
@@ -8296,9 +8296,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
   right: 0;
   background: repeating-linear-gradient(
     115deg,
-    color-mix(in oklch, var(--text-on-brass) 9%, transparent) 0 1.5px,
+    color-mix(in oklch, var(--text-on-brass) var(--gauge-texture), transparent) 0 1.5px,
     transparent 1.5px 10px);
   animation: effort-max-molten-drift 1.15s linear infinite;
+  animation-play-state: var(--gauge-drift);
 }
 
 @keyframes effort-max-molten-drift {
@@ -8310,7 +8311,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: linear-gradient(
     100deg,
     transparent 35%,
-    color-mix(in oklch, var(--crest) 45%, oklch(100% 0 0 / 30%)) 50%,
+    color-mix(in oklch, var(--gauge-crest) 45%, oklch(100% 0 0 / 30%)) 50%,
     transparent 65%);
 }
 
@@ -8326,17 +8327,18 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background:
     repeating-linear-gradient(
       115deg,
-      color-mix(in oklch, var(--text-on-brass) 9%, transparent) 0 1.5px,
+      color-mix(in oklch, var(--text-on-brass) var(--gauge-texture), transparent) 0 1.5px,
       transparent 1.5px 10px),
     linear-gradient(
       90deg,
-      var(--brass) 0%,
-      var(--apex) 40%,
-      color-mix(in oklch, var(--apex) 62%, white) 58%,
-      var(--apex) 76%,
-      color-mix(in oklch, var(--apex) 75%, var(--brass)) 100%);
+      var(--gauge-fill) 0%,
+      var(--gauge-apex) 40%,
+      color-mix(in oklch, var(--gauge-apex) 62%, white) 58%,
+      var(--gauge-apex) 76%,
+      color-mix(in oklch, var(--gauge-apex) 75%, var(--gauge-fill)) 100%);
   background-size: 100% 100%, 180% 100%;
   animation: effort-ultra-aurora-drift 3.6s ease-in-out infinite alternate;
+  animation-play-state: var(--gauge-drift);
 }
 
 @keyframes effort-ultra-aurora-drift {
@@ -8520,8 +8522,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 20px;
   margin: -10px 0 0 -10px;
   border-radius: var(--radius-pill);
-  background: var(--text-primary);
-  box-shadow: 0 1px 3px oklch(0% 0 0 / 55%);
+  background: var(--gauge-face);
+  box-shadow: var(--gauge-face-lift);
   transition:
     left var(--duration-fast) var(--ease-spring),
     transform var(--duration-fast) var(--ease-spring),
@@ -8531,7 +8533,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .effort-track:hover .effort-track-knob {
-  box-shadow: 0 2px 8px oklch(0% 0 0 / 62%);
+  box-shadow: var(--gauge-face-lift-strong);
   transform: scale(1.1);
 }
 
@@ -8539,7 +8541,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   box-shadow:
     0 0 0 2.5px var(--crest),
     var(--crest-halo),
-    0 1px 3px oklch(0% 0 0 / 55%);
+    var(--gauge-face-lift);
   /* 헤일로가 2.2s로 숨쉰다 — 감속 모션에서는 animation만 꺼져 위의 정적 링이 남는다. */
   animation: effort-max-crest-breathe 2.2s ease-in-out infinite;
 }
@@ -8549,14 +8551,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
     box-shadow:
       0 0 0 2.5px var(--crest),
       0 0 10px var(--crest-glow),
-      0 1px 3px oklch(0% 0 0 / 55%);
+      var(--gauge-face-lift);
   }
 
   50% {
     box-shadow:
       0 0 0 2.5px var(--crest),
       0 0 22px var(--crest-glow),
-      0 1px 3px oklch(0% 0 0 / 55%);
+      var(--gauge-face-lift);
   }
 }
 
@@ -8564,7 +8566,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   box-shadow:
     0 0 0 2.5px var(--apex),
     var(--apex-halo),
-    0 1px 3px oklch(0% 0 0 / 55%);
+    var(--gauge-face-lift);
 }
 
 /* 값을 쥐지 않은 손잡이는 속이 비어 있다 — 꽉 찬 손잡이는 어느 자리에 있든 "이 단을 골랐다"로 읽힌다. */
@@ -8572,7 +8574,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: var(--surface-pillar);
   box-shadow:
     inset 0 0 0 2px color-mix(in oklch, var(--text-tertiary) 85%, transparent),
-    0 1px 3px oklch(0% 0 0 / 45%);
+    var(--gauge-face-lift);
 }
 
 .effort-track-value {

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -61,9 +61,32 @@
   --coral-ink: var(--coral);
   --warn-ink: var(--warn);
   --positive-ink: var(--positive);
-  /* 신호 텍스트의 글로우 halo — 라이트 테마는 밝은 종이 위 blur로 읽혀 none으로 단락한다. */
+  /* 신호 텍스트의 글로우 halo — 라이트 테마는 밝은 종이 위 blur로 읽혀 0 0 transparent로 단락한다.
+     단락 값이 `none`이면 안 된다: halo는 단독(`box-shadow: var(--apex-halo)`)뿐 아니라 합성 목록
+     (`0 0 0 2.5px var(--crest), var(--crest-halo), …`) 안에서도 쓰이고, 목록 가운데의 `none`은
+     선언 전체를 무효로 만들어 라이트에서 게이트 티어 손잡이의 링이 통째로 사라진다(실측 확인). */
   --brass-halo: 0 0 18px var(--brass-glow);
   --positive-halo: 0 0 12px var(--positive-glow);
+
+  /* ── 계기 채널 ────────────────────────────────────────────────────────────
+     채워진 계기(추론강도 트랙·쿼터 막대)가 바탕에 지는 **무게**. 다크는 밝을수록 무겁고
+     라이트는 어두울수록 무겁다 — 명도 순서가 곧 무게 순서의 반대다. 그래서 대비(AA)만
+     재조율하고 순서를 다크 그대로 두면 라이트에서 사다리가 뒤집힌다: 평상 채움(L44.9)이
+     위험(L52.0)·경고(L55.0)보다 무겁고, 손잡이(L22.5)가 화면에서 가장 어두운 불투명체가 되는
+     것이 실측으로 확인됐다. 이 채널은 색이 아니라 그 순서를 테마별로 정한다.
+     다크 3종은 var 간접으로 base 값을 상속하고, 라이트만 자기 값으로 분화한다. */
+  --gauge-face: var(--text-primary);
+  --gauge-face-lift: 0 1px 3px oklch(0% 0 0 / 55%);
+  --gauge-face-lift-strong: 0 2px 8px oklch(0% 0 0 / 62%);
+  --gauge-fill: var(--brass);
+  --gauge-apex: var(--apex);
+  --gauge-crest: var(--crest);
+  --gauge-rim: var(--hairline);
+  --gauge-texture: 9%;
+  --gauge-drift: running;
+  --gauge-weight-quiet: 100%;
+  --gauge-weight-warn: 100%;
+  --gauge-weight-critical: 100%;
 
   /* Operations 캔버스(Map)는 bg0 근방의 저채도 심층 계조만 사용한다. */
   --canvas-abyss: oklch(11% 0.014 245);
@@ -418,13 +441,41 @@
   --apex: oklch(52% 0.14 296);
   --apex-ink: oklch(43% 0.13 296);
   --apex-glow: oklch(52% 0.14 296 / 15%);
-  --apex-halo: none;
+  --apex-halo: 0 0 transparent;
   --crest: oklch(54% 0.15 48);
   --crest-ink: oklch(44% 0.14 48);
   --crest-glow: oklch(54% 0.15 48 / 16%);
-  --crest-halo: none;
-  --brass-halo: none;
-  --positive-halo: none;
+  --crest-halo: 0 0 transparent;
+  --brass-halo: 0 0 transparent;
+  --positive-halo: 0 0 transparent;
+
+  /* 계기 채널의 라이트 극성 — 세 축이 함께 뒤집힌다.
+     (1) 무게 사다리 — 채움이 심각도에 따라 무거워진다. 트랙(L90.6) 위 합성 명도는
+         평상 58.0 → 경고 55.0 → 위험 52.0이고, 채도(0.010 → 0.110 → 0.161)가 같은 방향을 가리킨다.
+         평상만 알파를 쓰는 이유는 이 트랙의 여유 폭이 좁기 때문이다 — 비텍스트 대비 3.0배는 합성 L≤60을
+         요구하고(다크의 같은 자리도 3.03배로 딱 이 하한에 서 있다), 신호색은 base가 이미 L55·L52라
+         알파를 낮추는 순간 하한을 깬다. 실제로 26/48/72%를 실측하니 평상 1.44배·위험 2.80배로 미달했다.
+         무게 여유가 남은 단은 중립 잉크(L44.9) 하나뿐이라, 사다리를 세우는 일은 그 한 단을
+         신호색 위로 올리는 일과 같다.
+     (2) 손잡이 — 두 테마 모두 near-white다. 다크의 --text-primary는 near-white(L94)라 밝은 구슬이지만
+         라이트에서는 near-black(L22.5)이라 같은 토큰이 검은 덩어리가 된다. 구슬은 덩어리가 아니라
+         brass 채움에서 도려낸 자리로 읽혀야 한다.
+     (3) 색면 — 큰 brass 채움은 --brass-deep(L64/C0.10) 무게로 내려간다. 컴포저 전송 버튼이
+         color-mix로 이미 도착해 있던 값(L63.8/C0.103)과 같은 자리다.
+     게이트 티어(ULTRACODE/MAX)는 결(--gauge-texture)을 걷고 표류(--gauge-drift)를 멈춰 워시 한 겹으로
+     남긴다 — 종이 위에서 흐르는 금속 결은 계기가 아니라 소음이다. */
+  --gauge-face: oklch(99% 0.004 95);
+  --gauge-face-lift: 0 1px 3px oklch(30% 0.015 95 / 26%);
+  --gauge-face-lift-strong: 0 2px 8px oklch(30% 0.015 95 / 34%);
+  --gauge-fill: var(--brass-deep);
+  --gauge-apex: oklch(64% 0.1 296);
+  --gauge-crest: oklch(66% 0.1 48);
+  --gauge-rim: transparent;
+  --gauge-texture: 0%;
+  --gauge-drift: paused;
+  --gauge-weight-quiet: 71%;
+  --gauge-weight-warn: 100%;
+  --gauge-weight-critical: 100%;
 
   --canvas-abyss: oklch(97.8% 0.003 100);
   --canvas-sea-core: oklch(94% 0.006 98);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1130,12 +1130,20 @@ describe("Instrument core design contract", () => {
     expect(css).toMatch(/\.quota-meter--warning \{[^}]*--meter-accent: var\(--warn\);/);
     expect(css).toMatch(/\.quota-meter--critical \{[^}]*--meter-accent: var\(--coral\);/);
     const fill = css.match(/\.quota-meter__fill \{[^}]*\}/)?.[0] ?? "";
-    expect(fill).toContain("background: var(--meter-accent);");
+    expect(fill).toContain("background: color-mix(in oklab, var(--meter-accent) var(--meter-weight), transparent);");
+    // 심각도는 색상과 무게를 함께 탄다 — 종이 위에서 명도는 무게의 반대라 색상만 갈면
+    // 평상 막대가 위험 막대보다 무거워진다. 세 단이 모두 무게를 집어야 사다리가 성립한다.
+    expect(meterBase).toContain("--meter-weight: var(--gauge-weight-quiet);");
+    expect(css).toMatch(/\.quota-meter--warning \{[^}]*--meter-weight: var\(--gauge-weight-warn\);/);
+    expect(css).toMatch(/\.quota-meter--critical \{[^}]*--meter-weight: var\(--gauge-weight-critical\);/);
 
     // (b) 예측은 아직 쓰지 않은 몫이다 — 단색으로 칠하는 순간 이미 쓴 양으로 읽힌다.
     const projection = css.match(/\.quota-meter__projection \{[^}]*\}/)?.[0] ?? "";
     expect(projection).toContain("repeating-linear-gradient(");
     expect(projection).not.toMatch(/background:\s*var\(--meter-accent\)/);
+    // 빗금은 채움의 분수로 따라간다 — 고정 42%로 두면 채움이 가벼워진 테마에서 "아직 안 쓴 몫"이
+    // "이미 쓴 몫"보다 무거워져 막대가 정반대를 말한다.
+    expect(projection).toContain("calc(var(--meter-weight) * 0.42)");
 
     // (c) 경과 눈금은 상태가 아니라 시계다 — 신호색을 빌리면 위험 표식으로 읽히고,
     // 채움이 이 눈금보다 앞섰는지 뒤졌는지를 비교하는 기준 자체가 사라진다.
@@ -1892,8 +1900,11 @@ describe("Instrument core design contract", () => {
         expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id)[a-z-]*:$/);
       }
     }
-    // Light 테마만 팔레트 + 광학(color-scheme/shadow/scrollbar/신호 ink·halo/본문 regular 굵기 보정)을 허용한다.
-    // --weight-regular 단일 예외: 밝은 배경의 얇은 스템 광학 보정 — medium/bold 티어 오버라이드는 계속 차단.
+    // Light 테마만 팔레트 + 광학(color-scheme/shadow/scrollbar/신호 ink·halo/계기 무게/본문 regular 굵기 보정)을
+    // 허용한다. --weight-regular 단일 예외: 밝은 배경의 얇은 스템 광학 보정 — medium/bold 티어 오버라이드는 계속 차단.
+    // [doctrine] --gauge-* 는 형상이 아니라 **무게**를 정한다. 종이 위에서 명도는 무게의 반대이므로,
+    // 다크의 명도 순서를 그대로 상속하면 채워진 계기의 사다리가 뒤집힌다(실측: 평상 L44.9가 위험 L52.0보다 무거움).
+    // 그래서 이 채널만은 라이트가 자기 값으로 분화해야 하며, 형상·타이포 오버라이드 차단은 그대로 유지된다.
     const lightVariantBlocks = theme.match(/^:root\[data-theme="whites"\][^{]*\{[^}]*\}/gm) ?? [];
     expect(lightVariantBlocks).toHaveLength(1);
     for (const block of lightVariantBlocks) {
@@ -1901,7 +1912,7 @@ describe("Instrument core design contract", () => {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|provider|shadow|scrollbar)[a-z-]*|--weight-regular|color-scheme):$/);
+        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|provider|shadow|scrollbar|gauge)[a-z-]*|--weight-regular|color-scheme):$/);
       }
     }
     // 신호 ink 티어는 base에서 별칭으로 존재해 다크 3종이 var 간접으로 base 신호색을 상속한다.
@@ -2687,6 +2698,69 @@ describe("Effort track interaction grammar", () => {
     expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track\[data-apex="true"\]\[data-effort-level="ultra"\] \.effort-track-fill \{\s*animation: none;/);
   });
 
+  it("pins the gauge weight channel so light never inherits the dark lightness order", () => {
+    const components = source("styles/components.css");
+    const quota = externalSource(QUOTA_CSS_PATH).replace(/\r\n/g, "\n");
+    const theme = source("styles/theme.css");
+    const base = theme.slice(0, theme.indexOf(':root[data-theme="'));
+    const whites = theme.slice(theme.indexOf(':root[data-theme="whites"]'));
+
+    // 계기 무게는 테마마다 갈리는 값이다 — base가 채널을 열고 라이트가 전부 분화한다.
+    // 한 토큰이라도 라이트에서 빠지면 그 자리만 다크의 명도 순서를 상속해 사다리가 부분적으로 뒤집힌다.
+    const GAUGE_TOKENS = [
+      "--gauge-face", "--gauge-face-lift", "--gauge-face-lift-strong",
+      "--gauge-fill", "--gauge-apex", "--gauge-crest", "--gauge-rim",
+      "--gauge-texture", "--gauge-drift",
+      "--gauge-weight-quiet", "--gauge-weight-warn", "--gauge-weight-critical",
+    ] as const;
+    for (const token of GAUGE_TOKENS) {
+      expect(base).toContain(`${token}:`);
+      expect(whites).toContain(`${token}:`);
+      expect(theme.match(new RegExp(`${token}:`, "g"))).toHaveLength(2);
+    }
+
+    // 라이트의 무게 사다리는 단조 증가해야 한다 — 이 부등호가 무너지면 평상 막대가 위험 막대보다
+    // 무거워지는 실측 결함으로 되돌아간다.
+    const weightOf = (token: string): number => {
+      const match = whites.match(new RegExp(`${token}: (\\d+)%;`));
+      expect(match).not.toBeNull();
+      return Number(match![1]);
+    };
+    const quiet = weightOf("--gauge-weight-quiet");
+    const warn = weightOf("--gauge-weight-warn");
+    const critical = weightOf("--gauge-weight-critical");
+    // 평상은 반드시 신호 두 단보다 가벼워야 한다. 신호 단은 base 명도(L55·L52)가 이미 비텍스트
+    // 대비 3:1 하한(합성 L≤60)에 붙어 있어 무게를 더 뺄 수 없다 — 그래서 사다리를 세우는 여유는
+    // 중립 잉크 한 단에만 있고, 신호 단이 평상보다 가벼워지는 순간 다시 뒤집힌다.
+    expect(quiet).toBeLessThan(warn);
+    expect(warn).toBeLessThanOrEqual(critical);
+    // 다크 3종은 지금 그림 그대로다 — base는 사다리를 쓰지 않는다(전부 100%).
+    expect(base).toContain("--gauge-weight-quiet: 100%;");
+    expect(base).toContain("--gauge-weight-critical: 100%;");
+
+    // 손잡이는 "가장 밝은 면"이지 "바탕의 반대"가 아니다 — --text-primary를 쓰면 라이트에서
+    // near-black(L22.5) 덩어리가 되어 화면에서 가장 어두운 불투명체가 된다.
+    const knob = components.match(/^\.effort-track-knob \{[^}]*\}/m)?.[0] ?? "";
+    expect(knob).toContain("background: var(--gauge-face);");
+    expect(knob).not.toContain("var(--text-primary)");
+    expect(base).toContain("--gauge-face: var(--text-primary);");
+
+    // 합성 그림자 목록 안의 halo는 절대 `none`이 될 수 없다 — 목록 가운데의 none은 선언 전체를
+    // 무효로 만들어 라이트에서 게이트 티어 손잡이의 링이 통째로 사라진다.
+    expect(whites).not.toMatch(/--(?:apex|crest|brass|positive)-halo: none;/);
+    expect(components).toMatch(/var\(--crest-halo\),\s*var\(--gauge-face-lift\);/);
+    expect(components).toMatch(/var\(--apex-halo\),\s*var\(--gauge-face-lift\);/);
+
+    // 게이트 티어의 결·표류는 팔레트 토큰으로 꺼진다 — components.css는 테마 분기를 갖지 않는다.
+    expect(components).not.toContain('data-theme=');
+    expect(components).toMatch(/animation-play-state: var\(--gauge-drift\);/);
+    expect(components).toContain("color-mix(in oklch, var(--text-on-brass) var(--gauge-texture), transparent)");
+
+    // 쿼터 막대의 테두리도 같은 채널이다 — 라이트에서는 채움이 옅어져 액자만 남는다.
+    const bar = quota.match(/\.quota-meter__bar \{[^}]*\}/)?.[0] ?? "";
+    expect(bar).toContain("border: 1px solid var(--gauge-rim);");
+  });
+
   it("pins the Quick Launch ultracode recognition grammar", () => {
     const components = source("styles/components.css");
     const composer = source("components/quick-launch.tsx");
@@ -2899,7 +2973,8 @@ describe("Effort track interaction grammar", () => {
     expect(trackSource).toContain("var(--effort-track-gap)");
 
     // 스윕의 티어 분화: MAX는 구리빛 스윕, ULTRACODE는 스윕 대신 ✦ 별빛.
-    expect(components).toMatch(/data-effort-level="max"\] \.effort-track-fill::after \{[^}]*var\(--crest\)/);
+    // 스윕은 계속 crest 열을 말하되 무게는 계기 채널이 정한다 — base에서 --gauge-crest는 var(--crest)다.
+    expect(components).toMatch(/data-effort-level="max"\] \.effort-track-fill::after \{[^}]*var\(--gauge-crest\)/);
     expect(components).toMatch(/data-effort-level="ultra"\] \.effort-track-fill::before,[\s\S]{0,120}::after \{[^}]*content: "✦"/);
   });
 

--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -114,7 +114,7 @@
   height: 6px;
   margin-top: 4px;
   overflow: hidden;
-  border: 1px solid var(--hairline);
+  border: 1px solid var(--gauge-rim);
   border-radius: var(--radius-pill);
   background: var(--ink-veil);
 }
@@ -128,7 +128,7 @@
   left: 0;
   width: 58%;
   border-radius: var(--radius-pill);
-  background: var(--coral);
+  background: color-mix(in oklab, var(--coral) var(--gauge-weight-critical), transparent);
 }
 
 .quota-legend__swatch-elapsed {
@@ -143,7 +143,7 @@
   right: 0;
   background-image: repeating-linear-gradient(
     135deg,
-    color-mix(in oklab, var(--coral) 42%, transparent) 0 2px,
+    color-mix(in oklab, var(--coral) calc(var(--gauge-weight-critical) * 0.42), transparent) 0 2px,
     transparent 2px 5px
   );
 }
@@ -369,9 +369,14 @@
 }
 
 /* 심각도는 이 채널 하나로만 흐른다 — 채움과 예측 빗금이 각자 색을 집으면
-   한 막대가 두 판정을 말하게 된다. */
+   한 막대가 두 판정을 말하게 된다. 그 채널은 색상과 함께 무게(--meter-weight)를 싣는다.
+   종이 위에서는 명도가 곧 무게의 반대이므로, 색상만 갈면 가장 옅어야 할 평상 막대가 가장
+   무거워진다 — 라이트 실측에서 평상 채움은 L44.9로 위험(L52.0)·경고(L55.0)보다 어두웠고,
+   그래서 100% 소진된 막대가 22% 막대보다 가볍게 읽혔다. 무게를 같은 채널에 실어 두면
+   심각도 역전이 재조율이 아니라 구조로 막힌다. 다크 3종은 전부 100%라 지금 그림 그대로다. */
 .quota-meter {
   --meter-accent: var(--ink-fog);
+  --meter-weight: var(--gauge-weight-quiet);
   margin-top: 12px;
 }
 
@@ -405,17 +410,19 @@
 
 .quota-meter--warning {
   --meter-accent: var(--warn);
+  --meter-weight: var(--gauge-weight-warn);
 }
 
 .quota-meter--critical {
   --meter-accent: var(--coral);
+  --meter-weight: var(--gauge-weight-critical);
 }
 
 .quota-meter__bar {
   position: relative;
   height: 6px;
   overflow: hidden;
-  border: 1px solid var(--hairline);
+  border: 1px solid var(--gauge-rim);
   border-radius: var(--radius-pill);
   background: var(--ink-veil);
 }
@@ -425,7 +432,7 @@
   inset-block: 0;
   left: 0;
   border-radius: var(--radius-pill);
-  background: var(--meter-accent);
+  background: color-mix(in oklab, var(--meter-accent) var(--meter-weight), transparent);
   transition: width 200ms ease, background-color 200ms ease;
 }
 
@@ -436,7 +443,7 @@
   inset-block: 0;
   background-image: repeating-linear-gradient(
     135deg,
-    color-mix(in oklab, var(--meter-accent) 42%, transparent) 0 2px,
+    color-mix(in oklab, var(--meter-accent) calc(var(--meter-weight) * 0.42), transparent) 0 2px,
     transparent 2px 5px
   );
 }


### PR DESCRIPTION
## Summary

라이트 테마(Whites)는 잉크 스케일을 뒤집고 명도를 AA에 맞춰 재조율했지만, **명도의 순서**는 다크 그대로 두었습니다. 종이 위에서 명도 순서는 곧 무게 순서의 반대이므로, 채워진 계기가 거꾸로 읽히고 있었습니다.

격리 콘솔 실측(Operations 화면 전체 스윕): 불투명하면서 L<62 또는 C≥0.06인 요소는 화면에 **네 덩이뿐**이었고 전부 이 두 표면이었습니다.

| 요소 | 변경 전 | 문제 |
|---|---|---|
| Quota 채움 · 평상 | `oklch(45% .012 95)` | 위험(L52.0)·경고(L55.0)보다 **어두움** = 더 무거움 |
| 추론강도 손잡이 | `oklch(22.5% .012 95)` | 화면에서 가장 어두운 불투명체 |
| 추론강도 채움 | `oklch(56% .125 82)` | 설정 하나가 화면 최대 색면(1738px²) |
| ULTRACODE/MAX 채움 | brass→apex + 115° 빗결 + 3.6s 표류 | 종이 위 금속 결 |

`--gauge-*` 채널을 세워 **무게를 테마별로** 정합니다. 다크 3종은 `var` 간접으로 base 값을 상속해 렌더 결과가 동일하고, 라이트만 분화합니다.

- **무게 사다리** — 막대 채움이 색상과 함께 무게를 싣습니다. 트랙(L90.6) 위 합성 명도가 평상 58.9 → 경고 55.0 → 위험 52.0으로, 채도(0.011 → 0.110 → 0.161)와 같은 방향을 가리킵니다.
- **손잡이** — `--text-primary`(바탕의 반대)가 아니라 `--gauge-face`(가장 밝은 면)를 씁니다. 두 테마 모두 near-white라 구슬이 덩어리가 아니라 도려낸 자리로 읽힙니다.
- **색면** — 큰 brass 채움이 `--brass-deep`(L64/C0.10)으로 내려갑니다. 컴포저 전송 버튼이 `color-mix`로 이미 도착해 있던 값(L63.8/C0.103)과 같은 자리입니다.
- **게이트 티어** — 라이트에서 빗결(`--gauge-texture: 0%`)과 표류(`--gauge-drift: paused`)를 걷어 워시 한 겹 + ✦만 남깁니다.
- **부수 결함 수정** — 라이트 halo 토큰이 `none`이라 `box-shadow: 0 0 0 2.5px var(--crest), var(--crest-halo), …` 같은 **합성 목록 전체를 무효화**하고 있었습니다(실측: ULTRACODE 손잡이 `box-shadow: none`). `0 0 transparent`로 단락해 게이트 티어 링이 되살아납니다.

디자인 계약(`instrument-design-contract.test.ts`)을 함께 갱신했습니다 — base/라이트 토큰 패리티, 무게 사다리 단조성, 손잡이 면 출처, 합성 목록을 살리는 halo 단락값을 고정합니다.

### 알아둘 점

- 제안 단계의 알파 사다리(26/48/72%)는 **실측에서 비텍스트 대비 3.0배 하한을 깼습니다**(평상 1.44배·위험 2.80배). 신호색은 base 명도가 이미 L55·L52라 알파를 낮추는 순간 하한 아래로 떨어지므로, 무게 여유가 남은 단은 중립 잉크 하나뿐입니다. 71/100/100으로 재조율해 사다리 단조성과 3.12배 이상을 함께 확보했습니다.
- 빈 손잡이(`[data-auto="true"]`)의 드롭섀도가 다크에서 45% → 55%로 통일됩니다(같은 lift 채널). 지각 차이는 없습니다.
- 게이트 없는 `[data-at-max]` 트랙의 7% 빗결은 이번 범위 밖으로 두었습니다. 스윕 밴드만 `--gauge-face`로 옮겨 라이트에서 어두운 띠가 지나가던 것을 고쳤습니다.

## Test Plan

- [x] `vitest run tests/instrument-design-contract.test.ts` — 77 passed
- [x] `pnpm --filter @fleet-plugins/quota exec vitest run` — 34 passed
- [x] `tsc --noEmit` — exit 0
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] 격리 콘솔 헤디드 실측 — 라이트: 평상 채움 합성 L58.9(3.12배)·위험 L52.0(4.17배)·막대 테두리 transparent·손잡이 `oklch(0.99 .004 95)`·ULTRACODE 링 `oklch(0.52 .14 296) 0 0 0 2.5px` 복구·빗결 `alpha 0`·`animation-play-state: paused`
- [x] 격리 콘솔 헤디드 실측 — instrument/maritime/carbon 3종에서 `--gauge-face === --text-primary`, `--gauge-fill === --brass`, 막대 테두리 `=== --hairline`, 채움 합성값 `=== --ink-fog` 확인(렌더 동일)
- [x] `prefers-reduced-motion: reduce` 에뮬레이션 — 게이트 티어 `animation-name: none` 유지
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 22 entries validated