### PR TITLE
feat(fleet-console): make the streaming Chat ledger scannable

### DIFF
--- a/.changelog.d/chat-streaming-legibility-20260823.md
+++ b/.changelog.d/chat-streaming-legibility-20260823.md
@@ -1,0 +1,8 @@
+---
+branch: chat-streaming-legibility-20260823
+---
+
+### fleet-console
+#### Changed
+- Make the streaming Chat Mode ledger scannable: the model's sentences now stand at full reading brightness so prose no longer blends into the folded tool line, every tally clause leads with its tool-family mark, and the working clock carries the same progress ripple as the live line.
+  ko: 스트리밍 중인 Chat Mode 원장이 훑어 읽히도록, 모델 문장을 읽는 밝기로 올려 접힌 도구 줄과 섞이지 않게 하고 집계의 각 절 앞에 도구 계열 표식을 세웠으며, 작업 시계도 라이브 줄과 같은 진행 물결을 집니다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2084,6 +2084,14 @@ describe("Instrument core design contract", () => {
     // 타일 경계가 보이지 않으려면 그라데이션 양 끝이 같은 잉크여야 한다.
     expect(chatLiveTextBlock).toContain("var(--text-tertiary) 0%,");
     expect(chatLiveTextBlock).toContain("var(--text-tertiary) 100%");
+    // 진행 중 턴 헤드의 시계도 같은 물결을 진다 — 집계 줄과 같은 사실("이 턴이 아직 살아
+    // 있다")을 말하는 자리라 어휘가 갈리면 안 된다. 다만 이 자리의 잉크는 tertiary이므로
+    // 봉인의 기본 채움(secondary)을 덮어써야 모션을 끈 것이 밝기 변화로 읽히지 않는다.
+    expect(chatView0).toContain('<span className="agent-chat-live-text" aria-hidden="true">');
+    expect(chatView0).toContain('t("terminal.chat.turnWorking"');
+    expect(chat).toMatch(
+      /\.agent-chat-turn-head \.agent-chat-live-text \{\s*color: var\(--text-tertiary\);\s*\}/,
+    );
     // 물결 봉인은 모션만 죽이고 줄은 남긴다. `color: transparent`가 남으면 글자가 통째로
     // 사라지므로 그라데이션과 채움을 함께 되돌려야 한다(ULTRACODE 물결과 같은 함정).
     const chatLiveSealBlock = chat.match(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.agent-chat-live-text \{[^}]*\}/)?.[0] ?? "";
@@ -2115,6 +2123,24 @@ describe("Instrument core design contract", () => {
     for (const signal of ["--aurora", "--positive", "--warn", "--coral", "--brass", "--id-"]) {
       expect(chatJobGlyphBlock).not.toContain(signal);
     }
+    // 계열 표식은 잡 글리프와 같은 알파벳을 넓힌 것이다 — 같은 일을 두 면이 다른 기호로 부르면
+    // 표식이 어휘가 아니라 장식이 된다. 색은 쥐지 않는다: 계열은 어떤 채널에도 속하지 않고,
+    // 잉크를 쥐면 도는 줄의 물결이 이 글자에서만 끊긴다(배경 클립은 투명한 자식만 통과시킨다).
+    const chatTallyGlyphBlock = chat.match(/^\.agent-chat-tally-glyph \{[^}]*\}/m)?.[0] ?? "";
+    expect(chatTallyGlyphBlock).not.toContain("color:");
+    expect(chatTallyGlyphBlock).toContain("width: 1em;");
+    const chatView0Glyphs = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_VIEW_PATH), "utf8");
+    for (const [family, glyph] of [["delegate", "◆"], ["run", "❯"], ["workflow", "⣿"]] as const) {
+      expect(chatView0Glyphs, family).toContain(`${family}: "${glyph}",`);
+    }
+    // 표식과 그 문구는 한 덩어리다 — 절 사이 간격을 그대로 쓰면 표식이 앞 절 끝에 붙어 읽힌다.
+    const chatTallyClauseBlock = chat.match(/^\.agent-chat-tally-clause \{[^}]*\}/m)?.[0] ?? "";
+    expect(chatTallyClauseBlock).toContain("gap: var(--space-1);");
+    // 집계 줄의 자식은 링·글자 묶음·꺾쇠 셋뿐이고 줄바꿈은 묶음이 자기 안에서 진다. 여기서
+    // wrap을 열면 절이 많은 줄에서 꺾쇠가 홀로 다음 줄로 떨어진다(감싸는 flex는 좁아지기보다
+    // 넘기기를 먼저 고른다).
+    const chatTallyBlock = chat.match(/^\.agent-chat-tally \{[^}]*\}/m)?.[0] ?? "";
+    expect(chatTallyBlock).toContain("flex-wrap: nowrap;");
     // 두 뷰의 전환 진입은 캡션 밴드의 한 버튼이 진다 — 목적지 마크만 바뀐다.
     const chatView = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_VIEW_PATH), "utf8");
     const chatComposer = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_COMPOSER_PATH), "utf8");
