### PR TITLE
feat(fleet-plugin): stitch the repository panel's view seams

### DIFF
--- a/.changelog.d/repo-panel-flow-refit.md
+++ b/.changelog.d/repo-panel-flow-refit.md
@@ -1,0 +1,15 @@
+---
+branch: repo-panel-flow-refit
+---
+
+### fleet-console
+#### Changed
+- The Repository panel now folds the commit inspector into a one-line peek chip when you switch to the Changes view, so staging gets its full height back and one click returns you to the commit you were reading.
+  ko: 저장소 패널에서 변경 뷰로 전환하면 커밋 인스펙터가 한 줄 칩으로 접힙니다. 스테이징이 전체 높이를 되찾고, 칩 한 번으로 보던 커밋으로 돌아갑니다.
+- Opening a stash now shows a dedicated card with the stashed files - untracked ones included - and Apply, Apply-and-remove, and Delete right on the card, and the Stash button asks for an optional message before saving.
+  ko: 스태시를 열면 치워 둔 파일(untracked 포함)과 적용·적용 후 제거·삭제 버튼이 붙은 전용 카드가 열립니다. Stash 버튼은 저장 전에 메시지를 한 번 묻습니다.
+- The staging file list gained the same list/tree toggle as the commit inspector, and row actions now spell out Stage, Unstage, Discard, or Delete on hover instead of showing bare glyphs.
+  ko: 스테이징 파일 목록에 커밋 인스펙터와 같은 목록/트리 토글이 생겼고, 행 액션은 글리프 대신 호버 시 스테이지·내리기·버리기·삭제 라벨을 보여 줍니다.
+#### Fixed
+- Stashing or pulling from the toolbar now refreshes the staging list immediately, so the list no longer disagrees with the sidebar counts until a manual reload.
+  ko: 툴바에서 스태시·Pull을 실행하면 스테이징 목록이 즉시 갱신됩니다. 수동 새로고침 전까지 카운트와 목록이 어긋나던 문제가 사라집니다.

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -15,6 +15,7 @@ import { HunkView } from "./hunk-view.js";
 import { getT, localeTag, readErrorSentence, type RepositoryMessageKey } from "./i18n/index.js";
 import { formatCommitTime, refBadges, shortRefName, splitCommitSubject, type RefBadge, type RefBadgeKind } from "./repository-parsers.js";
 import { DIFF_DIVIDER_WIDTH, HISTORY_DETAIL_PANE_MIN_HEIGHT, HISTORY_LOG_PANE_MIN_HEIGHT, buildHistoryStackTemplate, buildInspectorChangesGridTemplate, buildInspectorDetailsGridTemplate, clampSplitPaneSize, installPointerDragLifecycle } from "./rail-layout.js";
+import { StashInspector } from "./stash-inspector.js";
 import { buildWorkspaceDockTemplate, clampWorkspaceDockHeight, normalizeWorkspaceDockHeight, readWorkspaceDockHeight, saveWorkspaceDockHeight } from "./workspace-layout.js";
 import { consumeRepositorySearchTarget, useRepositorySearchTarget } from "./repository-state.js";
 
@@ -308,16 +309,19 @@ interface HistoryPanelProps {
   readonly workspaceMainVisible?: boolean;
   readonly compareRequest?: { readonly base: string; readonly head: string; readonly baseLabel: string; readonly headLabel: string; readonly seq: number } | null;
   readonly inspectRequest?: { readonly fullHash: string; readonly seq: number } | null;
+  readonly stashRequest?: { readonly name: string; readonly sha: string; readonly subject: string; readonly seq: number } | null;
+  readonly onStashAction?: (action: "apply" | "pop" | "drop", name: string, sha: string) => Promise<boolean>;
+  readonly onReturnToHistory?: () => void;
   readonly onInspectorOpenChange?: (open: boolean) => void;
   readonly onClearRef?: () => void;
   readonly onWip?: () => void;
 }
 
-export function HistoryPanel({ ctx, repoRel, cacheScope = `${ctx.theaterId ?? ""}:${repoRel}`, externalRefreshToken = 0, active = true, refFilter = null, wipFiles, workspace = false, workspaceMain, workspaceMainVisible = false, compareRequest, inspectRequest, onInspectorOpenChange, onClearRef, onWip }: HistoryPanelProps) {
-  return <HistoryPanelBody key={cacheScope} ctx={ctx} repoRel={repoRel} cacheScope={cacheScope} externalRefreshToken={externalRefreshToken} active={active} refFilter={refFilter} wipFiles={wipFiles} workspace={workspace} workspaceMain={workspaceMain} workspaceMainVisible={workspaceMainVisible} compareRequest={compareRequest} inspectRequest={inspectRequest} onInspectorOpenChange={onInspectorOpenChange} onClearRef={onClearRef} onWip={onWip} />;
+export function HistoryPanel({ ctx, repoRel, cacheScope = `${ctx.theaterId ?? ""}:${repoRel}`, externalRefreshToken = 0, active = true, refFilter = null, wipFiles, workspace = false, workspaceMain, workspaceMainVisible = false, compareRequest, inspectRequest, stashRequest, onStashAction, onReturnToHistory, onInspectorOpenChange, onClearRef, onWip }: HistoryPanelProps) {
+  return <HistoryPanelBody key={cacheScope} ctx={ctx} repoRel={repoRel} cacheScope={cacheScope} externalRefreshToken={externalRefreshToken} active={active} refFilter={refFilter} wipFiles={wipFiles} workspace={workspace} workspaceMain={workspaceMain} workspaceMainVisible={workspaceMainVisible} compareRequest={compareRequest} inspectRequest={inspectRequest} stashRequest={stashRequest} onStashAction={onStashAction} onReturnToHistory={onReturnToHistory} onInspectorOpenChange={onInspectorOpenChange} onClearRef={onClearRef} onWip={onWip} />;
 }
 
-function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, active, refFilter, wipFiles, workspace, workspaceMain, workspaceMainVisible, compareRequest, inspectRequest, onInspectorOpenChange, onClearRef, onWip }: Required<Pick<HistoryPanelProps, "active" | "cacheScope" | "ctx" | "externalRefreshToken" | "refFilter" | "repoRel" | "wipFiles" | "workspace" | "workspaceMainVisible">> & Pick<HistoryPanelProps, "workspaceMain" | "compareRequest" | "inspectRequest" | "onInspectorOpenChange" | "onClearRef" | "onWip">) {
+function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, active, refFilter, wipFiles, workspace, workspaceMain, workspaceMainVisible, compareRequest, inspectRequest, stashRequest, onStashAction, onReturnToHistory, onInspectorOpenChange, onClearRef, onWip }: Required<Pick<HistoryPanelProps, "active" | "cacheScope" | "ctx" | "externalRefreshToken" | "refFilter" | "repoRel" | "wipFiles" | "workspace" | "workspaceMainVisible">> & Pick<HistoryPanelProps, "workspaceMain" | "compareRequest" | "inspectRequest" | "stashRequest" | "onStashAction" | "onReturnToHistory" | "onInspectorOpenChange" | "onClearRef" | "onWip">) {
   const t = getT(ctx.language);
   const [order, setOrder] = useState<LogOrder>(readHistoryOrder);
   // 정렬 축이 바뀌면 커밋 순서와 그래프 레이아웃이 통째로 달라지므로 캐시 슬롯도 분리한다.
@@ -329,6 +333,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
   const [target, setTarget] = useState<CommitTarget | null>(initialRestore?.target ?? null);
   const [pin, setPin] = useState<CompareAnchor | null>(null);
   const [comparePair, setComparePair] = useState<ComparePair | null>(null);
+  const [stashTarget, setStashTarget] = useState<{ readonly name: string; readonly sha: string; readonly subject: string } | null>(null);
   const [announce, setAnnounce] = useState("");
   const [filterText, setFilterText] = useState(initialRestore?.filterText ?? "");
   const [refreshToken, setRefreshToken] = useState(0);
@@ -358,6 +363,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
   const dockHeightRef = useRef(dockHeight);
   const handledCompareRequestSeqRef = useRef(0);
   const handledInspectRequestSeqRef = useRef(0);
+  const handledStashRequestSeqRef = useRef(0);
   const generation = useMemo<HistoryLoadGeneration>(() => ({ theaterId: ctx.theaterId, repoRel, refFilter, order, refreshToken: refreshToken + externalRefreshToken }), [ctx.theaterId, externalRefreshToken, order, refFilter, refreshToken, repoRel]);
   const generationRef = useRef(generation);
   generationRef.current = generation;
@@ -368,6 +374,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     setPin(anchor);
     setTarget(null);
     setComparePair(null);
+    setStashTarget(null);
     setAnnounce(t("repository.compare.announcePinned", { short: anchor.shortHash }));
   }, [t]);
   const unpin = useCallback(() => {
@@ -383,12 +390,14 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     setComparePair(pair);
     setPin(null);
     setTarget(null);
+    setStashTarget(null);
     setAnnounce(t("repository.compare.announceResult", { base: pair.baseLabel, head: pair.headLabel }));
   }, [commitIndexes, state, t]);
   const onRowActivate = useCallback((entry: LogCommitEntry, shiftKey: boolean) => {
     if (!shiftKey) {
       setTarget({ fullHash: entry.fullHash, entry });
       setComparePair(null);
+      setStashTarget(null);
       return;
     }
     if (pin) {
@@ -445,6 +454,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     handledCompareRequestSeqRef.current = compareRequest.seq;
     setPin(null);
     setTarget(null);
+    setStashTarget(null);
     setComparePair({ base: compareRequest.base, head: compareRequest.head, baseLabel: compareRequest.baseLabel, headLabel: compareRequest.headLabel });
     setAnnounce(t("repository.compare.announceResult", { base: compareRequest.baseLabel, head: compareRequest.headLabel }));
   }, [compareRequest, t]);
@@ -453,8 +463,17 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     handledInspectRequestSeqRef.current = inspectRequest.seq;
     setPin(null);
     setComparePair(null);
+    setStashTarget(null);
     setTarget({ fullHash: inspectRequest.fullHash });
   }, [inspectRequest]);
