### PR TITLE
fix(fleet-console): lift the dark liquid-glass terminal off the canvas

### DIFF
--- a/.changelog.d/dark-glass-terminal-surface.md
+++ b/.changelog.d/dark-glass-terminal-surface.md
@@ -1,0 +1,8 @@
+---
+branch: dark-glass-terminal-surface
+---
+
+### fleet-console
+#### Fixed
+- Liquid glass no longer sinks the terminal into the canvas on the dark themes: the pane now sits above the map with a light of its own, the panel caption is painted instead of showing raw canvas, and terminal black stays darker than the field it is drawn on.
+  ko: 리퀴드 글래스를 켜도 다크 테마의 터미널이 캔버스로 가라앉지 않습니다. 패널이 자체 광원을 얻어 지도 위로 떠오르고, 캡션은 캔버스가 비치는 대신 제대로 칠해지며, 터미널 검정이 필드보다 어둡게 유지됩니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4632,6 +4632,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-bottom-width: 0;
   border-bottom-style: none;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
+  /* companion 캡션은 .canvas-operation-titlebar가 아니라 그 기본 규칙의 fill 기본값이 닿지 않는다.
+     여기서 세워야 구조 규칙의 배경 목록이 값을 찾는다(워시 규칙은 companion을 겨누지 않는다). */
+  --caption-fill: var(--caption-base);
   background-clip: padding-box;
   color: var(--text-tertiary);
   cursor: default;
@@ -5938,8 +5941,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
    캡션·본문 이음새(창 한가운데)에 그어진다(실측 y=95, L21.9). */
 .canvas-operation:not(.is-deck-tile):not(.is-top-edge) > .canvas-operation-titlebar,
 .canvas-operation > .canvas-companion-caption {
+  /* 이 규칙은 base만 소유한다 — fill까지 세우면 (0,4,0)이 셸 아우로라 틴트(0,2,0)와
+     포커스 brass 워시(0,3,0)를 특이도로 눌러 떠 있는 캡션에서 두 신호가 통째로 사라진다. */
   --caption-base: var(--glass-tint-panel);
-  --caption-fill: var(--caption-base);
   background:
     linear-gradient(var(--caption-fill), var(--caption-fill)),
     radial-gradient(150% 420px at 50% -12px, var(--glass-pane-light) 0%, transparent 62%),

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2922,7 +2922,7 @@
 
 .operations-canvas.is-formation-view {
   background:
-    radial-gradient(100% 80% at 50% 42%, var(--canvas-sea-core), var(--canvas-sea-mid) 78%),
+    radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-sea-mid) 78%),
     var(--canvas-abyss);
   cursor: default;
 }
@@ -2946,7 +2946,7 @@
 
 .operations-canvas-sea {
   background:
-    radial-gradient(ellipse at 48% 42%, color-mix(in oklch, var(--canvas-sea-core) 82%, transparent), transparent 38%),
+    radial-gradient(ellipse at 48% 42%, color-mix(in oklch, var(--canvas-ambience) 82%, transparent), transparent 38%),
     radial-gradient(circle at 18% 18%, color-mix(in oklch, var(--aurora) 7%, transparent), transparent 34%),
     radial-gradient(circle at 84% 76%, color-mix(in oklch, var(--brass) 5%, transparent), transparent 36%),
     linear-gradient(145deg, var(--canvas-sea-near), var(--canvas-sea-mid) 58%, var(--canvas-sea-far));
@@ -3701,9 +3701,7 @@
    .canvas-operation.is-active > .canvas-operation-titlebar와 같은 한 값이다. */
 .canvas-triage-deck-cell:hover .canvas-operation.is-deck-tile > .canvas-operation-titlebar,
 .canvas-triage-deck-cell:has(> .canvas-triage-deck-pick:focus-visible) .canvas-operation.is-deck-tile > .canvas-operation-titlebar {
-  background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-panel-face));
-  /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
-  background-clip: padding-box;
+  --caption-fill: color-mix(in oklab, var(--brass) 10%, var(--caption-base));
 }
 
 /* 지도 모드의 Quick-Look — 은닉된 밴드 안의 칸을 판 위로 끌어올려 점 옆에 세운다. 좌표는
@@ -3938,12 +3936,11 @@
 }
 
 /* 순정 셸 패널 — Operation과 구별되도록 띠바에 아우로라(살아있는 것) 톤의 옅은 강조를 준다.
-   포커스·정체성 워시와 같은 문법이다: 패널 면 위에 얹는 틴트이지 다른 면이 아니므로
-   베이스는 반드시 --surface-panel이다(반투명 잉크 티어를 깔면 셸 패널만 이음새가 되살아난다).
-   background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
+   포커스·정체성 워시와 같은 문법이다: 캡션 면 위에 얹는 틴트이지 다른 면이 아니므로
+   베이스는 반드시 그 캡션이 앉은 면(--caption-base)이다 — 반투명 잉크 티어를 깔면 셸 패널만
+   이음새가 되살아난다. 채움만 바꾸고 배경 목록·clip·광원 층은 구조 규칙이 그대로 소유한다. */
 .canvas-operation--shell .canvas-operation-titlebar {
-  background: color-mix(in oklch, var(--aurora) 9%, var(--glass-tint-panel-face));
-  background-clip: padding-box;
+  --caption-fill: color-mix(in oklch, var(--aurora) 9%, var(--caption-base));
 }
 
 .canvas-context-menu {
@@ -4362,9 +4359,16 @@
   border: 1px solid var(--surface-rim);
   /* 상단 모서리는 캡션이 잇는다 — 본문이 따로 둥글면 두 개의 창처럼 읽힌다. */
   border-radius: 0 0 var(--radius-md) var(--radius-md);
-  /* 패널의 유일한 면 — 루트가 panel 유리 틴트를 칠하고, 캡션·본문 팬은 panel-face(게이트
-     열림 시 transparent)를 칠해 유리 한 장으로 읽힌다. xterm 필드만 원 토큰의 불투명을 지킨다. */
-  background: var(--glass-tint-panel);
+  /* 패널의 유일한 면 — 루트가 panel 유리 틴트를 칠하고, 박스 안의 본문 팬은 panel-face(게이트
+     열림 시 transparent)를 칠해 유리 한 장으로 읽힌다. 틴트 아래의 pane-light는 창 위쪽에 놓인
+     광원 한 겹이다: 유리 뒤가 캔버스(앱에서 가장 어두운 면)라 blur가 굴절시킬 빛이 없으므로,
+     재질은 명도가 아니라 이 기울기가 말한다. 게이트가 닫히면 pane-light는 none, 틴트는 불투명
+     --surface-panel이라 목록 전체가 오늘의 한 겹으로 축약된다. */
+  --pane-light-origin: -12px;
+  background:
+    linear-gradient(var(--glass-tint-panel), var(--glass-tint-panel)),
+    radial-gradient(150% 420px at 50% var(--pane-light-origin), var(--glass-pane-light) 0%, transparent 62%),
+    var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-panel);
   backdrop-filter: var(--glass-backdrop-panel);
   box-shadow: inset 0 1px 0 var(--glass-rim), var(--shadow-soft);