@@ -2126,6 +2152,13 @@ describe("Instrument core design contract", () => {
     expect(chatView).toContain('className="agent-chat-ledger-note markdown-body"');
     expect(chat).toContain(".agent-chat .agent-chat-ledger-note.markdown-body");
     expect(chat).not.toMatch(/\.agent-chat-ledger-note[^{]*\{[^}]*font-style:\s*italic/);
+    // 그 문장은 이 면에서 가장 밝다. tertiary였을 때 집계 줄과 같은 잉크라 스트리밍 중에는
+    // 문장과 장부가 한 덩어리 회색이었다. secondary로는 갈리지 않는다 — 잉크 스케일에서
+    // secondary(L70)와 tertiary(L64)는 6포인트뿐이라 실측에서 같은 회색으로 읽혔다.
+    const chatNoteInkBlock = chat.match(
+      /\.agent-chat \.agent-chat-ledger-note\.markdown-body p,\s*\n\.agent-chat \.agent-chat-ledger-note\.markdown-body li \{[^}]*\}/,
+    )?.[0] ?? "";
+    expect(chatNoteInkBlock).toContain("color: var(--text-primary);");
     expect((terminalEntry.match(/actionId="view-switch"/g) ?? [])).toHaveLength(2);
     expect(terminalEntry).toContain("<CaptionTerminalGlyph />");
     expect(terminalEntry).toContain("<CaptionChatGlyph />");

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -707,7 +707,8 @@ function ChatTurn({
   );
 }
 
-/** 진행 중 턴 헤드의 라이브 티커 — 시각 전용이라 라이브 리전이 아니다(매초 재낭독 방지). */
+/** 진행 중 턴 헤드의 라이브 티커 — 시각 전용이라 라이브 리전이 아니다(매초 재낭독 방지).
+ *  집계 줄과 같은 명도 물결을 진다: 둘 다 "이 턴이 아직 살아 있다"를 말하므로 같은 어휘다. */
 function TurnElapsedLabel({
   turn,
   language,
@@ -717,7 +718,11 @@ function TurnElapsedLabel({
 }) {
   const t = getT(language);
   const elapsedMs = useTurnElapsedMs(turn.startedAt, turn.state === "working");
-  return <span aria-hidden="true">{t("terminal.chat.turnWorking", { elapsed: formatElapsed(elapsedMs) })}</span>;
+  return (
+    <span className="agent-chat-live-text" aria-hidden="true">
+      {t("terminal.chat.turnWorking", { elapsed: formatElapsed(elapsedMs) })}
+    </span>
+  );
 }
 
 /**
@@ -889,13 +894,16 @@ function Tally({
   const clauses = groups.map((group, index) => (
     <React.Fragment key={`${group.family}-${group.name ?? ""}`}>
       {index > 0 ? <span className="agent-chat-tally-sep" aria-hidden="true">·</span> : null}
-      {/* 알려진 계열은 문구 하나로 끝나지만, `other`는 도구 이름이 곧 주어다. 그 이름만 따로
-          그려 한 단 밝은 잉크를 지운다 — 접히지 않은 스텝 줄의 동사가 이미 그 잉크를 쓰므로,
-          이것은 새 문법이 아니라 두 줄을 같은 문법으로 되돌리는 것이다. */}
-      {group.family === "other" && group.name !== undefined
-        ? <span className="agent-chat-tally-name">{group.name}</span>
-        : null}
-      <span>{groupLabel(group, t)}</span>
+      <span className="agent-chat-tally-clause">
+        <span className="agent-chat-tally-glyph" aria-hidden="true">{familyGlyph(group.family)}</span>
+        {/* 알려진 계열은 문구 하나로 끝나지만, `other`는 도구 이름이 곧 주어다. 그 이름만 따로
+            그려 한 단 밝은 잉크를 지운다 — 접히지 않은 스텝 줄의 동사가 이미 그 잉크를 쓰므로,
+            이것은 새 문법이 아니라 두 줄을 같은 문법으로 되돌리는 것이다. */}
+        {group.family === "other" && group.name !== undefined
+          ? <span className="agent-chat-tally-name">{group.name}</span>
+          : null}
+        <span>{groupLabel(group, t)}</span>
+      </span>
     </React.Fragment>
   ));
   // 라이브 줄은 자기가 살아 있다고 스스로 말해야 한다. 예전에는 최근 여덟 줄이 흘러가는 것
@@ -917,7 +925,10 @@ function Tally({
                 {index > 0 || clauses.length > 0
                   ? <span className="agent-chat-tally-sep" aria-hidden="true">·</span>
                   : null}
-                <span>{`${runningVerb(item.name ?? "", language)}${item.detail !== undefined && item.detail.length > 0 ? ` ${item.detail}` : ""}`}</span>
+                <span className="agent-chat-tally-clause">
+                  <span className="agent-chat-tally-glyph" aria-hidden="true">{familyGlyph(agentChatToolFamily(item.name))}</span>
+                  <span>{`${runningVerb(item.name ?? "", language)}${item.detail !== undefined && item.detail.length > 0 ? ` ${item.detail}` : ""}`}</span>
+                </span>
               </React.Fragment>
             ))}
           </span>