+  useEffect(() => {
+    if (!stashRequest || stashRequest.seq === handledStashRequestSeqRef.current) return;
+    handledStashRequestSeqRef.current = stashRequest.seq;
+    setPin(null);
+    setComparePair(null);
+    setTarget(null);
+    setStashTarget({ name: stashRequest.name, sha: stashRequest.sha, subject: stashRequest.subject });
+  }, [stashRequest]);
   useEffect(() => {
     if (
       !searchTarget
@@ -690,17 +709,34 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     stateCacheKeyRef.current = null;
     setRefreshToken((value) => value + 1);
   }, [historyCacheKey]);
-  const detailOpen = target !== null || comparePair !== null;
+  const detailOpen = target !== null || comparePair !== null || stashTarget !== null;
+  // 변경 뷰에서는 독이 화면을 따라오지 않는다 — 한 줄 칩으로 접혀 맥락만 남긴다(M1).
+  const dockCollapsed = workspace && workspaceMainVisible && detailOpen;
   const stackTemplate = detailOpen
-    ? workspace ? buildWorkspaceDockTemplate(dockHeight) : buildHistoryStackTemplate(logHeight)
+    ? dockCollapsed ? "minmax(0, 1fr) auto"
+      : workspace ? buildWorkspaceDockTemplate(dockHeight) : buildHistoryStackTemplate(logHeight)
     : undefined;
-  return <div ref={rootRef} className={`history-root${workspace ? " repository-ws-history" : ""}${isDragging ? " is-dragging" : ""}`} style={stackTemplate ? { gridTemplateRows: stackTemplate } : undefined} onKeyDown={(event) => { if (event.key !== "Escape" || target) return; /* 검사기가 열려 있으면 Esc는 검사기 닫기 한 겹만 벗긴다 — 같은 키로 핀까지 잃지 않게 */ if (pin) { unpin(); event.stopPropagation(); event.preventDefault(); } else if (comparePair) { setComparePair(null); event.stopPropagation(); event.preventDefault(); } }}>
+  const closeDetail = () => { setTarget(null); setComparePair(null); setStashTarget(null); };
+  const peekKindLabel = stashTarget ? t("repository.dock.peekStash") : comparePair ? t("repository.dock.peekCompare") : t("repository.dock.peekCommit");
+  const peekBodyLabel = stashTarget ? stashTarget.subject
+    : comparePair ? `${comparePair.baseLabel} ↔ ${comparePair.headLabel}`
+    : target ? (target.entry?.subject ?? target.fullHash.slice(0, 9))
+    : "";
+  return <div ref={rootRef} className={`history-root${workspace ? " repository-ws-history" : ""}${isDragging ? " is-dragging" : ""}`} style={stackTemplate ? { gridTemplateRows: stackTemplate } : undefined} onKeyDown={(event) => { if (event.key !== "Escape" || target || stashTarget) return; /* 검사기가 열려 있으면 Esc는 검사기 닫기 한 겹만 벗긴다 — 같은 키로 핀까지 잃지 않게 */ if (pin) { unpin(); event.stopPropagation(); event.preventDefault(); } else if (comparePair) { setComparePair(null); event.stopPropagation(); event.preventDefault(); } }}>
     <div className="history-list-pane" hidden={workspace && workspaceMainVisible}>
       <div className="history-toolbar"><div className="history-filter"><input className="history-filter-input" placeholder={t("repository.common.filterPlaceholder")} value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText && <button type="button" className="history-filter-clear" onClick={() => setFilterText("")}>✕</button>}</div>{pin && <button type="button" className="repository-ref-chip repository-pin-chip" title={t("repository.compare.pinnedHint")} onClick={unpin}>⇆ {t("repository.compare.pinnedChip", { short: pin.shortHash })} ✕</button>}{refFilter && <button type="button" className="repository-ref-chip" title={refFilter} onClick={onClearRef}>⎇ {shortRefName(refFilter)} ✕</button>}{state.kind === "ok" && <><span className="history-count" title={t("repository.history.countLegend")}>{filterText ? `${visible.length}/${state.commits.length}` : state.commits.length}</span><button type="button" className="history-order-toggle" aria-label={t("repository.history.orderToggle")} title={t(order === "topo" ? "repository.history.orderTopoHint" : "repository.history.orderDateHint")} onClick={toggleOrder}><OrderIcon order={order} />{t(order === "topo" ? "repository.history.orderTopo" : "repository.history.orderDate")}</button><button type="button" className="repository-refresh-btn" onClick={refreshHistory}>{t("repository.history.refresh")}</button></>}<span className="repository-sr-only" role="status">{announce}</span></div>
       <div ref={listRef} className="history-list" onScroll={updateCommitViewport}>{showWip && <button type="button" className="repository-wip-row" onClick={onWip}>{t("repository.history.uncommitted")} <span>{t(wip.files === 1 ? "repository.history.wipStats_one" : "repository.history.wipStats_other", { count: wip.files, additions: wip.additions, deletions: wip.deletions })}</span></button>}{state.kind === "loading" && <div className="history-empty">{t("repository.common.loading")}</div>}{state.kind === "error" && <div className="history-error">{readErrorSentence(t, state.message)}<button type="button" className="repository-refresh-btn" onClick={refreshHistory}>{t("repository.common.retry")}</button></div>}{state.kind === "ok" && state.commits.length === 0 && <div className="history-empty">{t("repository.history.empty")}</div>}{state.kind === "ok" && state.commits.length > 0 && visible.length === 0 && <div className="history-empty">{t("repository.common.noMatchingItems")}</div>}{state.kind === "ok" && layout && visible.length > 0 && <div ref={commitWindowRef} className="history-commit-window"><div className="history-window-spacer" aria-hidden="true" style={{ height: virtualWindow.topSpacerHeight }} />{windowRows.map(({ entry, graphNode }) => <CommitRow key={entry.fullHash} rowRef={(node) => { if (node) rowRefs.current.set(entry.fullHash, node); else rowRefs.current.delete(entry.fullHash); }} entry={entry} checkouts={state.checkouts} selected={target?.fullHash === entry.fullHash} picked={pin?.fullHash === entry.fullHash || comparePair?.base === entry.fullHash || comparePair?.head === entry.fullHash} pin={pin} graphNode={graphNode} onRowActivate={onRowActivate} onCompareAction={onCompareAction} locale={ctx.language} />)}<div className="history-window-spacer" aria-hidden="true" style={{ height: virtualWindow.bottomSpacerHeight }} /></div>}{state.kind === "ok" && state.commits.length > 0 && <div className="history-pagination">{state.hasMore ? loadingMore ? <span>{t("repository.history.loadingMore")}</span> : <button type="button" className="repository-refresh-btn" onClick={loadMore}>{t("repository.history.loadMore")}</button> : <><span>{t("repository.history.end")}</span>{state.truncated && <span>{t("repository.history.capped")}</span>}</>}{loadMoreError && <span className="history-pagination-error">{readErrorSentence(t, loadMoreError)}</span>}</div>}</div>
     </div>
     {workspaceMain !== undefined && <div className="repository-ws-main" hidden={!workspaceMainVisible}>{workspaceMain}</div>}
-    {detailOpen && <><div className="history-divider history-divider--horizontal" role="separator" aria-orientation="horizontal" aria-label={workspace ? t("repository.history.resizeDock") : t("repository.history.resizeLog")} onPointerDown={handleDivider} /><div className="history-detail-pane">{comparePair ? <CompareInspector ctx={ctx} repoRel={repoRel} pair={comparePair} onSwap={() => setComparePair({ base: comparePair.head, head: comparePair.base, baseLabel: comparePair.headLabel, headLabel: comparePair.baseLabel })} onClose={() => setComparePair(null)} /> : target ? <CommitInspector ctx={ctx} repoRel={repoRel} target={target} workspace={workspace} onSelectCommit={(next) => { setComparePair(null); setTarget(next); }} onPinCompare={() => setPinFrom({ fullHash: target.fullHash, shortHash: target.entry?.shortHash ?? target.fullHash.slice(0, 9) })} onClose={() => setTarget(null)} /> : null}</div></>}
+    {detailOpen && dockCollapsed && <div className="repository-ws-peek">
+      <button type="button" className="repository-ws-peek-main" title={t("repository.dock.peekReturn")} onClick={onReturnToHistory}>
+        <span className="repository-ws-peek-kind">{peekKindLabel}</span>
+        <span className="repository-ws-peek-label">{peekBodyLabel}</span>
+        <span className="repository-ws-peek-return" aria-hidden="true">↩ {t("repository.dock.peekReturn")}</span>
+      </button>
+      <button type="button" className="repository-ws-peek-close" aria-label={t("repository.dock.peekClose")} title={t("repository.dock.peekClose")} onClick={closeDetail}>✕</button>
+    </div>}
+    {detailOpen && !dockCollapsed && <><div className="history-divider history-divider--horizontal" role="separator" aria-orientation="horizontal" aria-label={workspace ? t("repository.history.resizeDock") : t("repository.history.resizeLog")} onPointerDown={handleDivider} /><div className="history-detail-pane">{comparePair ? <CompareInspector ctx={ctx} repoRel={repoRel} pair={comparePair} onSwap={() => setComparePair({ base: comparePair.head, head: comparePair.base, baseLabel: comparePair.headLabel, headLabel: comparePair.baseLabel })} onClose={() => setComparePair(null)} /> : target ? <CommitInspector ctx={ctx} repoRel={repoRel} target={target} workspace={workspace} onSelectCommit={(next) => { setComparePair(null); setTarget(next); }} onPinCompare={() => setPinFrom({ fullHash: target.fullHash, shortHash: target.entry?.shortHash ?? target.fullHash.slice(0, 9) })} onClose={() => setTarget(null)} /> : stashTarget ? <StashInspector ctx={ctx} repoRel={repoRel} stash={stashTarget} workspace={workspace} onAction={onStashAction} onClose={() => setStashTarget(null)} /> : null}</div></>}
   </div>;
 }
 function readLogPaneHeight(): number { return readSize(PREFS_LOG_PANE_HEIGHT, LOG_PANE_DEFAULT_HEIGHT, HISTORY_LOG_PANE_MIN_HEIGHT); }

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -485,6 +485,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     if (!entry) return;
     setFilterText("");
     setComparePair(null);
+    setStashTarget(null);
     setTarget({ fullHash: entry.fullHash, entry });
     consumeRepositorySearchTarget(searchTarget);
   }, [ctx.theaterId, repoRel, searchTarget, state]);
@@ -614,7 +615,8 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
   }, [showWip, updateCommitViewport, visible.length, workspaceMainVisible]);
   // 저장된 dock 높이는 현재 컨테이너 기준으로 정규화해 축소된 창에서 주 영역이 잘리지 않게 한다(저장값 자체는 보존).
   useLayoutEffect(() => {
-    if (!workspace || (target === null && comparePair === null)) return;
+    // 스태시 카드도 같은 독 그리드를 쓴다 — 대상에서 빠지면 축소된 창에서 저장된 높이가 컨테이너를 넘는다.
+    if (!workspace || (target === null && comparePair === null && stashTarget === null)) return;
     const root = rootRef.current;
     if (!root) return;
     const normalize = () => {
@@ -625,7 +627,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     const observer = new ResizeObserver(normalize);
     observer.observe(root);
     return () => observer.disconnect();
-  }, [comparePair, workspace, target]);
+  }, [comparePair, stashTarget, workspace, target]);
   const handleDivider = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
     const root = rootRef.current;