@@ -4628,7 +4632,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-bottom-width: 0;
   border-bottom-style: none;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
-  background: var(--glass-tint-panel-face);
   background-clip: padding-box;
   color: var(--text-tertiary);
   cursor: default;
@@ -5899,7 +5902,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-bottom-style: none;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
   overflow: visible;
-  background: var(--glass-tint-panel-face);
+  /* 캡션 채움은 두 단계다 — base는 이 캡션이 어느 면에 앉아 있는지(루트 유리 안/밖)를,
+     fill은 그 위에 상태·정체가 얹는 워시를 말한다. 워시 규칙은 fill만 바꾸고 background는
+     건드리지 않는다 — 배경 목록을 규칙마다 다시 적으면 clip과 광원 층이 매번 새로 리셋된다. */
+  --caption-base: var(--glass-tint-panel-face);
+  --caption-fill: var(--caption-base);
+  background: var(--caption-fill);
   background-clip: padding-box;
   cursor: grab;
   touch-action: none;
@@ -5918,6 +5926,37 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .canvas-operation:has(> .canvas-operation-titlebar) {
   border-top-width: 0;
   border-top-style: none;
+}
+
+/* 떠 있는 캡션(Cruise·Tactical·War Room·최대화)은 top:-32px로 루트 박스 **밖**에 선다 — 루트의
+   유리도 backdrop도 거기까지 오지 않으므로, 게이트가 panel-face를 transparent로 바꾸는 순간
+   캡션 뒤에는 아무 층도 남지 않았다(실측: 캡션이 캔버스와 0.1~1.1 L 차 = 무도장). 그래서 이
+   캡션만 루트와 같은 유리 한 겹을 자기가 든다. 흐름 안으로 들어오는 덱 타일 캡션과 본문 위로
+   접히는 상단 캡션(is-top-edge)은 루트 박스 안이라 그대로 루트 유리를 받는다 — 여기서 자기
+   틴트를 들면 이중 알파가 된다.
+   상단 하이라이트도 함께 옮긴다: 창의 꼭대기는 이 캡션이고, 루트에 남겨 두면 하이라이트가
+   캡션·본문 이음새(창 한가운데)에 그어진다(실측 y=95, L21.9). */
+.canvas-operation:not(.is-deck-tile):not(.is-top-edge) > .canvas-operation-titlebar,
+.canvas-operation > .canvas-companion-caption {
+  --caption-base: var(--glass-tint-panel);
+  --caption-fill: var(--caption-base);
+  background:
+    linear-gradient(var(--caption-fill), var(--caption-fill)),
+    radial-gradient(150% 420px at 50% -12px, var(--glass-pane-light) 0%, transparent 62%),
+    var(--glass-underlay);
+  background-clip: padding-box;
+  -webkit-backdrop-filter: var(--glass-backdrop-panel);
+  backdrop-filter: var(--glass-backdrop-panel);
+  box-shadow: inset 0 1px 0 var(--glass-rim);
+}
+
+.canvas-operation:not(.is-deck-tile):not(.is-top-edge):has(> .canvas-operation-titlebar),
+.canvas-operation:has(> .canvas-companion-caption) {
+  /* 광원 원점을 캡션 높이(32px)만큼 위로 민다 — 캡션과 본문은 서로 다른 박스지만 같은 절대 좌표의
+     광원 한 줄기를 나눠 샘플링해야 한 장으로 이어진다. 각자 자기 박스 기준으로 그리면 캡션에서
+     한 번, 본문에서 다시 한 번 밝아져 이음새에 어두운 띠가 생긴다. */
+  --pane-light-origin: -44px;
+  box-shadow: var(--shadow-soft-drop);
 }
 
 /* 덱 타일만 그 면제에서 빠진다 — 카드뷰 캡션은 흐름 안으로 들어오며 자기 보더를 내려놓으므로
@@ -5939,9 +5978,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
    워시는 캡션만 진다. 채팅·터미널 본문은 --surface-panel에 남아, 포커스가 로그 전체를
    다른 면으로 다시 칠하지 않는다. */
 .canvas-operation.is-active > .canvas-operation-titlebar {
-  background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-panel-face));
-  /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
-  background-clip: padding-box;
+  --caption-fill: color-mix(in oklab, var(--brass) 10%, var(--caption-base));
 }
 
 .canvas-operation.is-active > .canvas-operation-titlebar .canvas-operation-identity-name {
@@ -6746,8 +6783,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   border-radius: 0 0 calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px);
   /* terminal-shell의 8px 패딩이 xterm 뷰포트를 사방에서 감싸므로 이 면은 실제로 보이는 띠다 —
-     캡션·작업면과 다른 값을 주면 창 안에 액자 테가 생긴다. 패널 면 하나를 그대로 쓴다. */
-  background: var(--glass-tint-terminal);
+     캡션·작업면과 다른 값을 주면 창 안에 액자 테가 생긴다. field 채널 하나를 그대로 쓴다:
+     다크+게이트 열림에서는 비어(transparent) 패널 루트의 유리 한 장이 필드와 거터를 함께 칠하고,
+     라이트·게이트 닫힘에서는 xterm이 받는 불투명 실색과 같은 값을 칠해 격자 경계 띠를 없앤다.
+     여기서 자기 틴트를 들면 루트 유리와 겹쳐 창 안이 두 값이 된다(이중 알파). */
+  background: var(--glass-tint-field);
 }
 
 .canvas-operation-terminal .terminal-stage,

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -177,15 +177,29 @@
   --glass-tint-deep: var(--ink-deep);
   --glass-tint-abyss: var(--ink-abyss);
   --glass-tint-chrome: var(--surface-chrome);
