### PR TITLE
feat(fleet-console): give the Analyst the Chat ledger's streaming grammar

### DIFF
--- a/.changelog.d/analyst-streaming-grammar-20260823.md
+++ b/.changelog.d/analyst-streaming-grammar-20260823.md
@@ -1,0 +1,8 @@
+---
+branch: analyst-streaming-grammar-20260823
+---
+
+### fleet-console
+#### Changed
+- Give the Session Analyst the Chat ledger's streaming grammar: a finished turn now folds into the single sentence that already carried its outcome instead of repeating the same duration as both a heading and a pill, and the working clock and live activity line ripple the way the Chat log does. The latest-activity pulse and the artifact cards are unchanged.
+  ko: Session Analyst가 채팅 원장과 같은 스트리밍 문법을 씁니다. 끝난 턴은 같은 소요를 머리와 알약으로 두 번 말하는 대신 결말을 지고 있던 한 문장으로 접히고, 작업 시계와 진행 문구가 채팅 로그와 같은 물결을 집니다. 최신 활동 펄스와 아티팩트 카드는 그대로입니다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2318,7 +2318,9 @@ describe("Instrument core design contract", () => {
     // 결말의 성패는 스파인 노드가 진다 — 접힘 줄이 ✓를 또 들면 두 곳이 같은 말을 한다.
     expect(terminalAnalysisCss).not.toContain(".session-analyst__receipt-mark");
     // 물결은 채팅 원장의 것과 한 벌이다. 값이 갈라지면 같은 사실을 두 면이 다른 속도로 말한다.
-    const analystWave = terminalAnalysisCss.match(/\.session-analyst__live-text \{[^}]*\}/)?.[0] ?? "";
+    // 줄머리에 못을 박는다 — 앵커 없는 `.session-analyst__live-text {`는 합성 규칙의
+    // `strong.session-analyst__live-text {` 꼬리에도 물린다.
+    const analystWave = terminalAnalysisCss.match(/^\.session-analyst__live-text \{[^}]*\}/m)?.[0] ?? "";
     expect(analystWave).toContain("background-size: 200% 100%;");
     expect(analystWave).toContain("background-clip: text;");
     expect(analystWave).toContain("color: transparent;");