@@ -992,6 +1003,36 @@ function settledLabel(count: number, t: ReturnType<typeof getT>): string {
 }
 
 /** 복수형은 이 저장소 관례대로 호출부가 고른다(`_one`/`_other`). */
+/**
+ * 계열 표식 — 같은 종류의 일이 어디서 몇 번 있었는지를 읽기 전에 **보이게** 한다.
+ *
+ * 집계 줄은 절이 이어질수록 한 줄짜리 글자 덩어리가 되어, 무엇이 몇 건인지 세려면 문장을
+ * 읽어야 했다. 표식이 앞에 서면 세는 일이 읽기가 아니라 훑기가 된다.
+ *
+ * 알파벳은 제품에 이미 있는 잡 글리프(◆ 위임 · ❯ 셸 · ⣿ 워크플로 · ▪ 그 밖)를 그대로
+ * 물려받아 넓힌 것이다 — 같은 일을 두 면이 다른 기호로 부르면 표식이 어휘가 아니라 장식이
+ * 된다. 전부 텍스트 표현 문자다: 이모지를 쓰면 자기 색을 들고 와 채널 계약을 깬다.
+ */
+function familyGlyph(family: string): string {
+  return FAMILY_GLYPHS[family] ?? "▪";
+}
+
+const FAMILY_GLYPHS: Readonly<Record<string, string>> = {
+  read: "▤",
+  write: "✚",
+  edit: "✎",
+  run: "❯",
+  inspect: "◉",
+  search: "⌕",
+  fetch: "↧",
+  delegate: "◆",
+  workflow: "⣿",
+  stop: "■",
+  plan: "☰",
+  ask: "?",
+  propose: "▷",
+};
+
 function groupLabel(group: AgentChatStepGroup, t: ReturnType<typeof getT>): string {
   const plural = group.count === 1 ? "one" : "other";
   const key = `terminal.chat.group.${group.family}_${plural}` as Parameters<typeof t>[0];

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
@@ -354,6 +354,80 @@ describe("chat ledger — one live line, and a job anchor instead of a card", ()
 });
 
 /**
+ * 계열 표식 — 집계 줄은 절이 이어질수록 한 줄짜리 글자 덩어리가 된다. 표식이 절 앞에 서면
+ * 무엇이 몇 건인지 세는 일이 읽기가 아니라 훑기가 된다.
+ */
+describe("chat ledger — family glyphs on the tally clauses", () => {
+  it("marks every clause with its family, and shares the job glyph alphabet", () => {
+    logState = {
+      ...stateWith([]),
+      turns: [{
+        dispatch: { text: "go" },
+        items: [
+          { type: "text", text: "Looking around." },
+          { type: "tool", name: "Read", detail: "alpha.md", state: "ok" },
+          { type: "tool", name: "Bash", detail: "ls", state: "ok" },
+          { type: "tool", name: "Grep", detail: "needle", state: "ok" },
+        ] as AgentChatLogState["turns"][number]["items"],
+        state: "done",
+        toolCount: 3,
+        draft: "",
+      }],
+    };
+    mount();
+    const clauses = [...(container?.querySelectorAll(".agent-chat-tally-clause") ?? [])];
+    expect(clauses).toHaveLength(3);
+    expect(clauses.map((clause) => clause.querySelector(".agent-chat-tally-glyph")?.textContent))
+      .toEqual(["▤", "❯", "⌕"]);
+    // 셸은 잡 글리프(❯)와 같은 기호다 — 같은 일을 두 면이 다른 기호로 부르면 어휘가 아니라 장식이 된다.
+    expect(clauses[1]?.textContent).toContain("Ran 1 shell command");
+  });
+
+  it("marks the running clause too, so the live line reads the same way", () => {
+    logState = {
+      ...stateWith([]),
+      turns: [{
+        dispatch: { text: "go" },
+        items: [
+          { type: "text", text: "Working." },
+          { type: "tool", name: "Read", detail: "alpha.md", state: "ok" },
+          { type: "tool", name: "Bash", detail: "pnpm test", state: "running" },
+        ] as AgentChatLogState["turns"][number]["items"],
+        state: "working",
+        toolCount: 2,
+        draft: "",
+      }],
+    };
+    mount();
+    const live = container?.querySelector(".agent-chat-tally.is-live");
+    const running = live?.querySelector(".agent-chat-tally-running .agent-chat-tally-clause");
+    expect(running?.querySelector(".agent-chat-tally-glyph")?.textContent).toBe("❯");
+    expect(running?.textContent).toContain("Running pnpm test");
+  });
+
+  it("falls back to the neutral mark for a tool with no family", () => {
+    logState = {
+      ...stateWith([]),
+      turns: [{
+        dispatch: { text: "go" },
+        items: [
+          { type: "text", text: "Calling out." },
+          { type: "tool", name: "mcp__fleet__wiki_read", detail: "page", state: "ok" },
+        ] as AgentChatLogState["turns"][number]["items"],
+        state: "done",
+        toolCount: 1,
+        draft: "",
+      }],
+    };
+    mount();
+    const clause = container?.querySelector(".agent-chat-tally-clause");
+    expect(clause?.querySelector(".agent-chat-tally-glyph")?.textContent).toBe("▪");
+    // `other`는 도구 이름이 곧 주어다 — 표식이 그 이름을 밀어내지 않는다.
+    expect(clause?.querySelector(".agent-chat-tally-name")?.textContent).toBe("mcp__fleet__wiki_read");
+  });
+});
+
+/**
  * 병렬 도구 배치 — 한 assistant 메시지가 tool_use 블록을 여럿 실은 경우다. 그 스텝들은 다음
  * 사용자 메시지가 결과를 실어 올 때까지 **동시에** running으로 남으므로, 꼬리 하나만 라이브 줄로
  * 걷으면 나머지가 그대로 전폭 행으로 선다 — 배치가 클수록 한 줄 원장이 무너진다.

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -280,16 +280,26 @@
   margin-bottom: 0;
 }
 
+/* 구간 문장은 이 면에서 가장 밝다. 예전에는 답변보다 한 단 낮춘 tertiary였는데, 집계 줄이
+   같은 tertiary라 스트리밍 중에는 문장과 장부가 한 덩어리 회색으로 읽혔다(사용자 적발).
+   secondary로 한 단만 올리는 것으로는 갈리지 않는다 — 잉크 스케일에서 secondary(L70)와
+   tertiary(L64)는 6포인트뿐이고, 실측에서 둘을 나란히 두면 같은 회색으로 보인다. 세 티어
+   중 갈리는 것은 primary(L94)뿐이다. 답변보다 밝아지는 것은 뒤집힘이 아니다: 도는 동안
+   읽을 것은 이 문장이고, 턴이 끝나면 이 문장은 접힘 안으로 들어간다 — 펼쳐 본 사람은
+   결말이 아니라 과정을 읽으러 온 사람이다. */
 .agent-chat .agent-chat-ledger-note.markdown-body p,
 .agent-chat .agent-chat-ledger-note.markdown-body li {
-  color: var(--text-tertiary);
+  color: var(--text-primary);
 }
 
 /* 끝난 일상 스텝의 한 줄 집계 — 도구를 세우지 않고 "무엇을 몇 번 했는가"만 남긴다.
    면도 테두리도 없다: 이 줄은 카드가 아니라 문장이고, 카드는 예외에게만 준다. */
 .agent-chat-tally {
   display: flex;
-  flex-wrap: wrap;
+  /* 이 줄의 자식은 링·글자 묶음·꺾쇠 셋뿐이고 줄바꿈은 묶음이 자기 안에서 진다. 여기서
+     wrap을 열어 두면 절이 많은 줄에서 꺾쇠가 홀로 다음 줄로 떨어진다 — 감싸는 flex는
+     좁아지기보다 넘기기를 먼저 고르기 때문이다(절마다 계열 글리프가 서면서 더 자주 난다). */
+  flex-wrap: nowrap;
   align-items: baseline;
   gap: var(--space-2);
   padding: 2px var(--space-1);
@@ -301,6 +311,25 @@
 
 .agent-chat-tally-sep {
   color: var(--hairline-strong);
+}
+
+/* 계열 글리프와 그 문구는 한 덩어리다 — 절 사이 간격(space-2)을 그대로 쓰면 글리프가 앞
+   절 끝에 붙어 읽혀 무엇을 세는 표식인지 알 수 없다. */
+.agent-chat-tally-clause {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+/* 계열 표식. 색을 따로 쥐지 않는다 — 계열은 상태(신호)도 위치(brass)도 정체성도 아니라
+   어떤 채널에도 속하지 않고, 잉크를 쥐는 순간 도는 줄의 물결이 이 글자에서만 끊긴다
+   (배경 클립은 투명한 자식만 통과시킨다 — 구분점과 `other` 이름이 이미 그 예외다).
+   폭을 1em으로 고정해 여러 절이 같은 리듬으로 선다. */
+.agent-chat-tally-glyph {
+  flex: none;
+  width: 1em;
+  text-align: center;
 }
 
 /* 집계 줄의 글자 묶음. 도는 구간에서는 이 묶음만 물결지고 링과 꺾쇠는 제자리에 남는다. */
@@ -397,6 +426,7 @@
    차이는 이 글리프 하나뿐). 크기와 잉크를 한 단씩 올려 쉬는 상태에서도 읽히게 하고, hover는
    그 위 한 단으로 남긴다 — brass는 위치·포커스 채널이라 "눌린다"를 질 수 없다. */
 .agent-chat-tally-chev {
+  flex: none;
   font-size: var(--t-xs);
   line-height: 1;
   align-self: center;
@@ -1684,6 +1714,12 @@
     animation: none;
     background-image: none;
     color: var(--text-secondary);
+  }
+
+  /* 턴 헤드의 잉크는 tertiary다 — 봉인의 기본 채움(secondary)을 그대로 받으면 모션을 끈
+     것만으로 시계가 밝아져, 없는 상태 변화를 말하게 된다. */
+  .agent-chat-turn-head .agent-chat-live-text {
+    color: var(--text-tertiary);
   }
 
   /* 컴포저가 가운데에서 하단으로 내려앉는 이동을 세운다 — 자리는 그대로 바뀌되 한 프레임에 간다. */


### PR DESCRIPTION
## Summary

스트리밍 중인 Chat 원장에서 **모델 문장과 접힌 도구 집계가 같은 잉크**(둘 다 `--text-tertiary`)여서 한 덩어리 회색으로 읽혔습니다. 집계 절에는 표식도 없어 무엇이 몇 건인지 세려면 문장을 읽어야 했습니다.

- **구간 문장을 `--text-primary`로.** `secondary`(L70)는 `tertiary`(L64)와 6포인트뿐이라 나란히 두면 같은 회색으로 보입니다(실측). 갈리는 것은 `primary`(L94)뿐입니다.
- **집계 절마다 도구 계열 표식.** 제품에 이미 있던 잡 글리프(`◆` 위임 · `❯` 셸 · `⣿` 워크플로 · `▪` 그 밖)를 14개 계열로 넓혔습니다. 색은 쥐지 않습니다 — 계열은 어떤 채널에도 속하지 않고, 잉크를 쥐면 도는 줄의 물결이 그 글자에서만 끊깁니다.
- **꺾쇠가 절 줄에 남습니다.** 집계 줄이 자기 자식을 줄바꿈으로 갈라놓지 않게 해, 절이 많아도 열쇠가 홀로 세 번째 줄로 떨어지지 않습니다.
- **작업 시계도 라이브 줄과 같은 명도 물결을 집니다.**

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `test`(2367) / `build`
- [x] 터미널 플러그인 스위트 975건 (계열 글리프 동작 3건 신설)
- [x] `check:core-boundary` · `check:claude-agent-sdk-boundary`
- [x] `compile-changelog-fragments.mjs --check`
- [x] 격리 콘솔 실측 — Settings에서 `codex--gpt-5.6-luna` 추가 후 라이브 턴 2회
  - 노트 `oklch(0.94 …)` 대 집계 `oklch(0.64 …)` (이전 0포인트 → 30포인트)
  - 글리프 실렌더: `▤` 읽기 · `❯` 셸 · `▪ ToolSearch`(계열 밖 폴백)
  - 라이브 줄·작업 시계 모두 `agent-chat-live-sweep 2.4s` / `background-size: 200% 100%`, 글리프 채움 `rgba(0,0,0,0)`(물결 통과)
  - 페이지 오류 0 · rejection 0