-  /* 패널 채널 둘 — panel은 패널 루트가 유리 틴트로 쓰고, panel-face는 패널 안에서 같은
-     면을 덧칠하던 자식(캡션·본문 팬)이 쓴다. 게이트가 열리면 face는 transparent가 되어
-     루트 유리 한 장이 그대로 비친다 — 자식이 자기 틴트를 들면 겹침 얼룩(이중 알파)이 된다.
-     xterm 터미널 필드는 terminal 채널을 계산값으로 읽어 간다(allowTransparency) — 게이트가
-     닫히면 채널 기본값이 --surface-panel 불투명이라 구 판독 계약으로 돌아간다. */
+  /* 패널 채널 넷 — panel은 패널 루트와 떠 있는 캡션이 유리 틴트로 쓰고, panel-face는 패널 박스
+     안에서 같은 면을 덧칠하던 자식이 쓴다. 게이트가 열리면 face는 transparent가 되어 루트 유리
+     한 장이 그대로 비친다 — 박스 안의 자식이 자기 틴트를 들면 겹침 얼룩(이중 알파)이 된다.
+     떠 있는 캡션은 그 규칙에서 빠진다: top:-32px로 루트 박스 **밖**에 서므로 루트 유리가 거기까지
+     오지 않고, face를 들면 아무것도 칠해지지 않은 구멍이 된다(실측 — 캡션이 캔버스와 0.1~1.1 L 차).
+     field는 터미널 필드와 그것을 감싸는 거터가 함께 칠하는 값이다 — 다크+열림에서는 루트 유리
+     한 장이 둘 다 칠하므로 비우고, 라이트·닫힘에서는 xterm이 요구하는 불투명 실색을 그대로 칠해
+     필드와 거터가 같은 값에서 만난다. terminal은 유리 루트가 없는 레일 Shell 카드의 면이며,
+     xterm은 이 채널의 계산값을 읽어 간다(allowTransparency) — 게이트가 닫히면 채널 기본값이
+     --surface-panel 불투명이라 구 판독 계약으로 돌아간다. */
   --glass-tint-panel: var(--surface-panel);
   --glass-tint-panel-face: var(--surface-panel);
+  --glass-tint-field: var(--surface-panel);
   --glass-tint-terminal: var(--surface-panel);
   --glass-tint-band: var(--surface-band);
