### PR TITLE
fix(fleet-console): derive terminal transparency from the resolved field

### DIFF
--- a/.changelog.d/terminal-allow-transparency-derive.md
+++ b/.changelog.d/terminal-allow-transparency-derive.md
@@ -1,0 +1,8 @@
+---
+branch: terminal-allow-transparency-derive
+---
+
+### fleet-console
+#### Fixed
+- Terminal and agent panel text reads crisply again in the light theme. The terminal now takes its transparent drawing path only when its field is genuinely translucent, so an opaque light field keeps the full stroke weight it had before the liquid glass material arrived.
+  ko: 라이트 테마에서 터미널과 에이전트 패널 글자가 다시 또렷하게 읽힙니다. 이제 필드가 실제로 반투명할 때만 투명 드로잉 경로를 타므로, 불투명한 라이트 필드는 리퀴드 글래스 도입 이전의 획 굵기를 그대로 유지합니다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1984,8 +1984,21 @@ describe("Instrument core design contract", () => {
     // xterm은 CSS 변수를 못 받으므로 계산값을 읽어 넘긴다 — 이 경로가 사라지면 터미널 필드가
     // 토큰과 갈라져 캡션 이음새가 되살아난다.
     expect(surface).toContain('getComputedStyle(document.documentElement).getPropertyValue("--glass-tint-terminal")');
-    expect(fs.readFileSync(fileURLToPath(new URL("../../fleet-plugins/terminal/client/shared/terminal-options.ts", import.meta.url)), "utf8")).toContain("allowTransparency: true");
     expect(surface).toContain("...base, background: resolvePanelSurface(");
+
+    // allowTransparency는 상수가 아니라 해석된 배경의 알파에서 파생된다 — 상수 true는 불투명
+    // 필드(라이트 종이·게이트 닫힘)에서도 글리프를 투명 위에 그려 GPU가 감마 미보정 sRGB로
+    // 재합성하게 만들고, 획 잉크가 18.2% 사라진다(dpr=2 실측). 상수로 되돌리면 그 회귀가 재발한다.
+    const options = fs.readFileSync(fileURLToPath(new URL("../../fleet-plugins/terminal/client/shared/terminal-options.ts", import.meta.url)), "utf8");
+    expect(options).not.toMatch(/^\s*allowTransparency:/m);
+    expect(surface).toContain("allowTransparency: terminalFieldIsTranslucent(terminalTheme.background ?? \"\")");
+    expect(surface).toContain("terminal.options.allowTransparency = terminalFieldIsTranslucent(terminalTheme.background ?? \"\")");
+    // 뷰포트 인라인 배경이 먼저다 — 순서가 뒤집히면 xterm의 :not(.allow-transparency) 규칙이
+    // background-color:#000을 한 프레임 드러낸다.
+    const applyBlock = surface.slice(surface.indexOf("const applyTerminalTheme = () => {"));
+    expect(applyBlock.indexOf("syncTerminalViewportBackground(container, terminalTheme)")).toBeLessThan(
+      applyBlock.indexOf("terminal.options.allowTransparency ="),
+    );
 
     // ITheme의 background 리터럴은 토큰을 못 읽는 환경의 폴백일 뿐이다 — 테마별로 theme.css의
     // --surface-panel과 같은 값이어야 폴백이 다른 면을 그리지 않는다.

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-options.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-options.ts
@@ -20,9 +20,9 @@ export const TERMINAL_OPTIONS = {
   // Unicode11Addon은 terminal.unicode(proposed API)를 사용하므로 이 옵션이 true여야 한다.
   // false이면 addon.activate()가 "must set allowProposedApi" 오류를 던져 터미널 마운트가 깨진다.
   allowProposedApi: true,
-  // 리퀴드 글래스: 터미널 배경이 반투명 틴트일 수 있다 — 알파를 캔버스가 실제로 그리려면
-  // 이 옵션이 켜져 있어야 한다. 게이트가 닫힌 불투명 배경에서는 시각 차이가 없다.
-  allowTransparency: true,
+  // allowTransparency는 여기에 없다 — 해석된 배경의 알파에서 파생시켜야 하며
+  // terminal-surface의 terminalFieldIsTranslucent()가 그 단일 판정을 소유한다.
+  // 상수 true는 불투명 배경에서도 글리프 래스터 경로를 바꿔 획을 갉아먹는다(아래).
   // PTY 기반 TUI(nvim 등)는 raw LF와 cursor 제어 시퀀스를 직접 관리한다.
   // LF를 CRLF로 변환하면 alternate screen에서 열 위치가 틀어져 화면이 깨질 수 있다.
   convertEol: false,

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -311,6 +311,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         fontFamily: terminalFontSettings.family,
         fontSize: terminalFontSettings.size * appliedZoom * touchFontScaleRef.current,
         theme: terminalTheme,
+        allowTransparency: terminalFieldIsTranslucent(terminalTheme.background ?? ""),
         minimumContrastRatio: terminalContrastFloorFor(activeTheme),
       });
       terminalRef.current = terminal;
@@ -612,9 +613,13 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
     if (!terminal || !container) return;
     const applyTerminalTheme = () => {
       const terminalTheme = terminalThemeFor(activeTheme);
+      // 뷰포트 인라인 배경이 allowTransparency보다 먼저 자리를 잡아야 한다 — 이 옵션이 꺼지면
+      // xterm이 `.xterm:not(.allow-transparency)` 클래스를 떼고, 그 규칙의 background-color:#000이
+      // 인라인 값 없이 드러난다. 두 줄의 순서가 곧 그 검은 프레임을 막는 계약이다.
+      syncTerminalViewportBackground(container, terminalTheme);
+      terminal.options.allowTransparency = terminalFieldIsTranslucent(terminalTheme.background ?? "");
       terminal.options.theme = terminalTheme;
       terminal.options.minimumContrastRatio = terminalContrastFloorFor(activeTheme);
-      syncTerminalViewportBackground(container, terminalTheme);
     };
     applyTerminalTheme();
     // liquidGlassPane 의존이 곧 리로드 없는 즉시 전환이다 — 설정 토글이 data-glass 속성을
@@ -777,6 +782,27 @@ function normalizeCssColorToRgba(color: string): string | null {
   } catch {
     return color;
   }
+}
+
+/* xterm의 allowTransparency는 "필드가 실제로 반투명한가" 하나에서만 파생된다 — 테마도
+   게이트도 여기서 다시 판정하지 않고, resolvePanelSurface가 이미 정한 배경의 알파를 읽는다.
+
+   상수 true로 두면 안 된다. 이 옵션은 투명도 지원 여부가 아니라 글리프 래스터 경로를 고른다:
+   false면 TextureAtlas의 임시 캔버스가 {alpha:false}라 배경을 아는 상태에서 감마 보정된 텍스트가
+   구워지고, clearColor()가 배경과 일치하는 픽셀만 비워 AA 경계까지 알파 255의 사전합성 RGB로
+   아틀라스에 남는다(GPU는 복사만 한다). true면 글리프가 투명 위에 선형 커버리지 알파로만 그려지고
+   GlyphRenderer가 sRGB 바이트 공간에서 다시 합성한다 — 감마 미보정 lerp는 밝은 바탕 위 어두운
+   잉크의 커버리지를 과소 표현한다. 라이트(불투명 종이) 터미널에서 획 잉크가 18.2% 사라지고
+   가장자리가 거칠어지는 것이 dpr=2 실측으로 확인됐다(다크는 반대 부호로 +2.6%라 드러나지 않았다).
+   즉 불투명 배경에서 true는 이득이 없고 비용만 있다. */
+export function terminalFieldIsTranslucent(background: string): boolean {
+  const channels = /^rgba?\(([^)]+)\)$/i.exec(background.trim())?.[1]?.split(",");
+  // rgba()가 아니면 resolvePanelSurface가 정규화를 못 한 환경이다(ITheme 폴백, 또는 canvas 프로브
+  // 부재로 되돌아온 원문 oklch). 둘 다 xterm 자신도 알파를 파싱하지 못하는 환경이므로 불투명으로
+  // 읽는다. 알파가 실제로 필요한 유일한 경로(다크+게이트 열림)는 프로브를 거치지 않는
+  // "rgba(0, 0, 0, 0)" 리터럴이라 여기서 항상 검출된다.
+  if (!channels) return false;
+  return channels.length > 3 && Number.parseFloat(channels[3] ?? "1") < 1;
 }
 
 /* 게이트가 열려 있을 때만 backdrop 채널이 none이 아니다 — 세 게이트(설정·@supports·

--- a/runtime/fleet-plugins/terminal/tests/terminal-field-translucency.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-field-translucency.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@xterm/xterm", () => ({ Terminal: class Terminal {} }));
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class FitAddon {} }));
+vi.mock("@xterm/addon-unicode11", () => ({ Unicode11Addon: class Unicode11Addon {} }));
+vi.mock("@xterm/addon-webgl", () => ({ WebglAddon: class WebglAddon {} }));
+
+import { resolvePanelSurface, terminalFieldIsTranslucent } from "../client/shared/terminal-surface.js";
+
+/* 유리 게이트를 CSS 채널 계산값으로만 연다 — 제품과 같은 판정 경로를 타야 의미가 있다. */
+const openGlassGate = () => document.documentElement.style.setProperty("--glass-backdrop-strong", "blur(24px) saturate(1.7)");
+const closeGlassGate = () => document.documentElement.style.setProperty("--glass-backdrop-strong", "none");
+const setTerminalTint = (value: string) => document.documentElement.style.setProperty("--glass-tint-terminal", value);
+
+afterEach(() => {
+  document.documentElement.style.removeProperty("--glass-backdrop-strong");
+  document.documentElement.style.removeProperty("--glass-tint-terminal");
+});
+
+describe("terminalFieldIsTranslucent", () => {
+  it("reads the alpha channel of a normalized rgba() field", () => {
+    expect(terminalFieldIsTranslucent("rgba(0, 0, 0, 0)")).toBe(true);
+    expect(terminalFieldIsTranslucent("rgba(17, 24, 33, 0.620)")).toBe(true);
+    expect(terminalFieldIsTranslucent("rgba(250, 249, 246, 1.000)")).toBe(false);
+    expect(terminalFieldIsTranslucent("rgb(9, 15, 21)")).toBe(false);
+  });
+
+  /* 알파를 못 읽는 환경은 불투명으로 읽어야 한다 — 그 환경의 xterm도 알파를 파싱하지 못하므로,
+     투명으로 넘기면 글리프만 감마 미보정 경로로 보내고 얻는 것이 없다. */
+  it("treats an unresolvable color as opaque", () => {
+    expect(terminalFieldIsTranslucent("oklch(98.2% 0.004 100)")).toBe(false);
+    expect(terminalFieldIsTranslucent("oklch(13% .015 245 / 62%)")).toBe(false);
+    expect(terminalFieldIsTranslucent("")).toBe(false);
+  });
+});
+
+describe("resolved terminal field drives allowTransparency", () => {
+  /* 알파가 실제로 필요한 유일한 조합이다 — 여기서만 xterm이 투명 위에 글리프를 그려야
+     컨테이너의 유리 틴트 한 겹이 그대로 비친다. */
+  it("keeps the dark field translucent while the glass gate is open", () => {
+    openGlassGate();
+    setTerminalTint("rgb(17, 24, 33)");
+    expect(terminalFieldIsTranslucent(resolvePanelSurface("instrument", "oklch(16.5% 0.016 245)"))).toBe(true);
+  });
+
+  /* 라이트 필드는 유리가 켜져 있어도 불투명 종이다(--glass-on-tint-terminal에 알파가 없다).
+     여기서 allowTransparency가 켜지면 라이트 터미널 글자가 얇아지는 회귀가 재발한다. */
+  it("keeps the light field opaque even while the glass gate is open", () => {
+    openGlassGate();
+    setTerminalTint("rgb(250, 249, 246)");
+    expect(terminalFieldIsTranslucent(resolvePanelSurface("whites", "oklch(98.2% 0.004 100)"))).toBe(false);
+  });
+
+  it("keeps every field opaque once the glass gate is closed", () => {
+    closeGlassGate();
+    setTerminalTint("rgb(9, 15, 21)");
+    expect(terminalFieldIsTranslucent(resolvePanelSurface("instrument", "oklch(16.5% 0.016 245)"))).toBe(false);
+    setTerminalTint("rgb(250, 249, 246)");
+    expect(terminalFieldIsTranslucent(resolvePanelSurface("whites", "oklch(98.2% 0.004 100)"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- 리퀴드 글래스 작업(#888)이 모든 터미널에 상수 `allowTransparency: true`를 준 것이 라이트 테마 글자가 얇고 거칠어 보이는 회귀의 원인이었습니다. 이 옵션은 투명도 지원 여부가 아니라 **글리프 래스터 경로**를 고릅니다 — 꺼져 있으면 xterm이 불투명 임시 캔버스에 실제 배경 위로 글리프를 굽고 `clearColor()`가 배경 일치 픽셀만 비워, AA 경계까지 알파 255의 사전합성 RGB로 아틀라스에 남습니다(GPU는 복사만). 켜져 있으면 투명 위에 선형 커버리지 알파로만 그려지고 `GlyphRenderer`가 sRGB 바이트 공간에서 재합성하는데, 감마 미보정 lerp는 밝은 바탕 위 어두운 잉크의 커버리지를 과소 표현합니다.
- 라이트 필드는 설계상 불투명(`--glass-on-tint-terminal` 라이트만 알파 없음)이라 상수가 이득 없이 비용만 냈습니다 — dpr=2 실측으로 **획 잉크 18.2% 손실**(종이 249.0 기준 평균 휘도차 4.21). 다크는 반대 부호로 +2.6%라 드러나지 않았습니다.
- `resolvePanelSurface()`가 이미 해석하는 배경의 **알파에서 파생**시켜, 알파가 실제로 필요한 한 경우(다크 + 유리 게이트 열림, `rgba(0, 0, 0, 0)`)만 켜지고 불투명 필드에서는 꺼지게 했습니다. 뷰포트 인라인 배경을 옵션보다 먼저 써서 xterm의 `:not(.allow-transparency)` 규칙이 `background-color: #000`을 한 프레임도 드러내지 못하도록 순서를 계약으로 고정했습니다.

## Test Plan

- [x] `pnpm typecheck` — 전 워크스페이스 통과
- [x] `pnpm test` — fleet-console 2,368 / terminal 1,000 / desktop 302 등 전체 통과
- [x] 신규 `terminal-field-translucency.test.ts` — 알파 파생 판정과 네 상태(테마 x 게이트) 조합
- [x] `instrument-design-contract.test.ts` 갱신 — 상수 금지 + 파생 사용 + 뷰포트 배경 선행 순서 계약
- [x] `node scripts/compile-changelog-fragments.mjs --check` — fragment 1건 검증
- [x] E2E(dpr=2, agent-browser + CDP): 네 상태의 파생값·`.xterm` 클래스·뷰포트 실색·아틀라스 부분알파 실측. 다크+유리ON은 `true` 유지(변화 없음), 나머지는 `false`, 뷰포트가 `#000`으로 떨어지는 경우 없음
- [x] E2E 픽셀 회귀: 전체 뷰포트 diff에서 바뀐 11,390픽셀이 **전부 터미널 글자 필드 안**, 유리 크롬 차이 **0픽셀**(양쪽 바닥값 0 확인)
- [x] E2E PTY: cols x rows 66x21 유지, `onResize` 0건, WebSocket·버퍼 보존, 전환 후 `tput cols`/`tput lines` 정상 응답