### PR TITLE
fix(fleet-console): clear unseen mark on minimize

### DIFF
--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -15,7 +15,7 @@ import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
 import { useT } from "../i18n/index.js";
-import { getIdleArrivalIds, subscribeIdleArrival } from "../operation-marks.js";
+import { clearIdleArrival, getIdleArrivalIds, subscribeIdleArrival } from "../operation-marks.js";
 import { pluginRuntimeState, resolveOperationActivity } from "../operation-activity.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
@@ -969,6 +969,7 @@ export function OperationsCanvas({
             },
             onMinimize: () => {
               if (state.activeOperationId === operation.id) setActiveOperation(null);
+              clearIdleArrival(operation.id);
               if (triageActive) {
                 // War Room의 최소화는 deck에서 내리는 동작이다. 무대에 서 있던 패널이면 지목까지
                 // 거둬 무대를 함께 비운다 — 지목이 남으면 큐가 비어도 그 패널이 무대에 붙어 있다.

--- a/runtime/fleet-console/core/client/src/operation-actions.ts
+++ b/runtime/fleet-console/core/client/src/operation-actions.ts
@@ -4,7 +4,21 @@
 import type { FleetClientPlugin } from "@fleet-console/sdk/plugin";
 import type { OperationNode } from "./types.js";
 import { type DeferredDeletionReceipt, deleteOperation, fetchOperations } from "./api.js";
-import { getState, hydrateOperations } from "./store.js";
+import { minimizeOperation } from "./canvas/canvas-store.js";
+import { playMinimizeFlight } from "./canvas/panel-motion.js";
+import { clearIdleArrival } from "./operation-marks.js";
+import { getState, hydrateOperations, setActiveOperation } from "./store.js";
+
+// ─── minimize ──────────────────────────────────────────────────────────────────
+
+// 최소화는 패널을 치우는 명시적 처리다. War Room에서는 일반 포커스 확인을 막지만,
+// 사용자가 직접 최소화를 누른 Operation의 유휴 도착은 확인한 것으로 보고 미확인 마크를 걷는다.
+export function minimizeOperationCompletely(operationId: string): void {
+  if (getState().activeOperationId === operationId) setActiveOperation(null);
+  clearIdleArrival(operationId);
+  playMinimizeFlight(operationId);
+  minimizeOperation(operationId);
+}
 
 // ─── close ─────────────────────────────────────────────────────────────────────
 

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -9,11 +9,11 @@ import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } 
 import { ApiError, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, patchOperation, patchTheaterOrder, renameOperation, updateGroup, type DeferredDeletionReceipt } from "../api.js";
 import { clearActiveOperation, shouldReleaseActiveOperation } from "../active-operation-surface.js";
 import { availableCompanionPanels, blocksOperationsShortcutWhileEditing, isBlockingDialogOpen, resolveCompanionShortcutToggle, resolveOperationsArrowShortcutAction, usableCompanionShortcuts } from "../shortcuts.js";
-import { closeOperationCompletely, resumeOperationInPlace } from "../operation-actions.js";
+import { closeOperationCompletely, minimizeOperationCompletely, resumeOperationInPlace } from "../operation-actions.js";
 import { findTheaterShellId, forgetTheaterCompletely, isTheaterShellLaunch, registerTheaterFromPath } from "../theater.js";
-import { claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, consumePendingFitAllOperations, ensureDefaultGeometry, fitAllOperations, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getCompanionPanelVisibilityOverrides, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, resolveLaunchGeometry, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setTheaterOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
+import { claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, consumePendingFitAllOperations, ensureDefaultGeometry, fitAllOperations, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getCompanionPanelVisibilityOverrides, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperations, pruneOperations, resolveLaunchGeometry, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setTheaterOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
-import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js";
+import { playRestoreFlight } from "../canvas/panel-motion.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode } from "../canvas/operation-accent.js";
@@ -249,8 +249,7 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
         const currentIndex = order.indexOf(operationId);
         if (currentIndex === -1) return;
         const nextId = order.length > 1 ? order[(currentIndex + 1) % order.length] ?? null : null;
-        playMinimizeFlight(operationId);
-        minimizeOperation(operationId);
+        minimizeOperationCompletely(operationId);
         setActiveOperation(nextId);
         return;
       }
@@ -463,9 +462,7 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
   }, []);
 
   const handleMinimize = useCallback((operationId: string) => {
-    if (stateRef.current.activeOperationId === operationId) setActiveOperation(null);
-    playMinimizeFlight(operationId);
-    minimizeOperation(operationId);
+    minimizeOperationCompletely(operationId);
   }, []);
 
   const handleResume = useCallback((operationId: string) => {

--- a/runtime/fleet-console/tests/operation-minimize.test.ts
+++ b/runtime/fleet-console/tests/operation-minimize.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSnapshot, loadForTheater, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { minimizeOperationCompletely } from "../core/client/src/operation-actions.js";
+import { getIdleArrivalIds, markIdleArrival, resetIdleArrivalForTests, setIdleArrivalAcknowledgementSuspended } from "../core/client/src/operation-marks.js";
+import { getState, setState } from "../core/client/src/store.js";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  loadForTheater("theater-a");
+  setOperationGeometry("operation", { x: 0, y: 0, width: 640, height: 400, zIndex: 1 });
+  resetIdleArrivalForTests();
+  setState({
+    operations: [],
+    activeTheaterId: "theater-a",
+    activeOperationId: null,
+    activeOperationAcknowledged: true,
+  });
+});
+
+describe("Operation minimize action", () => {
+  it("acknowledges an unseen idle arrival even while War Room suspends focus acknowledgement", () => {
+    markIdleArrival("operation");
+    setIdleArrivalAcknowledgementSuspended(true);
+
+    minimizeOperationCompletely("operation");
+
+    expect(getSnapshot().minimized).toContain("operation");
+    expect(getIdleArrivalIds().has("operation")).toBe(false);
+  });
+
+  it("releases the active Operation before minimizing it", () => {
+    setState({ activeOperationId: "operation", activeOperationAcknowledged: false });
+
+    minimizeOperationCompletely("operation");
+
+    expect(getState().activeOperationId).toBeNull();
+    expect(getState().activeOperationAcknowledged).toBe(true);
+  });
+});

--- a/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
@@ -21,7 +21,8 @@ vi.mock("../core/client/src/plugin-registry.js", () => ({
 }));
 
 import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
-import { loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
+import { getTheaterCanvasSnapshot, loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
+import { getIdleArrivalIds, markIdleArrival, resetIdleArrivalForTests } from "../core/client/src/operation-marks.js";
 import { isTriageDeckMapMode, resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoom } from "../core/client/src/canvas/triage-store.js";
 import { getState, setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
@@ -60,7 +61,9 @@ beforeEach(() => {
   setCanvasState({
     viewport: { x: 0, y: 0, zoom: 1 },
     operations: { [OPERATION.id]: OPERATION.geometry! },
+    minimized: [],
   });
+  resetIdleArrivalForTests();
   setTriageActive(true);
   container = document.createElement("div");
   document.body.appendChild(container);
@@ -188,6 +191,24 @@ describe("War Room canvas controls reach", () => {
     // 터미널 안은 복사·붙여넣기가 있는 자리다 — 우리 메뉴가 그것을 빼앗지 않는다.
     expect(panelMenu.defaultPrevented).toBe(false);
     expect(container!.querySelector(".canvas-context-menu")).toBeNull();
+  });
+
+  it("acknowledges an unseen idle arrival when its War Room stage is minimized", () => {
+    vi.useFakeTimers();
+    try {
+      markIdleArrival(OPERATION.id);
+      renderCanvas();
+      act(() => { vi.advanceTimersByTime(2_000); });
+
+      const stage = container!.querySelector<HTMLElement>(`.canvas-operation[data-operation-id="${OPERATION.id}"]`);
+      expect(stage).not.toBeNull();
+      act(() => stage!.querySelector<HTMLButtonElement>(".canvas-operation-window-controls .canvas-operation-icon-button")!.click());
+
+      expect(getTheaterCanvasSnapshot(THEATER_A).minimized).toContain(OPERATION.id);
+      expect(getIdleArrivalIds().has(OPERATION.id)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Treat explicit panel minimization as acknowledgement of an Unseen idle arrival.
- Apply the same behavior to caption and keyboard minimize paths.
- Add regression coverage for War Room acknowledgement suspension.

## Test Plan
- [x] `corepack pnpm --filter @dotobokuri/fleet-console test`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`