+  /* 패널 광원(pane-light) — 유리 뒤가 앱에서 가장 어두운 캔버스라 blur가 굴절시킬 빛이 없다.
+     그래서 다크 유리는 자기 위쪽에 광원을 하나 얹어 재질을 명도가 아니라 기울기로 말한다.
+     이 채널은 광원의 **색**만 진다 — 기하(반경·중심)는 창의 구조라 components.css가 쓴다.
+     캡션과 본문은 서로 다른 박스지만 같은 절대 좌표의 광원을 샘플링해 한 줄기로 이어진다.
+     기본값 transparent는 게이트가 닫혔을 때 그 층이 통째로 투명해지는 것과 같다. */
+  --glass-pane-light: transparent;
+  /* 캔버스 대기광 — 유리가 실제로 굴절할 것을 뒤에 놓는다. 게이트가 닫히면 원래의 심해 계조. */
+  --canvas-ambience: var(--canvas-sea-core);
   --glass-backdrop-strong: none;
   --glass-backdrop-soft: none;
   --glass-backdrop-panel: none;
@@ -206,12 +220,18 @@
   --glass-on-tint-deep: oklch(16.5% 0.016 245 / 48%);
   --glass-on-tint-abyss: oklch(13% 0.014 245 / 50%);
   --glass-on-tint-chrome: oklch(19% 0.018 245 / 50%);
-  /* 다크 유리는 Ghostty 문법이다 — 틴트는 원 면보다 오히려 어둡게, 밀도(α)는 높게, 블러는
-     무겁게. 필드가 거의 검게 남아 대비를 지키고, 뒤 콘텐츠는 블러 너머 희미한 유령빛으로만
-     비친다. 명도를 올려 잿빛 워시를 만드는 방향은 실측 기각됐다. */
-  --glass-on-tint-panel: oklch(15% 0.018 245 / 55%);
-  --glass-on-tint-terminal: oklch(13% 0.015 245 / 62%);
+  /* 다크 유리의 밀도 문법 — 뒤에 비칠 빛이 없는 유리에서 투과는 재질감을 만들지 못하고 명도를
+     빼기만 한다(실측: 필드가 패널 면보다 3.1~6.1 L 아래로 내려앉아 사이드바·레일보다 어두워졌고,
+     ANSI black이 필드와 같거나 오히려 밝아졌다). 그래서 틴트는 원 면보다 살짝 위(+2 L)에 서고
+     밀도를 0.83으로 모은다. 명도만 올리면 잿빛 워시가 되므로 채도를 함께 1.7배로 싣고, 재질은
+     명도가 아니라 pane-light의 기울기가 말한다. 알파·명도를 다시 만지면 ANSI black과의 부호
+     (필드보다 어두울 것)를 반드시 재실측할 것. */
+  --glass-on-tint-panel: oklch(18.5% 0.028 245 / 83%);
+  --glass-on-tint-field: transparent;
+  --glass-on-tint-terminal: oklch(18.5% 0.028 245 / 83%);
   --glass-on-tint-band: oklch(13% 0.018 245 / 55%);
+  --glass-on-pane-light: oklch(25% 0.032 245);
+  --canvas-on-ambience: oklch(16% 0.022 245);
   --glass-on-backdrop-strong: blur(24px) saturate(1.7);
   --glass-on-backdrop-soft: blur(12px) saturate(1.5);
   --glass-on-backdrop-panel: blur(32px) saturate(1.45);
@@ -229,6 +249,9 @@
   --identity-small-tag: var(--aurora);
 
   --shadow-soft: 0 1px 0 0 oklch(96% 0.01 90 / 6%) inset, 0 18px 38px -22px oklch(0% 0 0 / 70%);
+  /* --shadow-soft에서 상단 inset 선만 뺀 변형 — 창의 꼭대기가 자기 박스 밖(떠 있는 캡션)에 있는
+     면이 쓴다. 그런 면이 inset 선을 들면 하이라이트가 창 한가운데(캡션·본문 이음새)에 그어진다. */
+  --shadow-soft-drop: 0 18px 38px -22px oklch(0% 0 0 / 70%);
   --shadow-floating: 0 1px 0 0 oklch(96% 0.01 90 / 8%) inset, 0 32px 60px -28px oklch(0% 0 0 / 80%);
   --shadow-anchor: 0 0 0 1px color-mix(in oklch, var(--brass) 16%, transparent), 0 12px 32px -16px color-mix(in oklch, var(--brass) 30%, transparent);
 
@@ -378,9 +401,12 @@
   --glass-on-tint-deep: oklch(20% 0.045 248 / 46%);
   --glass-on-tint-abyss: oklch(15% 0.04 250 / 48%);
   --glass-on-tint-chrome: oklch(27% 0.04 248 / 45%);
-  --glass-on-tint-panel: oklch(20% 0.04 248 / 55%);
-  --glass-on-tint-terminal: oklch(17% 0.035 248 / 62%);
+  --glass-on-tint-panel: oklch(25% 0.05 248 / 83%);
+  --glass-on-tint-field: transparent;
+  --glass-on-tint-terminal: oklch(25% 0.05 248 / 83%);
   --glass-on-tint-band: oklch(19% 0.045 248 / 50%);
+  --glass-on-pane-light: oklch(32% 0.055 248);
+  --canvas-on-ambience: oklch(18% 0.035 235);
   --glass-on-rim: oklch(96% 0.012 88 / 18%);
 
   --hairline: oklch(36% 0.035 248);