--- a/runtime/fleet-plugins/repository/client/i18n/index.ts
+++ b/runtime/fleet-plugins/repository/client/i18n/index.ts
@@ -241,6 +241,28 @@ const repositoryEn = {
   "repository.stash.dropped": "Stash dropped",
   "repository.stash.moved": "The stash list changed since you opened this menu. Nothing was touched — check the list and try again.",
 
+  // stash inspector card
+  "repository.stash.cardTitle": "Stashed changes",
+  "repository.stash.cardFiles": "Stashed files",
+  "repository.stash.showFailed": "Could not read this stash's files.",
+  "repository.stash.savePrompt": "Stash message",
+  "repository.stash.savePlaceholder": "Leave empty for the automatic message",
+  "repository.stash.saveConfirm": "Stash",
+  "repository.stash.saveCancel": "Cancel",
+
+  // workspace dock peek chip
+  "repository.dock.peekCommit": "Viewing commit",
+  "repository.dock.peekCompare": "Viewing comparison",
+  "repository.dock.peekStash": "Viewing stash",
+  "repository.dock.peekReturn": "Back to History",
+  "repository.dock.peekClose": "Stop viewing",
+
+  // staging row action labels
+  "repository.staging.actionStage": "Stage",
+  "repository.staging.actionUnstage": "Unstage",
+  "repository.staging.actionDiscard": "Discard",
+  "repository.staging.actionDelete": "Delete",
+
   // commit file tree
   "repository.filetree.tab": "File Tree",
   "repository.filetree.loading": "Loading tree…",
@@ -464,6 +486,22 @@ const repositoryKo: Record<keyof typeof repositoryEn, string> = {
   "repository.stash.popped": "스태시 적용 후 제거됨",
   "repository.stash.dropped": "스태시 삭제됨",
   "repository.stash.moved": "메뉴를 연 뒤 스태시 목록이 바뀌었습니다. 아무것도 건드리지 않았습니다 — 목록을 확인하고 다시 시도하세요.",
+  "repository.stash.cardTitle": "치워 둔 변경",
+  "repository.stash.cardFiles": "치워 둔 파일",
+  "repository.stash.showFailed": "이 스태시의 파일을 읽지 못했습니다.",
+  "repository.stash.savePrompt": "스태시 메시지",
+  "repository.stash.savePlaceholder": "비워 두면 자동 문구로 저장됩니다",
+  "repository.stash.saveConfirm": "스태시",
+  "repository.stash.saveCancel": "취소",
+  "repository.dock.peekCommit": "보던 커밋",
+  "repository.dock.peekCompare": "보던 비교",
+  "repository.dock.peekStash": "보던 스태시",
+  "repository.dock.peekReturn": "기록으로",
+  "repository.dock.peekClose": "그만 보기",
+  "repository.staging.actionStage": "스테이지",
+  "repository.staging.actionUnstage": "내리기",
+  "repository.staging.actionDiscard": "버리기",
+  "repository.staging.actionDelete": "삭제",
 
   "repository.filetree.tab": "파일 트리",
   "repository.filetree.loading": "트리 불러오는 중…",

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -272,6 +272,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const [historyExternalRefreshToken, setHistoryExternalRefreshToken] = useState(0);
   const [compareRequest, setCompareRequest] = useState<{ base: string; head: string; baseLabel: string; headLabel: string; seq: number } | null>(null);
   const [inspectRequest, setInspectRequest] = useState<{ fullHash: string; seq: number } | null>(null);
+  const [stashRequest, setStashRequest] = useState<{ name: string; sha: string; subject: string; seq: number } | null>(null);
   type SyncNotice =
     | { kind: "error"; code: "auth_failed" | "network" | "timeout" | "no_remote" | "git_failed" }
     | { kind: "success"; newRefs: number; updatedRefs: number; pruned: number };
@@ -514,9 +515,12 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   }, []);
   // 스테이징 뷰의 변이는 목록·울타리를 새로 읽는다 — repos 재스캔은 불필요하고,
   // 기록·refs 재적재는 커밋처럼 기록 축이 실제로 움직인 변이에만 지불한다.
-  const handleWorkspaceMutated = useCallback((options: { readonly history: boolean }) => {
+  const handleWorkspaceMutated = useCallback((options: { readonly history: boolean; readonly localState?: boolean }) => {
     setChangedFilesRetry((value) => value + 1);
     setWorkstateRetry((value) => value + 1);
+    // 스테이징 밖에서 워킹트리를 바꾼 동사(스태시·pull)는 스테이징 목록 재조회까지 지불해야 한다 —
+    // 카운트만 갱신되고 목록이 낡은 채 남는 불일치(M2)가 이 갈림에서 태어났다.
+    if (options.localState) setStateReloadToken((value) => value + 1);
     if (options.history) {
       setRefsRetry((value) => value + 1);
       setHistoryExternalRefreshToken((value) => value + 1);
@@ -564,8 +568,8 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       setVerbHinting(false);
     }, outcome.kind === "error" ? VERB_ERROR_HINT_MS : SYNC_HINT_MS);
   }, []);
-  const runToolbarVerb = useCallback(async (verb: VerbKind, route: string, body: Record<string, unknown>, successText: (payload: Record<string, unknown>) => string, mapError: (code: string) => string | null, surface: "button" | "notice" = "button") => {
-    if (!ctx.theaterId || verbBusy) return;
+  const runToolbarVerb = useCallback(async (verb: VerbKind, route: string, body: Record<string, unknown>, successText: (payload: Record<string, unknown>) => string, mapError: (code: string) => string | null, surface: "button" | "notice" = "button"): Promise<boolean> => {
+    if (!ctx.theaterId || verbBusy) return false;
     const emit = (kind: "success" | "error", text: string) => {
       if (surface === "notice") showRowNotice({ kind, text });
       else showVerbOutcome({ verb, kind, text });
@@ -583,13 +587,15 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       if (!response.ok) {
         const code = typeof payload.error === "string" ? payload.error : "git_failed";
         emit("error", mapError(code) ?? mapSharedVerbError(code, t) ?? code);
-        return;
+        return false;
       }
       emit("success", successText(payload));
       // 성공한 원격·스태시 동사만 전역 갱신을 지불한다 — 실패는 저장소를 바꾸지 않았다.
-      handleWorkspaceMutated({ history: true });
+      handleWorkspaceMutated({ history: true, localState: true });
+      return true;
     } catch {
       emit("error", t("repository.verb.failedNetwork"));
+      return false;
     } finally {
       setVerbBusy(null);
     }
@@ -605,17 +611,24 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     void runToolbarVerb("push", "push", {}, (payload) => verbCountText(payload.sent, "push", t), (code) =>
       code === "non_fast_forward" ? t("repository.verb.failedNonFastForward") : null);
   }, [runToolbarVerb, t]);
+  const [stashPromptOpen, setStashPromptOpen] = useState(false);
+  const stashButtonHostRef = useRef<HTMLSpanElement | null>(null);
   const handleStash = useCallback(() => {
-    void runToolbarVerb("stash", "stash", { action: "save" }, () => t("repository.verb.stashedResult"), (code) =>
+    setStashPromptOpen((current) => !current);
+  }, []);
+  const handleStashSave = useCallback((message: string) => {
+    setStashPromptOpen(false);
+    const trimmed = message.trim();
+    void runToolbarVerb("stash", "stash", { action: "save", ...(trimmed ? { message: trimmed } : {}) }, () => t("repository.verb.stashedResult"), (code) =>
       code === "nothing_to_stash" ? t("repository.verb.failedNothingToStash") : null);
   }, [runToolbarVerb, t]);
-  const handleStashRowAction = useCallback((action: "apply" | "pop" | "drop", name: string, sha: string) => {
+  const handleStashRowAction = useCallback(async (action: "apply" | "pop" | "drop", name: string, sha: string): Promise<boolean> => {
     // 스태시 동사도 툴바·스테이징과 같은 울타리를 진다 — 잠금 중 우회로가 되면 안 된다.
     if (writeLockedRef.current) {
       showRowNotice({ kind: "error", text: writeGuardRef.current ?? t("repository.guard.indexLocked") });
-      return;
+      return false;
     }
-    void runToolbarVerb("stash", "stash", { action, name, sha }, () =>
+    return runToolbarVerb("stash", "stash", { action, name, sha }, () =>
       t(action === "apply" ? "repository.stash.applied" : action === "pop" ? "repository.stash.popped" : "repository.stash.dropped"), (code) =>
       code === "stash_moved" ? t("repository.stash.moved") : null, "notice");
   }, [runToolbarVerb, showRowNotice, t]);
@@ -763,9 +776,9 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       seq: (prev?.seq ?? 0) + 1,
     }));
   }, [setSource]);
-  const openStashInspect = useCallback((sha: string) => {
+  const openStashInspect = useCallback((stashRow: { readonly name: string; readonly sha: string; readonly subject: string }) => {
     setSource("history");
-    setInspectRequest((prev) => ({ fullHash: sha, seq: (prev?.seq ?? 0) + 1 }));
+    setStashRequest((prev) => ({ ...stashRow, seq: (prev?.seq ?? 0) + 1 }));
   }, [setSource]);
 
   const wipFiles = changedFiles.kind === "ok" ? changedFiles.files : [];
@@ -795,7 +808,10 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? t("repository.panel.title")}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}<button type="button" className={`repository-sync-button${syncing ? " is-syncing" : ""}`} title={t("repository.sync.title")} aria-label={t("repository.sync.title")} disabled={syncing} onClick={() => { void syncRepository(); }}><span className={`repository-sync-icon${syncSettled ? " is-settled" : ""}`} aria-hidden="true"><span className="repository-sync-glyph repository-sync-glyph-idle">↻</span><span className="repository-sync-glyph repository-sync-glyph-settled">✓</span></span>{t("repository.sync.button")}{syncFailed && <span className="repository-sync-dot" title={t("repository.sync.lastFailed")} aria-hidden="true" />}{syncHintAvailable && <span className={`repository-sync-hint${syncHinting ? " is-open" : ""}`} aria-hidden="true">{t("repository.sync.upToDate")}</span>}</button><span className="repository-verb-cluster">
         <VerbToolbarButton glyph="⇩" label={t("repository.verb.pull")} title={t("repository.verb.pullTitle")} count={workstate?.behind ? <em className="repository-verb-count" title={t("repository.verb.behindCount", { count: workstate.behind })}>{workstate.behind}↓</em> : null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "pull"} outcome={verbOutcome?.verb === "pull" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "pull"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handlePull} />
         <VerbToolbarButton glyph="⇧" label={t("repository.verb.push")} title={t("repository.verb.pushTitle")} count={workstate?.ahead ? <em className="repository-verb-count" title={t("repository.verb.aheadCount", { count: workstate.ahead })}>{workstate.ahead}↑</em> : null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "push"} outcome={verbOutcome?.verb === "push" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "push"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handlePush} />
-        <VerbToolbarButton glyph="▤" label={t("repository.verb.stash")} title={t("repository.verb.stashTitle")} count={null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "stash"} outcome={verbOutcome?.verb === "stash" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "stash"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handleStash} />
+        <span className="repository-stash-anchor" ref={stashButtonHostRef}>
+          <VerbToolbarButton glyph="▤" label={t("repository.verb.stash")} title={t("repository.verb.stashTitle")} count={null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "stash"} outcome={verbOutcome?.verb === "stash" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "stash"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handleStash} />
+          {stashPromptOpen && <StashSavePopover t={t} hostRef={stashButtonHostRef} onSave={handleStashSave} onClose={() => setStashPromptOpen(false)} />}
+        </span>
       </span></div>
       <div className="repository-checkout-tabs" role="tablist" aria-label={t("repository.tabs.aria")}>
         {checkoutTabs.map((tab) => <button
@@ -820,7 +836,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       <div ref={layoutRef} className={`repository-ws-layout${isTreeDragging ? " is-dragging" : ""}`} style={{ "--ws-tree-width": `${treeWidth}px` } as React.CSSProperties}>
         <WorkspaceTree theaterId={ctx.theaterId ?? ""} t={t} repos={repos} reposError={reposError} reposTruncated={reposTruncated} scanDepth={scanDepth} worktrees={worktrees} worktreesError={worktreesError} refs={refs} refsError={refsError} changedFiles={changedFiles} selectedRel={repoRel} source={source} refFilter={refFilter} onRepository={handleSelectRepository} onScanDepth={setScanDepth} onRetryRepos={() => setReposRetry((value) => value + 1)} onReloadState={refreshRepositoryData} onRetryWorktrees={() => setWorktreesRetry((value) => value + 1)} onRetryRefs={() => setRefsRetry((value) => value + 1)} onSource={setSource} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} onCompare={openCompare} onStashInspect={openStashInspect} onStashAction={handleStashRowAction} />
         <div className="repository-divider repository-ws-tree-divider" onPointerDown={handleTreeDividerDown} role="separator" aria-orientation="vertical" aria-label={t("repository.common.resizeSourceTree")} />
-        <HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} cacheScope={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} externalRefreshToken={historyExternalRefreshToken} active refFilter={refFilter} wipFiles={wipFiles} workspace workspaceMain={workspaceMain} workspaceMainVisible={workspaceMainVisible} compareRequest={compareRequest} inspectRequest={inspectRequest} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} />
+        <HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} cacheScope={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} externalRefreshToken={historyExternalRefreshToken} active refFilter={refFilter} wipFiles={wipFiles} workspace workspaceMain={workspaceMain} workspaceMainVisible={workspaceMainVisible} compareRequest={compareRequest} inspectRequest={inspectRequest} stashRequest={stashRequest} onStashAction={handleStashRowAction} onReturnToHistory={() => setSource("history")} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} />
       </div>
     </div>
   );