@@ -2330,6 +2332,11 @@ describe("Instrument core design contract", () => {
     // 프레임과 같다(200% 이미지에 ΔP 200 = 2W = 타일 한 폭).
     expect(terminalAnalysisCss).toMatch(
       /@keyframes analyst-live-sweep \{\s*from \{ background-position: 200% 0; \}\s*to \{ background-position: 0% 0; \}/,
+    );
+    // 펄스 문구는 애니메이션을 둘 진다(도착 + 물결). 합성하지 않으면 도착 애니메이션이 같은
+    // 속성을 더 높은 특정성으로 쥐고 있어 물결이 조용히 죽고 정지된 그라데이션만 남는다.
+    expect(terminalAnalysisCss).toMatch(
+      /\.session-analyst__pulse-copy strong\.session-analyst__live-text \{[\s\S]*?analyst-stage-enter[\s\S]*?analyst-live-sweep 2\.4s linear infinite;/,
     );
     // 봉인은 모션만 죽인다 — `color: transparent`가 남으면 글자가 통째로 사라진다.
     const analystSeal = terminalAnalysisCss.match(

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2309,6 +2309,35 @@ describe("Instrument core design contract", () => {
     expect(terminalAnalysisCss).not.toMatch(/\.session-analyst__chips \{[^}]*position: absolute/);
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__turn-node \{/);
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__receipt > summary \{/);
+    // 끝난 턴의 접힘은 채팅 원장의 `.agent-chat-fold`와 같은 문법이다 — 문장이지 카드가 아니다.
+    // 알약(면·테두리)으로 되돌아가면 이 줄이 결말을 말하는 문장이 아니라 물건으로 읽힌다.
+    const analystReceiptSummary = terminalAnalysisCss.match(/\.session-analyst__receipt > summary \{[^}]*\}/)?.[0] ?? "";
+    expect(analystReceiptSummary).not.toContain("border:");
+    expect(analystReceiptSummary).not.toContain("background:");
+    expect(analystReceiptSummary).not.toContain("radius-pill");
+    // 결말의 성패는 스파인 노드가 진다 — 접힘 줄이 ✓를 또 들면 두 곳이 같은 말을 한다.
+    expect(terminalAnalysisCss).not.toContain(".session-analyst__receipt-mark");
+    // 물결은 채팅 원장의 것과 한 벌이다. 값이 갈라지면 같은 사실을 두 면이 다른 속도로 말한다.
+    const analystWave = terminalAnalysisCss.match(/\.session-analyst__live-text \{[^}]*\}/)?.[0] ?? "";
+    expect(analystWave).toContain("background-size: 200% 100%;");
+    expect(analystWave).toContain("background-clip: text;");
+    expect(analystWave).toContain("color: transparent;");
+    expect(analystWave).toContain("animation: analyst-live-sweep 2.4s linear infinite;");
+    for (const signal of ["--aurora", "--positive", "--warn", "--coral", "--brass", "--apex", "--id-"]) {
+      expect(analystWave, signal).not.toContain(signal);
+    }
+    // 되풀이는 이음매가 없어야 한다 — 이동량이 타일 한 폭의 정수배여야 마지막 프레임이 첫
+    // 프레임과 같다(200% 이미지에 ΔP 200 = 2W = 타일 한 폭).
+    expect(terminalAnalysisCss).toMatch(
+      /@keyframes analyst-live-sweep \{\s*from \{ background-position: 200% 0; \}\s*to \{ background-position: 0% 0; \}/,
+    );
+    // 봉인은 모션만 죽인다 — `color: transparent`가 남으면 글자가 통째로 사라진다.
+    const analystSeal = terminalAnalysisCss.match(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.session-analyst__live-text \{[^}]*\}/,
+    )?.[0] ?? "";
+    expect(analystSeal).toContain("animation: none;");
+    expect(analystSeal).toContain("background-image: none;");
+    expect(analystSeal).toContain("color: var(--text-secondary);");
     // 사용자 발화 정체성은 --id-cerulean 워시 문법(디스패치 버블과 동형)만 쓴다.
     expect(terminalAnalysisCss).toContain("color-mix(in oklch, var(--id-cerulean) 10%, var(--surface-panel-raised))");
     // 아티팩트는 드로어 안의 모드다 — 모드 세그먼트가 있고, 세로 핸들과 두 번째 컴패니언은 되살아나면 안 된다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -193,6 +193,10 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(container.querySelector(".session-analyst__chip-state")?.textContent).toContain("Analyzing");
     expect(container.querySelector(".session-analyst__pulse")?.textContent).toContain("Using wiki_read");
     expect(container.querySelector(".session-analyst__pulse")?.textContent).toContain("Tool status: running");
+    // 도는 동안의 시계와 펄스 문구는 채팅 원장과 같은 명도 물결을 진다 — 두 면이 같은 사실을
+    // 말하므로 어휘가 갈리면 안 된다. 오류일 때는 물결을 걷는다(진행이 아니라 결말이다).
+    expect(container.querySelector(".session-analyst__turn-head .session-analyst__live-text")).not.toBeNull();
+    expect(container.querySelector(".session-analyst__pulse-copy strong")?.classList.contains("session-analyst__live-text")).toBe(true);
     expect(container.querySelector(".session-analyst__chat ol")?.classList.contains("is-dimmed")).toBe(false);
     expect(container.querySelector("textarea")?.disabled).toBe(false);
     expect(container.querySelectorAll("select")).toHaveLength(0);
@@ -727,10 +731,14 @@ describe("Session Analyst Evidence Pulse", () => {
     const { container, root } = renderPanel();
     const composer = container.querySelector(".session-analyst__composer")!;
     const receipt = container.querySelector(".session-analyst__receipt")!;
-    expect(receipt.querySelector("summary")?.textContent).toContain("18s · 1 step");
+    // 끝난 턴은 채팅 원장과 같은 문법으로 한 문장에 접힌다 — 결말과 소요와 스텝 수가 한 줄이다.
+    expect(receipt.querySelector("summary")?.textContent).toContain("Answered in 18s · 1 step");
     expect(receipt.querySelector(".session-analyst__receipt-step")?.textContent).toContain("wiki_read");
     expect(container.querySelector(".session-analyst__stopped")).toBeNull();
-    expect(container.querySelector(".session-analyst__turn-head")?.textContent).toBe("Answered in 18s");
+    // 같은 시간을 두 번 말하지 않는다: 완료 머리는 접힘 줄에 흡수됐다(예전에는 머리의
+    // "Answered in 18s"와 알약의 "✓ 18s · 1 step"이 나란히 섰다).
+    expect(container.querySelector(".session-analyst__turn-head")).toBeNull();
+    expect(receipt.querySelector(".session-analyst__receipt-mark")).toBeNull();
     expect(container.querySelector(".session-analyst__chip-state")?.textContent).toContain("Complete");
     expect(composer.classList.contains("is-docked")).toBe(true);
     expect(container.querySelectorAll("select")).toHaveLength(0);

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -499,8 +499,13 @@ function AnalystTurn({ state, language, entry, isLast, liveElapsedMs, decorateEv
     <li className={`session-analyst__message session-analyst__message--analyst${working ? " is-working" : ""}${isError ? " is-error" : ""}${!isError && isStopped ? " is-stopped" : ""}`}>
       <span className="session-analyst__turn-spine" aria-hidden="true"><span className="session-analyst__turn-node" /></span>
       <div className="session-analyst__turn-main">
-        {working ? <div className="session-analyst__turn-head">{t("terminal.chat.turnWorking", { elapsed: formatElapsed(liveElapsedMs) })}</div> : null}
-        {!working && receipt?.outcome === "complete" ? <div className="session-analyst__turn-head">{t("terminal.analyst.turnAnswered", { elapsed: formatElapsed(receipt.durationMs) })}</div> : null}
+        {/* 도는 동안의 시계는 채팅 원장과 같은 명도 물결을 진다 — 두 면이 같은 사실("이 턴이
+            아직 살아 있다")을 말하므로 어휘가 갈리면 안 된다. */}
+        {working ? (
+          <div className="session-analyst__turn-head">
+            <span className="session-analyst__live-text">{t("terminal.chat.turnWorking", { elapsed: formatElapsed(liveElapsedMs) })}</span>
+          </div>
+        ) : null}
         {working || liveError ? <TurnPulse state={state} language={language} elapsedMs={liveElapsedMs} /> : null}
         {liveStopped ? <StoppedReceipt state={state} language={language} elapsedMs={liveElapsedMs} /> : null}
         {!liveStopped && !working && receipt?.outcome === "stopped" ? (
@@ -534,7 +539,12 @@ function TurnPulse({ state, language, elapsedMs }: { readonly state: AnalysisSta
       <div className={`session-analyst__pulse${isError ? " is-error" : ""}`} role={isError ? "alert" : "status"} aria-live={isError ? undefined : "polite"}>
         <span className="session-analyst__pulse-orbit" aria-hidden="true" />
         <span className="session-analyst__pulse-copy">
-          <strong key={`${state.phase}-${current.label}`}>{isError ? translateServerMessage(language, state.error ?? "") : current.label}</strong>
+          <strong
+            key={`${state.phase}-${current.label}`}
+            className={isError ? undefined : "session-analyst__live-text"}
+          >
+            {isError ? translateServerMessage(language, state.error ?? "") : current.label}
+          </strong>
           <small>{isError ? language === "ko" ? activity : `Last confirmed activity: ${activity}` : current.note}</small>
         </span>
         <time>{elapsed}</time>
@@ -558,13 +568,16 @@ function TurnReceipt({ language, durationMs, tools }: { readonly language: Conso
   const elapsed = formatElapsed(durationMs);
   const steps = tools;
   const stepsLabel = steps.length === 0 ? null : steps.length === 1 ? t("terminal.chat.oneStep") : t("terminal.chat.stepCount", { count: steps.length });
-  const summary = stepsLabel ? `${elapsed} · ${stepsLabel}` : elapsed;
+  // 끝난 턴은 한 문장으로 접힌다 — 채팅 원장의 접힘과 같은 문법이다. 예전에는 이 시간이 두 번
+  // 섰다: 머리의 "{elapsed} 만에 응답"과 알약의 "✓ {elapsed} · N스텝". 같은 사실을 두 모양으로
+  // 말하면 둘 중 무엇이 이 턴의 결말인지 읽는 쪽이 정해야 한다.
+  const answered = t("terminal.analyst.turnAnswered", { elapsed });
+  const summary = stepsLabel ? `${answered} · ${stepsLabel}` : answered;
   return (
     <details className="session-analyst__receipt">
       <summary aria-label={t("terminal.chat.receiptAria")}>
-        <span className="session-analyst__receipt-mark" aria-hidden="true">✓</span>
-        {summary}
-        <span className="session-analyst__receipt-chev" aria-hidden="true">❯</span>
+        <span className="session-analyst__receipt-label">{summary}</span>
+        <span className="session-analyst__receipt-chev" aria-hidden="true">⌄</span>
       </summary>
       {steps.length > 0 ? (
         <div className="session-analyst__receipt-body">

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -108,17 +108,46 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__truth-mark { display: block; margin: var(--space-1) 0 0 2px; color: var(--text-tertiary); font-size: var(--t-2xs); }
 
 /* 완료 턴의 과정 영수증 — 접힌 한 줄, 펼치면 도구 단계. 채팅 뷰 agent-chat-receipt와 동형. */
+/* 끝난 턴의 접힘 — 채팅 원장의 `.agent-chat-fold`와 같은 문법이다. 예전에는 알약이었는데,
+   면과 테두리를 두르면 이 줄이 문장이 아니라 카드로 읽힌다. 원장 쪽 주석이 말하는 그대로다:
+   카드는 예외에게만 준다. 결말의 성패는 스파인 노드가 이미 지므로 ✓도 걷었다. */
 .session-analyst__receipt { margin-top: var(--space-2); }
-.session-analyst__receipt > summary { list-style: none; cursor: pointer; display: inline-flex; align-items: center; gap: var(--space-2); font-family: var(--font-mono); font-size: var(--t-xs); color: var(--text-tertiary); padding: 4px var(--space-3); border: 1px solid var(--hairline); border-radius: var(--radius-pill); background: var(--surface-panel-raised); transition: color var(--duration-fast), border-color var(--duration-fast); }
-.session-analyst__receipt > summary:hover { color: var(--text-secondary); border-color: var(--hairline-strong); }
+.session-analyst__receipt > summary { list-style: none; cursor: pointer; display: inline-flex; align-items: center; gap: var(--space-2); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .06em; font-variant-numeric: tabular-nums; color: var(--text-tertiary); transition: color var(--duration-fast); }
+.session-analyst__receipt > summary:hover { color: var(--text-secondary); }
 .session-analyst__receipt > summary::-webkit-details-marker { display: none; }
-.session-analyst__receipt-mark { color: var(--positive); }
-.session-analyst__receipt-chev { font-size: 9px; transition: transform var(--duration-fast); }
-.session-analyst__receipt[open] .session-analyst__receipt-chev { transform: rotate(90deg); }
+.session-analyst__receipt-chev { font-size: var(--t-xs); line-height: 1; color: var(--text-tertiary); transition: transform var(--duration-fast); }
+.session-analyst__receipt[open] .session-analyst__receipt-chev { transform: rotate(180deg); }
 .session-analyst__receipt-body { padding: var(--space-1) 0 0 var(--space-3); }
-.session-analyst__receipt-step { display: flex; align-items: center; gap: var(--space-2); min-width: 0; margin-top: var(--space-1); font-family: var(--font-mono); font-size: var(--t-xs); color: var(--text-tertiary); padding: 4px var(--space-3); background: var(--surface-panel-raised); border: 1px solid var(--hairline); border-radius: var(--radius-xs); }
+/* 펼친 스텝도 카드가 아니라 줄이다 — 접힌 줄이 문장이 된 이상 그 안이 카드면 문법이 갈린다. */
+.session-analyst__receipt-step { display: flex; align-items: baseline; gap: var(--space-2); min-width: 0; margin-top: var(--space-1); font-family: var(--font-mono); font-size: var(--t-xs); color: var(--text-tertiary); }
 .session-analyst__receipt-step strong { color: var(--text-secondary); font-weight: var(--weight-medium); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-analyst__receipt-step small { color: var(--text-tertiary); white-space: nowrap; }
+
+/* 좌→우 명도 물결 — 채팅 원장의 `.agent-chat-live-text`와 한 벌이다. 값이 갈라지면 같은
+   사실을 두 면이 다른 속도로 말하게 되므로 그라데이션·크기·주기를 그대로 옮겼다.
+   [doctrine] 진행은 이미 링(aurora)이 말한다. 이 물결은 색 채널을 하나도 빌리지 않는
+   순수 명도 스윕이다. 되풀이가 이음매 없도록 이미지 200%에 ΔP 200을 쓴다 — 한 바퀴의
+   이동량이 정확히 타일 한 폭이라 마지막 프레임이 첫 프레임과 같다. */
+.session-analyst__live-text {
+  background-image: linear-gradient(
+    100deg,
+    var(--text-tertiary) 0%,
+    var(--text-tertiary) 34%,
+    var(--text-primary) 50%,
+    var(--text-tertiary) 66%,
+    var(--text-tertiary) 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: analyst-live-sweep 2.4s linear infinite;
+}
+
+@keyframes analyst-live-sweep {
+  from { background-position: 200% 0; }
+  to { background-position: 0% 0; }
+}
 /* 중단 영수증 — 진행이 멎은 자리의 기록. */
 .session-analyst__stopped.is-error { border-left-color: var(--coral); color: var(--coral-ink); }
 .session-analyst__stopped { display: flex; align-items: center; gap: var(--space-2); min-height: 30px; margin-top: var(--space-2); border-left: 2px solid var(--text-tertiary); background: var(--surface-panel-raised); padding: 0 var(--space-3); color: var(--text-tertiary); font-weight: var(--weight-regular); font-size: var(--t-2xs); line-height: 1.3; font-family: var(--font-mono); animation: analyst-receipt-settle var(--duration-base) var(--ease-glide) both; }
@@ -318,6 +347,11 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 }
 
 @media (prefers-reduced-motion: reduce) {
+  /* 물결 봉인 — 모션만 죽이고 줄은 남긴다. 그라데이션을 지우면서 채움도 함께 되돌려야
+     한다: `color: transparent`가 남으면 글자가 통째로 사라진다. */
+  .session-analyst__live-text { animation: none; background-image: none; color: var(--text-secondary); }
+  .session-analyst__turn-head .session-analyst__live-text { color: var(--text-tertiary); }
+
   .session-analyst__chip, .session-analyst__suggestions button, .session-analyst__followups-row button, .session-analyst__queue-item button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__select, .session-analyst__model-chip, .session-analyst__slash-hint, .session-analyst__send, .session-analyst__artifact-count, .session-analyst__artifact-count i, .session-analyst__receipt-chev, .session-analyst__chat-pane, .session-analyst__artifacts, .session-analyst__turn-node { transition: none; }
   .session-analyst__suggestions button:hover, .session-analyst__followups-row button:hover { transform: none; }
   .session-analyst__chip-dot, .session-analyst__turn-node, .session-analyst__pulse-orbit { animation: none !important; }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -102,6 +102,14 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__pulse.is-error .session-analyst__pulse-orbit { border-color: color-mix(in oklch, var(--coral) 35%, transparent); border-top-color: var(--coral); animation: none; }
 .session-analyst__pulse-copy { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .session-analyst__pulse-copy strong { font-weight: var(--weight-medium); overflow-wrap: anywhere; animation: analyst-stage-enter var(--duration-base) var(--ease-glide) both; }
+/* 이 문구는 애니메이션을 둘 진다: 도착(stage-enter)과 진행(물결). 위 규칙이 같은 속성을 더
+   높은 특정성으로 쥐고 있어 물결만 얹으면 조용히 사라지고 정지된 그라데이션만 남는다
+   (실측 적발 — 계약이 이 합성을 못으로 박는다). */
+.session-analyst__pulse-copy strong.session-analyst__live-text {
+  animation:
+    analyst-stage-enter var(--duration-base) var(--ease-glide) both,
+    analyst-live-sweep 2.4s linear infinite;
+}
 .session-analyst__pulse-copy small { font-family: var(--font-body); font-size: var(--t-xs); color: var(--text-tertiary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-analyst__pulse time { margin-left: auto; color: var(--aurora-ink); font-size: var(--t-2xs); }
 .session-analyst__pulse.is-error time { color: var(--coral-ink); }
@@ -349,7 +357,8 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 @media (prefers-reduced-motion: reduce) {
   /* 물결 봉인 — 모션만 죽이고 줄은 남긴다. 그라데이션을 지우면서 채움도 함께 되돌려야
      한다: `color: transparent`가 남으면 글자가 통째로 사라진다. */
-  .session-analyst__live-text { animation: none; background-image: none; color: var(--text-secondary); }
+  .session-analyst__live-text,
+  .session-analyst__pulse-copy strong.session-analyst__live-text { animation: none; background-image: none; color: var(--text-secondary); }
   .session-analyst__turn-head .session-analyst__live-text { color: var(--text-tertiary); }
 
   .session-analyst__chip, .session-analyst__suggestions button, .session-analyst__followups-row button, .session-analyst__queue-item button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__select, .session-analyst__model-chip, .session-analyst__slash-hint, .session-analyst__send, .session-analyst__artifact-count, .session-analyst__artifact-count i, .session-analyst__receipt-chev, .session-analyst__chat-pane, .session-analyst__artifacts, .session-analyst__turn-node { transition: none; }


### PR DESCRIPTION
## Summary

Session Analyst의 끝난 턴이 **같은 소요를 두 번** 말하고 있었습니다 — 머리의 `47s 만에 응답`과 알약의 `✓ 47s · 2스텝`. 둘 중 무엇이 이 턴의 결말인지 읽는 쪽이 정해야 했습니다. 채팅 원장은 이미 한 문장으로 접히는 문법으로 이 문제를 풀어 두었습니다.

- **끝난 턴을 그 한 문장으로 접습니다.** 분석가 자신의 문구에 스텝 수를 더해 `47s 만에 응답 · 2스텝 ⌄`. 중복 머리와 `✓`는 걷었습니다 — 결말의 성패는 스파인 노드가 이미 집니다.
- **접힘 줄과 펼친 스텝의 상자를 벗겼습니다.** 이 줄은 카드가 아니라 문장입니다(원장 쪽 주석의 그대로).
- **작업 시계와 진행 문구에 채팅 로그와 같은 명도 물결.** 두 면이 갈라지지 않도록 그라데이션·크기·주기를 그대로 옮기고 계약에 못을 박았습니다.
- **최신 활동 펄스, 정직성 마이크로카피, 아티팩트 작성/발행 카드는 그대로입니다.**

## Test Plan

- [x] `typecheck` / 콘솔 2368 / 터미널 플러그인 977 / `build`
- [x] `check:core-boundary` · `check:claude-agent-sdk-boundary` · changelog `--check`
- [x] 격리 콘솔 실측 — Settings에서 `codex--gpt-5.6-luna` 추가 후 분석가 턴 3회
  - 접힘: `3s 만에 응답⌄` · `10s 만에 응답 · 1스텝⌄` (중복 머리 없음, `✓` 없음)
  - 작업 시계 `analyst-live-sweep @ 2.4s`, `background-size: 200% 100%`, 채움 `rgba(0,0,0,0)`
  - 펄스 문구 `analyst-stage-enter, analyst-live-sweep @ 0.22s, 2.4s` — 두 애니메이션 합성
  - 페이지 오류 0 · rejection 0

### 실측이 잡은 결함 하나

펄스 문구에 물결만 얹었을 때 **조용히 죽었습니다.** 기존 도착 애니메이션(`analyst-stage-enter`)이 같은 `animation` 속성을 더 높은 특정성으로 쥐고 있어, 그라데이션과 `color: transparent`만 남고 스윕이 사라진 정지 화면이 됐습니다. 두 애니메이션을 합성하고 계약에 박았습니다(`05fc879d1`).