@@ -450,9 +476,12 @@
   --glass-on-tint-deep: oklch(18% 0.007 255 / 46%);
   --glass-on-tint-abyss: oklch(14% 0.006 255 / 48%);
   --glass-on-tint-chrome: oklch(24% 0.006 252 / 45%);
-  --glass-on-tint-panel: oklch(17% 0.008 252 / 55%);
-  --glass-on-tint-terminal: oklch(15% 0.007 252 / 62%);
+  --glass-on-tint-panel: oklch(21% 0.013 252 / 83%);
+  --glass-on-tint-field: transparent;
+  --glass-on-tint-terminal: oklch(21% 0.013 252 / 83%);
   --glass-on-tint-band: oklch(17% 0.007 255 / 50%);
+  --glass-on-pane-light: oklch(28% 0.014 252);
+  --canvas-on-ambience: oklch(18% 0.014 250);
   --glass-on-rim: oklch(95% 0.003 250 / 16%);
 
   --hairline: oklch(33% 0.006 252);
@@ -597,8 +626,14 @@
   --glass-on-tint-chrome: oklch(92% 0.005 100 / 52%);
   --glass-on-tint-panel: oklch(98.2% 0.004 100 / 60%);
   /* 라이트 필드는 불투명 종이 — mCR(가독 보정)이 배경 실색을 요구하고, 종이 위 젖빛 유리는
-     어차피 지각 불가 수준이다. 필드·거터가 같은 불투명 값으로 만나 격자 경계 띠가 없다. */
+     어차피 지각 불가 수준이다. 필드·거터가 같은 불투명 값으로 만나 격자 경계 띠가 없다.
+     field 채널이 terminal을 그대로 별칭하는 이유가 이것이다 — 다크만 루트 유리에 필드를 넘긴다. */
   --glass-on-tint-terminal: oklch(98.2% 0.004 100);
+  --glass-on-tint-field: var(--glass-on-tint-terminal);
+  /* 라이트는 유리 뒤가 이미 밝다 — 굴절할 빛이 부족한 문제가 없으므로 광원도 대기광도 얹지 않는다.
+     백지 위에 광원을 더하면 종이가 평평해지고 최명면 극성만 흐려진다. */
+  --glass-on-pane-light: transparent;
+  --canvas-on-ambience: var(--canvas-sea-core);
   --glass-on-tint-band: oklch(92% 0.006 100 / 52%);
   --glass-on-backdrop-strong: blur(26px) saturate(1.45);
   --glass-on-backdrop-soft: blur(12px) saturate(1.25);
@@ -624,6 +659,7 @@
   --hairline-strong: oklch(76% 0.014 100);
 
   --shadow-soft: 0 1px 0 0 oklch(99.5% 0.004 100 / 70%) inset, 0 18px 38px -22px oklch(30% 0.015 95 / 26%);
+  --shadow-soft-drop: 0 18px 38px -22px oklch(30% 0.015 95 / 26%);
   --shadow-floating: 0 1px 0 0 oklch(99.5% 0.004 100 / 80%) inset, 0 32px 60px -28px oklch(28% 0.015 95 / 30%);
   --shadow-anchor: 0 0 0 1px color-mix(in oklch, var(--brass) 22%, transparent), 0 12px 32px -16px color-mix(in oklch, var(--brass) 26%, transparent);
 
@@ -651,8 +687,11 @@
     --glass-tint-chrome: var(--glass-on-tint-chrome);
     --glass-tint-panel: var(--glass-on-tint-panel);
     --glass-tint-panel-face: transparent;
+    --glass-tint-field: var(--glass-on-tint-field);
     --glass-tint-terminal: var(--glass-on-tint-terminal);
     --glass-tint-band: var(--glass-on-tint-band);
+    --glass-pane-light: var(--glass-on-pane-light);
+    --canvas-ambience: var(--canvas-on-ambience);
     --glass-backdrop-strong: var(--glass-on-backdrop-strong);
     --glass-backdrop-soft: var(--glass-on-backdrop-soft);
     --glass-backdrop-panel: var(--glass-on-backdrop-panel);
@@ -673,8 +712,11 @@
       --glass-tint-chrome: var(--surface-chrome);
       --glass-tint-panel: var(--surface-panel);
       --glass-tint-panel-face: var(--surface-panel);
+      --glass-tint-field: var(--surface-panel);
       --glass-tint-terminal: var(--surface-panel);
       --glass-tint-band: var(--surface-band);
