### PR TITLE
style(fleet-console): inline chat session coordinates

### DIFF
--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -3131,7 +3131,7 @@ describe("Effort track interaction grammar", () => {
     expect(reduced).toContain(".agent-chat-ask-dot");
   });
 
-  it("pins the chat session-coordinate grammar — neutral by default, apex only for ultracode", () => {
+  it("pins the inline chat session-coordinate grammar — no badge, apex only on ultracode content", () => {
     const chat = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_CSS_PATH), "utf8");
     const view = fs.readFileSync(fileURLToPath(TERMINAL_CHAT_VIEW_PATH), "utf8");
     const block = (selector: string): string => {
@@ -3140,11 +3140,19 @@ describe("Effort track interaction grammar", () => {
       return chat.slice(start, chat.indexOf("}", start));
     };
 
-    // 좌표는 상태(신호)도 위치(brass)도 정체성도 아니다 — 기본형은 어떤 채널도 타지 않는다.
-    const chip = block(".agent-chat-coord");
-    expect(chip).toContain("border: 1px solid var(--hairline);");
+    // 좌표는 최근 백그라운드 작업 글리프처럼 툴 행에 직접 선다. 별도 배지 표면(테두리·바탕·
+    // radius)을 다시 만들지 않고, 상태·위치·정체성 채널도 빌리지 않는다.
+    const coordinate = block(".agent-chat-coord");
+    expect(coordinate).toContain("border: 0;");
+    expect(coordinate).toContain("background: transparent;");
+    expect(coordinate).toContain("padding: 0;");
+    expect(coordinate).not.toContain("border-radius:");
+    const model = block(".agent-chat-coord-model");
+    expect(model).toContain("min-width: 0;");
+    expect(model).toContain("overflow: hidden;");
+    expect(model).toContain("text-overflow: ellipsis;");
     for (const channel of ["--aurora", "--warn", "--coral", "--positive", "--brass", "--id-"]) {
-      expect(chip, channel).not.toContain(channel);
+      expect(coordinate, channel).not.toContain(channel);
     }
 
     // 색을 얻는 것은 강도 한 자리이고, 그 어휘는 런치 트랙의 것이다: MAX는 crest, ULTRACODE는 apex.
@@ -3159,9 +3167,10 @@ describe("Effort track interaction grammar", () => {
       /@keyframes agent-chat-ultracode-wave \{\s*from \{ background-position: 0 0; \}\s*to \{ background-position: -200% 0; \}/,
     );
 
-    // apex를 중립 토큰과 섞을 때는 oklab이다 — oklch는 짧은 hue 호를 지나 라이트 테마에서
-    // apex(295)와 종이색(100) 사이가 coral(신호 채널)을 관통한다.
-    expect(block(".agent-chat-coord.is-ultracode")).toContain("color-mix(in oklab, var(--apex)");
+    // ultracode도 바깥 배지를 되살리지 않는다. apex는 별과 강도 글자만 얻고 모델명·행 표면은
+    // 중립으로 남는다.
+    expect(chat).not.toContain(".agent-chat-coord.is-ultracode {");
+    expect(block(".agent-chat-coord.is-ultracode .agent-chat-coord-mark")).toContain("color: var(--apex-ink);");
 
     // 물결은 모션이므로 감속에서 멈춘다. 그라데이션을 지우면서 채움도 되돌려야 글자가 남는다.
     const reduced = chat.slice(chat.indexOf("@media (prefers-reduced-motion: reduce)"));
@@ -3169,10 +3178,11 @@ describe("Effort track interaction grammar", () => {
       /\.agent-chat-coord-effort\[data-effort-level="ultra"\] \{[\s\S]*?animation: none;[\s\S]*?-webkit-text-fill-color: var\(--apex-ink\);/,
     );
 
-    // 좌표를 말하는 자리는 이제 이 배지 하나다 — 로그 첫 줄의 태생 기록이 퇴역했으므로
-    // 좁은 폭에서도 배지가 물러나지 않는다(물러나면 좌표를 볼 길이 사라진다).
+    // 좌표를 말하는 자리는 이제 이 각인 하나다 — 로그 첫 줄의 태생 기록이 퇴역했으므로
+    // 좁은 폭에서도 각인이 물러나지 않는다(물러나면 좌표를 볼 길이 사라진다). 단독·그룹 선택자
+    // 모두 막는다: 예전 정규식은 `.hint, .coord`를 놓쳐 숨김이 남아도 green이었다.
     expect(chat).not.toContain(".agent-chat-birth");
-    expect(chat).not.toMatch(/@container \([^)]*\) \{\s*\.agent-chat-coord \{\s*display: none;/);
+    expect(chat).not.toMatch(/@container\s*\([^)]*\)\s*\{[\s\S]*?\.agent-chat-coord\s*(?:,|\{)[\s\S]*?display:\s*none;/);
 
     // 좌표는 사실이지 컨트롤이 아니다 — 세션이 실행 정책을 소유하므로 여기서 바꿀 수 없고,
     // 누를 수 있게 그리면 거짓 약속이 된다.

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-session-coordinates.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-session-coordinates.test.tsx
@@ -74,70 +74,70 @@ function mount(payload: Record<string, unknown>, language: "en" | "ko" = "en"): 
   })));
 }
 
-const chip = () => container?.querySelector(".agent-chat-coord");
+const coordinate = () => container?.querySelector(".agent-chat-coord");
 const effort = () => container?.querySelector<HTMLElement>(".agent-chat-coord-effort");
 
 describe("chat session coordinates", () => {
-  it("states the session's model and effort in the chip row", () => {
+  it("states the session's model and effort inline in the tool row", () => {
     mount({ session: { harness: "claude-code", model: "opus[1m]", effort: "ultra" } });
-    expect(chip()?.querySelector(".agent-chat-coord-model")?.textContent).toBe("Opus");
+    expect(coordinate()?.querySelector(".agent-chat-coord-model")?.textContent).toBe("Opus");
     expect(effort()?.textContent).toBe("ULTRACODE");
     expect(effort()?.dataset.effortLevel).toBe("ultra");
     // 축약하지 않은 사실은 툴팁에 남는다.
-    expect(chip()?.getAttribute("title")).toBe("opus[1m] · ultra");
+    expect(coordinate()?.getAttribute("title")).toBe("opus[1m] · ultra");
   });
 
   // 좌표는 사실이지 컨트롤이 아니다 — 세션이 실행 정책을 소유하므로 여기서 바꿀 수 없다.
   // 누를 수 있게 그리면 거짓 약속이 된다.
   it("is a named mark, not an interactive control", () => {
     mount({ session: { harness: "claude-code", model: "sonnet", effort: "high" } });
-    expect(chip()?.tagName).toBe("SPAN");
-    expect(chip()?.querySelector("button")).toBeNull();
+    expect(coordinate()?.tagName).toBe("SPAN");
+    expect(coordinate()?.querySelector("button")).toBeNull();
     // 일반 span의 aria-label은 무시될 수 있다 — 이름을 지는 역할이 있어야 한 문장으로 읽힌다.
-    expect(chip()?.getAttribute("role")).toBe("img");
-    expect(chip()?.getAttribute("aria-label")).toBe("This session runs on Sonnet at HIGH");
+    expect(coordinate()?.getAttribute("role")).toBe("img");
+    expect(coordinate()?.getAttribute("aria-label")).toBe("This session runs on Sonnet at HIGH");
   });
 
   it("marks only an ultracode session with the apex channel", () => {
     mount({ session: { harness: "claude-code", model: "opus[1m]", effort: "xhigh" } });
-    expect(chip()?.classList.contains("is-ultracode")).toBe(false);
+    expect(coordinate()?.classList.contains("is-ultracode")).toBe(false);
     act(() => root?.unmount());
     container?.remove();
     mount({ session: { harness: "claude-code", model: "opus[1m]", effort: "ultra" } });
-    expect(chip()?.classList.contains("is-ultracode")).toBe(true);
+    expect(coordinate()?.classList.contains("is-ultracode")).toBe(true);
   });
 
   // 이름만으로는 같은 자리에 선 두 모델이 어디서 온 것인지 말하지 못한다.
   it("marks the supplier that actually ran, and falls back to the neutral mark", () => {
     mount({ session: { harness: "claude-code", model: "claude-gateway--xai--grok-4.6", effort: "high" } });
-    expect(chip()?.querySelector(".agent-chat-coord-glyph")?.getAttribute("data-provider")).toBe("xai");
-    expect(chip()?.querySelector(".agent-chat-coord-glyph svg")).not.toBeNull();
+    expect(coordinate()?.querySelector(".agent-chat-coord-glyph")?.getAttribute("data-provider")).toBe("xai");
+    expect(coordinate()?.querySelector(".agent-chat-coord-glyph svg")).not.toBeNull();
     // 글리프는 마크 자리를 잇는다 — 둘이 함께 서면 줄의 리듬이 어긋난다.
-    expect(chip()?.querySelector(".agent-chat-coord-mark")).toBeNull();
+    expect(coordinate()?.querySelector(".agent-chat-coord-mark")).toBeNull();
     act(() => root?.unmount());
     container?.remove();
     // ultracode는 그 자리에 자기 별을 세운다 — 티어가 공급자보다 먼저 읽혀야 한다.
     mount({ session: { harness: "claude-code", model: "claude-gateway--xai--grok-4.6", effort: "ultra" } });
-    expect(chip()?.querySelector(".agent-chat-coord-mark")?.textContent).toBe("✦");
-    expect(chip()?.querySelector(".agent-chat-coord-glyph")).toBeNull();
+    expect(coordinate()?.querySelector(".agent-chat-coord-mark")?.textContent).toBe("✦");
+    expect(coordinate()?.querySelector(".agent-chat-coord-glyph")).toBeNull();
     act(() => root?.unmount());
     container?.remove();
     // 공급자를 읽지 못한 세션은 중립 마름모로 돌아간다.
     mount({});
-    expect(chip()?.querySelector(".agent-chat-coord-glyph")).toBeNull();
-    expect(chip()?.querySelector(".agent-chat-coord-mark")?.textContent).toBe("◇");
+    expect(coordinate()?.querySelector(".agent-chat-coord-glyph")).toBeNull();
+    expect(coordinate()?.querySelector(".agent-chat-coord-mark")?.textContent).toBe("◇");
   });
 
   it("says the coordinates were left to the default instead of naming a model", () => {
     mount({});
-    expect(chip()?.querySelector(".agent-chat-coord-model")?.textContent).toBe("Default");
+    expect(coordinate()?.querySelector(".agent-chat-coord-model")?.textContent).toBe("Default");
     expect(effort()?.textContent).toBe("AUTO");
     expect(effort()?.dataset.effortLevel).toBe("auto");
-    expect(chip()?.hasAttribute("title")).toBe(false);
-    expect(chip()?.getAttribute("aria-label")).toBe("This session runs on Default at AUTO");
+    expect(coordinate()?.hasAttribute("title")).toBe(false);
+    expect(coordinate()?.getAttribute("aria-label")).toBe("This session runs on Default at AUTO");
   });
 
-  // 좌표를 말하는 자리는 하나다 — 컴포저의 배지가 상시로 서 있으므로 로그가 같은 사실을
+  // 좌표를 말하는 자리는 하나다 — 컴포저의 인라인 각인이 상시로 서 있으므로 로그가 같은 사실을
   // 첫 줄에 한 번 더 적지 않는다.
   it("leaves the log to the conversation and keeps the coordinates on the composer", () => {
     mount({ session: { harness: "claude-code", model: "opus[1m]", effort: "ultra" } }, "ko");

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -25,7 +25,7 @@ import {
   type AgentChatTurn,
   type AgentChatTurnItem,
 } from "./chat-events.js";
-import { CHAT_EFFORT_RUNGS, readAgentChatSessionCoordinates, type AgentChatSessionCoordinates } from "./session-coordinates.js";
+import { readAgentChatSessionCoordinates, type AgentChatSessionCoordinates } from "./session-coordinates.js";
 import { AgentChatComposer, type AgentChatQueueCancelOutcome } from "./composer.js";
 import { useViewSwitchState } from "../view-switch-store.js";
 import "@fleet-console/markdown/styles.css";
@@ -539,12 +539,13 @@ export function AgentChatView({
 }
 
 /**
- * 이 세션의 실행 좌표를 상시로 말하는 칩.
+ * 이 세션의 실행 좌표를 상시로 말하는 각인.
  *
  * 여러 채팅 패널이 한 화면에 서면, 무거운 지시를 어디로 던질지는 좌표가 정한다 — 그래서 이 표식은
- * 대화 안이 아니라 칩 줄 맨 앞, 패널을 훑는 눈이 먼저 닿는 자리에 선다. 평상시에는 중립이라
- * 대화를 이기지 않고, 신호(상태) 채널도 쓰지 않는다. 색을 얻는 것은 강도뿐이며, 그 어휘는
- * 런치 트랙의 것을 그대로 쓴다.
+ * 대화 안이 아니라 컴포저 툴 행 맨 앞, 패널을 훑는 눈이 먼저 닿는 자리에 선다. 최근 백그라운드
+ * 작업 글리프처럼 별도 배지를 두르지 않고 프레임에 직접 놓여, 컴포저를 여러 상자로 쪼개지 않는다.
+ * 평상시에는 중립이라 대화를 이기지 않고, 신호(상태) 채널도 쓰지 않는다. 색을 얻는 것은 강도뿐이며,
+ * 그 어휘는 런치 트랙의 것을 그대로 쓴다.
  *
  * 컨트롤이 아니라 사실이므로 버튼이 아니다. 누를 수 있게 그리면 "여기서 바꿀 수 있다"는
  * 거짓 약속이 된다 — 좌표를 바꾸는 길은 새 세션을 여는 것뿐이다.

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -1055,7 +1055,6 @@
   color: var(--coral);
 }
 
-/* 컨트롤 행 — Quick Launch bar와 같은 문법: 좌측은 좌표(사실)와 키 안내, 우측은 액션. */
 /* 예약 목록 — field 위 자기 자리에 선다.
 
    바에 두지 않는 이유는 폭이다: 좌표 배지와 계기가 이미 그 행을 쓰고 있어 예약은 한 줄로
@@ -1140,6 +1139,8 @@
   outline: none;
 }
 
+/* 컨트롤 행 — Quick Launch bar와 같은 문법: 좌측은 프레임에 바로 새긴 좌표(사실)와 키 안내,
+   우측은 액션. 좌표에 별도 배지를 두르지 않아 툴 행 자체가 한 장으로 읽힌다. */
 .agent-chat-composer-bar {
   display: flex;
   align-items: center;
@@ -1591,21 +1592,21 @@
    살므로, 컴포저가 숨는 순간 글리프도 함께 사라진다. 스트립이 컴포저 경계에 걸터앉던 시절의
    별도 카드 앵커는 그와 함께 폐기됐다. */
 
-/* ── 세션 좌표 칩 ────────────────────────────────────────────────────────
-   이 세션이 무엇으로 도는가(모델 · 강도). 칩 줄 맨 앞, 패널을 훑는 눈이 먼저 닿는 자리다.
-   [doctrine] 기본형은 어떤 채널도 타지 않는다 — hairline 테두리와 tertiary 글자뿐이다.
-   좌표는 상태(신호)도 위치(brass)도 정체성(--id-*)도 아니므로 그 채널들을 빌리면 안 된다.
-   색을 얻는 것은 강도 한 자리이며, 그 어휘는 런치 트랙의 것을 그대로 쓴다:
-   MAX는 crest, ULTRACODE는 apex, 미지정(auto)은 파선 밑줄.
-   컨트롤이 아니라 사실이므로 hover 반응도 두지 않는다. */
+/* ── 세션 좌표 각인 ───────────────────────────────────────────────────────
+   이 세션이 무엇으로 도는가(모델 · 강도). 최근 백그라운드 작업 글리프처럼 컴포저 툴 행에
+   직접 놓인다 — 별도 테두리·바탕·radius가 없어 프레임 안에 또 하나의 배지가 생기지 않는다.
+   [doctrine] 기본형은 어떤 채널도 타지 않는다. 좌표는 상태(신호)도 위치(brass)도
+   정체성(--id-*)도 아니므로 tertiary 잉크만 쓰고, 색을 얻는 것은 강도 한 자리뿐이다:
+   MAX는 crest, ULTRACODE는 apex, 미지정(auto)은 파선 밑줄. 컨트롤이 아니라 사실이므로
+   hover 반응도 두지 않는다. */
 .agent-chat-coord {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 5px var(--space-3);
-  border-radius: var(--radius-xs);
-  border: 1px solid var(--hairline);
-  background: var(--ink-mid);
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
   font-family: var(--font-mono);
   font-size: var(--t-xs);
   letter-spacing: 0.06em;
@@ -1619,9 +1620,14 @@
   line-height: 1;
 }
 
-/* 모델 이름은 잘리지 않는다 — 좌표는 한 줄짜리 사실이고, 줄임표가 붙으면 어느 모델로 도는지가
-   반쪽만 남는다. 배지 자체가 nowrap이라 이름이 길면 배지가 그만큼 길어진다. */
+/* 인라인 각인은 우측 액션의 자리를 침범하지 않는다. 모델명만 남은 폭을 쓰고 줄임표로 접으며,
+   공급자 표식과 강도는 끝까지 남긴다 — 전체 원문은 좌표 루트의 title·접근성 이름이 진다. 배지일
+   때처럼 내용 폭을 그대로 고집하면, 긴 미등록 모델명이 좁은 패널에서 Stop·Queue 위로 흐른다. */
 .agent-chat-coord-model {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: var(--text-secondary);
 }
 
@@ -1675,13 +1681,8 @@
   to { background-position: -200% 0; }
 }
 
-/* 무장한 세션의 칩만 apex 테두리를 얻는다.
-   [doctrine] apex를 중립 토큰과 섞을 때는 oklab이다 — oklch는 두 hue 사이 짧은 호를 지나므로,
-   라이트 테마(hairline hue 100)에서 apex(295)와의 혼합이 coral(신호 채널)을 관통한다. */
-.agent-chat-coord.is-ultracode {
-  border-color: color-mix(in oklab, var(--apex) 48%, var(--hairline-strong));
-}
-
+/* ultracode는 배지 외곽선 대신 별과 강도 글자만 apex를 얻는다. 좌표 전체를 다시 두르면
+   배지를 걷어 낸 뜻이 사라지고, 모델명까지 티어 신호로 오염된다. */
 .agent-chat-coord.is-ultracode .agent-chat-coord-mark {
   color: var(--apex-ink);
 }
@@ -1702,10 +1703,9 @@
   height: 100%;
 }
 
-/* 칩 줄은 본문 위에 떠 있고 폭을 스스로 늘린다 — 좌표 칩까지 서면 최소 폭(320px) 패널에서
-   줄이 패널 왼쪽 밖으로 나간다(실측: 340px 줄 vs 296px 여유). 그때 물러나는 것은 좌표 칩이다:
-   같은 사실을 로그 첫 줄의 태생 기록이 이미 말하고 있고, 그 줄은 폭을 다투지 않는다.
-   가르는 것은 뷰포트가 아니라 이 패널의 폭이다 — 넓은 창 안에서도 패널은 얼마든지 좁아진다. */
+/* 남는 폭은 모델명이 줄임표로 접는다. 좌표는 태생 기록 퇴역 뒤 유일한 실행 좌표이므로 좁은
+   패널에서도 물러나지 않는다. 가르는 것은 뷰포트가 아니라 이 패널의 폭이다 — 넓은 창 안에서도
+   패널은 얼마든지 좁아진다. */
 @container (max-width: 600px) {
   .agent-chat-composer-hint .is-optional {
     display: none;
@@ -1713,8 +1713,7 @@
 }
 
 @container (max-width: 470px) {
-  .agent-chat-composer-hint,
-  .agent-chat-coord {
+  .agent-chat-composer-hint {
     display: none;
   }
 

--- a/runtime/fleet-plugins/terminal/client/agent/chat/composer.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/composer.tsx
@@ -52,7 +52,7 @@ import { discardLaunchAttachment, messageAgentSession, uploadLaunchAttachment } 
  *
  * 전송은 Quick Launch 멘션 전달과 같은 경로(`messageAgentSession`)라 서버 계약 변경이 없다.
  * 모델·강도는 컨트롤이 아니라 사실 표시다 — 좌표를 바꾸는 길은 새 세션을 여는 것뿐이라
- * 이 바에 선 칩과 계기는 읽히기만 한다.
+ * 이 바에 직접 새긴 좌표와 계기는 읽히기만 한다.
  */
 
 interface ComposerDraftAttachment {
@@ -96,7 +96,7 @@ export function AgentChatComposer({
   onCancelQueued,
 }: {
   readonly context: OperationRenderContext;
-  /** 세션 좌표의 사실 표시 — 모델·강도 배지가 컨트롤 행 좌측에 앉는다. */
+  /** 세션 좌표의 사실 표시 — 모델·강도가 별도 배지 없이 컨트롤 행 좌측에 직접 앉는다. */
   readonly coordinate: React.ReactNode;
   /**
    * 문맥 미터 — 읽는 계기이지 컨트롤이 아니다. 발사 버튼 바로 왼쪽에 앉아, 보내기 직전에

--- a/runtime/fleet-plugins/terminal/client/agent/chat/session-coordinates.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/session-coordinates.ts
@@ -29,12 +29,6 @@ const NATIVE_MODEL_LABELS: Readonly<Record<string, string>> = {
   sonnet: "Sonnet",
 };
 
-/**
- * 강도 사다리 — 낮은 쪽부터. 이 순서가 곧 계기의 축이다: 모델마다 내놓는 단이 달라도 어휘 전체는
- * 하나이고, "이 세션이 축의 어디쯤인가"는 그 하나의 어휘 위에서만 참이 된다.
- */
-export const CHAT_EFFORT_RUNGS = ["low", "medium", "high", "xhigh", "max", "ultra"] as const;
-
 const EFFORT_LABELS: Readonly<Record<string, string>> = {
   low: "LOW",
   medium: "MED",
@@ -68,7 +62,7 @@ function modelLabel(model: string): string {
   const named = NATIVE_MODEL_LABELS[model];
   if (named) return named;
   const bare = model.startsWith(GATEWAY_MODEL_PREFIX) ? model.slice(GATEWAY_MODEL_PREFIX.length) : model;
-  // 게이트웨이 id는 `<provider>--<model>` 범위형이다. 칩은 한 줄이므로 모델 쪽만 남긴다.
+  // 게이트웨이 id는 `<provider>--<model>` 범위형이다. 각인은 한 줄이므로 모델 쪽만 남긴다.
   const separator = bare.lastIndexOf("--");
   return separator < 0 ? bare : bare.slice(separator + 2);
 }


### PR DESCRIPTION
## Summary
- remove the badge surface around Chat session model and effort coordinates
- keep provider and effort marks integrated in the composer tool row
- preserve coordinates in narrow panels while truncating long model labels safely

## Test Plan
- [x] Run the Chat session coordinate and instrument design contract tests
- [x] Run the Terminal plugin typecheck
- [x] Build the Fleet Console production bundle
- [x] Verify the changed UI in an isolated Console