### PR TITLE
style: conform console overlays and desktop entry to design charter

### DIFF
--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2780,7 +2780,7 @@
 /* War Room의 메뉴는 이 모드의 층 위에 서야 한다 — 덱(80)과 레일(90)이 같은 스태킹 문맥에서 위에
    있으면 메뉴가 보여도 항목의 클릭을 덱 카드가 먼저 받는다. Cruise의 30은 그대로 둔다. */
 .operation-launch-control--triage {
-  z-index: 100;
+  z-index: var(--z-overlay);
 }
 
 .workspace-add-button {
@@ -3051,7 +3051,7 @@
 .canvas-mode-curtain {
   position: absolute;
   inset: 0;
-  z-index: 110;
+  z-index: var(--z-curtain);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -8835,6 +8835,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   align-content: center;
   gap: var(--space-3);
   min-height: calc(100vh - 140px);
+  min-height: calc(100dvh - 140px);
   padding: var(--space-10);
   color: var(--text-tertiary);
 }
@@ -10460,6 +10461,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
   .commissioning-card {
     max-height: calc(100vh - (var(--space-3) * 2));
+    max-height: calc(100dvh - (var(--space-3) * 2));
     padding: var(--space-4);
   }
 
@@ -11544,6 +11546,7 @@ body[data-codex-side="true"] .command-card {
   .whatsnew-card {
     width: 100%;
     max-height: calc(100vh - 24px);
+    max-height: calc(100dvh - 24px);
     border-radius: var(--radius-md);
   }
 
@@ -12122,7 +12125,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
 .command-band-github-version { margin-left: auto; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); white-space: nowrap; }
 
 .keyboard-shortcuts-scrim { position: fixed; inset: 0; z-index: 80; display: grid; place-items: center; background: color-mix(in oklch, var(--ink-abyss) 64%, transparent); }
-.keyboard-shortcuts-dialog { width: min(520px, calc(100vw - 48px)); max-height: min(680px, calc(100vh - 64px)); overflow: auto; padding: 12px; border: 1px solid var(--surface-rim-strong); border-radius: var(--radius-md); background: linear-gradient(var(--glass-tint-deep), var(--glass-tint-deep)), var(--glass-underlay); -webkit-backdrop-filter: var(--glass-backdrop-strong); backdrop-filter: var(--glass-backdrop-strong); box-shadow: var(--shadow-floating); outline: none; }
+.keyboard-shortcuts-dialog { width: min(520px, calc(100vw - 48px)); max-height: min(680px, calc(100vh - 64px)); max-height: min(680px, calc(100dvh - 64px)); overflow: auto; padding: 12px; border: 1px solid var(--surface-rim-strong); border-radius: var(--radius-md); background: linear-gradient(var(--glass-tint-deep), var(--glass-tint-deep)), var(--glass-underlay); -webkit-backdrop-filter: var(--glass-backdrop-strong); backdrop-filter: var(--glass-backdrop-strong); box-shadow: var(--shadow-floating); outline: none; }
 .keyboard-shortcuts-dialog-head { display: flex; align-items: center; justify-content: space-between; padding: 2px 4px 10px; color: var(--text-primary); }
 .keyboard-shortcuts-dialog-head button { width: 24px; height: 24px; border-radius: var(--radius-xs); color: var(--text-tertiary); }
 .keyboard-shortcuts-dialog-head button:hover { background: var(--surface-glass); color: var(--text-primary); }
@@ -12222,7 +12225,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
 .feature-tour-layer {
   position: fixed;
   inset: 0;
-  z-index: 120;
+  z-index: var(--z-tour);
   pointer-events: none;
 }
 
@@ -13770,7 +13773,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
 .control-reclaimed-notice {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: var(--z-overlay);
   display: grid;
   place-items: center;
   padding: clamp(var(--space-4), 5vw, var(--space-8));

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -78,9 +78,9 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
 .update-curtain {
   position: fixed;
   inset: 0;
-  /* 이 콘솔이 지금 사라지는 중이라는 것보다 급한 화면은 없다 — 온보딩 투어(120)와 모드
+  /* 이 콘솔이 지금 사라지는 중이라는 것보다 급한 화면은 없다 — 온보딩 투어(--z-tour)와 모드
      커튼까지 덮는다. 그 위로 무언가를 누를 수 있게 두면, 곧 없어질 콘솔로 손을 부른다. */
-  z-index: 130;
+  z-index: var(--z-teardown);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -298,6 +298,17 @@
 
   --chrome-band-height: 44px;
 
+  /* 전면 오버레이 층 사다리 — 값이 아니라 순서가 계약이다: 공지·모달(overlay) < 라이트박스 <
+     모드 커튼 < 온보딩 투어 < teardown(사라지는 콘솔보다 급한 화면은 없다). 번들이 달라도
+     같은 사다리를 소비해야 임의의 큰 수가 teardown 위로 올라서는 역전이 재발하지 않는다.
+     국소 스태킹(패널 내부 0~95)과 스코프 토큰(--z-rail·--z-select-popover 등)은 이 사다리
+     밖의 자기 계약이고, 코덱스 리딩 시트의 극단값은 별도 독트린 예외다. */
+  --z-overlay: 100;
+  --z-lightbox: 104;
+  --z-curtain: 110;
+  --z-tour: 120;
+  --z-teardown: 130;
+
   --ease-spring: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-glide: cubic-bezier(0.4, 0.14, 0.2, 1);
   --duration-fast: 140ms;

--- a/runtime/fleet-console/markdown/styles.css
+++ b/runtime/fleet-console/markdown/styles.css
@@ -667,7 +667,9 @@ code.hljs {
 .diagram-lightbox {
   position: fixed;
   inset: 0;
-  /* 오버레이 사다리 소비 — 임의 1200은 커튼·투어·teardown 위로 올라서는 역전이었다. */
+  /* 오버레이 사다리 소비. 네이티브 <dialog>.showModal() 경로는 top layer에 서서 z-index의
+     지배 밖이므로(teardown 커튼과의 겹침은 별도 과제), 이 값은 dialog 미지원 폴백
+     (div[role=dialog]) 스태킹만 정한다 — 그 경로의 임의 1200은 teardown 위 역전이었다. */
   z-index: var(--z-lightbox);
   display: grid;
   place-items: center;

--- a/runtime/fleet-console/markdown/styles.css
+++ b/runtime/fleet-console/markdown/styles.css
@@ -667,7 +667,8 @@ code.hljs {
 .diagram-lightbox {
   position: fixed;
   inset: 0;
-  z-index: 1200;
+  /* 오버레이 사다리 소비 — 임의 1200은 커튼·투어·teardown 위로 올라서는 역전이었다. */
+  z-index: var(--z-lightbox);
   display: grid;
   place-items: center;
   width: 100vw;

--- a/runtime/fleet-desktop/assets/entry/entry.css
+++ b/runtime/fleet-desktop/assets/entry/entry.css
@@ -1,3 +1,9 @@
+/* Passive entry surface — self-contained by contract (no Console CSS import, CSP blocks webfonts).
+   The mini palette below mirrors the current Instrument charter in theme.css; when the charter
+   moves, re-sync values here by hand. Channel rules apply as in the Console: signal tokens carry
+   state only (positive=complete, coral=danger, brass=location/progress), identity/environment
+   badges stay on neutral ink. Font stacks resolve to system fallbacks unless the faces are
+   installed locally — the Pretendard fallback keeps Korean glyph weight aligned when present. */
 :root {
   color-scheme: dark;
   --ink-abyss: oklch(13% 0.014 245);
@@ -9,15 +15,17 @@
   --ink-pearl: oklch(94% 0.008 90);
   --brass: oklch(80% 0.085 78);
   --brass-glow: oklch(80% 0.085 78 / 13%);
-  --aurora: oklch(77% 0.085 200);
+  --positive: oklch(76% 0.11 160);
   --coral: oklch(68% 0.13 25);
   --hairline: oklch(29% 0.018 245);
-  --radius-sm: 6px;
+  --radius-xs: 6px;
   --chrome-band-height: 44px;
-  --font-display: "Fraunces Variable", "Fraunces", ui-serif, Georgia, serif;
-  --font-body: "Manrope Variable", "Manrope", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-display: "Fraunces Variable", "Fraunces", "Pretendard Variable", ui-serif, Georgia, serif;
+  --font-body: "Manrope Variable", "Manrope", "Pretendard Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   --font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
   --ease-spring: cubic-bezier(0.16, 1, 0.3, 1);
+  --duration-base: 220ms;
+  --duration-slow: 360ms;
 }
 
 * { box-sizing: border-box; }
@@ -25,27 +33,28 @@ html, body { height: 100%; margin: 0; }
 body { display: grid; grid-template-rows: 44px 1fr auto; background: var(--ink-abyss); color: var(--ink-spectral); font-family: var(--font-body); }
 .chrome-band { height: var(--chrome-band-height); display: flex; align-items: center; padding: 0 16px; border-bottom: 1px solid var(--hairline); background: var(--ink-deep); -webkit-app-region: drag; }
 .brand { display: flex; align-items: baseline; gap: 8px; margin-left: 88px; }
-.brand strong { color: var(--ink-pearl); font-family: var(--font-display); font-size: 16px; font-weight: 580; }
-.brand span { color: var(--ink-fog); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .12em; text-transform: uppercase; }
-.dev-tag { display: none; margin-left: auto; color: var(--aurora); border: 1px solid color-mix(in oklab, var(--aurora) 45%, transparent); border-radius: 999px; background: color-mix(in oklab, var(--aurora) 13%, transparent); padding: 2px 10px; font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; }
+.brand strong { color: var(--ink-pearl); font-family: var(--font-display); font-size: 17px; font-weight: 600; }
+.brand span { color: var(--ink-fog); font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em; text-transform: uppercase; }
+/* 환경 배지는 정체성이지 상태가 아니다 — 신호색 없이 중립 잉크 칩으로 선다. */
+.dev-tag { display: none; margin-left: auto; color: var(--ink-spectral); border: 1px solid var(--ink-rim); border-radius: var(--radius-xs); background: none; padding: 2px 10px; font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; }
 .dev-tag.is-visible { display: inline-block; }
 .entry-body { display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 0; padding: 40px 24px 28px; }
 .boot-stack { width: min(480px, 100%); }
-.boot-step { display: grid; grid-template-columns: 22px 1fr auto; align-items: baseline; gap: 10px; padding: 9px 2px; opacity: .38; transition: opacity 300ms var(--ease-spring); }
+.boot-step { display: grid; grid-template-columns: 22px 1fr auto; align-items: baseline; gap: 10px; padding: 9px 2px; opacity: .38; transition: opacity var(--duration-slow) var(--ease-spring); }
 .boot-step.active, .boot-step.complete, .boot-step.warning, .boot-step.failed { opacity: 1; }
 .boot-dot { width: 9px; height: 9px; border: 1.5px solid var(--ink-rim); border-radius: 50%; align-self: center; justify-self: center; }
 .boot-step.active .boot-dot { border-color: var(--brass); box-shadow: 0 0 0 3px var(--brass-glow); }
-.boot-step.complete .boot-dot { border-color: var(--aurora); background: var(--aurora); }
+.boot-step.complete .boot-dot { border-color: var(--positive); background: var(--positive); }
 .boot-step.warning .boot-dot, .boot-step.failed .boot-dot { border-color: var(--coral); background: var(--coral); }
-.boot-name { color: var(--ink-pearl); font-size: 13.5px; }
-.boot-sub, .boot-result { display: block; margin-top: 1px; color: var(--ink-fog); font-family: var(--font-mono); font-size: 10.5px; }
-.boot-result { align-self: baseline; font-size: 11px; }
-.boot-step.complete .boot-result { color: var(--aurora); }
+.boot-name { color: var(--ink-pearl); font-size: 13px; }
+.boot-sub, .boot-result { display: block; margin-top: 1px; color: var(--ink-fog); font-family: var(--font-mono); font-size: 11px; }
+.boot-result { align-self: baseline; }
+.boot-step.complete .boot-result { color: var(--positive); }
 .boot-step.warning .boot-result, .boot-step.failed .boot-result { color: var(--coral); }
 .boot-bar { grid-column: 2 / 4; height: 3px; margin-top: 7px; overflow: hidden; border-radius: 2px; background: var(--ink-veil); }
-.boot-bar-fill { height: 100%; background: var(--brass); transition: width 240ms linear; }
-.handoff { margin: 20px 0 0; padding: 11px 14px; border: 1px dashed color-mix(in oklab, var(--aurora) 45%, transparent); border-radius: var(--radius-sm); color: var(--aurora); font-family: var(--font-mono); font-size: 11px; opacity: 0; transition: opacity 300ms; }
+.boot-bar-fill { height: 100%; background: var(--brass); transition: width var(--duration-base) linear; }
+.handoff { margin: 20px 0 0; padding: 11px 14px; border: 1px dashed color-mix(in oklab, var(--positive) 45%, transparent); border-radius: var(--radius-xs); color: var(--positive); font-family: var(--font-mono); font-size: 11px; opacity: 0; transition: opacity var(--duration-slow); }
 .handoff.is-visible { opacity: 1; }
-.entry-foot { display: flex; gap: 16px; padding: 10px 16px; border-top: 1px solid var(--hairline); background: var(--ink-deep); color: var(--ink-rim); font-family: var(--font-mono); font-size: 10.5px; }
+.entry-foot { display: flex; gap: 16px; padding: 10px 16px; border-top: 1px solid var(--hairline); background: var(--ink-deep); color: var(--ink-rim); font-family: var(--font-mono); font-size: 11px; }
 .entry-foot span:last-child { margin-left: auto; text-align: right; }
 @media (prefers-reduced-motion: reduce) { * { transition-duration: .01ms !important; } }

--- a/runtime/fleet-desktop/tests/package-boundary.test.ts
+++ b/runtime/fleet-desktop/tests/package-boundary.test.ts
@@ -31,7 +31,7 @@ describe("desktop package boundary", () => {
     expect(html).not.toMatch(/<(script|button|a|form|input)\b|contenteditable|tabindex/i);
     expect(html).not.toMatch(/https?:|runtime\/fleet-console/i);
     expect(css).toContain("--brass:");
-    expect(css).toContain("--aurora:");
+    expect(css).toContain("--positive:");
     expect(css).toContain("--coral:");
     expect(css).toContain("--chrome-band-height");
     expect(css).not.toMatch(/@import|url\(/i);

--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -173,7 +173,7 @@
   margin-left: -4px;
   padding: 0;
   border: 0;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   background: transparent;
   opacity: 0.35;

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -60,7 +60,7 @@
   width: 4px;
   cursor: col-resize;
   background: var(--surface-rim);
-  transition: background 140ms;
+  transition: background var(--duration-fast);
 }
 
 .repository-divider:hover {
@@ -104,7 +104,7 @@
   font-size: var(--t-sm);
   padding: 3px 8px;
   outline: none;
-  transition: border-color 140ms;
+  transition: border-color var(--duration-fast);
 }
 
 .repository-filter-input:focus,
@@ -169,8 +169,8 @@
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
-  border-radius: 6px;
-  transition: color 0.14s, background 0.14s;
+  border-radius: var(--radius-xs);
+  transition: color var(--duration-fast), background var(--duration-fast);
 }
 
 .repository-toggle-btn:hover {
@@ -709,7 +709,7 @@
   width: 4px;
   cursor: col-resize;
   background: var(--surface-rim);
-  transition: background 140ms;
+  transition: background var(--duration-fast);
 }
 
 .history-divider:hover {

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -325,7 +325,7 @@
 
 .scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) .scuttlebutt-qk-wing-l,
 .scuttlebutt-bird.is-alert .scuttlebutt-qk:not([data-morph="bori"]) .scuttlebutt-qk-wing-r {
-  animation-duration: 0.22s;
+  animation-duration: var(--duration-base);
 }
 
 .scuttlebutt-bird.is-alert .scuttlebutt-qk-mark {

--- a/runtime/fleet-plugins/skills/client/skills.css
+++ b/runtime/fleet-plugins/skills/client/skills.css
@@ -524,7 +524,8 @@
   inset: 0;
   justify-content: center;
   position: fixed;
-  z-index: 200;
+  /* 오버레이 사다리 소비 — 임의 200은 teardown(--z-teardown) 위로 올라서는 역전이었다. */
+  z-index: var(--z-overlay);
 }
 
 .skills-overlay-dialog {


### PR DESCRIPTION
## Summary
- `/redesign-existing-projects` 감사(아티팩트 재가분)의 승인 스펙 전체 인도: **P1** fleet-desktop entry 미니 팔레트를 현행 Instrument 헌장으로 재동기화 — complete 단계·handoff가 aurora(awaiting)가 아닌 positive(완료) 채널을 말하고, DEV 환경 배지는 신호색을 벗고 중립 잉크 칩이 되며, 타이포(하프픽셀 제거·580→600)·radius(`--radius-sm`→`--radius-xs`)·duration이 콘솔 사다리에 스냅되고, 폰트 스택에 Pretendard CJK 폴백이 붙습니다(자립 계약 유지 — 콘솔 CSS import 없음).
- **P2** ① theme.css base `:root`에 전면 오버레이 층 사다리 `--z-overlay/lightbox/curtain/tour/teardown` 신설, 코어(트리아지·커튼·투어·회수 공지·teardown)와 skills 모달(임의 200)·markdown 다이어그램 라이트박스(임의 1200)를 이관 — 두 임의 값이 teardown 커튼 위로 올라서던 층 역전을 함께 교정. ② 어휘 밖 radius 토큰화(quota 드래그 핸들 4px→xs, repository 토글 6px→xs). ③ 토큰 값과 일치하는 raw duration 치환(repository 140ms/0.14s→`--duration-fast`, scuttlebutt 0.22s→`--duration-base`). ④ 뷰포트 상한 오버레이 4곳에 `100dvh` 폴백 이중 선언.
- desktop package-boundary 계약을 새 entry 팔레트로 이동(`--aurora`→`--positive` 단언).

## Test Plan
- [x] `instrument-design-contract.test.ts` 78/78 green (오버레이 토큰은 base :root 정의로 custom-property 게이트 통과)
- [x] fleet-console 전체 테스트 2368 passed · typecheck · build green
- [x] 터치한 플러그인 자체 러너: quota 34 · repository 441 · scuttlebutt 145 · skills 125 green
- [x] fleet-desktop 테스트 302 green (package-boundary 계약 공갱신)
- [x] entry 표면 정적 하네스 헤디드 시각 검증 — complete=positive 초록, active=brass 링, warning=coral, DEV 배지 중립 칩, 재가 시안과 합치