+      --glass-pane-light: transparent;
+      --canvas-ambience: var(--canvas-sea-core);
       --glass-backdrop-strong: none;
       --glass-backdrop-soft: none;
       --glass-backdrop-panel: none;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -660,7 +660,9 @@ describe("Instrument core design contract", () => {
     // 치워두기의 두 번 눌러 확정 안내는 패널 안 HUD가 소유한다 — 레일이 사라져도 이 기능은 그대로다.
     expect(canvas).toContain("setAsideArmed");
     expect(canvas).not.toMatch(/canvas-triage-(?:frame|bracket|hud(?:-eye|-name)?|curtain-kicker|curtain-ruler)/);
-    expect(components).toContain("radial-gradient(100% 80% at 50% 42%, var(--canvas-sea-core), var(--canvas-sea-mid) 78%)");
+    // Formation 판의 중앙은 대기광 채널이 정한다 — 유리가 굴절할 빛을 패널 뒤에 놓기 위해서다.
+    // 채널 기본값은 --canvas-sea-core이므로 게이트가 닫히면 이 그라디언트는 원래 픽셀로 돌아간다.
+    expect(components).toContain("radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-sea-mid) 78%)");
     expect(components).toContain("background-size: 48px 48px !important;");
     expect(components).toContain(".canvas-formation-guide {");
     // 캡션은 순번을 싣지 않는다 — 번호는 빈 자리를 가리키는 가이드만 진다.
@@ -700,6 +702,50 @@ describe("Instrument core design contract", () => {
     expect(css).toContain(":focus-visible");
     // brass 채움 버튼은 전용 on-brass 텍스트 티어를 소비한다 — abyss 재결합은 라이트 AA 회귀다.
     expect(css).toMatch(/\.fc-btn--primary \{[^}]*color: var\(--text-on-brass\);/);
+  });
+
+  // 다크 유리의 판독 계약 — 유리 뒤가 앱에서 가장 어두운 캔버스라 투과는 명도를 빼기만 한다.
+  // 이 셋이 함께 살아 있어야 필드가 캔버스로 가라앉지 않고, 창이 한 장으로 읽힌다.
+  it("keeps the dark glass pane lit, single-layered, and topped by exactly one highlight", () => {
+    const components = source("styles/components.css");
+    const theme = source("styles/theme.css");
+
+    // 떠 있는 캡션은 top:-32px로 유리 루트 박스 **밖**에 선다 — 루트의 유리도 backdrop도 거기까지
+    // 오지 않으므로 자기 유리 한 겹을 들어야 한다. 게이트가 panel-face를 transparent로 바꾸는 순간
+    // 캡션 뒤에는 아무 층도 남지 않고 캔버스가 그대로 드러난다(실측: 캔버스와 0.1~1.1 L 차).
+    const floatingCaption =
+      components.match(
+        /\.canvas-operation:not\(\.is-deck-tile\):not\(\.is-top-edge\) > \.canvas-operation-titlebar,\n\.canvas-operation > \.canvas-companion-caption \{[^}]*\}/,
+      )?.[0] ?? "";
+    expect(floatingCaption).toContain("--caption-base: var(--glass-tint-panel);");
+    expect(floatingCaption).toContain(
+      "radial-gradient(150% 420px at 50% -12px, var(--glass-pane-light) 0%, transparent 62%),",
+    );
+    expect(floatingCaption).toContain("var(--glass-underlay);");
+    expect(floatingCaption).toContain("backdrop-filter: var(--glass-backdrop-panel);");
+    // 창의 상단 하이라이트는 꼭대기 한 곳뿐이다 — 캡션이 들고 본문 루트는 내려놓는다.
+    // 루트가 계속 들면 하이라이트가 캡션·본문 이음새(창 한가운데)에 그어진다.
+    expect(floatingCaption).toContain("box-shadow: inset 0 1px 0 var(--glass-rim);");
+    const floatingRoot =
+      components.match(
+        /\.canvas-operation:not\(\.is-deck-tile\):not\(\.is-top-edge\):has\(> \.canvas-operation-titlebar\),\n\.canvas-operation:has\(> \.canvas-companion-caption\) \{[^}]*\}/,
+      )?.[0] ?? "";
+    expect(floatingRoot).toContain("--pane-light-origin: -44px;");
+    expect(floatingRoot).toContain("box-shadow: var(--shadow-soft-drop);");
+    expect(theme).toContain("--shadow-soft-drop:");
+
+    // 새 채널 셋의 닫힌-게이트 기본값이 곧 구 불투명 계약이다.
+    expect(theme).toContain("--glass-tint-field: var(--surface-panel);");
+    expect(theme).toContain("--glass-pane-light: transparent;");
+    expect(theme).toContain("--canvas-ambience: var(--canvas-sea-core);");
+    // 다크 3종의 유리 재료는 밀도 문법이다 — 틴트가 원 면보다 어두우면 필드가 캔버스로 가라앉고
+    // ANSI black이 필드보다 밝아진다(실측 maritime +1.2 L·carbon +1.1 L 역전).
+    expect(theme).toContain("--glass-on-tint-panel: oklch(18.5% 0.028 245 / 83%);");
+    expect(theme).toContain("--glass-on-tint-panel: oklch(25% 0.05 248 / 83%);");
+    expect(theme).toContain("--glass-on-tint-panel: oklch(21% 0.013 252 / 83%);");
+    // 다크에서만 필드를 루트 유리에 넘긴다 — 라이트는 mCR이 불투명 실색을 요구한다.
+    expect(theme).toContain("--glass-on-tint-field: var(--glass-on-tint-terminal);");
+    expect((theme.match(/--glass-on-tint-field: transparent;/g) ?? []).length).toBe(3);
   });
 
   // 텍스트 3티어만 대비를 통제하므로 원료 잉크를 color에 직접 쓰면 판독 하한을 한곳에서 보장할 수 없다.
