### PR TITLE
fix(fleet-console): distinguish restored Chat snapshot turns

### DIFF
--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-context-meter.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-context-meter.test.tsx
@@ -37,6 +37,7 @@ function stateWith(context: AgentChatContext | null, turnState: AgentChatTurn["s
   return {
     turns: [turn(turnState)],
     replaying: false,
+    snapshotting: false,
     errorCode: null,
     jobs: [],
     context,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-context-meter.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-context-meter.test.tsx
@@ -38,6 +38,7 @@ function stateWith(context: AgentChatContext | null, turnState: AgentChatTurn["s
     turns: [turn(turnState)],
     replaying: false,
     snapshotting: false,
+    observedTurns: 0,
     errorCode: null,
     jobs: [],
     context,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-events.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-events.ts
@@ -70,7 +70,7 @@ export interface AgentChatContextSlice {
 export type AgentChatStreamEvent =
   | { readonly kind: "replay-start" }
   /** 접속 시점의 snapshot이 모두 도착했다. 이 앞의 live opener는 복원이지 새 도착이 아니다. */
-  | { readonly kind: "snapshot-end" }
+  | { readonly kind: "snapshot-end"; readonly turns: number }
   /**
    * 측정된 문맥 창 내역. control 채널만이 카테고리 분해를 알고, 그 왕복은 30초쯤 걸린다(실측).
    * `asOf`가 그 값이 언제의 것인지 말한다 — 부재는 `"start"`이며 옛 저널의 뜻이기도 하다.
@@ -176,7 +176,7 @@ export function readChatJournalEvent(raw: string): AgentChatJournalEvent | null 
     case "replay-start":
       return { seq: entry.seq, event: { kind: "replay-start" } };
     case "snapshot-end":
-      return { seq: entry.seq, event: { kind: "snapshot-end" } };
+      return { seq: entry.seq, event: { kind: "snapshot-end", turns: numberOr(event.turns, 0) } };
     case "context": {
       // 총량과 창 크기가 없으면 그릴 수 있는 것이 없다. 0짜리 미터는 사실이 아니라 빈칸이다.
       if (typeof event.total !== "number" || typeof event.max !== "number" || event.max <= 0) return null;
@@ -588,6 +588,8 @@ export interface AgentChatLogState {
   readonly replaying: boolean;
   /** 현재 접속이 보유하던 snapshot을 아직 받고 있다. replay-end 뒤의 in-flight tail도 포함한다. */
   readonly snapshotting: boolean;
+  /** 이 세션에서 snapshot으로 이미 관찰한 누적 턴 수. 저널 상한과 무관한 단조 좌표다. */
+  readonly observedTurns: number;
   readonly errorCode: string | null;
   /** 도착 순서를 지키는 잡 원장. 살아 있는 것과 끝난 것이 한 목록에 함께 산다. */
   readonly jobs: readonly AgentChatJob[];
@@ -602,6 +604,7 @@ export const initialAgentChatLogState: AgentChatLogState = {
   turns: [],
   replaying: false,
   snapshotting: true,
+  observedTurns: 0,
   errorCode: null,
   jobs: [],
   context: null,
@@ -614,9 +617,9 @@ export const initialAgentChatLogState: AgentChatLogState = {
 export function reduceAgentChatLog(state: AgentChatLogState, event: AgentChatStreamEvent): AgentChatLogState {
   switch (event.kind) {
     case "replay-start":
-      return { ...initialAgentChatLogState, replaying: true };
+      return { ...initialAgentChatLogState, observedTurns: state.observedTurns, replaying: true };
     case "snapshot-end":
-      return { ...state, snapshotting: false };
+      return { ...state, snapshotting: false, observedTurns: event.turns };
     case "replay-end": {
       // 이 이벤트 앞의 턴은 전부 재생된 과거다. 보통은 각 턴이 turn-end로 닫히지만 두 경우에
       // 열린 채 남는다: 마지막 턴의 시각 차가 없어 서버가 소요 시간을 말하지 못했을 때, 그리고

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-events.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-events.ts
@@ -69,6 +69,8 @@ export interface AgentChatContextSlice {
 
 export type AgentChatStreamEvent =
   | { readonly kind: "replay-start" }
+  /** 접속 시점의 snapshot이 모두 도착했다. 이 앞의 live opener는 복원이지 새 도착이 아니다. */
+  | { readonly kind: "snapshot-end" }
   /**
    * 측정된 문맥 창 내역. control 채널만이 카테고리 분해를 알고, 그 왕복은 30초쯤 걸린다(실측).
    * `asOf`가 그 값이 언제의 것인지 말한다 — 부재는 `"start"`이며 옛 저널의 뜻이기도 하다.
@@ -173,6 +175,8 @@ export function readChatJournalEvent(raw: string): AgentChatJournalEvent | null 
   switch (event.kind) {
     case "replay-start":
       return { seq: entry.seq, event: { kind: "replay-start" } };
+    case "snapshot-end":
+      return { seq: entry.seq, event: { kind: "snapshot-end" } };
     case "context": {
       // 총량과 창 크기가 없으면 그릴 수 있는 것이 없다. 0짜리 미터는 사실이 아니라 빈칸이다.
       if (typeof event.total !== "number" || typeof event.max !== "number" || event.max <= 0) return null;
@@ -582,6 +586,8 @@ export function readAgentChatJobDetailPayload(payload: unknown): AgentChatJobDet
 export interface AgentChatLogState {
   readonly turns: readonly AgentChatTurn[];
   readonly replaying: boolean;
+  /** 현재 접속이 보유하던 snapshot을 아직 받고 있다. replay-end 뒤의 in-flight tail도 포함한다. */
+  readonly snapshotting: boolean;
   readonly errorCode: string | null;
   /** 도착 순서를 지키는 잡 원장. 살아 있는 것과 끝난 것이 한 목록에 함께 산다. */
   readonly jobs: readonly AgentChatJob[];
@@ -595,6 +601,7 @@ const MAX_DRAFT_CHARS = 60_000;
 export const initialAgentChatLogState: AgentChatLogState = {
   turns: [],
   replaying: false,
+  snapshotting: true,
   errorCode: null,
   jobs: [],
   context: null,
@@ -608,6 +615,8 @@ export function reduceAgentChatLog(state: AgentChatLogState, event: AgentChatStr
   switch (event.kind) {
     case "replay-start":
       return { ...initialAgentChatLogState, replaying: true };
+    case "snapshot-end":
+      return { ...state, snapshotting: false };
     case "replay-end": {
       // 이 이벤트 앞의 턴은 전부 재생된 과거다. 보통은 각 턴이 turn-end로 닫히지만 두 경우에
       // 열린 채 남는다: 마지막 턴의 시각 차가 없어 서버가 소요 시간을 말하지 못했을 때, 그리고

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
@@ -44,6 +44,7 @@ function stateWith(turns: readonly AgentChatTurn[]): AgentChatLogState {
     turns,
     replaying: false,
     snapshotting: false,
+    observedTurns: 0,
     errorCode: null,
     jobs: [],
     context: null,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
@@ -43,6 +43,7 @@ function stateWith(turns: readonly AgentChatTurn[]): AgentChatLogState {
   return {
     turns,
     replaying: false,
+    snapshotting: false,
     errorCode: null,
     jobs: [],
     context: null,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-replay-banner.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-replay-banner.test.tsx
@@ -12,6 +12,7 @@ vi.mock("./chat-store.js", () => ({
   useAgentChatStream: () => ({
     turns,
     replaying: false,
+    snapshotting: false,
     errorCode: null,
     jobs: [],
     context: null,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-replay-banner.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-replay-banner.test.tsx
@@ -13,6 +13,7 @@ vi.mock("./chat-store.js", () => ({
     turns,
     replaying: false,
     snapshotting: false,
+    observedTurns: 0,
     errorCode: null,
     jobs: [],
     context: null,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
@@ -13,6 +13,7 @@ function makeLogState(): AgentChatLogState {
     turns: [{ dispatch: { text: "go" }, items: [{ type: "text", text: "answer" }], state: "done", toolCount: 0, draft: "" }],
     replaying: false,
     snapshotting: false,
+    observedTurns: 0,
     errorCode: null,
     jobs: [],
     context: null,
@@ -276,6 +277,7 @@ describe("chat log scroll anchor", () => {
     logState = {
       ...logState,
       replaying: false,
+      observedTurns: 2,
       turns: [
         ...logState.turns,
         { dispatch: { text: "queued instruction" }, items: [], state: "working", toolCount: 0, draft: "" },
@@ -283,6 +285,38 @@ describe("chat log scroll anchor", () => {
     };
     mountView();
     logState = { ...logState, snapshotting: false };
+    mountView();
+
+    expect(container?.querySelector(".agent-chat-composer-queued")).toBeNull();
+  });
+
+  it("clears a queued receipt from the monotonic coordinate when capped history shrinks", async () => {
+    logState = {
+      ...makeLogState(),
+      observedTurns: 2_000,
+      turns: [{ dispatch: { text: "running" }, items: [], state: "working", toolCount: 0, draft: "" }],
+    };
+    mountView();
+    const field = container?.querySelector<HTMLTextAreaElement>(".agent-chat-composer-input");
+    if (!field) throw new Error("Missing chat composer input");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setter?.call(field, "queued over cap");
+      field.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      container?.querySelector<HTMLButtonElement>(".agent-chat-composer-send")?.click();
+    });
+
+    logState = { ...logState, snapshotting: true };
+    mountView();
+    // JOURNAL_CAP이 과거를 밀어 화면에는 한 턴만 남아도 서버 누적 좌표는 새 턴을 말한다.
+    logState = {
+      ...logState,
+      snapshotting: false,
+      observedTurns: 2_001,
+      turns: [{ dispatch: { text: "queued over cap" }, items: [], state: "working", toolCount: 0, draft: "" }],
+    };
     mountView();
 
     expect(container?.querySelector(".agent-chat-composer-queued")).toBeNull();

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
@@ -23,6 +23,11 @@ function makeLogState(): AgentChatLogState {
 let logState: AgentChatLogState = makeLogState();
 
 vi.mock("./chat-store.js", () => ({ useAgentChatStream: () => logState }));
+vi.mock("../api.js", () => ({
+  discardLaunchAttachment: async () => {},
+  messageAgentSession: async () => {},
+  uploadLaunchAttachment: async () => ({ id: "attachment" }),
+}));
 vi.mock("@fleet-console/markdown/styles.css", () => ({}));
 vi.mock("./chat.css", () => ({}));
 
@@ -246,6 +251,41 @@ describe("chat log scroll anchor", () => {
     mountView();
 
     expect(container?.querySelector(".agent-chat-follow")?.textContent).toBe("Follow");
+  });
+
+  it("clears a queued receipt when its turn starts during reconnect", async () => {
+    logState = {
+      ...makeLogState(),
+      turns: [{ dispatch: { text: "running" }, items: [], state: "working", toolCount: 0, draft: "" }],
+    };
+    mountView();
+    const field = container?.querySelector<HTMLTextAreaElement>(".agent-chat-composer-input");
+    if (!field) throw new Error("Missing chat composer input");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setter?.call(field, "queued instruction");
+      field.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      container?.querySelector<HTMLButtonElement>(".agent-chat-composer-send")?.click();
+    });
+    expect(container?.querySelector(".agent-chat-composer-queued")?.textContent).toContain("1");
+
+    logState = { ...logState, snapshotting: true };
+    mountView();
+    logState = {
+      ...logState,
+      replaying: false,
+      turns: [
+        ...logState.turns,
+        { dispatch: { text: "queued instruction" }, items: [], state: "working", toolCount: 0, draft: "" },
+      ],
+    };
+    mountView();
+    logState = { ...logState, snapshotting: false };
+    mountView();
+
+    expect(container?.querySelector(".agent-chat-composer-queued")).toBeNull();
   });
 
   it("counts new turns while the reader is away and clears the count on follow", () => {

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
@@ -12,6 +12,7 @@ function makeLogState(): AgentChatLogState {
   return {
     turns: [{ dispatch: { text: "go" }, items: [{ type: "text", text: "answer" }], state: "done", toolCount: 0, draft: "" }],
     replaying: false,
+    snapshotting: false,
     errorCode: null,
     jobs: [],
     context: null,
@@ -211,7 +212,7 @@ describe("chat log scroll anchor", () => {
   });
 
   it("does not count replay history before replay-end", () => {
-    logState = { ...makeLogState(), turns: [], replaying: true };
+    logState = { ...makeLogState(), turns: [], replaying: true, snapshotting: true };
     const log = mountView();
     stubMetrics(log, { scrollHeight: 1000, clientHeight: 400 });
     log.scrollTop = 200;
@@ -221,6 +222,27 @@ describe("chat log scroll anchor", () => {
       ...logState,
       turns: [{ dispatch: { text: "history" }, items: [], state: "done", toolCount: 0, draft: "" }],
     };
+    mountView();
+
+    expect(container?.querySelector(".agent-chat-follow")?.textContent).toBe("Follow");
+  });
+
+  it("does not count an in-flight turn restored after replay-end as a new arrival", () => {
+    logState = { ...makeLogState(), turns: [], replaying: true, snapshotting: true };
+    const log = mountView();
+    stubMetrics(log, { scrollHeight: 1000, clientHeight: 400 });
+    log.scrollTop = 200;
+    act(() => { log.dispatchEvent(new Event("scroll")); });
+
+    // 서버는 working 문법을 지키려고 opener를 replay-end 뒤에 두지만, snapshot-end 전까지는
+    // 이미 보던 턴의 복원이다. Follow 칩이 새 도착으로 세면 안 된다.
+    logState = {
+      ...logState,
+      replaying: false,
+      turns: [{ dispatch: { text: "in flight" }, items: [], state: "working", toolCount: 0, draft: "" }],
+    };
+    mountView();
+    logState = { ...logState, snapshotting: false };
     mountView();
 
     expect(container?.querySelector(".agent-chat-follow")?.textContent).toBe("Follow");

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-scroll-anchor.test.tsx
@@ -290,6 +290,32 @@ describe("chat log scroll anchor", () => {
     expect(container?.querySelector(".agent-chat-composer-queued")).toBeNull();
   });
 
+  it("does not let restored history consume a receipt queued during snapshot delivery", async () => {
+    logState = {
+      ...makeLogState(),
+      snapshotting: true,
+      observedTurns: 10,
+      turns: [{ dispatch: { text: "restored" }, items: [], state: "working", toolCount: 0, draft: "" }],
+    };
+    mountView();
+    const field = container?.querySelector<HTMLTextAreaElement>(".agent-chat-composer-input");
+    if (!field) throw new Error("Missing chat composer input");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setter?.call(field, "queued during snapshot");
+      field.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      container?.querySelector<HTMLButtonElement>(".agent-chat-composer-send")?.click();
+    });
+
+    // 이 receipt보다 앞서 시작한 턴이 snapshot-end에서 드러나도 새 지시를 소비하지 않는다.
+    logState = { ...logState, snapshotting: false, observedTurns: 11 };
+    mountView();
+
+    expect(container?.querySelector(".agent-chat-composer-queued")?.textContent).toContain("1");
+  });
+
   it("clears a queued receipt from the monotonic coordinate when capped history shrinks", async () => {
     logState = {
       ...makeLogState(),

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-session-coordinates.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-session-coordinates.test.tsx
@@ -12,6 +12,7 @@ vi.mock("./chat-store.js", () => ({
     turns: [],
     replaying: false,
     snapshotting: false,
+    observedTurns: 0,
     errorCode: null,
     jobs: [],
     context: null,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-session-coordinates.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-session-coordinates.test.tsx
@@ -11,6 +11,7 @@ vi.mock("./chat-store.js", () => ({
   useAgentChatStream: () => ({
     turns: [],
     replaying: false,
+    snapshotting: false,
     errorCode: null,
     jobs: [],
     context: null,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-store.ts
@@ -52,7 +52,11 @@ export function useAgentChatStream(operationId: string, live = true): AgentChatV
         // 서버는 접속마다 보유 저널을 처음부터 되쓴다. 채팅 출생은 replay-start를 남기지
         // 않고, JOURNAL_CAP에 걸린 세션은 그 마커가 앞에서 잘린다. 열릴 때 비우지 않으면
         // 재접속 리플레이가 남은 턴·잡·질문 카드 위에 겹친다(옛 EventSource onopen과 같은 자리).
-        if (next === "open") setLog(() => initialAgentChatLogState);
+        if (next === "open") {
+          // 화면 로그는 snapshot으로 다시 쓰되, 서버가 준 누적 턴 좌표는 재접속 전 값을 보존한다.
+          // 저널 상한으로 과거 행이 잘려도 이 좌표와 새 snapshot-end의 차이는 단조다.
+          setLog((current) => ({ ...initialAgentChatLogState, observedTurns: current.observedTurns }));
+        }
         setConnection(next);
       },
       onEvent: (raw) => {

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -104,8 +104,8 @@ export function AgentChatView({
   // 팔로우 상태를 뒤집어, 한 번 튄 스크롤이 영영 바닥으로 돌아오지 못한다.
   const suppressScrollRef = React.useRef(0);
   const previousTurnCountRef = React.useRef(state.turns.length);
-  // 재접속 직전 턴 수. snapshot 안에서 그보다 늘어난 몫은 끊긴 동안 시작한 예약 턴이다.
-  const snapshotTurnBaselineRef = React.useRef<number | null>(state.snapshotting ? 0 : null);
+  // 재접속 직전 서버 누적 좌표. 저널 상한으로 화면의 과거 턴이 잘려도 이 값은 역행하지 않는다.
+  const snapshotTurnBaselineRef = React.useRef<number | null>(state.snapshotting ? state.observedTurns : null);
   const previousReadyAnswersRef = React.useRef(0);
 
   // 아직 아무 턴도 오가지 않은 세션. 재생 중이거나 연결 전에는 판단을 미룬다 — 그때의 "비어
@@ -166,14 +166,14 @@ export function AgentChatView({
     if (state.snapshotting) {
       // open이 로그를 비우기 전의 수를 보존한다. snapshot 안에서 같은 턴을 복원한 것은 새 도착이
       // 아니지만, 끊긴 동안 예약 턴이 실제로 시작했다면 그 receipt는 snapshot-end에서 내려야 한다.
-      if (snapshotTurnBaselineRef.current === null) snapshotTurnBaselineRef.current = previous;
+      if (snapshotTurnBaselineRef.current === null) snapshotTurnBaselineRef.current = state.observedTurns;
       return;
     }
     const baseline = snapshotTurnBaselineRef.current;
     snapshotTurnBaselineRef.current = null;
     const arrived = baseline === null
       ? Math.max(0, state.turns.length - previous)
-      : Math.max(0, state.turns.length - baseline);
+      : Math.max(0, state.observedTurns - baseline);
     if (arrived === 0) return;
     // 새 턴이 열렸다면 이 마운트가 접수한 예약 하나도 실행을 시작했다. 이 축은 화면 영속 receipt일
     // 뿐 서버 큐의 권위가 아니므로, 실제 turn-start보다 먼저 추측해서 내리지 않는다.

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -104,6 +104,8 @@ export function AgentChatView({
   // 팔로우 상태를 뒤집어, 한 번 튄 스크롤이 영영 바닥으로 돌아오지 못한다.
   const suppressScrollRef = React.useRef(0);
   const previousTurnCountRef = React.useRef(state.turns.length);
+  // 재접속 직전 턴 수. snapshot 안에서 그보다 늘어난 몫은 끊긴 동안 시작한 예약 턴이다.
+  const snapshotTurnBaselineRef = React.useRef<number | null>(state.snapshotting ? 0 : null);
   const previousReadyAnswersRef = React.useRef(0);
 
   // 아직 아무 턴도 오가지 않은 세션. 재생 중이거나 연결 전에는 판단을 미룬다 — 그때의 "비어
@@ -161,15 +163,24 @@ export function AgentChatView({
   React.useEffect(() => {
     const previous = previousTurnCountRef.current;
     previousTurnCountRef.current = state.turns.length;
-    // replay-end 뒤에도 진행 중 턴의 opener가 live 문법으로 복원될 수 있다. snapshot-end가 오기
-    // 전까지는 이번 접속이 이미 보유하던 상태이지 새 도착이 아니다. 그 뒤부터 열린 턴만 receipt와
-    // 미확인 집계를 움직인다. 빈 chat-born 세션의 첫 턴도 snapshot-end 뒤라 놓치지 않는다.
-    if (state.snapshotting || state.turns.length <= previous) return;
-    const arrived = state.turns.length - previous;
+    if (state.snapshotting) {
+      // open이 로그를 비우기 전의 수를 보존한다. snapshot 안에서 같은 턴을 복원한 것은 새 도착이
+      // 아니지만, 끊긴 동안 예약 턴이 실제로 시작했다면 그 receipt는 snapshot-end에서 내려야 한다.
+      if (snapshotTurnBaselineRef.current === null) snapshotTurnBaselineRef.current = previous;
+      return;
+    }
+    const baseline = snapshotTurnBaselineRef.current;
+    snapshotTurnBaselineRef.current = null;
+    const arrived = baseline === null
+      ? Math.max(0, state.turns.length - previous)
+      : Math.max(0, state.turns.length - baseline);
+    if (arrived === 0) return;
     // 새 턴이 열렸다면 이 마운트가 접수한 예약 하나도 실행을 시작했다. 이 축은 화면 영속 receipt일
     // 뿐 서버 큐의 권위가 아니므로, 실제 turn-start보다 먼저 추측해서 내리지 않는다.
     setQueuedTurns((current) => Math.max(0, current - arrived));
-    if (!nearBottomRef.current) setUnseenTurns((current) => current + arrived);
+    // snapshot 안의 증가는 끊긴 동안 시작한 예약일 수 있지만, 이미 보던 턴의 복원이기도 하다.
+    // 화면 도착 신호는 snapshot 밖에서 직접 열린 턴만 센다.
+    if (baseline === null && !nearBottomRef.current) setUnseenTurns((current) => current + arrived);
   }, [state.snapshotting, state.turns.length]);
 
   React.useEffect(() => {

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -161,16 +161,16 @@ export function AgentChatView({
   React.useEffect(() => {
     const previous = previousTurnCountRef.current;
     previousTurnCountRef.current = state.turns.length;
-    // 서버 저널에는 최초 replay-end가 남아 있고, 그 뒤부터 turns가 늘어나는 것은 live turn-start다.
-    // replay-start가 상한에서 잘려도 replay-end 뒤에 과거 턴을 추가하는 경로는 없으므로 별도
-    // "완료" 축을 복제하지 않고 이벤트 순서 자체를 따른다. 빈 chat-born 세션의 첫 턴도 놓치지 않는다.
-    if (state.replaying || state.turns.length <= previous) return;
+    // replay-end 뒤에도 진행 중 턴의 opener가 live 문법으로 복원될 수 있다. snapshot-end가 오기
+    // 전까지는 이번 접속이 이미 보유하던 상태이지 새 도착이 아니다. 그 뒤부터 열린 턴만 receipt와
+    // 미확인 집계를 움직인다. 빈 chat-born 세션의 첫 턴도 snapshot-end 뒤라 놓치지 않는다.
+    if (state.snapshotting || state.turns.length <= previous) return;
     const arrived = state.turns.length - previous;
     // 새 턴이 열렸다면 이 마운트가 접수한 예약 하나도 실행을 시작했다. 이 축은 화면 영속 receipt일
     // 뿐 서버 큐의 권위가 아니므로, 실제 turn-start보다 먼저 추측해서 내리지 않는다.
     setQueuedTurns((current) => Math.max(0, current - arrived));
     if (!nearBottomRef.current) setUnseenTurns((current) => current + arrived);
-  }, [state.replaying, state.turns.length]);
+  }, [state.snapshotting, state.turns.length]);
 
   React.useEffect(() => {
     const ready = state.turns.filter((turn) => turn.state !== "working" && turn.answer !== undefined).length;

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -106,6 +106,9 @@ export function AgentChatView({
   const previousTurnCountRef = React.useRef(state.turns.length);
   // 재접속 직전 서버 누적 좌표. 저널 상한으로 화면의 과거 턴이 잘려도 이 값은 역행하지 않는다.
   const snapshotTurnBaselineRef = React.useRef<number | null>(state.snapshotting ? state.observedTurns : null);
+  // snapshot이 시작될 때 이미 서 있던 receipt만 그 snapshot에서 시작한 턴과 맞춘다. 전달 중 새로
+  // 넣은 지시는 이 기준 뒤의 것이므로, 앞서 시작한 턴이 대신 소비하면 안 된다.
+  const snapshotQueuedBaselineRef = React.useRef(0);
   const previousReadyAnswersRef = React.useRef(0);
 
   // 아직 아무 턴도 오가지 않은 세션. 재생 중이거나 연결 전에는 판단을 미룬다 — 그때의 "비어
@@ -166,14 +169,18 @@ export function AgentChatView({
     if (state.snapshotting) {
       // open이 로그를 비우기 전의 수를 보존한다. snapshot 안에서 같은 턴을 복원한 것은 새 도착이
       // 아니지만, 끊긴 동안 예약 턴이 실제로 시작했다면 그 receipt는 snapshot-end에서 내려야 한다.
-      if (snapshotTurnBaselineRef.current === null) snapshotTurnBaselineRef.current = state.observedTurns;
+      if (snapshotTurnBaselineRef.current === null) {
+        snapshotTurnBaselineRef.current = state.observedTurns;
+        snapshotQueuedBaselineRef.current = queuedTurns;
+      }
       return;
     }
     const baseline = snapshotTurnBaselineRef.current;
     snapshotTurnBaselineRef.current = null;
     const arrived = baseline === null
       ? Math.max(0, state.turns.length - previous)
-      : Math.max(0, state.observedTurns - baseline);
+      : Math.min(snapshotQueuedBaselineRef.current, Math.max(0, state.observedTurns - baseline));
+    snapshotQueuedBaselineRef.current = 0;
     if (arrived === 0) return;
     // 새 턴이 열렸다면 이 마운트가 접수한 예약 하나도 실행을 시작했다. 이 축은 화면 영속 receipt일
     // 뿐 서버 큐의 권위가 아니므로, 실제 turn-start보다 먼저 추측해서 내리지 않는다.
@@ -181,7 +188,7 @@ export function AgentChatView({
     // snapshot 안의 증가는 끊긴 동안 시작한 예약일 수 있지만, 이미 보던 턴의 복원이기도 하다.
     // 화면 도착 신호는 snapshot 밖에서 직접 열린 턴만 센다.
     if (baseline === null && !nearBottomRef.current) setUnseenTurns((current) => current + arrived);
-  }, [state.snapshotting, state.turns.length]);
+  }, [queuedTurns, state.observedTurns, state.snapshotting, state.turns.length]);
 
   React.useEffect(() => {
     const ready = state.turns.filter((turn) => turn.state !== "working" && turn.answer !== undefined).length;

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
@@ -41,6 +41,7 @@ function stateWith(jobs: readonly AgentChatJob[]): AgentChatLogState {
   return {
     turns: [{ dispatch: { text: "go" }, items: [], state: "done", toolCount: 0, draft: "" }],
     replaying: false,
+    snapshotting: false,
     errorCode: null,
     jobs,
     context: null,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
@@ -42,6 +42,7 @@ function stateWith(jobs: readonly AgentChatJob[]): AgentChatLogState {
     turns: [{ dispatch: { text: "go" }, items: [], state: "done", toolCount: 0, draft: "" }],
     replaying: false,
     snapshotting: false,
+    observedTurns: 0,
     errorCode: null,
     jobs,
     context: null,

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-events.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-events.ts
@@ -73,6 +73,8 @@ export interface AgentChatContextSlice {
 
 export type AgentChatStreamEvent =
   | { readonly kind: "replay-start" }
+  /** 접속 시점의 snapshot이 모두 도착했다. 이 앞의 live opener는 복원이지 새 도착이 아니다. */
+  | { readonly kind: "snapshot-end" }
   /**
    * 이 턴이 **시작될 때까지의** 문맥 창 내역.
    *

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-events.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-events.ts
@@ -74,7 +74,7 @@ export interface AgentChatContextSlice {
 export type AgentChatStreamEvent =
   | { readonly kind: "replay-start" }
   /** 접속 시점의 snapshot이 모두 도착했다. 이 앞의 live opener는 복원이지 새 도착이 아니다. */
-  | { readonly kind: "snapshot-end" }
+  | { readonly kind: "snapshot-end"; readonly turns: number }
   /**
    * 이 턴이 **시작될 때까지의** 문맥 창 내역.
    *

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -340,6 +340,8 @@ class AgentChatSession {
    * 하나이고, 중지도 여기를 닫는다.
    */
   private turnOpen = false;
+  /** 이 세션이 연 누적 턴 수. 저널이 앞을 버려도 재접속 receipt가 비교할 단조 좌표다. */
+  private observedTurns = 0;
   /** 열린 턴의 완주를 기다리는 디스패치. 턴이 닫히면 풀린다. */
   private awaitingTurn: (() => void) | null = null;
   /**
@@ -564,7 +566,7 @@ class AgentChatSession {
     }
     // 이 접속이 보유하던 snapshot의 끝. replay-end 뒤에 live로 복원한 진행 중 턴도 여기까지는
     // 새 도착이 아니다. 이후 push()가 보내는 이벤트만 이번 접속의 진짜 live tail이다.
-    listener({ seq: this.seq + 0.5, event: { kind: "snapshot-end" } });
+    listener({ seq: this.seq + 0.5, event: { kind: "snapshot-end", turns: this.observedTurns } });
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
@@ -1447,6 +1449,7 @@ class AgentChatSession {
   private openTurn(options: { readonly dispatched: boolean }): void {
     if (this.turnOpen) return;
     this.turnOpen = true;
+    this.observedTurns += 1;
     // 자식이 스스로 연 턴은 자식이 이미 알고 있다. 디스패치가 연 턴은 `send()`가 닿아야 그렇다.
     this.turnReachedChild = !options.dispatched;
     this.push({ kind: "turn-start", at: Date.now() });

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -562,6 +562,9 @@ class AgentChatSession {
     } else {
       for (const entry of snapshot) listener(entry);
     }
+    // 이 접속이 보유하던 snapshot의 끝. replay-end 뒤에 live로 복원한 진행 중 턴도 여기까지는
+    // 새 도착이 아니다. 이후 push()가 보내는 이벤트만 이번 접속의 진짜 live tail이다.
+    listener({ seq: this.seq + 0.5, event: { kind: "snapshot-end" } });
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -500,7 +500,7 @@ describe("AgentChatRegistry", () => {
     session.subscribe((entry) => events.push(entry));
     expect(events[0]?.event).toEqual({ kind: "replay-start" });
     expect(events.at(-2)?.event).toEqual({ kind: "replay-end", turns: 2 });
-    expect(events.at(-1)?.event).toEqual({ kind: "snapshot-end" });
+    expect(events.at(-1)?.event).toMatchObject({ kind: "snapshot-end", turns: expect.any(Number) });
     expect(events.slice(1, -2).some((entry) => entry.event.kind === "replay-end")).toBe(false);
     await registry.disposeAll();
   });
@@ -540,7 +540,7 @@ describe("AgentChatRegistry", () => {
     // live 문법의 opener까지가 복원 상태이며, 뒤 이벤트부터 새 도착임을 클라이언트에 말한다.
     const state = events.reduce((current, entry) => reduceAgentChatLog(current, entry.event), initialAgentChatLogState);
     expect(state.turns.at(-1)?.state).toBe("working");
-    expect(events.at(-1)?.event).toEqual({ kind: "snapshot-end" });
+    expect(events.at(-1)?.event).toMatchObject({ kind: "snapshot-end", turns: expect.any(Number) });
     expect(state.snapshotting).toBe(false);
 
     await registry.disposeAll();

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -242,6 +242,10 @@ function kinds(events: readonly AgentChatJournalEvent[]): readonly string[] {
   return events.map((entry) => entry.event.kind);
 }
 
+function withoutSnapshotEnd(events: readonly AgentChatJournalEvent[]): readonly AgentChatJournalEvent[] {
+  return events.filter((entry) => entry.event.kind !== "snapshot-end");
+}
+
 describe("AgentChatRegistry — chat-born sessions", () => {
   it("starts the first turn without a resume coordinate after an empty replay boundary", async () => {
     const home = tempDir("chat-home-");
@@ -253,7 +257,7 @@ describe("AgentChatRegistry — chat-born sessions", () => {
     const events: AgentChatJournalEvent[] = [];
     session.subscribe((entry) => events.push(entry));
     // 되돌릴 과거가 0턴이라는 사실도 명시적으로 닫힌 경계가 말한다.
-    expect(kinds(events)).toEqual(["replay-start", "replay-end"]);
+    expect(kinds(events)).toEqual(["replay-start", "replay-end", "snapshot-end"]);
 
     session.send("let us talk about the render path");
     await drainTurn(registry, "op-1");
@@ -441,10 +445,11 @@ describe("AgentChatRegistry", () => {
 
     const events: AgentChatJournalEvent[] = [];
     session.subscribe((entry) => events.push(entry));
-    expect(events[0]?.event).toEqual({ kind: "replay-start" });
-    const replayEnd = events.at(-1)?.event;
+    const snapshot = withoutSnapshotEnd(events);
+    expect(snapshot[0]?.event).toEqual({ kind: "replay-start" });
+    const replayEnd = snapshot.at(-1)?.event;
     expect(replayEnd).toMatchObject({ kind: "replay-end" });
-    const held = events.slice(1, -1).map((entry) => entry.event);
+    const held = snapshot.slice(1, -1).map((entry) => entry.event);
     const dispatches = held.filter((event) => event.kind === "dispatch").length;
     // 합성 경계 안의 원래 replay-end는 live tail보다 먼저 재생을 끝내므로 전달하지 않는다.
     expect(held.some((event) => event.kind === "replay-end")).toBe(false);
@@ -466,13 +471,14 @@ describe("AgentChatRegistry", () => {
 
     const events: AgentChatJournalEvent[] = [];
     session.subscribe((entry) => events.push(entry));
-    const held = events.slice(1, -1).map((entry) => entry.event);
+    const snapshot = withoutSnapshotEnd(events);
+    const held = snapshot.slice(1, -1).map((entry) => entry.event);
     expect(held[0]?.kind).not.toBe("dispatch");
     const state = held.reduce((current, event) => reduceAgentChatLog(current, event), {
       ...initialAgentChatLogState,
       replaying: true,
     });
-    const replayEnd = events.at(-1)?.event;
+    const replayEnd = snapshot.at(-1)?.event;
     expect(replayEnd?.kind === "replay-end" ? replayEnd.turns : -1).toBe(state.turns.length);
     await registry.disposeAll();
   });
@@ -493,8 +499,9 @@ describe("AgentChatRegistry", () => {
     const events: AgentChatJournalEvent[] = [];
     session.subscribe((entry) => events.push(entry));
     expect(events[0]?.event).toEqual({ kind: "replay-start" });
-    expect(events.at(-1)?.event).toEqual({ kind: "replay-end", turns: 2 });
-    expect(events.slice(1, -1).some((entry) => entry.event.kind === "replay-end")).toBe(false);
+    expect(events.at(-2)?.event).toEqual({ kind: "replay-end", turns: 2 });
+    expect(events.at(-1)?.event).toEqual({ kind: "snapshot-end" });
+    expect(events.slice(1, -2).some((entry) => entry.event.kind === "replay-end")).toBe(false);
     await registry.disposeAll();
   });
 
@@ -522,16 +529,19 @@ describe("AgentChatRegistry", () => {
     // mid-turn으로 재접속하는 두 번째 구독자 — subscribe는 이 순간의 저널을 동기로 되쓴다.
     const events: AgentChatJournalEvent[] = [];
     session.subscribe((entry) => events.push(entry));
-    const kindsList = events.map((entry) => entry.event.kind);
+    const kindsList = kinds(events);
     const endIdx = kindsList.indexOf("replay-end");
     const startIdx = kindsList.indexOf("turn-start");
     // 진행 중 턴의 turn-start는 경계(replay-end) 뒤에 live로 온다.
     expect(endIdx).toBeGreaterThanOrEqual(0);
     expect(startIdx).toBeGreaterThan(endIdx);
 
-    // 재접속 스냅숏을 리듀스하면 마지막 턴은 done이 아니라 working이다.
+    // 재접속 스냅숏을 리듀스하면 마지막 턴은 done이 아니라 working이다. snapshot-end는 이
+    // live 문법의 opener까지가 복원 상태이며, 뒤 이벤트부터 새 도착임을 클라이언트에 말한다.
     const state = events.reduce((current, entry) => reduceAgentChatLog(current, entry.event), initialAgentChatLogState);
     expect(state.turns.at(-1)?.state).toBe("working");
+    expect(events.at(-1)?.event).toEqual({ kind: "snapshot-end" });
+    expect(state.snapshotting).toBe(false);
 
     await registry.disposeAll();
   });
@@ -557,7 +567,7 @@ describe("AgentChatRegistry", () => {
     // mid-turn 재접속: 재생 스냅숏엔 밀려난 dispatch/turn-start가 없다.
     const events: AgentChatJournalEvent[] = [];
     session.subscribe((entry) => events.push(entry));
-    const kindsList = events.map((entry) => entry.event.kind);
+    const kindsList = kinds(events);
     const endIdx = kindsList.indexOf("replay-end");
     const startIdx = kindsList.indexOf("turn-start");
     // 여는 좌표가 실제로 밀려났음을 못 박는다 — dispatch가 남아 있으면 정상 경로이지 이 상한 경로가
@@ -631,7 +641,7 @@ describe("AgentChatRegistry", () => {
 
     const events: AgentChatJournalEvent[] = [];
     session.subscribe((entry) => events.push(entry));
-    expect(kinds(events)).toEqual(["replay-start", "dispatch", "text", "replay-end"]);
+    expect(kinds(events)).toEqual(["replay-start", "dispatch", "text", "replay-end", "snapshot-end"]);
     await registry.disposeAll();
   });
 
@@ -659,7 +669,7 @@ describe("AgentChatRegistry", () => {
       "replay-start",
       "dispatch", "text", "turn-end",
       "turn-start", "text", "turn-end",
-      "replay-end",
+      "replay-end", "snapshot-end",
     ]);
     // 접힌 턴의 시작은 묶음의 첫 줄이고, 끝맺지 못한 운반체는 앞 턴의 끝을 늘리지 않는다.
     expect(events.map((entry) => entry.event).filter((event) => event.kind === "turn-end")).toEqual([


### PR DESCRIPTION
## Summary
- mark the end of each Chat reconnect snapshot after restoring an in-flight turn
- keep restored turns out of unseen-arrival and queued-receipt accounting
- add reconnect regression coverage and reuse the existing event-kind test helper

## Test Plan
- [x] `pnpm --dir runtime/fleet-plugins/terminal exec vitest run tests/agent-chat-session.test.ts client/agent/chat/chat-scroll-anchor.test.tsx client/agent/chat/chat-store.test.tsx tests/agent-chat-events.test.ts tests/agent-chat-log-reducer.test.ts --config vitest.config.ts`
- [x] `pnpm --dir runtime/fleet-plugins/terminal typecheck`
- [x] `pnpm --dir runtime/fleet-plugins/terminal build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`