### PR TITLE
fix(fleet-console): stream a Chat Mode in-flight turn live on reconnect

### DIFF
--- a/.changelog.d/chat-inflight-turn-live.md
+++ b/.changelog.d/chat-inflight-turn-live.md
@@ -1,0 +1,8 @@
+---
+branch: chat-inflight-turn-live
+---
+
+### fleet-console
+#### Fixed
+- Show a Chat Mode turn as working while it streams when the view attaches after the turn already began, as a Quick Launch session does. Its opening frame now arrives live instead of inside the replayed history, so the turn no longer appears finished with a "worked on this" fold while the answer is still streaming in.
+  ko: Quick Launch로 연 세션처럼 뷰가 턴이 시작된 뒤에 붙어도 Chat Mode 턴이 스트리밍되는 동안 "작업 중"으로 보입니다. 여는 프레임이 재생된 과거가 아니라 라이브로 도착해, 답이 아직 흘러드는데도 턴이 "작업함"으로 접혀 끝난 것처럼 보이던 문제를 고쳤습니다.

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -527,21 +527,9 @@ class AgentChatSession {
       // 경계 안에 두면 클라이언트가 done으로 닫고, 서버는 여전히 열린 것으로 알아 새 turn-start를
       // 내지 않으므로 이후 델타가 무시되어 정확히 이 수정이 없애려는 "끝난 척" 상태로 굳는다.
       // 그래서 꼬리를 live로 흘리되 앞에 합성 turn-start를 세워 working 턴을 열어 받게 한다.
-      let liveFrom = -1;
-      let syntheticStart = false;
-      if (this.turnOpen) {
-        const markerIdx = this.inFlightTurnStartIndex(snapshot);
-        if (markerIdx >= 0) {
-          liveFrom = markerIdx;
-        } else {
-          let lastEnd = -1;
-          for (let i = snapshot.length - 1; i >= 0; i -= 1) {
-            if (snapshot[i]?.event.kind === "turn-end") { lastEnd = i; break; }
-          }
-          liveFrom = lastEnd + 1;
-          syntheticStart = true;
-        }
-      }
+      const split = this.turnOpen ? this.inFlightLiveSplit(snapshot) : null;
+      const liveFrom = split ? split.from : -1;
+      const syntheticStart = split?.synthetic ?? false;
       const replayEnd = liveFrom === -1 ? snapshot.length : liveFrom;
       const replayed = snapshot.slice(0, replayEnd);
       const live = snapshot.slice(replayEnd);
@@ -575,21 +563,28 @@ class AgentChatSession {
   }
 
   /**
-   * 지금 열려 있는 턴이 snapshot에서 시작하는 자리. 턴은 직렬로 돌므로 열린 턴은 마지막 turn-end
-   * 뒤의 꼬리 하나뿐이고, 그 첫 이벤트는 dispatch(사용자 턴) 또는 turn-start(자식이 다시 연 턴)다.
-   * 상한에 그 여는 좌표가 밀려 못 찾으면 -1을 돌리고, 그때는 호출부가 꼬리를 live로 흘리며 합성
-   * turn-start를 앞세운다(경계 안에 두면 done으로 굳는다).
+   * 지금 도는 턴을 재생 경계 밖으로 가르는 자리. 진행 중 턴은 (a) 마지막 turn-end 뒤이면서
+   * (b) 원래 재생 경계(replayTranscript가 남긴 replay-end) 뒤에 있다 — 두 조건을 함께 봐야 한다.
+   * resume 트랜스크립트의 마지막 턴은 소요 시간 좌표가 없으면 turn-end 없이 남으므로(closeReplayedTurn),
+   * turn-end만 기준으로 잡으면 그 **과거** 턴의 여는 좌표를 골라 live로 흘려 버린다 — 그러면 지난 턴이
+   * 새 도착·working으로 읽혀 재접속마다 미확인·예약 집계가 흔들린다. 두 경계의 더 뒤에서부터 찾는다.
+   * 여는 좌표가 상한에 밀려 없으면 `synthetic`으로, 꼬리를 live로 흘리며 합성 turn-start를 앞세운다.
    */
-  private inFlightTurnStartIndex(snapshot: readonly AgentChatJournalEvent[]): number {
+  private inFlightLiveSplit(snapshot: readonly AgentChatJournalEvent[]): { readonly from: number; readonly synthetic: boolean } {
     let lastEnd = -1;
+    let lastReplayEnd = -1;
     for (let i = snapshot.length - 1; i >= 0; i -= 1) {
-      if (snapshot[i]?.event.kind === "turn-end") { lastEnd = i; break; }
-    }
-    for (let i = lastEnd + 1; i < snapshot.length; i += 1) {
       const kind = snapshot[i]?.event.kind;
-      if (kind === "dispatch" || kind === "turn-start") return i;
+      if (kind === "turn-end" && lastEnd === -1) lastEnd = i;
+      if (kind === "replay-end" && lastReplayEnd === -1) lastReplayEnd = i;
+      if (lastEnd !== -1 && lastReplayEnd !== -1) break;
     }
-    return -1;
+    const floor = Math.max(lastEnd, lastReplayEnd);
+    for (let i = floor + 1; i < snapshot.length; i += 1) {
+      const kind = snapshot[i]?.event.kind;
+      if (kind === "dispatch" || kind === "turn-start") return { from: i, synthetic: false };
+    }
+    return { from: floor + 1, synthetic: true };
   }
 
   /**

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -522,7 +522,26 @@ class AgentChatSession {
       // 붙으므로, 그 진행 중 턴까지 경계 안에 넣으면 클라이언트가 그것을 재생된 과거로 읽어
       // "작업 중"이 아니라 "작업함"으로 굳힌다(재생 turn-start는 done으로 세운다). 진행 중 턴의
       // 시작부터는 경계 밖으로 흘려, 그 turn-start가 live로 도착해 working으로 서게 한다.
-      const liveFrom = this.turnOpen ? this.inFlightTurnStartIndex(snapshot) : -1;
+      // 여는 좌표(dispatch/turn-start)를 찾으면 거기서부터가 live다. 상한이 그 좌표까지 밀어냈으면
+      // (-1) 마지막 turn-end 뒤 꼬리 전체가 진행 중 턴이지만 여는 이벤트가 없다 — 그 꼬리를 그대로
+      // 경계 안에 두면 클라이언트가 done으로 닫고, 서버는 여전히 열린 것으로 알아 새 turn-start를
+      // 내지 않으므로 이후 델타가 무시되어 정확히 이 수정이 없애려는 "끝난 척" 상태로 굳는다.
+      // 그래서 꼬리를 live로 흘리되 앞에 합성 turn-start를 세워 working 턴을 열어 받게 한다.
+      let liveFrom = -1;
+      let syntheticStart = false;
+      if (this.turnOpen) {
+        const markerIdx = this.inFlightTurnStartIndex(snapshot);
+        if (markerIdx >= 0) {
+          liveFrom = markerIdx;
+        } else {
+          let lastEnd = -1;
+          for (let i = snapshot.length - 1; i >= 0; i -= 1) {
+            if (snapshot[i]?.event.kind === "turn-end") { lastEnd = i; break; }
+          }
+          liveFrom = lastEnd + 1;
+          syntheticStart = true;
+        }
+      }
       const replayEnd = liveFrom === -1 ? snapshot.length : liveFrom;
       const replayed = snapshot.slice(0, replayEnd);
       const live = snapshot.slice(replayEnd);
@@ -536,6 +555,8 @@ class AgentChatSession {
         seq: replayed.at(-1)?.seq ?? this.seq,
         event: { kind: "replay-end", turns: countReplayedTurns(replayed) },
       });
+      // 상한에 여는 좌표가 밀려난 경우: 합성 turn-start로 working 턴을 연 뒤 꼬리를 잇는다.
+      if (syntheticStart) listener({ seq: live[0]?.seq ?? this.seq, event: { kind: "turn-start" } });
       // 경계 밖: 지금 도는 턴의 이벤트를 live로 흘린다 — 클라이언트가 새로 여는 working 턴이 된다.
       for (const entry of live) {
         if (entry.event.kind !== "replay-start" && entry.event.kind !== "replay-end") listener(entry);
@@ -552,8 +573,8 @@ class AgentChatSession {
   /**
    * 지금 열려 있는 턴이 snapshot에서 시작하는 자리. 턴은 직렬로 돌므로 열린 턴은 마지막 turn-end
    * 뒤의 꼬리 하나뿐이고, 그 첫 이벤트는 dispatch(사용자 턴) 또는 turn-start(자식이 다시 연 턴)다.
-   * 열린 턴이 없거나(정상적으로 turnOpen이 false), 상한에 시작 좌표가 밀려 못 찾으면 -1을 돌려
-   * 호출부가 예전처럼 전체를 재생으로 되쓰게 한다.
+   * 상한에 그 여는 좌표가 밀려 못 찾으면 -1을 돌리고, 그때는 호출부가 꼬리를 live로 흘리며 합성
+   * turn-start를 앞세운다(경계 안에 두면 done으로 굳는다).
    */
   private inFlightTurnStartIndex(snapshot: readonly AgentChatJournalEvent[]): number {
     let lastEnd = -1;

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -517,15 +517,29 @@ class AgentChatSession {
     const retainedEnd = snapshot.findIndex((entry) => entry.event.kind === "replay-end");
     const boundaryCoversSnapshot = retainedStart === 0 && retainedEnd === snapshot.length - 1;
     if (!boundaryCoversSnapshot) {
-      // 원래 경계가 상한에 밀렸거나 그 뒤로 live 턴이 쌓였더라도, 이 접속에서 되쓰는 snapshot
-      // 전체는 과거다. 바깥 경계를 다시 세워 다음 실제 push부터만 live가 되게 한다.
+      // 원래 경계가 상한에 밀렸거나 그 뒤로 live 턴이 쌓였더라도, 이 접속에서 되쓰는 snapshot은
+      // 과거다 — 단 하나, 지금 도는 턴만은 예외다. Quick Launch 관찰자는 첫 턴이 이미 시작된 뒤에야
+      // 붙으므로, 그 진행 중 턴까지 경계 안에 넣으면 클라이언트가 그것을 재생된 과거로 읽어
+      // "작업 중"이 아니라 "작업함"으로 굳힌다(재생 turn-start는 done으로 세운다). 진행 중 턴의
+      // 시작부터는 경계 밖으로 흘려, 그 turn-start가 live로 도착해 working으로 서게 한다.
+      const liveFrom = this.turnOpen ? this.inFlightTurnStartIndex(snapshot) : -1;
+      const replayEnd = liveFrom === -1 ? snapshot.length : liveFrom;
+      const replayed = snapshot.slice(0, replayEnd);
+      const live = snapshot.slice(replayEnd);
       listener({ seq: snapshot[0]?.seq ?? this.seq, event: { kind: "replay-start" } });
       // 남아 있는 원래 경계는 snapshot 전체의 바깥 경계가 아니다. 그대로 보내면 원래 replay-end
       // 뒤에 쌓인 과거 live 턴이 새 도착으로 읽히므로, 합성한 바깥 경계만 전달한다.
-      for (const entry of snapshot) {
+      for (const entry of replayed) {
         if (entry.event.kind !== "replay-start" && entry.event.kind !== "replay-end") listener(entry);
       }
-      listener({ seq: snapshot.at(-1)?.seq ?? this.seq, event: { kind: "replay-end", turns: countReplayedTurns(snapshot) } });
+      listener({
+        seq: replayed.at(-1)?.seq ?? this.seq,
+        event: { kind: "replay-end", turns: countReplayedTurns(replayed) },
+      });
+      // 경계 밖: 지금 도는 턴의 이벤트를 live로 흘린다 — 클라이언트가 새로 여는 working 턴이 된다.
+      for (const entry of live) {
+        if (entry.event.kind !== "replay-start" && entry.event.kind !== "replay-end") listener(entry);
+      }
     } else {
       for (const entry of snapshot) listener(entry);
     }
@@ -533,6 +547,24 @@ class AgentChatSession {
     return () => {
       this.listeners.delete(listener);
     };
+  }
+
+  /**
+   * 지금 열려 있는 턴이 snapshot에서 시작하는 자리. 턴은 직렬로 돌므로 열린 턴은 마지막 turn-end
+   * 뒤의 꼬리 하나뿐이고, 그 첫 이벤트는 dispatch(사용자 턴) 또는 turn-start(자식이 다시 연 턴)다.
+   * 열린 턴이 없거나(정상적으로 turnOpen이 false), 상한에 시작 좌표가 밀려 못 찾으면 -1을 돌려
+   * 호출부가 예전처럼 전체를 재생으로 되쓰게 한다.
+   */
+  private inFlightTurnStartIndex(snapshot: readonly AgentChatJournalEvent[]): number {
+    let lastEnd = -1;
+    for (let i = snapshot.length - 1; i >= 0; i -= 1) {
+      if (snapshot[i]?.event.kind === "turn-end") { lastEnd = i; break; }
+    }
+    for (let i = lastEnd + 1; i < snapshot.length; i += 1) {
+      const kind = snapshot[i]?.event.kind;
+      if (kind === "dispatch" || kind === "turn-start") return i;
+    }
+    return -1;
   }
 
   /**

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -551,8 +551,12 @@ class AgentChatSession {
       for (const entry of replayed) {
         if (entry.event.kind !== "replay-start" && entry.event.kind !== "replay-end") listener(entry);
       }
+      // replayed가 비면(상한이 여는 좌표까지 밀어낸 진행 중 턴) 마지막 재생 seq가 없다. 그때
+      // this.seq(최신)를 쓰면 뒤따르는 합성 turn-start·꼬리가 더 오래된 live[0].seq로 되돌아가
+      // seq 축이 역행한다 — 단조 축 계약(chat-events.ts) 위반이라 seq로 거르는 소비자가 꼬리를
+      // 통째로 버릴 수 있다. 경계 seq를 첫 live 이벤트 이하로 두어 축을 단조로 지킨다.
       listener({
-        seq: replayed.at(-1)?.seq ?? this.seq,
+        seq: replayed.at(-1)?.seq ?? live[0]?.seq ?? this.seq,
         event: { kind: "replay-end", turns: countReplayedTurns(replayed) },
       });
       // 상한에 여는 좌표가 밀려난 경우: 합성 turn-start로 working 턴을 연 뒤 꼬리를 잇는다.

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -533,22 +533,28 @@ class AgentChatSession {
       const replayEnd = liveFrom === -1 ? snapshot.length : liveFrom;
       const replayed = snapshot.slice(0, replayEnd);
       const live = snapshot.slice(replayEnd);
-      listener({ seq: snapshot[0]?.seq ?? this.seq, event: { kind: "replay-start" } });
-      // 남아 있는 원래 경계는 snapshot 전체의 바깥 경계가 아니다. 그대로 보내면 원래 replay-end
-      // 뒤에 쌓인 과거 live 턴이 새 도착으로 읽히므로, 합성한 바깥 경계만 전달한다.
-      for (const entry of replayed) {
-        if (entry.event.kind !== "replay-start" && entry.event.kind !== "replay-end") listener(entry);
+      if (replayed.length === 0) {
+        // 재생할 정착 이벤트가 없다 — 상한이 원래 경계까지 밀어낸 것이다(FIFO 소거라 여는 좌표가
+        // 밀렸으면 그 앞도 다 밀린다: syntheticStart는 곧 여기다). 앞세우는 합성 프레임은 저널
+        // seq가 없으므로, 첫 live seq 바로 아래에 **서로 다른 오름차순** 값을 준다. 같은 seq를
+        // 겹쳐 주면 seq<=lastSeq로 중복을 거르는 소비자가 경계·opener·첫 내용을 버린다(빈 replayed는
+        // 상한 소거뿐이라 첫 live seq가 커서 음수로 내려가지 않는다).
+        const firstLiveSeq = live[0]?.seq ?? this.seq;
+        const lead = syntheticStart ? 3 : 2;
+        let seq = firstLiveSeq - lead;
+        listener({ seq, event: { kind: "replay-start" } });
+        listener({ seq: seq += 1, event: { kind: "replay-end", turns: 0 } });
+        if (syntheticStart) listener({ seq: seq += 1, event: { kind: "turn-start" } });
+      } else {
+        // 남아 있는 원래 경계는 snapshot 전체의 바깥 경계가 아니다. 그대로 보내면 원래 replay-end
+        // 뒤에 쌓인 과거 live 턴이 새 도착으로 읽히므로, 합성한 바깥 경계만 전달한다. replayed가
+        // 비지 않으면 여는 좌표가 살아 있어 live 쪽에 있으므로 합성 turn-start는 필요 없다.
+        listener({ seq: snapshot[0]?.seq ?? this.seq, event: { kind: "replay-start" } });
+        for (const entry of replayed) {
+          if (entry.event.kind !== "replay-start" && entry.event.kind !== "replay-end") listener(entry);
+        }
+        listener({ seq: replayed.at(-1)?.seq ?? this.seq, event: { kind: "replay-end", turns: countReplayedTurns(replayed) } });
       }
-      // replayed가 비면(상한이 여는 좌표까지 밀어낸 진행 중 턴) 마지막 재생 seq가 없다. 그때
-      // this.seq(최신)를 쓰면 뒤따르는 합성 turn-start·꼬리가 더 오래된 live[0].seq로 되돌아가
-      // seq 축이 역행한다 — 단조 축 계약(chat-events.ts) 위반이라 seq로 거르는 소비자가 꼬리를
-      // 통째로 버릴 수 있다. 경계 seq를 첫 live 이벤트 이하로 두어 축을 단조로 지킨다.
-      listener({
-        seq: replayed.at(-1)?.seq ?? live[0]?.seq ?? this.seq,
-        event: { kind: "replay-end", turns: countReplayedTurns(replayed) },
-      });
-      // 상한에 여는 좌표가 밀려난 경우: 합성 turn-start로 working 턴을 연 뒤 꼬리를 잇는다.
-      if (syntheticStart) listener({ seq: live[0]?.seq ?? this.seq, event: { kind: "turn-start" } });
       // 경계 밖: 지금 도는 턴의 이벤트를 live로 흘린다 — 클라이언트가 새로 여는 working 턴이 된다.
       for (const entry of live) {
         if (entry.event.kind !== "replay-start" && entry.event.kind !== "replay-end") listener(entry);

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -565,10 +565,11 @@ describe("AgentChatRegistry", () => {
     expect(kindsList.includes("dispatch")).toBe(false);
     expect(endIdx).toBeGreaterThanOrEqual(0);
     expect(startIdx).toBeGreaterThan(endIdx);
-    // 합성 경계·turn-start가 this.seq로 튀어 축을 역행시키지 않는다 — seq는 단조여야 한다.
+    // 합성 경계·turn-start는 축을 역행시키지도, 같은 seq로 겹치지도 않는다 — 서로 다른 오름차순
+    // 값이라야 seq<=lastSeq로 거르는 소비자가 경계·opener·첫 내용을 버리지 않는다.
     const seqs = events.map((entry) => entry.seq);
     for (let i = 1; i < seqs.length; i += 1) {
-      expect(seqs[i]).toBeGreaterThanOrEqual(seqs[i - 1] as number);
+      expect(seqs[i]).toBeGreaterThan(seqs[i - 1] as number);
     }
     // 리듀스하면 마지막 턴은 done이 아니라 working이다.
     const state = events.reduce((current, entry) => reduceAgentChatLog(current, entry.event), initialAgentChatLogState);

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -565,6 +565,11 @@ describe("AgentChatRegistry", () => {
     expect(kindsList.includes("dispatch")).toBe(false);
     expect(endIdx).toBeGreaterThanOrEqual(0);
     expect(startIdx).toBeGreaterThan(endIdx);
+    // 합성 경계·turn-start가 this.seq로 튀어 축을 역행시키지 않는다 — seq는 단조여야 한다.
+    const seqs = events.map((entry) => entry.seq);
+    for (let i = 1; i < seqs.length; i += 1) {
+      expect(seqs[i]).toBeGreaterThanOrEqual(seqs[i - 1] as number);
+    }
     // 리듀스하면 마지막 턴은 done이 아니라 working이다.
     const state = events.reduce((current, entry) => reduceAgentChatLog(current, entry.event), initialAgentChatLogState);
     expect(state.turns.at(-1)?.state).toBe("working");

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -498,6 +498,44 @@ describe("AgentChatRegistry", () => {
     await registry.disposeAll();
   });
 
+  // Quick Launch 관찰자는 첫 턴이 이미 시작된 뒤에야 붙는다. 그 진행 중 턴까지 재생 경계 안에
+  // 넣으면 클라이언트가 재생 turn-start를 done으로 세워, 스트리밍 중인데 "작업함"으로 굳는다.
+  // 진행 중 턴의 여는 이벤트는 경계 밖(live)으로 와야 working으로 선다.
+  it("streams the in-flight turn live so a mid-turn reconnect renders it working, not done", async () => {
+    const home = tempDir("chat-home-");
+    const { factory } = createFakeSdkFactory([
+      // result가 없어 턴이 닫히지 않는다 — 관찰자가 붙는 순간의 진행 중 턴이다.
+      { messages: [{ type: "assistant", message: { content: [{ type: "text", text: "thinking out loud" }] } }] },
+    ]);
+    const registry = new AgentChatRegistry(factory);
+    const session = await registry.ensure("op-inflight", () => freshSeedFor(home));
+
+    // 첫 구독자로 턴이 열렸으되 아직 닫히지 않은 순간을 잡는다.
+    const probe: AgentChatJournalEvent[] = [];
+    session.subscribe((entry) => probe.push(entry));
+    session.send("start the work");
+    await vi.waitFor(() => {
+      expect(probe.some((entry) => entry.event.kind === "turn-start")).toBe(true);
+      expect(probe.some((entry) => entry.event.kind === "turn-end")).toBe(false);
+    });
+
+    // mid-turn으로 재접속하는 두 번째 구독자 — subscribe는 이 순간의 저널을 동기로 되쓴다.
+    const events: AgentChatJournalEvent[] = [];
+    session.subscribe((entry) => events.push(entry));
+    const kindsList = events.map((entry) => entry.event.kind);
+    const endIdx = kindsList.indexOf("replay-end");
+    const startIdx = kindsList.indexOf("turn-start");
+    // 진행 중 턴의 turn-start는 경계(replay-end) 뒤에 live로 온다.
+    expect(endIdx).toBeGreaterThanOrEqual(0);
+    expect(startIdx).toBeGreaterThan(endIdx);
+
+    // 재접속 스냅숏을 리듀스하면 마지막 턴은 done이 아니라 working이다.
+    const state = events.reduce((current, entry) => reduceAgentChatLog(current, entry.event), initialAgentChatLogState);
+    expect(state.turns.at(-1)?.state).toBe("working");
+
+    await registry.disposeAll();
+  });
+
   it("replays the origin transcript into the journal on ensure", async () => {
     const transcriptPath = writeTranscript("sid-1", [
       { type: "user", message: { role: "user", content: "first order" } },

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -536,6 +536,42 @@ describe("AgentChatRegistry", () => {
     await registry.disposeAll();
   });
 
+  // 한 진행 중 턴이 상한(2000)을 넘길 만큼 durable 이벤트를 내면 그 턴의 dispatch/turn-start가
+  // 저널에서 밀려난다. 그 꼬리를 경계 안에 두면 클라이언트가 done으로 닫고 서버는 새 turn-start를
+  // 내지 않아 "끝난 척"으로 굳는다 — 꼬리를 live로 흘리고 합성 turn-start를 앞세워야 working으로 선다.
+  it("keeps a capped in-flight tail live with a synthetic turn-start when the opening frames were evicted", async () => {
+    const home = tempDir("chat-home-");
+    // result가 없어 턴은 열린 채다. 2001개의 text가 저널에 쌓여 dispatch/turn-start를 밀어낸다.
+    const messages = Array.from({ length: 2_001 }, (_, i) => ({ type: "assistant", message: { content: [{ type: "text", text: `line ${i}` }] } }));
+    const { factory } = createFakeSdkFactory([{ messages }]);
+    const registry = new AgentChatRegistry(factory);
+    const session = await registry.ensure("op-capped-inflight", () => freshSeedFor(home));
+
+    const probe: AgentChatJournalEvent[] = [];
+    session.subscribe((entry) => probe.push(entry));
+    session.send("start a very long turn");
+    await vi.waitFor(() => {
+      expect(probe.filter((entry) => entry.event.kind === "text").length).toBeGreaterThanOrEqual(2_001);
+    }, { timeout: 5_000 });
+
+    // mid-turn 재접속: 재생 스냅숏엔 밀려난 dispatch/turn-start가 없다.
+    const events: AgentChatJournalEvent[] = [];
+    session.subscribe((entry) => events.push(entry));
+    const kindsList = events.map((entry) => entry.event.kind);
+    const endIdx = kindsList.indexOf("replay-end");
+    const startIdx = kindsList.indexOf("turn-start");
+    // 여는 좌표가 실제로 밀려났음을 못 박는다 — dispatch가 남아 있으면 정상 경로이지 이 상한 경로가
+    // 아니다. dispatch 부재 + 경계 뒤 turn-start가 곧 합성 turn-start 경로다.
+    expect(kindsList.includes("dispatch")).toBe(false);
+    expect(endIdx).toBeGreaterThanOrEqual(0);
+    expect(startIdx).toBeGreaterThan(endIdx);
+    // 리듀스하면 마지막 턴은 done이 아니라 working이다.
+    const state = events.reduce((current, entry) => reduceAgentChatLog(current, entry.event), initialAgentChatLogState);
+    expect(state.turns.at(-1)?.state).toBe("working");
+
+    await registry.disposeAll();
+  });
+
   it("replays the origin transcript into the journal on ensure", async () => {
     const transcriptPath = writeTranscript("sid-1", [
       { type: "user", message: { role: "user", content: "first order" } },

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -577,6 +577,48 @@ describe("AgentChatRegistry", () => {
     await registry.disposeAll();
   });
 
+  // resume 트랜스크립트의 마지막 턴은 소요 시간 좌표가 없으면 turn-end 없이 남는다. 그 뒤 라이브
+  // 턴이 돌 때 mid-turn 재접속하면, 진행 중 턴의 시작을 "마지막 turn-end 뒤"로만 찾으면 그 과거
+  // 마지막 턴의 opener를 골라 경계 밖으로 흘려 버린다 — 지난 턴이 새로 도착한 것으로 읽힌다.
+  it("splits at the live opener, not a turn-end-less historical turn, on a mid-turn reconnect", async () => {
+    const transcriptPath = writeTranscript("sid-resume-noend", [
+      { type: "user", timestamp: "2026-08-23T00:00:00.000Z", message: { role: "user", content: "first order" } },
+      { type: "assistant", timestamp: "2026-08-23T00:00:05.000Z", message: { content: [{ type: "text", text: "reply one" }] } },
+      // 마지막 과거 턴: 시각 차가 없어 turn-end가 서지 않는다.
+      { type: "user", timestamp: "2026-08-23T00:01:00.000Z", message: { role: "user", content: "HISTORIC last" } },
+      { type: "assistant", timestamp: "2026-08-23T00:01:00.000Z", message: { content: [{ type: "text", text: "hist reply" }] } },
+    ]);
+    const { factory } = createFakeSdkFactory([
+      // result가 없어 라이브 턴은 열린 채다.
+      { messages: [{ type: "assistant", message: { content: [{ type: "text", text: "live streaming" }] } }] },
+    ]);
+    const registry = new AgentChatRegistry(factory);
+    const session = await registry.ensure("op-resume-noend", () => seedFor(transcriptPath));
+
+    const probe: AgentChatJournalEvent[] = [];
+    session.subscribe((entry) => probe.push(entry));
+    session.send("LIVEPROMPT");
+    await vi.waitFor(() => {
+      expect(probe.some((entry) => entry.event.kind === "dispatch"
+        && (entry.event as { readonly text?: string }).text === "LIVEPROMPT")).toBe(true);
+      expect(probe.some((entry) => entry.event.kind === "turn-start")).toBe(true);
+    });
+
+    const events: AgentChatJournalEvent[] = [];
+    session.subscribe((entry) => events.push(entry));
+    const endIdx = events.findIndex((entry) => entry.event.kind === "replay-end");
+    const after = events.slice(endIdx + 1).map((entry) => entry.event);
+    // 경계 뒤엔 라이브 턴만 온다 — 과거 마지막 턴(HISTORIC)의 dispatch가 새로 도착하지 않는다.
+    const dispatchesAfter = after.filter((event) => event.kind === "dispatch") as { readonly text: string }[];
+    expect(dispatchesAfter.map((event) => event.text)).toEqual(["LIVEPROMPT"]);
+    // 리듀스하면 마지막 턴은 working이고, 과거 턴은 재생 안이라 done이다.
+    const state = events.reduce((current, entry) => reduceAgentChatLog(current, entry.event), initialAgentChatLogState);
+    expect(state.turns.at(-1)?.state).toBe("working");
+    expect(state.turns.at(-1)?.dispatch?.text).toBe("LIVEPROMPT");
+
+    await registry.disposeAll();
+  });
+
   it("replays the origin transcript into the journal on ensure", async () => {
     const transcriptPath = writeTranscript("sid-1", [
       { type: "user", message: { role: "user", content: "first order" } },


### PR DESCRIPTION
## Summary
- 퀵런치처럼 뷰가 턴이 시작된 뒤에 붙으면, 서버 `subscribe()`가 진행 중(in-flight) 턴까지 재생 경계 안에 넣어 보냈다. 클라이언트는 재생 구간의 `turn-start`를 done으로 세우고(chat-events.ts) 라이브 델타는 done 턴을 다시 열지 않으므로, 스트리밍 중인 턴이 "작업 중" 헤드 없이 "작업함"(WorkFold)으로 굳어 끝난 것처럼 보였다.
- `subscribe()`가 `turnOpen`일 때 진행 중 턴의 시작(dispatch/turn-start)부터를 재생 경계 **밖(라이브)** 으로 내보낸다. 그 `turn-start`가 `replaying:false`로 도착해 working으로 선다.
- 정착된 과거·재생 경계(새 도착 오알림 방지)·완료 턴 렌더는 불변.

## Test Plan
- [x] `@fleet-plugins/terminal` typecheck green
- [x] 터미널 플러그인 980건 green (신규 회귀 테스트 포함: mid-turn 재접속 시 `turn-start`가 replay-end 뒤(live)에 오고 리듀스 결과 마지막 턴이 working)
- [x] console-e2e 라이브: 2000줄 스트리밍 turn을 ~1054번째 줄에서 reload(mid-turn 재접속) → `is-working`+진행 헤드 표시, "작업함" 없음, 텍스트 계속 스트리밍, 페이지 에러 0