@@ -1734,11 +1780,19 @@ describe("Instrument core design contract", () => {
     // 패널은 하나의 면이다 — 루트가 panel 유리 틴트를, 캡션·본문 팬은 panel-face(게이트 열림 시
     // transparent)를 소비해 유리 한 장으로 읽힌다. 자식이 자기 틴트를 들면 이중 알파 얼룩이 된다.
     const operationBlock = components.match(/^\.canvas-operation \{[^}]*\}/m)?.[0] ?? "";
-    expect(operationBlock).toContain("background: var(--glass-tint-panel);");
+    expect(operationBlock).toContain("linear-gradient(var(--glass-tint-panel), var(--glass-tint-panel)),");
+    expect(operationBlock).toContain("var(--glass-underlay);");
+    // 유리 뒤가 캔버스(앱에서 가장 어두운 면)라 blur가 굴절시킬 빛이 없다 — 재질은 명도가 아니라
+    // 창 위쪽 광원의 기울기가 말한다. 기하는 절대 좌표라 캡션과 본문이 같은 광원을 나눠 샘플링한다.
+    expect(operationBlock).toContain("radial-gradient(150% 420px at 50% var(--pane-light-origin), var(--glass-pane-light) 0%, transparent 62%),");
     expect(operationBlock).toContain("backdrop-filter: var(--glass-backdrop-panel);");
     expect(operationBlock).not.toContain("--surface-window");
     const titlebarBlock = components.match(/^\.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
-    expect(titlebarBlock).toContain("background: var(--glass-tint-panel-face);");
+    // 캡션 채움은 base(어느 면에 앉았는가)와 fill(그 위의 상태·정체 워시) 두 단계다 — 워시 규칙이
+    // background를 다시 적으면 clip과 광원 층이 규칙마다 리셋된다.
+    expect(titlebarBlock).toContain("--caption-base: var(--glass-tint-panel-face);");
+    expect(titlebarBlock).toContain("--caption-fill: var(--caption-base);");
+    expect(titlebarBlock).toContain("background: var(--caption-fill);");
     expect(titlebarBlock).toContain("background var(--duration-base) var(--ease-spring)");
     // 캡션 아웃라인은 본문과 같은 --surface-rim이다. inherit는 본문 윗변을 비운 뒤
     // 계산색이 갈라져 캡션만 선이 빠진다.
@@ -1748,7 +1802,9 @@ describe("Instrument core design contract", () => {
     expect(titlebarBlock).not.toContain("border-color: inherit;");
     expect(titlebarBlock).not.toContain("border-bottom: none;");
     const panelBodyBlock = components.match(/^\.canvas-operation-terminal \{[^}]*\}/m)?.[0] ?? "";
-    expect(panelBodyBlock).toContain("background: var(--glass-tint-terminal);");
+    // 터미널 필드·거터는 field 채널 하나로 만난다 — 다크+열림에서는 비어(transparent) 루트 유리
+    // 한 장이 둘 다 칠하고, 라이트·닫힘에서는 xterm이 받는 불투명 실색을 그대로 칠한다.
+    expect(panelBodyBlock).toContain("background: var(--glass-tint-field);");
     // 레일 Shell 카드도 같은 면이다 — xterm이 terminal 유리 채널을 따라 반투명해지므로
     // 카드 면도 panel-face로 물러나 유리 한 장으로 읽힌다(게이트가 닫히면 둘 다 불투명 복원).
     const terminalShellBlock = components.match(/^\.terminal-shell \{[^}]*\}/m)?.[0] ?? "";
@@ -2630,7 +2686,8 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("top: -32px;");
     expect(components).toContain("background-clip: padding-box;");
     const shellCaptionBlock = components.match(/\.canvas-operation--shell \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
-    expect(shellCaptionBlock).toContain("background-clip: padding-box;");
+    expect(shellCaptionBlock).toContain("--caption-fill: color-mix(in oklch, var(--aurora) 9%, var(--caption-base));");
+    expect(shellCaptionBlock).not.toContain("background:");
     const captionSeamBlock = components.match(/\.canvas-operation:has\(> \.canvas-operation-titlebar\) \{[^}]*\}/)?.[0] ?? "";
     expect(captionSeamBlock).toContain("border-top-width: 0;");
     expect(captionSeamBlock).toContain("border-top-style: none;");
@@ -2646,7 +2703,7 @@ describe("Instrument core design contract", () => {
     // warn과 brass가 한 덩어리 금색으로 읽힌다. 워시는 캡션만 진다 — 채팅 본문까지
     // 따라가면 활성 패널 전체가 다른 면으로 바뀐다.
     expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar {");
-    expect(components).toContain("color-mix(in oklab, var(--brass) 10%, var(--glass-tint-panel-face))");
+    expect(components).toContain("--caption-fill: color-mix(in oklab, var(--brass) 10%, var(--caption-base));");
     expect(components).not.toContain("--surface-window");
     expect(components).not.toContain(".canvas-operation-titlebar::before");
     expect(components).toContain("background: var(--caption-rail, transparent);");
@@ -3491,8 +3548,8 @@ describe("War Room deck panel grammar", () => {
     expect(components).toContain(".canvas-triage-deck-pick:focus-visible {");
     // 겨눈 카드의 캡션 워시는 포커스 패널과 같은 한 값이다 — 새 값을 만들지 않는다.
     const wash = components.match(/\.canvas-triage-deck-cell:hover \.canvas-operation\.is-deck-tile > \.canvas-operation-titlebar,\n[^{]*\{[^}]*\}/)?.[0] ?? "";
-    expect(wash).toContain("background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-panel-face));");
-    expect(wash).toContain("background-clip: padding-box;");
+    expect(wash).toContain("--caption-fill: color-mix(in oklab, var(--brass) 10%, var(--caption-base));");
+    expect(wash).not.toContain("background:");
   });
 
   it("mixes the map quick-look border in oklab so brass stays on the location channel", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -718,6 +718,9 @@ describe("Instrument core design contract", () => {
         /\.canvas-operation:not\(\.is-deck-tile\):not\(\.is-top-edge\) > \.canvas-operation-titlebar,\n\.canvas-operation > \.canvas-companion-caption \{[^}]*\}/,
       )?.[0] ?? "";
     expect(floatingCaption).toContain("--caption-base: var(--glass-tint-panel);");
+    // 구조 규칙은 base만 소유한다 — 이 (0,4,0) 선택자가 fill까지 세우면 셸 아우로라 틴트(0,2,0)와
+    // 포커스 brass 워시(0,3,0)를 특이도로 눌러 떠 있는 캡션에서 두 신호가 통째로 사라진다.
+    expect(floatingCaption).not.toContain("--caption-fill:");
     expect(floatingCaption).toContain(
       "radial-gradient(150% 420px at 50% -12px, var(--glass-pane-light) 0%, transparent 62%),",
     );


### PR DESCRIPTION
## Summary
- 다크 테마에서 리퀴드 글래스를 켜면 Operation 터미널 면이 불투명 면보다 3.1~6.1 L 내려앉아 사이드바·레일보다 어두워지고, ANSI black이 필드와 같거나(instrument −0.4 L) 오히려 밝아지는(maritime +1.2 L·carbon +1.1 L) 문제를 고칩니다. 유리 뒤가 앱에서 가장 어두운 캔버스라 투과가 빛을 들이지 않고 빼기만 하던 것이 원인입니다.
- 떠 있는 캡션은 `top:-32px`로 유리 루트 박스 **밖**에 서기 때문에, 게이트가 `--glass-tint-panel-face`를 `transparent`로 바꾸는 순간 뒤에 아무 층도 남지 않아 캔버스가 그대로 드러나 있었습니다(실측 캔버스와 0.1~1.1 L 차). 캡션이 자기 유리 한 겹을 들고, 창의 상단 하이라이트를 캡션·본문 이음새(창 한가운데, 실측 y=95 L21.9)에서 창의 꼭대기로 옮깁니다.
- 다크 유리를 밀도 문법으로 재조율합니다: 틴트는 패널 면보다 2 L 위 + 채도 1.7배 + α 0.83, 재질은 명도가 아니라 창 위쪽 광원(`--glass-pane-light`)의 기울기가 말합니다. 캡션과 본문이 같은 절대 좌표의 광원 한 줄기를 나눠 샘플링해 한 장으로 이어지고, 캔버스에는 대기광 채널(`--canvas-ambience`)을 두어 블러가 굴절할 것을 뒤에 놓습니다.
- 새 채널 셋(`--glass-tint-field`·`--glass-pane-light`·`--canvas-ambience`)의 닫힌-게이트 기본값은 현행 불투명 계약 그대로라, 세 게이트(@supports 미달·prefers-reduced-transparency·설정 해제) 중 하나만 닫혀도 오늘의 픽셀로 복원됩니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 192 passed / 1 skipped (2369 tests)
- [x] `pnpm --filter @fleet-plugins/terminal test` — 93 passed (1000 tests)
- [x] `pnpm test` (workspace) — console·terminal·desktop 전부 green
- [x] `pnpm typecheck` (workspace) — green
- [x] `pnpm build` (workspace) — green
- [x] `pnpm check:core-boundary`, `pnpm check:localized-attributes` — 위반 없음
- [x] `node scripts/compile-changelog-fragments.mjs --dry-run` — 프래그먼트 컴파일 확인
- [x] 격리 콘솔 헤디드 실측(1280×577, Tactical): 4테마 × ON/OFF 8샷
  - instrument ON 필드 17.2~19.1 / OFF 16.5 · maritime ON 22.9~25.0 / OFF 22.9 · carbon ON 19.8~21.5 / OFF 18.9
  - 세 다크 테마 모두 패널이 크롬 위로 복귀, ANSI black −3.8~−4.9 L로 부호 정상화, 창 안 이음새 소멸(seam=fieldTop)
  - whites는 필드 98.2 불변, 캡션 94.9 → 97.0으로 개선
  - 캡션 드롭다운 메뉴가 backdrop-filter 스태킹에 갇히지 않음을 DOM+스크린샷으로 확인