@@ -851,7 +867,7 @@ interface WorkspaceTreeProps {
   readonly onSource: (source: Source) => void;
   readonly onRef: (ref: string) => void;
   readonly onCompare: (base: string, head: string) => void;
-  readonly onStashInspect: (stashSha: string) => void;
+  readonly onStashInspect: (stash: { readonly name: string; readonly sha: string; readonly subject: string }) => void;
   readonly onStashAction?: (action: "apply" | "pop" | "drop", name: string, sha: string) => void;
 }
 
@@ -923,7 +939,7 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
         <SourceIcon source={row.source} /><span>{row.primary}</span>{row.current && <i>HEAD</i>}
       </button>
       {refs.defaultBase && row.ref !== refs.defaultBase ? <button type="button" className="repository-tree-action" title={t("repository.compare.withBase")} aria-label={t("repository.compare.withBase")} onClick={() => onCompare(refs.defaultBase!, row.ref!)}>⇆</button> : null}
-    </div> : <button type="button" key={row.key} className={`repository-ws-tree-row${row.current ? " is-current" : ""}`} disabled={!row.stashSha} onClick={() => { if (row.stashSha) onStashInspect(row.stashSha); }} onContextMenu={(event) => {
+    </div> : <button type="button" key={row.key} className={`repository-ws-tree-row${row.current ? " is-current" : ""}`} disabled={!row.stashSha} onClick={() => { if (row.stashSha) onStashInspect({ name: row.sub ?? row.key, sha: row.stashSha, subject: row.primary }); }} onContextMenu={(event) => {
       if (row.source !== "stashes" || !onStashAction) return;
       event.preventDefault();
       setRefContextMenu({ row, anchor: { x: event.clientX, y: event.clientY } });
@@ -1048,6 +1064,53 @@ function RepositoryRefContextMenu({ anchor, boundaryRef, rowRef, currentRef, def
   return <div ref={menuRef} className="repository-context-menu" role="menu" style={style}>
     <button type="button" className="repository-context-menu-item" role="menuitem" disabled={!currentRef || currentRef === rowRef} onClick={() => activate(currentRef)}>{t("repository.compare.withCurrent")}</button>
     <button type="button" className="repository-context-menu-item" role="menuitem" disabled={!defaultBase || defaultBase === rowRef} onClick={() => activate(defaultBase)}>{t("repository.compare.withBase")}</button>
+  </div>;
+}
+
+/**
+ * Stash 버튼의 메시지 팝오버 — 즉시 실행 대신 메시지를 한 번 묻는다(M5).
+ * 비워 두고 확정하면 git의 자동 문구("WIP on …")로 저장된다. Enter=저장, Esc=닫기.
+ */
+function StashSavePopover({ t, hostRef, onSave, onClose }: {
+  readonly t: T;
+  readonly hostRef: RefObject<HTMLSpanElement | null>;
+  readonly onSave: (message: string) => void;
+  readonly onClose: () => void;
+}) {
+  const [message, setMessage] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const focusFrame = window.requestAnimationFrame(() => inputRef.current?.focus());
+    return () => window.cancelAnimationFrame(focusFrame);
+  }, []);
+  useEffect(() => {
+    const host = hostRef.current;
+    const handleOutsidePointer = (event: PointerEvent) => {
+      // 앵커(버튼 포함) 밖 클릭만 닫는다 — 버튼 재클릭은 토글 핸들러가 맡는다.
+      if (event.target instanceof Node && host && !host.contains(event.target)) onClose();
+    };
+    document.addEventListener("pointerdown", handleOutsidePointer, true);
+    return () => document.removeEventListener("pointerdown", handleOutsidePointer, true);
+  }, [hostRef, onClose]);
+  return <div className="repository-stash-popover" role="dialog" aria-label={t("repository.stash.savePrompt")} onKeyDown={(event) => {
+    if (event.key === "Escape") { event.preventDefault(); event.stopPropagation(); onClose(); }
+  }}>
+    <label className="repository-stash-popover-label" htmlFor="repository-stash-message">{t("repository.stash.savePrompt")}</label>
+    <input
+      id="repository-stash-message"
+      ref={inputRef}
+      type="text"
+      className="repository-stash-popover-input"
+      placeholder={t("repository.stash.savePlaceholder")}
+      value={message}
+      maxLength={500}
+      onChange={(event) => setMessage(event.target.value)}
+      onKeyDown={(event) => { if (event.key === "Enter") { event.preventDefault(); onSave(message); } }}
+    />
+    <div className="repository-stash-popover-actions">
+      <button type="button" className="repository-refresh-btn" onClick={() => onClose()}>{t("repository.stash.saveCancel")}</button>
+      <button type="button" className="repository-refresh-btn repository-stash-popover-confirm" onClick={() => onSave(message)}>{t("repository.stash.saveConfirm")}</button>
+    </div>
   </div>;
 }
 

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -395,6 +395,9 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     setChangedFiles({ kind: "loading" });
     setCompareRequest(null);
     setInspectRequest(null);
+    // stashRequest도 같은 one-shot이다 — 남겨 두면 리마운트된 패널이 seq 0에서 옛 요청을 재생해
+    // 다른 체크아웃 위에 낡은 스태시 카드를 세운다.
+    setStashRequest(null);
     setRefs({ branches: [], remotes: [], tags: [], stashes: [] });
     repoRelRef.current = nextRepoRel;
     setRepoRel(nextRepoRel);
@@ -760,6 +763,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       // epoch 리마운트는 handled-seq ref를 초기화하므로, 잔존 one-shot 요청을 함께 비워야 착지가 재생 없이 깨끗하다.
       setCompareRequest(null);
       setInspectRequest(null);
+      setStashRequest(null);
       setHistoryLandingEpoch((value) => value + 1);
       setSource(decision.landing);
       return;

--- a/runtime/fleet-plugins/repository/client/repository-tree.tsx
+++ b/runtime/fleet-plugins/repository/client/repository-tree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 
 import type { DiffFileEntry } from "../server/types.js";
 
@@ -15,6 +15,8 @@ interface DiffTreeViewProps {
   readonly onSelect: (entry: DiffFileEntry) => void;
   readonly collapsedFolders?: ReadonlySet<string>;
   readonly onToggleFolder?: (path: string) => void;
+  /** 스테이징처럼 행 단위 동사가 필요한 호스트가 잎 행 오른쪽에 끼워 넣는 액션 슬롯. */
+  readonly renderActions?: (entry: DiffFileEntry) => ReactNode;
 }
 
 interface TreeCommonProps {
@@ -22,6 +24,7 @@ interface TreeCommonProps {
   readonly onSelect: (entry: DiffFileEntry) => void;
   readonly collapsedFolders?: ReadonlySet<string>;
   readonly onToggleFolder?: (path: string) => void;
+  readonly renderActions?: (entry: DiffFileEntry) => ReactNode;
 }
 
 interface TreeChildrenProps extends TreeCommonProps {
@@ -67,7 +70,7 @@ export function buildDiffTree(files: readonly DiffFileEntry[]): TreeNode {
 
 // ─── DiffTreeView (export) ────────────────────────────────────────────────────
 
-export function DiffTreeView({ files, selectedPath, onSelect, collapsedFolders, onToggleFolder }: DiffTreeViewProps) {
+export function DiffTreeView({ files, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions }: DiffTreeViewProps) {
   const tree = buildDiffTree(files);
   return (
     <DiffTreeChildren
@@ -78,13 +81,14 @@ export function DiffTreeView({ files, selectedPath, onSelect, collapsedFolders, 
       onSelect={onSelect}
       collapsedFolders={collapsedFolders}
       onToggleFolder={onToggleFolder}
+      renderActions={renderActions}
     />
   );
 }
 
 // ─── 내부 컴포넌트 ─────────────────────────────────────────────────────────────
 
-function DiffTreeChildren({ node, depth, parentPath, selectedPath, onSelect, collapsedFolders, onToggleFolder }: TreeChildrenProps) {
+function DiffTreeChildren({ node, depth, parentPath, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions }: TreeChildrenProps) {
   return (
     <>
       {Object.entries(node.dirs).map(([key, child]) => (
@@ -98,6 +102,7 @@ function DiffTreeChildren({ node, depth, parentPath, selectedPath, onSelect, col
           onSelect={onSelect}
           collapsedFolders={collapsedFolders}
           onToggleFolder={onToggleFolder}
+          renderActions={renderActions}
         />
       ))}
       {node.files.map((f) => (
@@ -107,13 +112,14 @@ function DiffTreeChildren({ node, depth, parentPath, selectedPath, onSelect, col
           depth={depth}
           selectedPath={selectedPath}
           onSelect={onSelect}
+          renderActions={renderActions}
         />
       ))}
     </>
   );
 }
 
-function DiffTreeFolder({ dirKey, node, depth, parentPath, selectedPath, onSelect, collapsedFolders, onToggleFolder }: TreeFolderProps) {
+function DiffTreeFolder({ dirKey, node, depth, parentPath, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions }: TreeFolderProps) {
   // VS Code 스타일: 자식 디렉터리 하나 + 파일 없음인 체인을 압축해 "a/b" 한 노드로 표시
   let label = dirKey;
   let resolvedNode = node;
@@ -158,22 +164,23 @@ function DiffTreeFolder({ dirKey, node, depth, parentPath, selectedPath, onSelec
           onSelect={onSelect}
           collapsedFolders={collapsedFolders}
           onToggleFolder={onToggleFolder}
+          renderActions={renderActions}
         />
       )}
     </div>
   );
 }
 
-function DiffTreeLeaf({ entry, depth, selectedPath, onSelect }: TreeLeafProps) {
+function DiffTreeLeaf({ entry, depth, selectedPath, onSelect, renderActions }: TreeLeafProps) {
   const isSelected = entry.path === selectedPath;
   const handleClick = useCallback(() => onSelect(entry), [entry, onSelect]);
   const indent = depth * 16 + 12;
   const name = entry.path.split("/").pop() ?? entry.path;
 
-  return (
+  const main = (
     <button
       type="button"
-      className={`repository-file-row${isSelected ? " is-cur" : ""}`}
+      className={renderActions ? "repository-staging-row-main" : `repository-file-row${isSelected ? " is-cur" : ""}`}
       style={{ paddingLeft: `${indent}px` }}
       title={entry.path}
       onClick={handleClick}
@@ -190,5 +197,13 @@ function DiffTreeLeaf({ entry, depth, selectedPath, onSelect }: TreeLeafProps) {
         {entry.deletions > 0 && <span className="repository-deletions">−{entry.deletions}</span>}
       </span>
     </button>
+  );
+  if (!renderActions) return main;
+  // 스테이징 잎은 리스트 행과 같은 래퍼 문법을 쓴다 — 행 hover가 액션 라벨을 여는 축이 같아야 한다.
+  return (
+    <div className={`repository-file-row repository-staging-row${isSelected ? " is-cur" : ""}`}>
+      {main}
+      <span className="repository-stage-actions">{renderActions(entry)}</span>
+    </div>
   );
 }

--- a/runtime/fleet-plugins/repository/client/repository-tree.tsx
+++ b/runtime/fleet-plugins/repository/client/repository-tree.tsx
@@ -17,6 +17,8 @@ interface DiffTreeViewProps {
   readonly onToggleFolder?: (path: string) => void;
   /** 스테이징처럼 행 단위 동사가 필요한 호스트가 잎 행 오른쪽에 끼워 넣는 액션 슬롯. */
   readonly renderActions?: (entry: DiffFileEntry) => ReactNode;
+  /** 충돌 항목의 칩 라벨 — 리스트 행과 같은 표식을 잎에도 세운다(충돌 U가 untracked로 보이면 안 된다). */
+  readonly conflictLabel?: string;
 }
 
 interface TreeCommonProps {
@@ -25,6 +27,7 @@ interface TreeCommonProps {
   readonly collapsedFolders?: ReadonlySet<string>;
   readonly onToggleFolder?: (path: string) => void;
   readonly renderActions?: (entry: DiffFileEntry) => ReactNode;
+  readonly conflictLabel?: string;
 }
 
 interface TreeChildrenProps extends TreeCommonProps {
@@ -70,7 +73,7 @@ export function buildDiffTree(files: readonly DiffFileEntry[]): TreeNode {
 
 // ─── DiffTreeView (export) ────────────────────────────────────────────────────
 
-export function DiffTreeView({ files, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions }: DiffTreeViewProps) {
+export function DiffTreeView({ files, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions, conflictLabel }: DiffTreeViewProps) {
   const tree = buildDiffTree(files);
   return (
     <DiffTreeChildren
@@ -82,13 +85,14 @@ export function DiffTreeView({ files, selectedPath, onSelect, collapsedFolders, 
       collapsedFolders={collapsedFolders}
       onToggleFolder={onToggleFolder}
       renderActions={renderActions}
+      conflictLabel={conflictLabel}
     />
   );
 }
 
 // ─── 내부 컴포넌트 ─────────────────────────────────────────────────────────────
 
-function DiffTreeChildren({ node, depth, parentPath, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions }: TreeChildrenProps) {
+function DiffTreeChildren({ node, depth, parentPath, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions, conflictLabel }: TreeChildrenProps) {
   return (
     <>
       {Object.entries(node.dirs).map(([key, child]) => (
@@ -103,6 +107,7 @@ function DiffTreeChildren({ node, depth, parentPath, selectedPath, onSelect, col
           collapsedFolders={collapsedFolders}
           onToggleFolder={onToggleFolder}
           renderActions={renderActions}
+          conflictLabel={conflictLabel}
         />
       ))}
       {node.files.map((f) => (
@@ -113,13 +118,14 @@ function DiffTreeChildren({ node, depth, parentPath, selectedPath, onSelect, col
           selectedPath={selectedPath}
           onSelect={onSelect}
           renderActions={renderActions}
+          conflictLabel={conflictLabel}
         />
       ))}
     </>
   );
 }
 
-function DiffTreeFolder({ dirKey, node, depth, parentPath, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions }: TreeFolderProps) {
+function DiffTreeFolder({ dirKey, node, depth, parentPath, selectedPath, onSelect, collapsedFolders, onToggleFolder, renderActions, conflictLabel }: TreeFolderProps) {
   // VS Code 스타일: 자식 디렉터리 하나 + 파일 없음인 체인을 압축해 "a/b" 한 노드로 표시
   let label = dirKey;
   let resolvedNode = node;
@@ -165,13 +171,14 @@ function DiffTreeFolder({ dirKey, node, depth, parentPath, selectedPath, onSelec
           collapsedFolders={collapsedFolders}
           onToggleFolder={onToggleFolder}
           renderActions={renderActions}
+          conflictLabel={conflictLabel}
         />
       )}
     </div>
   );
 }
 
-function DiffTreeLeaf({ entry, depth, selectedPath, onSelect, renderActions }: TreeLeafProps) {
+function DiffTreeLeaf({ entry, depth, selectedPath, onSelect, renderActions, conflictLabel }: TreeLeafProps) {
   const isSelected = entry.path === selectedPath;
   const handleClick = useCallback(() => onSelect(entry), [entry, onSelect]);
   const indent = depth * 16 + 12;
@@ -193,6 +200,7 @@ function DiffTreeLeaf({ entry, depth, selectedPath, onSelect, renderActions }: T
         <span className="repository-file-fn">{name}</span>
       </span>
       <span className="repository-nums">
+        {entry.conflicted && conflictLabel && <span className="repository-conflict-chip">{conflictLabel}</span>}
         {entry.additions > 0 && <span className="repository-additions">+{entry.additions}</span>}
         {entry.deletions > 0 && <span className="repository-deletions">−{entry.deletions}</span>}
       </span>

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -2055,3 +2055,163 @@
 
 /* 스태시 컨텍스트 메뉴의 파괴 동사 — 무장 시에만 coral. */
 .repository-context-menu-danger.is-armed { color: var(--coral-ink); }
+
+/* ─── 동선 정비(P1+P2): 보던 커밋 칩 · 스태시 카드 · 스테이징 트리/라벨 ───────── */
+
+/* 변경 뷰에서 커밋/비교/스태시 상세는 한 줄 칩으로 접힌다(M1) — 독은 화면을 따라오지 않는다. */
+.repository-ws-history > .repository-ws-peek {
+  grid-row: 2;
+  grid-column: 1;
+}
+.repository-ws-peek {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  min-width: 0;
+  padding: 4px 8px;
+  border-top: 1px solid var(--surface-rim);
+  background: color-mix(in oklab, var(--surface-glass) 70%, transparent);
+}
+.repository-ws-peek-main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 3px 8px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--t-sm);
+  cursor: pointer;
+  text-align: left;
+}
+.repository-ws-peek-main:hover { border-color: var(--hairline-strong); color: var(--text-primary); }
+.repository-ws-peek-kind {
+  flex: none;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--t-xs);
+  color: var(--text-tertiary);
+}
+.repository-ws-peek-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.repository-ws-peek-return {
+  flex: none;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--t-xs);
+  color: var(--text-tertiary);
+}
+.repository-ws-peek-main:hover .repository-ws-peek-return { color: var(--text-secondary); }
+.repository-ws-peek-close {
+  flex: none;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+.repository-ws-peek-close:hover { color: var(--text-primary); border-color: var(--hairline); }
+
+/* 스태시 카드(M3·M4) — 인스펙터 결을 물려받되, 머리는 세그먼트 대신 제목+이름 칩이다. */
+.repository-stash-inspector-head {
+  align-items: center;
+  gap: 8px;
+}
+.repository-stash-inspector-title {
+  font-size: var(--t-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.repository-stash-inspector-name {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--t-xs);
+  color: var(--text-tertiary);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-pill);
+  padding: 1px 8px;
+  margin-right: auto;
+}
+.repository-stash-inspector-body {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  min-height: 0;
+}
+.repository-stash-inspector-subject {
+  padding: 8px 12px 4px;
+  font-size: var(--t-sm);
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.repository-stash-inspector-actions {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--hairline);
+}
+.repository-stash-inspector-drop.is-armed {
+  color: var(--coral-ink);
+  border-color: color-mix(in oklab, var(--coral) 45%, transparent);
+  background: color-mix(in oklab, var(--coral) 12%, transparent);
+}
+
+/* Stash 메시지 팝오버(M5) — 즉시 실행 대신 메시지를 한 번 묻는 작은 비모달 표면. */
+.repository-stash-anchor { position: relative; display: inline-flex; }
+.repository-stash-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  display: grid;
+  gap: 6px;
+  width: 240px;
+  padding: 10px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-xs);
+  background: var(--surface-glass);
+  box-shadow: var(--shadow-floating);
+}
+.repository-stash-popover-label {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--t-xs);
+  color: var(--text-tertiary);
+}
+.repository-stash-popover-input {
+  min-width: 0;
+  padding: 5px 8px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-xs);
+  /* 입력 재질은 커밋 상자와 같은 결 — 원료 잉크 단독 배경은 디자인 계약이 금지한다. */
+  background: color-mix(in oklch, var(--ink-abyss) 35%, transparent);
+  color: var(--text-primary);
+  font-size: var(--t-sm);
+}
+.repository-stash-popover-input:focus-visible { outline: 1px solid var(--brass); outline-offset: 0; }
+.repository-stash-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+/* 스테이징 목록/트리 토글(M6) — 커밋 인스펙터와 같은 토글이 같은 뜻으로 선다. */
+.repository-staging-viewbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 8px 0;
+}
+
+/* 행 액션 라벨(M10) — 글리프 옆에 뜻을 적는다. 행 hover/focus에서만 열려 평소 밀도는 유지한다. */
+.repository-stage-action-text {
+  display: none;
+  margin-left: 4px;
+}
+.repository-staging-row:hover .repository-stage-action-text,
+.repository-staging-row:focus-within .repository-stage-action-text { display: inline; }

--- a/runtime/fleet-plugins/repository/client/staging-view.tsx
+++ b/runtime/fleet-plugins/repository/client/staging-view.tsx
@@ -435,7 +435,7 @@ function StagingSection({ t, view, label, files, emptyLabel, actionLabel, action
       {files.length === 0
         ? <div className="repository-empty-row">{emptyLabel}</div>
         : view === "tree"
-          ? <DiffTreeView files={files} selectedPath={selectedPath} onSelect={onSelect} renderActions={rowActions} />
+          ? <DiffTreeView files={files} selectedPath={selectedPath} onSelect={onSelect} renderActions={rowActions} conflictLabel={t("repository.staging.conflict")} />
           : files.map((entry) => <StagingFileRow key={`${entry.status}:${entry.path}`} t={t} entry={entry} isSelected={entry.path === selectedPath} onSelect={onSelect} actions={rowActions(entry)} />)}
     </div>
   </section>;

--- a/runtime/fleet-plugins/repository/client/staging-view.tsx
+++ b/runtime/fleet-plugins/repository/client/staging-view.tsx
@@ -5,7 +5,9 @@ import type { RailPanelContext } from "@fleet-console/sdk/rail";
 
 import type { CommitResult, DiffFileEntry, StatusResult, WorkstateResult } from "../server/types.js";
 import { getT, readErrorSentence, type RepositoryMessageKey } from "./i18n/index.js";
+import { FilesViewToggle, readFilesViewMode, saveFilesViewMode, type FilesViewMode } from "./changed-files.js";
 import { HunkView } from "./hunk-view.js";
+import { DiffTreeView } from "./repository-tree.js";
 import { DIFF_DIVIDER_WIDTH, HUNK_PANE_MIN_WIDTH, clampListPaneWidth } from "./rail-layout.js";
 
 type T = Translate<RepositoryMessageKey>;
@@ -87,6 +89,12 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<StagingNotice | null>(null);
   const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 커밋 인스펙터와 같은 선호 키를 읽는다 — 목록/트리는 화면마다 다른 취향이 아니라 한 문법이다.
+  const [filesView, setFilesView] = useState<FilesViewMode>(() => readFilesViewMode());
+  const chooseFilesView = useCallback((mode: FilesViewMode) => {
+    setFilesView(mode);
+    saveFilesViewMode(mode);
+  }, []);
   const [listPaneWidth, setListPaneWidth] = useState(readListPaneWidth);
   const listPaneWidthRef = useRef(listPaneWidth);
   const [isDragging, setIsDragging] = useState(false);
@@ -297,8 +305,12 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
             길이를 더하면 사용자가 찾을 수 있는 파일 수보다 큰 값을 말하게 된다. 경로로 센다. */}
         {status.kind === "ok" && status.truncated && <div className="repository-truncated-note">{t("repository.status.capped", { count: new Set([...staged, ...unstaged].map((entry) => entry.path)).size })}</div>}
         {status.kind === "ok" && <>
+          <div className="repository-staging-viewbar">
+            <FilesViewToggle mode={filesView} onMode={chooseFilesView} t={t} />
+          </div>
           <StagingSection
             t={t}
+            view={filesView}
             label={t("repository.staging.unstaged")}
             files={unstaged}
             emptyLabel={t("repository.staging.emptyUnstaged")}
@@ -322,7 +334,9 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
                   : t("repository.staging.discardFile", { path: entry.path })}
                 disabled={busy || writeLocked}
                 onClick={(event) => { event.stopPropagation(); armOrDiscard(entry); }}
-              >{armedDiscard === entry.path ? t(entry.status === "U" ? "repository.staging.deleteArm" : "repository.staging.discardArm") : "⌫"}</button>}
+              >{armedDiscard === entry.path
+                ? t(entry.status === "U" ? "repository.staging.deleteArm" : "repository.staging.discardArm")
+                : <><span aria-hidden="true">⌫</span><span className="repository-stage-action-text">{t(entry.status === "U" ? "repository.staging.actionDelete" : "repository.staging.actionDiscard")}</span></>}</button>}
               <button
                 type="button"
                 className="repository-stage-action"
@@ -330,11 +344,12 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
                 title={t("repository.staging.stageFile", { path: entry.path })}
                 disabled={busy || writeLocked}
                 onClick={(event) => { event.stopPropagation(); stagePaths([entry.path]); }}
-              >+</button>
+              ><span aria-hidden="true">+</span><span className="repository-stage-action-text">{t("repository.staging.actionStage")}</span></button>
             </>}
           />
           <StagingSection
             t={t}
+            view={filesView}
             label={t("repository.staging.staged")}
             files={staged}
             emptyLabel={t("repository.staging.emptyStaged")}
@@ -350,7 +365,7 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
                 title={t("repository.staging.unstageFile", { path: entry.path })}
               disabled={busy || writeLocked}
               onClick={(event) => { event.stopPropagation(); unstageEntries([entry]); }}
-            >−</button>}
+            ><span aria-hidden="true">−</span><span className="repository-stage-action-text">{t("repository.staging.actionUnstage")}</span></button>}
           />
         </>}
       </div>
@@ -397,8 +412,9 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
   </div>;
 }
 
-function StagingSection({ t, label, files, emptyLabel, actionLabel, actionDisabled, onAction, selectedPath, onSelect, rowActions }: {
+function StagingSection({ t, view, label, files, emptyLabel, actionLabel, actionDisabled, onAction, selectedPath, onSelect, rowActions }: {
   readonly t: T;
+  readonly view: FilesViewMode;
   readonly label: string;
   readonly files: readonly DiffFileEntry[];
   readonly emptyLabel: string;
@@ -418,7 +434,9 @@ function StagingSection({ t, label, files, emptyLabel, actionLabel, actionDisabl
     <div className="repository-staging-rows">
       {files.length === 0
         ? <div className="repository-empty-row">{emptyLabel}</div>
-        : files.map((entry) => <StagingFileRow key={`${entry.status}:${entry.path}`} t={t} entry={entry} isSelected={entry.path === selectedPath} onSelect={onSelect} actions={rowActions(entry)} />)}
+        : view === "tree"
+          ? <DiffTreeView files={files} selectedPath={selectedPath} onSelect={onSelect} renderActions={rowActions} />
+          : files.map((entry) => <StagingFileRow key={`${entry.status}:${entry.path}`} t={t} entry={entry} isSelected={entry.path === selectedPath} onSelect={onSelect} actions={rowActions(entry)} />)}
     </div>
   </section>;
 }

--- a/runtime/fleet-plugins/repository/client/stash-inspector.tsx
+++ b/runtime/fleet-plugins/repository/client/stash-inspector.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { RailPanelContext } from "@fleet-console/sdk/rail";
+
+import type { DiffFileEntry } from "../server/types.js";
+import { FileRow } from "./changed-files.js";
+import { getT, readErrorSentence } from "./i18n/index.js";
+
+// 제품 공용 파괴 동사 무장 시간 — 스테이징 버리기·프레임 닫기와 같은 1.5s.
+const DROP_ARM_MS = 1500;
+
+/** show가 돌려준 원시 상태 문자를 목록 행의 상태 축으로 좁힌다 — 복사(C)는 새 경로 추가로 읽는다. */
+function readShownStatus(raw: string): DiffFileEntry["status"] {
+  return raw === "A" || raw === "D" || raw === "R" || raw === "T" || raw === "U" ? raw : raw === "C" ? "A" : "M";
+}
+
+type StashShowState =
+  | { readonly kind: "loading" }
+  | { readonly kind: "ok"; readonly files: readonly DiffFileEntry[]; readonly truncated?: boolean }
+  | { readonly kind: "error"; readonly message: string };
+
+export interface StashInspectorTarget {
+  readonly name: string;
+  readonly sha: string;
+  readonly subject: string;
+}
+
+/**
+ * 스태시 전용 카드 — 커밋 인스펙터가 untracked 스태시를 "변경된 파일 0"으로 보여 주던 함정(M3)의
+ * 대체 표면이다. 치워 둔 파일(untracked 포함)과 출구(적용/적용 후 제거/삭제)를 한 카드에 붙인다.
+ */
+export function StashInspector({ ctx, repoRel, stash, workspace, onAction, onClose }: {
+  readonly ctx: RailPanelContext;
+  readonly repoRel: string;
+  readonly stash: StashInspectorTarget;
+  readonly workspace: boolean;
+  readonly onAction?: ((action: "apply" | "pop" | "drop", name: string, sha: string) => Promise<boolean>) | undefined;
+  readonly onClose: () => void;
+}) {
+  const t = getT(ctx.language);
+  const [state, setState] = useState<StashShowState>({ kind: "loading" });
+  const [busy, setBusy] = useState(false);
+  const [dropArmed, setDropArmed] = useState(false);
+  const dropTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!ctx.theaterId) { setState({ kind: "error", message: "no_theater" }); return; }
+    let cancelled = false;
+    setState({ kind: "loading" });
+    // 오류 코드(stash_moved 등)를 읽어야 하는 경로는 raw fetch — api.fetch는 비2xx payload를 버린다.
+    fetch("/plugins/repository/stash", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, action: "show", name: stash.name, sha: stash.sha }),
+    }).then(async (response) => {
+      const payload = await response.json().catch(() => ({})) as { readonly files?: readonly { readonly status: string; readonly path: string }[]; readonly truncated?: boolean; readonly error?: string };
+      if (!response.ok) throw new Error(typeof payload.error === "string" ? payload.error : "git_failed");
+      // 카드 목록은 상태·경로만 그린다 — show는 수치를 세지 않으므로 0을 "수치 없음"으로 쓴다(FileRow는 0을 숨긴다).
+      const files: DiffFileEntry[] = (payload.files ?? []).map((entry) => ({ path: entry.path, status: readShownStatus(entry.status), additions: 0, deletions: 0 }));
+      return { files, truncated: payload.truncated === true };
+    }).then(({ files, truncated }) => {
+      if (cancelled) return;
+      setState({ kind: "ok", files, ...(truncated ? { truncated: true } : {}) });
+    }).catch((error: unknown) => {
+      if (cancelled) return;
+      setState({ kind: "error", message: error instanceof Error ? error.message : "unknown" });
+    });
+    return () => { cancelled = true; };
+  }, [ctx.theaterId, repoRel, stash.name, stash.sha]);
+  useEffect(() => () => { if (dropTimerRef.current !== null) clearTimeout(dropTimerRef.current); }, []);
+
+  const run = useCallback(async (action: "apply" | "pop" | "drop") => {
+    if (!onAction || busy) return;
+    setBusy(true);
+    try {
+      const succeeded = await onAction(action, stash.name, stash.sha);
+      // 스태시가 목록에서 사라지는 동사만 카드를 접는다 — apply는 스태시가 남으므로 계속 볼 수 있어야 한다.
+      if (succeeded && action !== "apply") onClose();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, onAction, onClose, stash.name, stash.sha]);
+
+  const handleDrop = useCallback(() => {
+    if (dropArmed) {
+      if (dropTimerRef.current !== null) { clearTimeout(dropTimerRef.current); dropTimerRef.current = null; }
+      setDropArmed(false);
+      void run("drop");
+      return;
+    }
+    setDropArmed(true);
+    if (dropTimerRef.current !== null) clearTimeout(dropTimerRef.current);
+    dropTimerRef.current = setTimeout(() => {
+      dropTimerRef.current = null;
+      setDropArmed(false);
+    }, DROP_ARM_MS);
+  }, [dropArmed, run]);
+
+  return <div className={`history-inspector repository-stash-inspector${workspace ? " repository-ws-inspector" : ""}`} onKeyDown={(event) => { if (event.key === "Escape") { event.preventDefault(); onClose(); } }}>
+    <div className="history-segmented repository-stash-inspector-head">
+      <span className="repository-stash-inspector-title">{t("repository.stash.cardTitle")}</span>
+      <span className="repository-stash-inspector-name">{stash.name}</span>
+      <button type="button" className="history-detail-close history-inspector-close" aria-label={t("repository.history.closeInspector")} title={t("repository.history.closeInspector")} onClick={onClose}>✕</button>
+    </div>
+    <div className="repository-stash-inspector-body">
+      <div className="repository-stash-inspector-subject" title={stash.subject}>{stash.subject}</div>
+      <div className="history-files-title">
+        <span className="history-files-label">{t("repository.stash.cardFiles")}</span>
+        {state.kind === "ok" && <span className="history-files-stats">{state.files.length}</span>}
+      </div>
+      <div className="history-files-scroll">
+        {state.kind === "loading" && <div className="history-inspector-empty">{t("repository.common.loading")}</div>}
+        {state.kind === "error" && <div className="history-inspector-empty history-inspector-error">{state.message === "stash_moved" ? t("repository.stash.moved") : `${t("repository.stash.showFailed")} ${readErrorSentence(t, state.message)}`}</div>}
+        {state.kind === "ok" && state.files.length === 0 && <div className="history-inspector-empty">{t("repository.history.noChangedFiles")}</div>}
+        {state.kind === "ok" && state.files.map((file) => <FileRow key={file.path} entry={file} isSelected={false} onSelect={() => undefined} t={t} />)}
+        {state.kind === "ok" && state.truncated && <div className="history-truncated">{t("repository.commit.capped")}</div>}
+      </div>
+      {onAction && <div className="repository-stash-inspector-actions">
+        <button type="button" className="repository-refresh-btn" disabled={busy} onClick={() => void run("apply")}>{t("repository.stash.apply")}</button>
+        <button type="button" className="repository-refresh-btn" disabled={busy} onClick={() => void run("pop")}>{t("repository.stash.pop")}</button>
+        <button type="button" className={`repository-refresh-btn repository-stash-inspector-drop${dropArmed ? " is-armed" : ""}`} disabled={busy} onClick={handleDrop}>{dropArmed ? t("repository.stash.dropArm") : t("repository.stash.drop")}</button>
+      </div>}
+    </div>
+  </div>;
+}

--- a/runtime/fleet-plugins/repository/routes.ts
+++ b/runtime/fleet-plugins/repository/routes.ts
@@ -98,7 +98,7 @@ export default definePlugin({
     registerRouter(ctx, "stash", async ({ req, res }) => {
       await handleRepositoryStash(req, res, ctx);
       return true;
-    }, { method: "POST", path: "", summary: "Save, apply, pop, or drop a stash.", category: "Repository Plugin", gate: "origin-write", transport: "http" });
+    }, { method: "POST", path: "", summary: "Save, apply, pop, drop, or show a stash.", category: "Repository Plugin", gate: "origin-write", transport: "http" });
     registerRouter(ctx, "push", async ({ req, res }) => {
       await handleRepositoryPush(req, res, ctx);
       return true;

--- a/runtime/fleet-plugins/repository/server/stash.ts
+++ b/runtime/fleet-plugins/repository/server/stash.ts
@@ -16,10 +16,26 @@ const STASH_HARDENING_ARGS = [
   "-c", `core.hooksPath=${process.platform === "win32" ? "NUL" : "/dev/null"}`,
 ] as const;
 
-export type StashAction = "save" | "apply" | "pop" | "drop";
+export type StashAction = "save" | "apply" | "pop" | "drop" | "show";
 
 export function readStashAction(value: unknown): StashAction | null {
-  return value === "save" || value === "apply" || value === "pop" || value === "drop" ? value : null;
+  return value === "save" || value === "apply" || value === "pop" || value === "drop" || value === "show" ? value : null;
+}
+
+const STASH_SHOW_STATUS_RE = /^[A-Z]\d{0,3}$/;
+const MAX_STASH_SHOW_FILES = 500;
+
+/** `--name-status` 한 줄(`M\tpath` 또는 `R100\told\tnew`)을 카드가 그릴 상태·경로로 줄인다. */
+export function parseStashShowLine(line: string): { readonly status: string; readonly path: string } | null {
+  const fields = line.split("\t");
+  if (fields.length < 2) return null;
+  const rawStatus = fields[0]!.trim();
+  if (!STASH_SHOW_STATUS_RE.test(rawStatus)) return null;
+  // 리네임/복사는 스코어 접미를 벗기고, 경로는 마지막 필드(신 경로)를 취한다.
+  const status = rawStatus[0]!;
+  const path = fields[fields.length - 1]!;
+  if (path === "") return null;
+  return { status, path };
 }
 
 function classifyStashError(stderr: string): "stash_conflict" | "nothing_to_stash" | null {
@@ -108,6 +124,22 @@ export async function handleRepositoryStash(
     }
     if (!resolved.toLowerCase().startsWith((sha as string).toLowerCase())) {
       ctx.host.http.writeJson(res, 409, { error: "stash_moved" });
+      return;
+    }
+    if (action === "show") {
+      // 카드는 "치워 둔 것"을 보여 준다 — untracked만 담긴 스태시가 부모 diff로는 0개 파일로
+      // 보이는 함정이 이 액션의 존재 이유이므로, --include-untracked가 빠지면 안 된다.
+      const shown = await runGit([
+        ...STASH_HARDENING_ARGS,
+        "stash", "show", "--include-untracked", "--name-status", name as string,
+      ], { cwd: gitCwd });
+      const files = shown.stdout.split("\n")
+        .map(parseStashShowLine)
+        .filter((entry): entry is { status: string; path: string } => entry !== null);
+      ctx.host.http.writeJson(res, 200, {
+        files: files.slice(0, MAX_STASH_SHOW_FILES),
+        ...(files.length > MAX_STASH_SHOW_FILES ? { truncated: true } : {}),
+      });
       return;
     }
     await runGit([...STASH_HARDENING_ARGS, "stash", action, name as string], { cwd: gitCwd });

--- a/runtime/fleet-plugins/repository/server/stash.ts
+++ b/runtime/fleet-plugins/repository/server/stash.ts
@@ -25,17 +25,27 @@ export function readStashAction(value: unknown): StashAction | null {
 const STASH_SHOW_STATUS_RE = /^[A-Z]\d{0,3}$/;
 const MAX_STASH_SHOW_FILES = 500;
 
-/** `--name-status` 한 줄(`M\tpath` 또는 `R100\told\tnew`)을 카드가 그릴 상태·경로로 줄인다. */
-export function parseStashShowLine(line: string): { readonly status: string; readonly path: string } | null {
-  const fields = line.split("\t");
-  if (fields.length < 2) return null;
-  const rawStatus = fields[0]!.trim();
-  if (!STASH_SHOW_STATUS_RE.test(rawStatus)) return null;
-  // 리네임/복사는 스코어 접미를 벗기고, 경로는 마지막 필드(신 경로)를 취한다.
-  const status = rawStatus[0]!;
-  const path = fields[fields.length - 1]!;
-  if (path === "") return null;
-  return { status, path };
+/**
+ * `--name-status -z`의 NUL 구분 레코드를 카드가 그릴 상태·경로로 줄인다.
+ * 줄 지향 출력은 core.quotePath가 비ASCII(한글 포함)·탭·개행 경로를 C-quote로 감싸
+ * 실제 파일명이 깨져 보인다 — NUL 레코드는 경로를 원문 그대로 나른다.
+ * 레코드 문법: `STATUS NUL path NUL`, 리네임/복사는 `R### NUL old NUL new NUL`.
+ */
+export function parseStashShowRecords(stdout: string): { readonly status: string; readonly path: string }[] {
+  const tokens = stdout.split("\0");
+  const files: { status: string; path: string }[] = [];
+  let index = 0;
+  while (index < tokens.length) {
+    const rawStatus = tokens[index]!.trim();
+    if (!STASH_SHOW_STATUS_RE.test(rawStatus)) { index += 1; continue; }
+    const status = rawStatus[0]!;
+    const pathCount = status === "R" || status === "C" ? 2 : 1;
+    const path = tokens[index + pathCount];
+    if (path === undefined || path === "") { index += 1; continue; }
+    files.push({ status, path });
+    index += 1 + pathCount;
+  }
+  return files;
 }
 
 function classifyStashError(stderr: string): "stash_conflict" | "nothing_to_stash" | null {
@@ -131,11 +141,9 @@ export async function handleRepositoryStash(
       // 보이는 함정이 이 액션의 존재 이유이므로, --include-untracked가 빠지면 안 된다.
       const shown = await runGit([
         ...STASH_HARDENING_ARGS,
-        "stash", "show", "--include-untracked", "--name-status", name as string,
+        "stash", "show", "--include-untracked", "--name-status", "-z", name as string,
       ], { cwd: gitCwd });
-      const files = shown.stdout.split("\n")
-        .map(parseStashShowLine)
-        .filter((entry): entry is { status: string; path: string } => entry !== null);
+      const files = parseStashShowRecords(shown.stdout);
       ctx.host.http.writeJson(res, 200, {
         files: files.slice(0, MAX_STASH_SHOW_FILES),
         ...(files.length > MAX_STASH_SHOW_FILES ? { truncated: true } : {}),

--- a/runtime/fleet-plugins/repository/tests/staging-routes.test.ts
+++ b/runtime/fleet-plugins/repository/tests/staging-routes.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { handleRepositoryCommitCreate, classifyCommitError } from "../server/commit-create.js";
 import { runGit } from "../server/git-executor.js";
 import { handleRepositoryDiscard, handleRepositoryStage, handleRepositoryUnstage, readStagePaths } from "../server/stage.js";
-import { handleRepositoryStash, parseStashShowLine, readStashAction } from "../server/stash.js";
+import { handleRepositoryStash, parseStashShowRecords, readStashAction } from "../server/stash.js";
 import { handleRepositoryStatus, parseStatusV2 } from "../server/status.js";
 import type { StatusResult } from "../server/types.js";
 
@@ -193,13 +193,22 @@ describe("Repository staging routes", () => {
     expect((await runGit(["stash", "list"], { cwd: repo })).stdout.trim()).not.toBe("");
   });
 
-  it("parses --name-status lines and rejects garbage", () => {
-    expect(parseStashShowLine("M\tsrc/ui/panel.ts")).toEqual({ status: "M", path: "src/ui/panel.ts" });
-    expect(parseStashShowLine("R100\told.ts\tnew.ts")).toEqual({ status: "R", path: "new.ts" });
-    expect(parseStashShowLine("A\tloose.txt")).toEqual({ status: "A", path: "loose.txt" });
-    expect(parseStashShowLine("")).toBeNull();
-    expect(parseStashShowLine("garbage line")).toBeNull();
-    expect(parseStashShowLine("\tno-status")).toBeNull();
+  it("parses -z NUL records, renames and non-ASCII paths intact", () => {
+    expect(parseStashShowRecords("M\0src/ui/panel.ts\0A\0loose.txt\0")).toEqual([
+      { status: "M", path: "src/ui/panel.ts" },
+      { status: "A", path: "loose.txt" },
+    ]);
+    // 리네임은 old/new 두 경로를 나르고, 카드는 신 경로를 취한다.
+    expect(parseStashShowRecords("R100\0old.ts\0new.ts\0M\0docs/guide.md\0")).toEqual([
+      { status: "R", path: "new.ts" },
+      { status: "M", path: "docs/guide.md" },
+    ]);
+    // 비ASCII 경로가 원문 그대로 살아남는 것이 -z의 존재 이유다.
+    expect(parseStashShowRecords("A\0\uBB38\uC11C/\uD55C\uAE00 \uD30C\uC77C.md\0")).toEqual([
+      { status: "A", path: "\uBB38\uC11C/\uD55C\uAE00 \uD30C\uC77C.md" },
+    ]);
+    expect(parseStashShowRecords("")).toEqual([]);
+    expect(parseStashShowRecords("garbage")).toEqual([]);
   });
 
   it("rejects malformed stash names and unknown actions", async () => {

--- a/runtime/fleet-plugins/repository/tests/staging-routes.test.ts
+++ b/runtime/fleet-plugins/repository/tests/staging-routes.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { handleRepositoryCommitCreate, classifyCommitError } from "../server/commit-create.js";
 import { runGit } from "../server/git-executor.js";
 import { handleRepositoryDiscard, handleRepositoryStage, handleRepositoryUnstage, readStagePaths } from "../server/stage.js";
-import { handleRepositoryStash, readStashAction } from "../server/stash.js";
+import { handleRepositoryStash, parseStashShowLine, readStashAction } from "../server/stash.js";
 import { handleRepositoryStatus, parseStatusV2 } from "../server/status.js";
 import type { StatusResult } from "../server/types.js";
 
@@ -172,6 +172,34 @@ describe("Repository staging routes", () => {
     expect(writes[0]!.status).toBe(200);
     expect(await fs.readFile(path.join(repo, "tracked.txt"), "utf8")).toContain("wip");
     expect(await fs.readFile(path.join(repo, "loose.txt"), "utf8")).toBe("loose\n");
+  });
+
+  it("shows a stash's files including untracked ones — the 0-file card trap (M3)", async () => {
+    await fs.appendFile(path.join(repo, "tracked.txt"), "wip\n");
+    await fs.writeFile(path.join(repo, "loose.txt"), "loose\n");
+    let writes: JsonWrite[] = [];
+    await handleRepositoryStash(req, res, makeContext(repo, { theaterId: "t", action: "save" }, writes));
+    expect(writes[0]!.status).toBe(200);
+
+    const stashSha = (await runGit(["rev-parse", "--verify", "stash@{0}"], { cwd: repo })).stdout.trim();
+    writes = [];
+    await handleRepositoryStash(req, res, makeContext(repo, { theaterId: "t", action: "show", name: "stash@{0}", sha: stashSha }, writes));
+    expect(writes[0]!.status).toBe(200);
+    const files = (writes[0]!.payload as { files: readonly { status: string; path: string }[] }).files;
+    const paths = files.map((file) => file.path).sort();
+    // untracked(loose.txt)가 빠지면 이 액션의 존재 이유가 사라진다.
+    expect(paths).toEqual(["loose.txt", "tracked.txt"]);
+    // show는 읽기다 — 스태시가 그대로 남아 있어야 한다.
+    expect((await runGit(["stash", "list"], { cwd: repo })).stdout.trim()).not.toBe("");
+  });
+
+  it("parses --name-status lines and rejects garbage", () => {
+    expect(parseStashShowLine("M\tsrc/ui/panel.ts")).toEqual({ status: "M", path: "src/ui/panel.ts" });
+    expect(parseStashShowLine("R100\told.ts\tnew.ts")).toEqual({ status: "R", path: "new.ts" });
+    expect(parseStashShowLine("A\tloose.txt")).toEqual({ status: "A", path: "loose.txt" });
+    expect(parseStashShowLine("")).toBeNull();
+    expect(parseStashShowLine("garbage line")).toBeNull();
+    expect(parseStashShowLine("\tno-status")).toBeNull();
   });
 
   it("rejects malformed stash names and unknown actions", async () => {


### PR DESCRIPTION
## Summary
- 변경 뷰로 전환하면 커밋/비교/스태시 인스펙터가 한 줄 "보던 커밋" 칩으로 접힙니다 — 스테이징이 전체 높이를 되찾고, 칩 클릭이 기록+상세를 복원하며 ✕가 상세를 닫습니다 (M1).
- 툴바 스태시·Pull 성공 직후 스테이징 목록을 즉시 재조회해 카운트와 목록의 불일치를 없앱니다 (M2).
- 스태시 항목을 커밋 인스펙터 대신 전용 카드로 엽니다: 새 stash `show` 액션(`--include-untracked --name-status`, sha 대조 유지)이 치워 둔 파일(untracked 포함)을 보여 주고, 적용/적용 후 제거/무장 삭제가 카드에 붙습니다 (M3·M4). Stash 버튼은 저장 전에 메시지를 한 번 묻습니다(비우면 자동 문구) (M5).
- 커밋 인스펙터의 목록/트리 토글을 스테이징 파일 목록에 이식했고(DiffTreeView에 행 액션 슬롯 추가), 행 액션은 호버 시 스테이지·내리기·버리기·삭제 라벨을 병기합니다 (M6·M10).

배경: 저장소 패널 동선 12종 실사용 감사에서 수집한 마찰 M1~M12 중 재가된 P1+P2 범위입니다. 제안 아티팩트: https://claude.ai/code/artifact/bcecf416-9645-4627-999e-ef98075dfb37

## Test Plan
- [x] `runtime/fleet-plugins/repository` vitest 441/441 통과 (신규: stash show 통합 2건 + parseStashShowLine 단위)
- [x] `tsc --noEmit` 클린 (origin/canary 리베이스 후 재확인)
- [x] 격리 콘솔 실브라우저 QA: 칩 접힘/복귀/닫기 · 스태시 팝오버(autofocus·Enter·메시지 반영) · 스태시 직후 목록 0행 갱신 · 스태시 카드(untracked 포함 3파일·인라인 pop 후 자동 닫힘·목록 3행 복원) · 트리 토글(src/ui·server 폴더·잎 액션 6) · 무장 문구·비교 칩 회귀 — 페이지 에러 0