### PR TITLE
feat(fleet-console): pane-aware reading grammar for Codex surfaces

### DIFF
--- a/.changelog.d/codex-reading-refit.md
+++ b/.changelog.d/codex-reading-refit.md
@@ -1,0 +1,15 @@
+---
+branch: codex-reading-refit
+---
+
+### fleet-console
+
+#### Changed
+- Codex reading surfaces now scale document typography to the pane they actually occupy, start with a one-line outline spine that mirrors the current section, and fold long tag rows, so an entry opened in the split pane starts with its body visible instead of a full-screen preamble.
+  ko: Codex 읽기 표면이 문서 타이포그래피를 실제 놓인 페인 폭에 맞춰 조절하고, 현재 섹션을 되비추는 한 줄 개요 스파인으로 시작하며, 긴 태그 줄을 접어서, 분할 페인에서 항목을 열면 전주 대신 본문이 바로 보입니다.
+- The Codex AI composer dock moved from floating over the document to a fixed row at the reading frame boundary, so it no longer covers the paragraph being read, and its annotation counter appears only when annotations exist.
+  ko: Codex AI 컴포저 도크가 문서 위 부유에서 읽기 프레임 경계의 고정 행으로 내려와 읽는 중인 문단을 더 이상 가리지 않으며, 주석 카운터는 주석이 있을 때만 표시됩니다.
+- Codex catalog rows read denser: the repeated current status label is gone, the update time sits right-aligned on the title row, exceptional states (draft, deprecated, stale) surface as badges, and tags stay on one line with a +N marker.
+  ko: Codex 카탈로그 행이 더 촘촘하게 읽힙니다. 반복되던 current 상태 표기가 사라지고, 갱신 시각이 제목 행 우측에 정렬되며, 예외 상태(초안·폐기·낡음)는 배지로 드러나고, 태그는 +N 표식과 함께 한 줄을 유지합니다.
+- Tag chips in a Codex entry header are now buttons that filter the catalog by that tag, and the header timestamp uses the same relative time as the catalog with the absolute date in its tooltip.
+  ko: Codex 항목 헤더의 태그 칩이 그 태그로 카탈로그를 거르는 버튼이 되었고, 헤더 시각 표기는 카탈로그와 같은 상대시간을 쓰며 절대 날짜는 툴팁으로 보존됩니다.

--- a/packages/fleet-wiki/src/briefing.ts
+++ b/packages/fleet-wiki/src/briefing.ts
@@ -138,6 +138,7 @@ function toRankedHit(
     rawSourceRefs: entry.rawSourceRefs?.map((item) => item.ref),
     status: entry.status,
     confidence: entry.confidence,
+    revalidateAfter: entry.revalidateAfter,
     aliases: entry.aliases,
     type: entry.type,
     matchedFields: [matchedField],

--- a/packages/fleet-wiki/src/types.ts
+++ b/packages/fleet-wiki/src/types.ts
@@ -267,6 +267,7 @@ export interface BriefingHit {
   rawSourceRefs?: string[];
   status?: WikiEntryFrontmatter["status"];
   confidence?: WikiEntryFrontmatter["confidence"];
+  revalidateAfter?: string;
   aliases?: string[];
   type?: WikiEntryFrontmatter["type"];
   matchedFields: string[];

--- a/packages/fleet-wiki/tests/wiki-briefing.test.ts
+++ b/packages/fleet-wiki/tests/wiki-briefing.test.ts
@@ -128,6 +128,8 @@ describe("wiki briefing", () => {
 
     expect(hits[0]?.id).toBe("stale-alpha");
     expect(hits[0]?.stale).toBe(true);
+    // 소비자가 낡음 판정을 직접 재계산할 수 있도록 원본 재검증 시각도 히트에 실린다.
+    expect(hits[0]?.revalidateAfter).toBe("2020-01-01T00:00:00.000Z");
     expect(hits[0]?.matchedFields).toEqual(expect.arrayContaining(["alias", "tag", "title", "body"]));
     expect(hits[0]?.matchedSnippets?.length).toBeGreaterThan(1);
     expect(hits[0]?.whyThisMatched).toContain("Matched fields:");

--- a/runtime/fleet-console/core/client/src/codex-host.ts
+++ b/runtime/fleet-console/core/client/src/codex-host.ts
@@ -36,6 +36,8 @@ let activeNavigatorWorkspaceId: string | null = null;
 // Reader 싱글톤 — split·오버레이 사이를 같은 노드로 relocate하여 콘텐츠·스크롤 보존
 let readerHostNode: HTMLDivElement | null = null;
 let tocHostNode: HTMLDivElement | null = null;
+// Cowork 도크 싱글톤 호스트 — 프레임 경계 슬롯(.codex-reader-composer)로 relocate된다.
+let dockHostNode: HTMLDivElement | null = null;
 let readerController: ReadingController | null = null;
 let activeReaderKind: "entry" | "drydock" | "conflicts" | "schema" | null = null;
 let activeReaderEntryId: string | null = null;
@@ -85,6 +87,11 @@ export function setNavigatorTheater(theaterId: string | null): void {
   navigatorController?.setTheater(theaterId);
 }
 
+/** 리더 문서의 태그 칩 클릭을 카탈로그 태그 필터로 잇는다. */
+export function setNavigatorTagFilter(tag: string): void {
+  navigatorController?.setActiveTag(tag);
+}
+
 export function restoreCodexReaderSession(theaterId: string): string | null {
   prepareReaderTheater(theaterId);
   const session = readReaderSession(theaterId);
@@ -126,11 +133,13 @@ export function refreshCodexHealth(): void {
 export function mountReaderInto(
   readSlot: HTMLElement,
   tocSlot: HTMLElement,
+  dockSlot: HTMLElement,
   opts: ReaderSlotOptions,
 ): void {
   scrollRestoreCleanup?.();
   const rNode = ensureReaderHostNode();
   const tNode = ensureTocHostNode();
+  const dNode = ensureDockHostNode();
   if (activeReaderKind === "entry" && rNode.parentElement) {
     persistCurrentReaderSession(rNode.parentElement.scrollTop);
   }
@@ -167,6 +176,7 @@ export function mountReaderInto(
   // DOM의 appendChild는 기존 부모에서 자동 detach → split·오버레이 사이를 콘텐츠 보존으로 relocate
   if (rNode.parentElement !== readSlot) readSlot.appendChild(rNode);
   if (tNode.parentElement !== tocSlot) tocSlot.appendChild(tNode);
+  if (dNode.parentElement !== dockSlot) dockSlot.appendChild(dNode);
 
   const { sessionTheaterId: _sessionTheaterId, ...readingOpts } = opts;
   if (!readerController || activeReaderKind !== opts.kind || !sameTheater) {
@@ -174,6 +184,7 @@ export function mountReaderInto(
     readerController = mountReadingInto(rNode, {
       ...readingOpts,
       tocContainer: tNode,
+      dockContainer: dNode,
       onEntryRendered: handleEntryRendered,
       onTocChanged: handleTocChanged,
     });
@@ -199,6 +210,7 @@ export function mountReaderInto(
     onDecided: opts.onDecided,
     onRelatedClick: opts.onRelatedClick,
     onClose: opts.onClose,
+    onTagClick: opts.onTagClick,
     theaterId: opts.theaterId,
   });
   syncInlineOutline(tNode);
@@ -236,6 +248,7 @@ export function teardownReaderNodes(): void {
   activeEntryRequest = null;
   if (readerHostNode?.parentElement) readerHostNode.parentElement.removeChild(readerHostNode);
   if (tocHostNode?.parentElement) tocHostNode.parentElement.removeChild(tocHostNode);
+  if (dockHostNode?.parentElement) dockHostNode.parentElement.removeChild(dockHostNode);
 }
 
 export function teardownCodex(): void {
@@ -473,4 +486,12 @@ function ensureTocHostNode(): HTMLDivElement {
     tocHostNode.className = "codex-toc-host";
   }
   return tocHostNode;
+}
+
+function ensureDockHostNode(): HTMLDivElement {
+  if (!dockHostNode) {
+    dockHostNode = document.createElement("div");
+    dockHostNode.className = "codex-dock-host";
+  }
+  return dockHostNode;
 }

--- a/runtime/fleet-console/core/client/src/codex/components/meta-chips.ts
+++ b/runtime/fleet-console/core/client/src/codex/components/meta-chips.ts
@@ -19,18 +19,69 @@ export interface EntryStatusBadge {
   title: string;
 }
 
-export function renderMetaChips(frontmatter: EntryFrontmatter | SearchEntry): string {
+export interface RenderMetaChipsOptions {
+  /** true면 태그 칩이 카탈로그 태그 필터를 실행하는 버튼이 된다(기본 false = 정적 표기). */
+  interactiveTags?: boolean;
+}
+
+// 태그가 이 수를 넘으면 앞쪽만 남기고 +N 토글로 접는다 — 좁은 분할 페인에서 칩이
+// 여러 줄을 차지해 본문 도달을 밀어내는 것을 막는다(정확히 임계값이면 전부 표시).
+const TAG_CLAMP_LIMIT = 4;
+const TAG_CLAMP_VISIBLE = 3;
+
+export function renderMetaChips(
+  frontmatter: EntryFrontmatter | SearchEntry,
+  options: RenderMetaChipsOptions = {},
+): string {
   const locale = resolveActiveLocale();
   const t = getT(locale);
-  const tags = frontmatter.tags.map((tag) => `<span class="chip chip-tag">${escapeHtml(tag)}</span>`).join("");
+  const clamped = frontmatter.tags.length > TAG_CLAMP_LIMIT;
+  const tags = frontmatter.tags
+    .map((tag, index) => renderTagChip(tag, {
+      interactive: options.interactiveTags === true,
+      overflow: clamped && index >= TAG_CLAMP_VISIBLE,
+      filterLabel: t("codex.nav.filterByTag", { tag }),
+    }))
+    .join("");
+  const overflowCount = frontmatter.tags.length - TAG_CLAMP_VISIBLE;
+  const moreToggle = clamped
+    ? `<button type="button" class="chip chip-more" data-chips-toggle aria-expanded="false" aria-label="${escapeAttribute(t("codex.meta.moreTags", { count: overflowCount }))}">+${overflowCount}</button>`
+    : "";
   const badge = renderStatusBadge(frontmatter);
+  const updatedLabel = formatRelativeUpdated(frontmatter.updated);
   return `
-    <div class="meta-chips">
+    <div class="meta-chips"${clamped ? ' data-collapsed="true"' : ""}>
       ${tags}
+      ${moreToggle}
       ${badge}
-      <span class="chip">${escapeHtml(t("codex.meta.updated", { date: formatDate(frontmatter.updated, locale) }))}</span>
+      <span class="chip" title="${escapeAttribute(formatDate(frontmatter.updated, locale))}">${escapeHtml(t("codex.meta.updated", { date: updatedLabel }))}</span>
     </div>
   `;
+}
+
+function renderTagChip(
+  tag: string,
+  opts: { interactive: boolean; overflow: boolean; filterLabel: string },
+): string {
+  const className = `chip chip-tag${opts.overflow ? " chip-tag--overflow" : ""}`;
+  if (!opts.interactive) return `<span class="${className}">${escapeHtml(tag)}</span>`;
+  // 카탈로그의 태그 칩과 같은 약속 — 칩 모양이면 눌러서 그 태그로 거른다.
+  return `<button type="button" class="${className}" data-doc-tag="${escapeAttribute(tag)}" aria-label="${escapeAttribute(opts.filterLabel)}">${escapeHtml(tag)}</button>`;
+}
+
+/** 카탈로그·문서 헤더가 공유하는 갱신 시각 문법 — 일/달/년 단위 상대시간. */
+export function formatRelativeUpdated(iso: string): string {
+  const updated = new Date(iso);
+  if (Number.isNaN(updated.getTime())) return iso;
+  const now = new Date();
+  const updatedDay = Date.UTC(updated.getFullYear(), updated.getMonth(), updated.getDate());
+  const today = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  const t = getT(resolveActiveLocale());
+  const elapsedDays = Math.max(0, Math.floor((today - updatedDay) / 86_400_000));
+  if (elapsedDays === 0) return t("codex.nav.updatedToday");
+  if (elapsedDays < 30) return t("codex.nav.updatedDaysAgo", { count: elapsedDays });
+  if (elapsedDays < 365) return t("codex.nav.updatedMonthsAgo", { count: Math.floor(elapsedDays / 30) });
+  return t("codex.nav.updatedYearsAgo", { count: Math.floor(elapsedDays / 365) });
 }
 
 export function renderTagChips(tags: string[]): string {
@@ -43,7 +94,7 @@ function renderStatusBadge(frontmatter: EntryFrontmatter | SearchEntry): string 
   return `<span class="chip ${badge.tone === "deprecated" ? "chip-coral" : badge.tone === "stale" ? "chip-stale" : ""}" title="${escapeAttribute(badge.title)}">${escapeHtml(badge.label)}</span>`;
 }
 
-function getEntryStatusBadge(frontmatter: EntryFrontmatter | SearchEntry, now: Date = new Date()): EntryStatusBadge | null {
+export function getEntryStatusBadge(frontmatter: EntryFrontmatter | SearchEntry, now: Date = new Date()): EntryStatusBadge | null {
   const t = getT(resolveActiveLocale());
   const status = frontmatter.status;
   const stale = typeof frontmatter.revalidateAfter === "string"
@@ -63,12 +114,9 @@ function getEntryStatusBadge(frontmatter: EntryFrontmatter | SearchEntry, now: D
       title: frontmatter.revalidateAfter ?? t("codex.meta.stale"),
     };
   }
-  if (status === "current" || status === "draft") {
-    return {
-      label: status,
-      tone: "neutral",
-      title: status,
-    };
+  // current는 기본 상태다 — 배지는 예외(초안·폐기·낡음)에만 말을 얹는다.
+  if (status === "draft") {
+    return { label: status, tone: "neutral", title: status };
   }
   return null;
 }

--- a/runtime/fleet-console/core/client/src/codex/components/navigator.ts
+++ b/runtime/fleet-console/core/client/src/codex/components/navigator.ts
@@ -557,9 +557,14 @@ export function mountNavigatorInto(
       renderList(getState());
     },
     setActiveTag(tag: string | null): void {
-      if (activeTag === tag) return;
-      activeTag = tag;
+      // 광고된 액션은 "카탈로그를 이 태그로 거른다"이다 — 스키마 모드에 있어도 먼저
+      // 항목 목록으로 복귀해야 같은 태그 재클릭이 무반응으로 보이지 않는다.
       mode = "entries";
+      if (activeTag === tag) {
+        renderList(getState());
+        return;
+      }
+      activeTag = tag;
       requestServerSearch();
     },
     refreshHealth(): void {

--- a/runtime/fleet-console/core/client/src/codex/components/navigator.ts
+++ b/runtime/fleet-console/core/client/src/codex/components/navigator.ts
@@ -1,6 +1,7 @@
 import { getGlobalSettingsStoreState } from "../../global-settings-store.js";
 import { getT } from "../../i18n/index.js";
 import { resolveConsoleLanguage } from "../../whatsnew-i18n.js";
+import { formatRelativeUpdated, getEntryStatusBadge } from "./meta-chips.js";
 import { fetchHealth, fetchSearch } from "../api.js";
 import { getState, subscribeState } from "../state.js";
 import type { AppState } from "../state.js";
@@ -18,6 +19,8 @@ export interface NavigatorController {
   destroy(): void;
   setTheater(theaterId: string | null): void;
   setCurrentEntry(entryId: string | null): void;
+  /** 리더 문서의 태그 칩 등 바깥 표면이 카탈로그 태그 필터를 직접 건다. */
+  setActiveTag(tag: string | null): void;
   refreshHealth(): void;
   /** 로케일 변경 시 셸·목록 문구를 다시 그린다(검색·선택 상태 유지). */
   refreshLocale(): void;
@@ -84,20 +87,6 @@ function renderTagChip(tag: string, isActive: boolean): string {
   return `<button class="codex-nav-tag${isActive ? " is-active" : ""}" data-tag="${escapeHtml(tag)}" type="button" aria-pressed="${String(isActive)}" aria-label="${escapeHtml(label)}">${escapeHtml(tag)}</button>`;
 }
 
-function formatRelativeUpdated(iso: string): string {
-  const updated = new Date(iso);
-  if (Number.isNaN(updated.getTime())) return iso;
-  const now = new Date();
-  const updatedDay = Date.UTC(updated.getFullYear(), updated.getMonth(), updated.getDate());
-  const today = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
-  const t = consoleT();
-  const elapsedDays = Math.max(0, Math.floor((today - updatedDay) / 86_400_000));
-  if (elapsedDays === 0) return t("codex.nav.updatedToday");
-  if (elapsedDays < 30) return t("codex.nav.updatedDaysAgo", { count: elapsedDays });
-  if (elapsedDays < 365) return t("codex.nav.updatedMonthsAgo", { count: Math.floor(elapsedDays / 30) });
-  return t("codex.nav.updatedYearsAgo", { count: Math.floor(elapsedDays / 365) });
-}
-
 function renderEntry(entry: WikiIndexEntry, options: RenderEntryOptions): string {
   const tagMatches = options.query
     ? entry.tags.some((tag) => tag.toLowerCase().includes(options.query.toLowerCase()))
@@ -106,8 +95,18 @@ function renderEntry(entry: WikiIndexEntry, options: RenderEntryOptions): string
     .slice(0, 3)
     .map((tag) => renderTagChip(tag, tag === options.activeTag))
     .join("");
-  const kind = escapeHtml(entry.status ?? "current");
+  const overflowTags = entry.tags.slice(3);
+  const more = overflowTags.length > 0
+    ? `<span class="codex-nav-more" title="${escapeHtml(overflowTags.join(", "))}" aria-hidden="true">+${overflowTags.length}</span>`
+    : "";
   const updated = entry.updated ?? "";
+
+  // 행 우측 한 칸은 변별 정보만 싣는다 — current는 그룹 헤더가 이미 말하므로 시간을,
+  // 예외 상태(초안·폐기·낡음)는 그 배지를 싣는다(전체 시각은 title 툴팁에 보존).
+  const badge = getEntryStatusBadge(entry);
+  const aside = badge
+    ? `<span class="codex-nav-status is-${badge.tone}" title="${escapeHtml(badge.title)}">${escapeHtml(badge.label)}</span>`
+    : `<span class="when" title="${escapeHtml(updated)}">${escapeHtml(formatRelativeUpdated(updated))}</span>`;
 
   return `<div
     class="codex-nav-entry${options.isCurrent ? " is-current" : ""}"
@@ -116,9 +115,9 @@ function renderEntry(entry: WikiIndexEntry, options: RenderEntryOptions): string
     ${options.isCurrent ? 'aria-current="page"' : ""}
   >
     <button class="t" type="button" title="${escapeHtml(entry.title)}">${highlightMatch(entry.title, tagMatches ? "" : options.query)}</button>
-    ${tags ? `<span class="tg">${tags}</span>` : ""}
+    ${aside}
+    ${tags ? `<span class="tg">${tags}${more}</span>` : ""}
     ${options.snippet ? `<span class="snippet">${highlightMatch(options.snippet, options.query)}</span>` : ""}
-    <span class="meta" title="${escapeHtml(updated)}">${kind} · ${escapeHtml(formatRelativeUpdated(updated))}</span>
   </div>`;
 }
 
@@ -556,6 +555,12 @@ export function mountNavigatorInto(
       if (currentEntryId === entryId) return;
       currentEntryId = entryId;
       renderList(getState());
+    },
+    setActiveTag(tag: string | null): void {
+      if (activeTag === tag) return;
+      activeTag = tag;
+      mode = "entries";
+      requestServerSearch();
     },
     refreshHealth(): void {
       loadHealth();

--- a/runtime/fleet-console/core/client/src/codex/components/toc-sheet.ts
+++ b/runtime/fleet-console/core/client/src/codex/components/toc-sheet.ts
@@ -54,6 +54,15 @@ export function installTocScrollSpy(
 
   const scrollRoot = article.closest<HTMLElement>(".codex-reading-sheet-read, .codex-doc-scroll");
   const visibleHeadings = new Set<string>();
+  let lastEmittedId: string | null = null;
+
+  // 접힌 아웃라인 스파인이 "지금 읽는 섹션"을 되비출 수 있도록 활성 전환을 이벤트로 알린다.
+  const emitActive = (activeId: string | null) => {
+    if (activeId === lastEmittedId) return;
+    lastEmittedId = activeId;
+    const text = activeId ? items.find((item) => item.id === activeId)?.text ?? "" : "";
+    tocPanel.dispatchEvent(new CustomEvent("codex-toc-active", { bubbles: true, detail: { id: activeId, text } }));
+  };
 
   const observer = new IntersectionObserver(
     (entries) => {
@@ -69,6 +78,7 @@ export function installTocScrollSpy(
         headings[0]?.id ??
         null;
       setActiveLink(links, activeId);
+      emitActive(activeId);
     },
     {
       root: scrollRoot,
@@ -79,8 +89,12 @@ export function installTocScrollSpy(
 
   for (const h of headings) observer.observe(h);
   setActiveLink(links, headings[0]?.id ?? null);
+  emitActive(headings[0]?.id ?? null);
 
-  return () => observer.disconnect();
+  return () => {
+    observer.disconnect();
+    emitActive(null);
+  };
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
@@ -37,10 +37,15 @@ export interface MountCoworkInlineOptions {
   entryId: string;
   /** 렌더 중복 제거용 엔트리 제목 */
   title: string;
-  /** 리딩 뷰를 감싸는 article — 필/도크의 포지셔닝 호스트 */
+  /** 리딩 뷰를 감싸는 article — 선택 필/코멘트 컴포저의 포지셔닝 호스트 */
   article: HTMLElement;
   /** 엔트리 마크다운이 렌더된 본문 요소 — 초안 렌더 시 이 내용만 교체 */
   body: HTMLElement;
+  /**
+   * 도크(컴포저 바)가 정박할 프레임 경계 요소. 본문 스크롤 흐름 밖에 두어야
+   * 읽는 중인 문단을 가리지 않는다. 생략 시 article 말미(레거시 흐름 내 위치).
+   */
+  dockHost?: HTMLElement;
   onApplied(): void;
 }
 
@@ -109,7 +114,9 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   tip.className = "cowork-tip";
   tip.hidden = true;
   options.article.classList.add("cowork-host");
-  options.article.append(anchor, dockZone, tip);
+  options.article.append(anchor, tip);
+  // 도크는 스크롤포트 밖 프레임 경계에 선다 — 본문 위 부유(가림)를 만들지 않는다.
+  (options.dockHost ?? options.article).append(dockZone);
 
   const unmountSettingsSelect = () => {
     settingsSelectRoot?.unmount();
@@ -259,7 +266,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
       ${dirty && !running ? renderReview(changed) : ""}
       <div class="cowork-bar${running ? " is-running" : ""}" data-cowork-form>
         ${running ? '<span class="cowork-glow" aria-hidden="true"></span>' : ""}
-        <button type="button" class="cowork-chip${panelOpen ? " is-active" : ""}" data-cowork-action="toggle-panel" aria-expanded="${panelOpen}" aria-label="${escapeAttribute(t("codex.cowork.annotationsAria"))}" ${running ? "disabled" : ""}><span aria-hidden="true">✦</span>${annotations.length}</button>
+        ${annotations.length > 0 || panelOpen ? `<button type="button" class="cowork-chip${panelOpen ? " is-active" : ""}" data-cowork-action="toggle-panel" aria-expanded="${panelOpen}" aria-label="${escapeAttribute(t("codex.cowork.annotationsAria"))}" ${running ? "disabled" : ""}><span aria-hidden="true">✦</span>${annotations.length}</button>` : ""}
         <input class="cowork-dock-input" name="prompt" autocomplete="off" value="${escapeAttribute(promptText)}" placeholder="${escapeAttribute(annotations.length ? t("codex.cowork.instructionOptional") : t("codex.cowork.askAi"))}" aria-label="${escapeAttribute(t("codex.cowork.instructionAria"))}" ${running ? "disabled" : ""}>
         <button type="button" class="cowork-chip cowork-chip--config${configOpen ? " is-active" : ""}" data-cowork-action="toggle-config" aria-expanded="${configOpen}" aria-label="${escapeAttribute(t("codex.cowork.agentSettingsAria"))}" ${running ? "disabled" : ""}>${escapeHtml(settings.model || "agent")}${chipEffortGauge()}</button>
         ${running
@@ -814,6 +821,15 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   options.article.addEventListener("change", onChange);
   options.article.addEventListener("mouseover", onMouseOverMark);
   options.article.addEventListener("mouseleave", onMouseLeaveArticle);
+  // 도크가 article 밖 프레임 경계에 있으면 도크 상호작용 위임을 도크 존에 따로 건다.
+  // (article 내 레거시 배치에서는 버블링이 닿으므로 이중 등록 시 토글류가 두 번 뒤집힌다.)
+  const dockDetached = !options.article.contains(dockZone);
+  if (dockDetached) {
+    dockZone.addEventListener("keydown", onKeyDown);
+    dockZone.addEventListener("click", onClick);
+    dockZone.addEventListener("input", onInput);
+    dockZone.addEventListener("change", onChange);
+  }
 
   return {
     destroy() {
@@ -829,6 +845,12 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
       options.article.removeEventListener("change", onChange);
       options.article.removeEventListener("mouseover", onMouseOverMark);
       options.article.removeEventListener("mouseleave", onMouseLeaveArticle);
+      if (dockDetached) {
+        dockZone.removeEventListener("keydown", onKeyDown);
+        dockZone.removeEventListener("click", onClick);
+        dockZone.removeEventListener("input", onInput);
+        dockZone.removeEventListener("change", onChange);
+      }
       anchor.remove();
       dockZone.remove();
       tip.remove();

--- a/runtime/fleet-console/core/client/src/codex/main.ts
+++ b/runtime/fleet-console/core/client/src/codex/main.ts
@@ -55,6 +55,9 @@ export function mountNavigatorApp(
     setCurrentEntry(entryId: string | null): void {
       controller.setCurrentEntry(entryId);
     },
+    setActiveTag(tag: string | null): void {
+      controller.setActiveTag(tag);
+    },
     refreshHealth(): void {
       controller.refreshHealth();
     },

--- a/runtime/fleet-console/core/client/src/codex/reading-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/reading-controller.ts
@@ -61,7 +61,7 @@ export interface ReadingController {
   destroy(): void;
   setEntry(entryId: string): Promise<void>;
   navigateSub(subId: string | undefined): Promise<void>;
-  refreshCallbacks(next: Partial<Pick<MountReadingOptions, "onPatchOpen" | "onConflictOpen" | "onDecided" | "onRelatedClick" | "onClose" | "theaterId">>): void;
+  refreshCallbacks(next: Partial<Pick<MountReadingOptions, "onPatchOpen" | "onConflictOpen" | "onDecided" | "onRelatedClick" | "onClose" | "onTagClick" | "theaterId">>): void;
   /** 로케일 변경 시 현재 문서·스크롤을 유지한 채 문구만 다시 그린다. */
   refreshLocale(): Promise<void>;
 }
@@ -78,9 +78,13 @@ export interface MountReadingOptions {
   readonly onConflictOpen?: (conflictId: string | undefined) => void;
   /** 승인/반려 결정 완료 후 목록 갱신을 트리거하는 콜백 */
   readonly onDecided?: () => void;
+  /** 문서 헤더 태그 칩 클릭 — 카탈로그 태그 필터로 라우팅된다. */
+  readonly onTagClick?: (tag: string) => void;
   readonly onEntryRendered?: (entryId: string) => void;
   readonly onTocChanged?: (count: number) => void;
   readonly tocContainer: HTMLElement;
+  /** Cowork 도크가 정박할 프레임 경계 슬롯(스크롤포트 밖). */
+  readonly dockContainer?: HTMLElement;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -143,6 +147,33 @@ export function mountReadingInto(
       event.preventDefault();
       const entryId = decodeURIComponent(wikiLink.pathname.slice("/entry/".length));
       if (entryId) liveOpts.onRelatedClick(entryId);
+      return;
+    }
+
+    // 문서 헤더 태그 칩 — 카탈로그의 같은 시각 어휘와 같은 약속(태그 필터)으로 응답한다.
+    const docTag = target.closest<HTMLElement>("[data-doc-tag]");
+    if (docTag?.dataset.docTag) {
+      event.preventDefault();
+      liveOpts.onTagClick?.(docTag.dataset.docTag);
+      return;
+    }
+
+    // 태그 칩 접힘 토글(+N ↔ −) — 재렌더 없이 컨테이너 상태만 뒤집는다.
+    const chipsToggle = target.closest<HTMLElement>("[data-chips-toggle]");
+    if (chipsToggle) {
+      event.preventDefault();
+      const chips = chipsToggle.closest<HTMLElement>(".meta-chips");
+      if (!chips) return;
+      const collapsed = chips.dataset.collapsed !== "true";
+      chips.dataset.collapsed = String(collapsed);
+      chipsToggle.setAttribute("aria-expanded", String(!collapsed));
+      const overflowCount = chips.querySelectorAll(".chip-tag--overflow").length;
+      const t = consoleT();
+      chipsToggle.textContent = collapsed ? `+${overflowCount}` : "−";
+      chipsToggle.setAttribute(
+        "aria-label",
+        collapsed ? t("codex.meta.moreTags", { count: overflowCount }) : t("codex.meta.collapseTags"),
+      );
       return;
     }
 
@@ -342,7 +373,7 @@ export function mountReadingInto(
           <header class="document-header">
             ${renderSheetBreadcrumb(entry.frontmatter.title)}
             <h1>${escapeHtml(entry.frontmatter.title)}</h1>
-            ${renderMetaChips(entry.frontmatter)}
+            ${renderMetaChips(entry.frontmatter, { interactiveTags: true })}
           </header>
           <div class="markdown-body" id="codex-reader-body">
             ${markdownHtml}
@@ -367,6 +398,7 @@ export function mountReadingInto(
           title: entry.frontmatter.title,
           article,
           body,
+          dockHost: opts.dockContainer,
           onApplied: () => { void renderEntryView(entryId); },
         });
       }

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -98,6 +98,41 @@ kbd {
   color: var(--brass-bright);
 }
 
+/* 문서 헤더의 태그 칩은 카탈로그와 같은 약속(누르면 태그 필터)을 지키는 버튼이다. */
+button.chip {
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide);
+}
+
+button.chip-tag:hover,
+button.chip-tag:focus-visible {
+  background: color-mix(in oklch, var(--brass) 22%, transparent);
+  border-color: color-mix(in oklch, var(--brass) 55%, transparent);
+}
+
+button.chip:focus-visible {
+  outline: 2px solid color-mix(in oklch, var(--brass) 68%, transparent);
+  outline-offset: 1px;
+}
+
+/* 접힌 태그 초과분 표식(+N) — 점선 테두리로 "더 있음"을 말하는 토글. */
+.chip-more {
+  background: transparent;
+  border-style: dashed;
+  border-color: var(--surface-rim-strong);
+  color: var(--text-tertiary);
+}
+
+.chip-more:hover,
+.chip-more:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 45%, transparent);
+  color: var(--brass-bright);
+}
+
+.meta-chips[data-collapsed="true"] .chip-tag--overflow {
+  display: none;
+}
+
 .chip-aurora {
   background: color-mix(in oklch, var(--aurora) 12%, transparent);
   border-color: color-mix(in oklch, var(--aurora) 35%, transparent);
@@ -386,6 +421,32 @@ kbd {
 .document--utility .document-header {
   padding-bottom: var(--space-4);
   margin-bottom: var(--space-4);
+}
+
+/* ─── 문서 타이포 컨테이너 문법 ────────────────────────────────────────────────
+   리더 스크롤포트(.codex-doc-scroll·.codex-reading-sheet-read)가 codex-reader
+   컨테이너다. 제목 스케일은 뷰포트가 아니라 "문서가 실제로 놓인 폭"에 응답해,
+   분할·덱·패널 리사이즈가 한 규칙을 공유한다. @container 규칙은 특정성 가산이
+   없어 소스 순서로만 이기므로(reference: @container 특정성 0), 셀렉터를
+   .codex-reader-host로 승급해 base 재배치에도 지지 않게 한다. */
+.codex-reader-host .document h1 {
+  /* 리더 페인은 작업면이다 — 스탠드얼론 히어로 스케일(display-2xl)을 쓰지 않는다. */
+  font-size: var(--font-size-display-lg);
+}
+
+@container codex-reader (max-width: 960px) {
+  .codex-reader-host .document h1 {
+    font-size: var(--font-size-display-md);
+  }
+}
+
+@container codex-reader (max-width: 640px) {
+  .codex-reader-host .document h1 {
+    font-size: var(--font-size-title-xl);
+    font-weight: var(--weight-medium);
+    letter-spacing: -0.01em;
+    line-height: 1.25;
+  }
 }
 
 .lead {
@@ -2595,9 +2656,10 @@ kbd {
 }
 
 .codex-nav-entry {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 2px var(--space-2);
   width: 100%;
   padding: var(--space-2) var(--space-3);
   background: transparent;
@@ -2634,12 +2696,55 @@ kbd {
 }
 
 .codex-nav-entry .tg {
+  grid-column: 1 / -1;
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
+  flex-wrap: nowrap;
+  overflow: hidden;
   gap: var(--space-1);
 }
 
+/* 우측 한 칸 — current 행은 시간, 예외 상태 행은 그 배지가 대신 선다. */
+.codex-nav-entry .when {
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.codex-nav-status {
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  padding: 1px var(--space-1);
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+}
+
+.codex-nav-status.is-deprecated {
+  border-color: color-mix(in oklch, var(--coral) 45%, transparent);
+  color: var(--coral-ink);
+}
+
+/* 낡음 표식은 헤더 칩(.chip-stale)과 같은 집 관용구(brass 틴트)를 따른다. */
+.codex-nav-status.is-stale {
+  border-color: color-mix(in oklch, var(--brass) 40%, transparent);
+  color: var(--brass-bright);
+}
+
+.codex-nav-more {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  color: var(--text-tertiary);
+  padding: 1px var(--space-1);
+}
+
 .codex-nav-entry .snippet {
+  grid-column: 1 / -1;
   display: -webkit-box;
   overflow: hidden;
   color: var(--text-tertiary);
@@ -2668,8 +2773,14 @@ kbd {
 }
 
 .codex-nav-tag {
-  display: inline-flex;
-  align-items: center;
+  /* 한 줄 태그 행에서 좁은 페인이 칩을 짜부라뜨리면 내부 줄바꿈 대신 말줄임으로 줄인다
+     (inline-flex는 텍스트 말줄임이 걸리지 않아 block 계열로 둔다). */
+  display: inline-block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.5;
   padding: 1px var(--space-1);
   background: transparent;
   border: 1px solid var(--surface-rim);
@@ -2717,10 +2828,6 @@ kbd {
 .codex-reading-sheet .markdown-body {
   max-inline-size: 72ch;
   margin-inline: auto;
-}
-
-.codex-reading-sheet .document-header h1 {
-  font-size: var(--font-size-display-md);
 }
 
 /* ─── Cowork inline copilot ─────────────────────────────────────────────────
@@ -2822,20 +2929,16 @@ kbd {
 .cowork-composer textarea::placeholder { color: var(--text-tertiary); }
 .cowork-composer-actions { display: flex; justify-content: flex-end; gap: var(--space-1); }
 
-/* 도크 존 — 리딩 시트 스크롤포트 하단에 붙는 sticky 스택 */
+/* 도크 존 — 스크롤포트 밖 프레임 경계 행(.codex-reader-composer)의 내용물.
+   본문 위 부유가 아니므로 z-index·pointer-events 게임이 필요 없다. */
 .cowork-dock-zone {
-  position: sticky;
-  bottom: var(--space-3);
-  z-index: 7;
   display: none;
   flex-direction: column;
   align-items: center;
   gap: var(--space-2);
-  margin-top: var(--space-6);
-  pointer-events: none;
+  padding: var(--space-2) var(--space-4) var(--space-3);
 }
 .cowork-dock-zone.is-open { display: flex; animation: cowork-rise var(--duration-base) var(--ease-spring); }
-.cowork-dock-zone > * { pointer-events: auto; }
 
 .cowork-revision-stream {
   position: relative;

--- a/runtime/fleet-console/core/client/src/components/codex-reading-sheet.tsx
+++ b/runtime/fleet-console/core/client/src/components/codex-reading-sheet.tsx
@@ -7,6 +7,7 @@ import {
   navigateCodexReaderHistory,
   refreshCodexHealth,
   saveReaderScroll,
+  setNavigatorTagFilter,
   subscribeCodexReaderHistory,
 } from "../codex-host.js";
 import { useConsoleState } from "../hooks/use-store.js";
@@ -35,6 +36,7 @@ export function CodexReadingSheet() {
   const sheetRef = useRef<HTMLDivElement>(null);
   const readRef = useRef<HTMLDivElement>(null);
   const tocRef = useRef<HTMLDivElement>(null);
+  const dockRef = useRef<HTMLDivElement>(null);
 
   const readerKey = reader
     ? `${reader.kind}:${reader.kind === "entry" ? reader.entryId : reader.kind === "drydock" ? (reader.patchId ?? "") : reader.kind === "conflicts" ? (reader.id ?? "") : (reader.templateId ?? "")}`
@@ -86,7 +88,7 @@ export function CodexReadingSheet() {
 
   // 콘텐츠 effect: reader 호스트 노드를 시트 슬롯으로 relocate
   useEffect(() => {
-    if (!isOpen || !readRef.current || !tocRef.current || !reader) return;
+    if (!isOpen || !readRef.current || !tocRef.current || !dockRef.current || !reader) return;
 
     const kind = reader.kind;
     const subId =
@@ -95,7 +97,7 @@ export function CodexReadingSheet() {
     // 리더 fetch는 Theater id가 아니라 해석된 codex workspace id로 나가야 한다 —
     // Theater id는 /console/codex/w/ 라우터에서 workspace_not_found로 떨어진다.
     const workspaceId = resolvedCodexWorkspaceIdFor(theaterId);
-    mountReaderInto(readRef.current, tocRef.current, {
+    mountReaderInto(readRef.current, tocRef.current, dockRef.current, {
       initialEntryId: kind === "entry" ? reader.entryId : "",
       kind,
       subId,
@@ -117,6 +119,8 @@ export function CodexReadingSheet() {
         openCodexReader({ kind: "conflicts", id });
         expandCodexReader();
       },
+      // 덱이 열려 있어도 카탈로그 레일은 살아 있다 — 태그 칩은 그 레일을 그대로 거른다.
+      onTagClick: (tag) => setNavigatorTagFilter(tag),
       onDecided: () => {
         void loadInitialData();
         refreshCodexHealth();
@@ -187,7 +191,10 @@ export function CodexReadingSheet() {
             className="codex-reading-sheet-toc"
             aria-label={t("chrome.codexReading.onThisPage")}
           />
-          <div ref={readRef} className="codex-reading-sheet-read" />
+          <div className="codex-reading-sheet-main">
+            <div ref={readRef} className="codex-reading-sheet-read" />
+            <div ref={dockRef} className="codex-reader-composer" />
+          </div>
         </div>
       </div>
     ),

--- a/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
@@ -438,6 +438,8 @@ export const pagesEn = {
 
   // codex — meta chips / toc / op-badge
   "codex.meta.updated": "Updated {date}",
+  "codex.meta.moreTags": "Show {count} more tags",
+  "codex.meta.collapseTags": "Collapse tags",
   "codex.meta.stale": "stale",
   "codex.meta.statusStaleTitle": "{status} · stale",
   "codex.toc.noSections": "No sections",
@@ -948,6 +950,8 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "codex.reading.workspaceSchema": "워크스페이스 Schema",
 
   "codex.meta.updated": "업데이트 {date}",
+  "codex.meta.moreTags": "태그 {count}개 더 보기",
+  "codex.meta.collapseTags": "태그 접기",
   "codex.meta.stale": "오래됨",
   "codex.meta.statusStaleTitle": "{status} · 오래됨",
   "codex.toc.noSections": "섹션 없음",

--- a/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
@@ -14,6 +14,7 @@ import {
   refreshCodexLocale,
   restoreCodexReaderSession,
   saveReaderScroll,
+  setNavigatorTagFilter,
   setNavigatorTheater,
   setOnRequestOpenReader,
   subscribeCodexReaderHistory,
@@ -71,6 +72,8 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
   const navRef = useRef<HTMLDivElement>(null);
   const readRef = useRef<HTMLDivElement>(null);
   const tocRef = useRef<HTMLDivElement>(null);
+  const dockRef = useRef<HTMLDivElement>(null);
+  const outlineRef = useRef<HTMLElement>(null);
   const latestContextKeyRef = useRef("");
   const localeRef = useRef(locale);
   const contextKey = theaterId ?? "";
@@ -80,6 +83,7 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
       : null,
   );
   const [outlineCollapsed, setOutlineCollapsed] = useState(readOutlineCollapsed);
+  const [activeSection, setActiveSection] = useState("");
 
   const reader = state.codexReader;
   const hasReader = reader !== null;
@@ -164,10 +168,10 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
   // split reader mount — expanded=true면 오버레이가 처리 중이므로 건너뜀
   useEffect(() => {
     if (!shouldMountCodex || !workspaceId || !hasReader || expanded) return;
-    if (!readRef.current || !tocRef.current || !reader) return;
+    if (!readRef.current || !tocRef.current || !dockRef.current || !reader) return;
     const kind = reader.kind;
     const subId = kind === "drydock" ? reader.patchId : kind === "conflicts" ? reader.id : kind === "schema" ? reader.templateId : undefined;
-    mountReaderInto(readRef.current, tocRef.current, {
+    mountReaderInto(readRef.current, tocRef.current, dockRef.current, {
       initialEntryId: kind === "entry" ? reader.entryId : "",
       kind,
       subId,
@@ -177,6 +181,7 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
       onClose: () => closeCodexReader(),
       onPatchOpen: (pid) => openCodexReader({ kind: "drydock", patchId: pid }),
       onConflictOpen: (id) => openCodexReader({ kind: "conflicts", id }),
+      onTagClick: (tag) => setNavigatorTagFilter(tag),
       onDecided: () => {
         void loadInitialData();
         refreshCodexHealth();
@@ -184,6 +189,18 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
       },
     });
   }, [shouldMountCodex, workspaceId, hasReader, expanded, readerKey, locale]);
+
+  // 접힌 아웃라인 스파인이 현재 섹션명을 되비추도록 스크롤 스파이의 활성 전환을 구독한다.
+  useEffect(() => {
+    const outline = outlineRef.current;
+    if (!outline) return;
+    const onActive = (event: Event) => {
+      const detail = (event as CustomEvent<{ text?: string }>).detail;
+      setActiveSection(detail?.text ?? "");
+    };
+    outline.addEventListener("codex-toc-active", onActive);
+    return () => outline.removeEventListener("codex-toc-active", onActive);
+  }, [hasReader, expanded]);
 
   // 로케일 변경 시 imperative DOM 문구를 갱신한다(문서·스크롤 보존).
   useEffect(() => {
@@ -229,6 +246,7 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
           </button>
         </div>
         <section
+          ref={outlineRef}
           className="codex-doc-outline"
           data-codex-outline
           data-collapsed={outlineCollapsed}
@@ -244,12 +262,18 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
               writeOutlineCollapsed(next);
             }}
           >
-            <span>{t("codex.nav.outline")} · <span data-codex-outline-count>0</span></span>
+            <span className="codex-doc-outline-label">
+              <span>{t("codex.nav.outline")} · <span data-codex-outline-count>0</span></span>
+              {outlineCollapsed && activeSection ? (
+                <span className="codex-doc-outline-current" title={activeSection}>{activeSection}</span>
+              ) : null}
+            </span>
             <span className="codex-doc-outline-chevron" aria-hidden="true">⌄</span>
           </button>
           <div ref={tocRef} className="codex-doc-toc-inline" />
         </section>
         <div ref={readRef} className="codex-doc-scroll" />
+        <div ref={dockRef} className="codex-reader-composer" />
       </div>
       <div ref={navRef} className="codex-nav-pane" />
     </div>
@@ -323,10 +347,12 @@ async function resolveCodexWorkspace(theaterId: string): Promise<Omit<CodexWorks
 }
 
 function readOutlineCollapsed(): boolean {
+  // 기본은 접힌 스파인 — 펼침은 명시적 선택으로만 유지된다(전주가 본문 도달을 밀지 않도록).
   try {
-    return localStorage.getItem("fleet.codex.outline.collapsed") === "true";
+    const stored = localStorage.getItem("fleet.codex.outline.collapsed");
+    return stored === null ? true : stored === "true";
   } catch {
-    return false;
+    return true;
   }
 }
 

--- a/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
@@ -199,8 +199,14 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
       setActiveSection(detail?.text ?? "");
     };
     outline.addEventListener("codex-toc-active", onActive);
+    // 덱(확대) 동안의 활성 전환 이벤트는 이 리스너 밖에서 지나간다 — 재부착 시점에
+    // 재배치된 TOC의 활성 표식에서 상태를 다시 읽어 낡은 섹션명이 남지 않게 한다.
+    // (리더 마운트 effect가 먼저 선언되어 TOC 재배치가 이 시점엔 끝나 있다.)
+    const active = outline.querySelector<HTMLElement>('.codex-doc-toc-inline [aria-current="location"]');
+    setActiveSection(active?.textContent ?? "");
     return () => outline.removeEventListener("codex-toc-active", onActive);
-  }, [hasReader, expanded]);
+    // 아웃라인이 (재)마운트되는 모든 전이에서 다시 걸려야 한다 — 리더 마운트 effect와 같은 의존성.
+  }, [shouldMountCodex, workspaceId, hasReader, expanded, readerKey]);
 
   // 로케일 변경 시 imperative DOM 문구를 갱신한다(문서·스크롤 보존).
   useEffect(() => {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -11681,14 +11681,26 @@ body[data-codex-side="true"] .command-card {
   grid-template-columns: 220px minmax(0, 1fr);
 }
 
+.codex-reading-sheet-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
 .codex-reading-sheet-read {
   --codex-reader-gutter-x: var(--space-8);
   position: relative;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   /* --space-7은 미정의 토큰이라 shorthand 전체가 무효화되어 padding 0이 됐었다(.document
      패딩이 가리던 잠복 결함). .document 플랫화로 이 거터가 유일한 가터가 되므로 정의된
-     토큰만 사용해야 한다. 하단 여유는 sticky Cowork 도크가 마지막 문단을 덮지 않을 만큼 둔다. */
-  padding: var(--space-6) var(--space-8) calc(var(--space-10) + 88px);
+     토큰만 사용해야 한다. Cowork 도크는 스크롤 밖 컴포저 행으로 내려가 본문을 덮지 않는다. */
+  padding: var(--space-6) var(--space-8) var(--space-10);
+  /* 문서 타이포 컨테이너 — 분할·덱이 같은 @container 문법(codex/styles/components.css)을 공유한다. */
+  container-type: inline-size;
+  container-name: codex-reader;
 }
 
 /* 덱은 넓다 — 본문은 읽기 measure로 캡하고 중앙 정렬한다. 전폭이 필요한 유틸 표면
@@ -11856,7 +11868,25 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
   min-height: 0;
   overflow-y: auto;
   position: relative;
-  padding: var(--space-5) var(--space-6) calc(var(--space-10) + 88px);
+  padding: var(--space-5) var(--space-6) var(--space-10);
+  container-type: inline-size;
+  container-name: codex-reader;
+}
+
+/* Cowork 도크의 프레임 경계 슬롯 — 스크롤포트 아래 고정 행이라 본문을 가리지 않는다.
+   entry 밖 화면(대기열·충돌·스키마)에서는 도크가 없어 행 자체가 접힌다. */
+.codex-reader-composer {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--surface-rim);
+  background: color-mix(in oklch, var(--surface-glass) 55%, transparent);
+}
+
+.codex-reader-composer:not(:has(.cowork-dock-zone.is-open)) {
+  display: none;
+}
+
+.codex-reader-composer > .codex-dock-host {
+  width: 100%;
 }
 
 /* split 좌측 문서는 읽기 measure 캡 없이 doc-pane 폭을 채운다(베이스 .markdown-body의
@@ -11900,6 +11930,30 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   cursor: pointer;
+}
+
+.codex-doc-outline-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.codex-doc-outline-label > span:first-child {
+  flex: none;
+}
+
+/* 접힌 스파인이 되비추는 현재 섹션 — 위치 표시일 뿐 상태가 아니므로 본문 서체·본문 색으로. */
+.codex-doc-outline-current {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .codex-doc-outline-toggle:hover,

--- a/runtime/fleet-console/core/host/codex/routes.ts
+++ b/runtime/fleet-console/core/host/codex/routes.ts
@@ -305,6 +305,7 @@ async function handleSearch(url: URL, response: ServerResponse, context: RouteCo
       updated: hit.updated,
       path: `wiki/${hit.id}.md`,
       status: hit.status,
+      revalidateAfter: hit.revalidateAfter,
       rawSourceRef: hit.rawSourceRef,
       rawSourceRefs: hit.rawSourceRefs,
       score: hit.score,

--- a/runtime/fleet-console/tests/codex-cowork-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-ui.test.ts
@@ -145,6 +145,8 @@ describe("Cowork inline copilot", () => {
     // 엔트리를 열면 채팅박스(도크)가 세션 없이도 무조건 떠 있고, 세션은 아직 생성되지 않는다.
     expect(article.querySelector(".cowork-dock-zone")?.classList.contains("is-open")).toBe(true);
     expect(article.querySelector(".cowork-dock-input")).not.toBeNull();
+    // 주석 0개에서는 ✦0 칩을 그리지 않는다 — 무정보 카운트는 소음이다.
+    expect(article.querySelector('[data-cowork-action="toggle-panel"]')).toBeNull();
     expect(article.querySelector(".cowork-review")).toBeNull();
     expect(body.textContent).toContain("Published body.");
     expect(fetchMock.mock.calls.map(call => String(call[0])).some(url => url.endsWith("/cowork/sessions"))).toBe(false);
@@ -382,13 +384,56 @@ describe("Cowork inline copilot", () => {
     }
 
     expect(article.querySelectorAll(".cowork-agent-row")).toHaveLength(1);
-    article.querySelector<HTMLElement>('[data-cowork-action="toggle-panel"]')!.click();
+    // 주석이 0개면 ✦ 칩은 렌더되지 않는다 — 설정 토글 재클릭으로 팝오버를 닫는다.
+    expect(article.querySelector('[data-cowork-action="toggle-panel"]')).toBeNull();
+    article.querySelector<HTMLElement>('[data-cowork-action="toggle-config"]')!.click();
     await vi.waitFor(() => expect(article.querySelector(".cowork-config")).toBeNull());
     expect(document.querySelectorAll(".cowork-effort-flyout")).toHaveLength(0);
 
     controller.destroy();
     expect(article.querySelector(".cowork-dock-zone")).toBeNull();
     expect(document.querySelectorAll(".cowork-agent-row")).toHaveLength(0);
+    article.remove();
+  });
+
+  it("anchors the dock in a detached frame host and keeps dock interactions working", async () => {
+    const listeners = new Map<string, EventListener>();
+    class FakeEventSource { addEventListener(type: string, listener: EventListener) { listeners.set(type, listener); } close() {} }
+    vi.stubGlobal("EventSource", FakeEventSource);
+    const fresh = sessionDto({ id: "cowork-detached", draft: BASE_DRAFT, revision: 0, annotations: [] });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/cowork/entries/")) return new Response(JSON.stringify({ error: "cowork_session_not_found" }), { status: 404 });
+      if (url.includes("/options")) return new Response(JSON.stringify({ models: ["sonnet"], efforts: ["medium"], defaultModel: "sonnet", defaultEffort: "medium" }));
+      if (url.endsWith("/cowork/sessions")) return new Response(JSON.stringify(fresh), { status: 201 });
+      return new Response(JSON.stringify(fresh));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { article, body } = host();
+    const dockHost = document.createElement("div");
+    document.body.append(dockHost);
+
+    const controller = mountCoworkInline({ theaterId: "theater", entryId: "entry", title: "Entry", article, body, dockHost, onApplied: vi.fn() });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    // 도크는 article(스크롤 흐름)이 아니라 프레임 경계 호스트에 정박한다.
+    expect(article.querySelector(".cowork-dock-zone")).toBeNull();
+    expect(dockHost.querySelector(".cowork-dock-zone")?.classList.contains("is-open")).toBe(true);
+
+    // article 밖에서도 도크 위임이 살아 있다 — 입력·전송이 세션 지연 생성으로 이어진다.
+    const input = dockHost.querySelector<HTMLInputElement>(".cowork-dock-input")!;
+    input.value = "boundary dock send";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    dockHost.querySelector<HTMLElement>('[data-cowork-action="send"]')!.click();
+    await vi.waitFor(() => {
+      const urls = fetchMock.mock.calls.map(call => String(call[0]));
+      expect(urls.some(url => url.endsWith("/cowork/sessions"))).toBe(true);
+      expect(urls.some(url => url.endsWith("/prompt"))).toBe(true);
+    });
+
+    controller.destroy();
+    expect(dockHost.querySelector(".cowork-dock-zone")).toBeNull();
+    dockHost.remove();
     article.remove();
   });
 

--- a/runtime/fleet-console/tests/codex-host-state.test.ts
+++ b/runtime/fleet-console/tests/codex-host-state.test.ts
@@ -119,7 +119,8 @@ describe("Codex host in-memory state", () => {
   it("reopens history entries and truncates the forward branch after a new entry", () => {
     const readSlot = document.createElement("div");
     const tocSlot = document.createElement("div");
-    document.body.append(readSlot, tocSlot);
+    const dockSlot = document.createElement("div");
+    document.body.append(readSlot, tocSlot, dockSlot);
     const requestEntry = vi.fn();
     const options = {
       initialEntryId: "entry-a",
@@ -131,18 +132,18 @@ describe("Codex host in-memory state", () => {
     };
 
     mountNavigatorInto(document.body.appendChild(document.createElement("div")), "workspace-a");
-    mountReaderInto(readSlot, tocSlot, options);
-    mountReaderInto(readSlot, tocSlot, { ...options, initialEntryId: "entry-b" });
-    mountReaderInto(readSlot, tocSlot, { ...options, initialEntryId: "entry-c" });
+    mountReaderInto(readSlot, tocSlot, dockSlot, options);
+    mountReaderInto(readSlot, tocSlot, dockSlot, { ...options, initialEntryId: "entry-b" });
+    mountReaderInto(readSlot, tocSlot, dockSlot, { ...options, initialEntryId: "entry-c" });
     expect(codexMocks.navigatorController.setCurrentEntry).toHaveBeenLastCalledWith("entry-c");
     expect(getCodexReaderHistoryState()).toEqual({ canGoBack: true, canGoForward: false });
 
     navigateCodexReaderHistory(-1);
     expect(requestEntry).toHaveBeenLastCalledWith("entry-b");
-    mountReaderInto(readSlot, tocSlot, { ...options, initialEntryId: "entry-b" });
+    mountReaderInto(readSlot, tocSlot, dockSlot, { ...options, initialEntryId: "entry-b" });
     expect(getCodexReaderHistoryState()).toEqual({ canGoBack: true, canGoForward: true });
 
-    mountReaderInto(readSlot, tocSlot, { ...options, initialEntryId: "entry-d" });
+    mountReaderInto(readSlot, tocSlot, dockSlot, { ...options, initialEntryId: "entry-d" });
     expect(getCodexReaderHistoryState()).toEqual({ canGoBack: true, canGoForward: false });
     navigateCodexReaderHistory(1);
     expect(requestEntry).toHaveBeenCalledTimes(1);
@@ -157,8 +158,9 @@ describe("Codex host in-memory state", () => {
 
     const readSlot = document.createElement("div");
     const tocSlot = document.createElement("div");
-    document.body.append(readSlot, tocSlot);
-    mountReaderInto(readSlot, tocSlot, {
+    const dockSlot = document.createElement("div");
+    document.body.append(readSlot, tocSlot, dockSlot);
+    mountReaderInto(readSlot, tocSlot, dockSlot, {
       initialEntryId: "entry-restored",
       kind: "entry",
       theaterId: "workspace-a",
@@ -180,7 +182,8 @@ describe("Codex host in-memory state", () => {
 
     const readSlot = document.createElement("div");
     const tocSlot = document.createElement("div");
-    document.body.append(readSlot, tocSlot);
+    const dockSlot = document.createElement("div");
+    document.body.append(readSlot, tocSlot, dockSlot);
     const options = {
       kind: "entry" as const,
       theaterId: "workspace-a",
@@ -188,8 +191,8 @@ describe("Codex host in-memory state", () => {
       onRelatedClick: vi.fn(),
       onClose: vi.fn(),
     };
-    mountReaderInto(readSlot, tocSlot, { ...options, initialEntryId: "entry-restored" });
-    mountReaderInto(readSlot, tocSlot, { ...options, initialEntryId: "entry-new" });
+    mountReaderInto(readSlot, tocSlot, dockSlot, { ...options, initialEntryId: "entry-restored" });
+    mountReaderInto(readSlot, tocSlot, dockSlot, { ...options, initialEntryId: "entry-new" });
     codexMocks.readerMountOptions.at(-1)?.onEntryRendered?.("entry-new");
 
     readSlot.scrollTop = 480;
@@ -205,9 +208,11 @@ describe("Codex host in-memory state", () => {
   it("keeps the saved reader position when its previous slot was already detached", () => {
     const firstReadSlot = document.createElement("div");
     const firstTocSlot = document.createElement("div");
+    const firstDockSlot = document.createElement("div");
     const nextReadSlot = document.createElement("div");
     const nextTocSlot = document.createElement("div");
-    document.body.append(firstReadSlot, firstTocSlot, nextReadSlot, nextTocSlot);
+    const nextDockSlot = document.createElement("div");
+    document.body.append(firstReadSlot, firstTocSlot, firstDockSlot, nextReadSlot, nextTocSlot, nextDockSlot);
     const options = {
       initialEntryId: "entry-a",
       kind: "entry" as const,
@@ -217,13 +222,13 @@ describe("Codex host in-memory state", () => {
       onClose: vi.fn(),
     };
 
-    mountReaderInto(firstReadSlot, firstTocSlot, options);
+    mountReaderInto(firstReadSlot, firstTocSlot, firstDockSlot, options);
     firstReadSlot.scrollTop = 137;
     saveReaderScroll();
     firstReadSlot.remove();
     firstReadSlot.scrollTop = 0;
 
-    mountReaderInto(nextReadSlot, nextTocSlot, options);
+    mountReaderInto(nextReadSlot, nextTocSlot, nextDockSlot, options);
 
     expect(nextReadSlot.scrollTop).toBe(137);
   });
@@ -319,9 +324,11 @@ function mountRelocatedReader(scrollTop: number): {
 } {
   const firstReadSlot = document.createElement("div");
   const firstTocSlot = document.createElement("div");
+  const firstDockSlot = document.createElement("div");
   const nextReadSlot = document.createElement("div");
   const nextTocSlot = document.createElement("div");
-  document.body.append(firstReadSlot, firstTocSlot, nextReadSlot, nextTocSlot);
+  const nextDockSlot = document.createElement("div");
+  document.body.append(firstReadSlot, firstTocSlot, firstDockSlot, nextReadSlot, nextTocSlot, nextDockSlot);
   const options = {
     initialEntryId: "entry-a",
     kind: "entry" as const,
@@ -331,11 +338,11 @@ function mountRelocatedReader(scrollTop: number): {
     onClose: vi.fn(),
   };
 
-  mountReaderInto(firstReadSlot, firstTocSlot, options);
+  mountReaderInto(firstReadSlot, firstTocSlot, firstDockSlot, options);
   firstReadSlot.scrollTop = scrollTop;
   saveReaderScroll();
   firstReadSlot.remove();
-  mountReaderInto(nextReadSlot, nextTocSlot, options);
+  mountReaderInto(nextReadSlot, nextTocSlot, nextDockSlot, options);
   return { firstReadSlot, nextReadSlot, nextTocSlot };
 }
 

--- a/runtime/fleet-console/tests/codex-panel-state.test.tsx
+++ b/runtime/fleet-console/tests/codex-panel-state.test.tsx
@@ -145,6 +145,29 @@ describe("Codex rail panel in-memory state", () => {
     expect(panelMocks.closeCodexReader).toHaveBeenCalledOnce();
     expect(panelMocks.setNavigatorTheater).toHaveBeenLastCalledWith("00000000000b");
   });
+
+  it("resynchronizes the collapsed outline spine from the relocated TOC after expanded view", async () => {
+    // 실제 relocate처럼 mountReaderInto가 TOC 슬롯을 현재 활성 표식으로 채운다.
+    let activeHeading = "Goals";
+    panelMocks.mountReaderInto.mockImplementation((...args: unknown[]) => {
+      const toc = args[1] as HTMLElement;
+      toc.innerHTML = `<a class="ti active" aria-current="location">${activeHeading}</a>`;
+    });
+    panelMocks.consoleState.codexReader = { kind: "entry", entryId: "entry-a" } as never;
+    await renderPanel("theater-a");
+    expect(container.querySelector(".codex-doc-outline-current")?.textContent).toBe("Goals");
+
+    // 덱(확대) 동안 다른 섹션/엔트리로 이동해 TOC 활성 표식이 바뀌었다.
+    panelMocks.consoleState.codexReaderExpanded = true;
+    await renderPanel("theater-a");
+    expect(container.querySelector(".codex-doc-outline-current")).toBeNull();
+    activeHeading = "Problem";
+
+    // 접기 복귀 시 리스너 재부착만으로는 낡은 "Goals"가 남는다 — 재배치된 TOC에서 재동기화되어야 한다.
+    panelMocks.consoleState.codexReaderExpanded = false;
+    await renderPanel("theater-a");
+    expect(container.querySelector(".codex-doc-outline-current")?.textContent).toBe("Problem");
+  });
 });
 
 async function renderPanel(theaterId: string): Promise<void> {

--- a/runtime/fleet-console/tests/codex-panel-state.test.tsx
+++ b/runtime/fleet-console/tests/codex-panel-state.test.tsx
@@ -96,7 +96,7 @@ describe("Codex rail panel in-memory state", () => {
     panelMocks.consoleState.codexReader = { kind: "drydock", patchId: "patch-a" };
     await renderPanel("theater-a");
 
-    const readerOptions = panelMocks.mountReaderInto.mock.calls.at(-1)?.[2] as { onDecided?: () => void } | undefined;
+    const readerOptions = panelMocks.mountReaderInto.mock.calls.at(-1)?.[3] as { onDecided?: () => void } | undefined;
     expect(readerOptions?.onDecided).toBeTypeOf("function");
     readerOptions?.onDecided?.();
 
@@ -111,7 +111,7 @@ describe("Codex rail panel in-memory state", () => {
       await Promise.resolve();
     });
 
-    const readerOptions = panelMocks.mountReaderInto.mock.calls.at(-1)?.[2] as { onDecided?: () => void } | undefined;
+    const readerOptions = panelMocks.mountReaderInto.mock.calls.at(-1)?.[3] as { onDecided?: () => void } | undefined;
     expect(readerOptions?.onDecided).toBeTypeOf("function");
     readerOptions?.onDecided?.();
 

--- a/runtime/fleet-console/tests/codex-schema-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-schema-ui.test.ts
@@ -409,6 +409,39 @@ describe("Codex schema UI contract", () => {
     controller.destroy();
   });
 
+  it("returns to the entries catalog when a document tag action repeats the active tag from schema mode", async () => {
+    vi.resetModules();
+    const state = await import("../core/client/src/codex/state.js");
+    const { mountNavigatorInto } = await import("../core/client/src/codex/components/navigator.js");
+    Object.assign(state.getState(), {
+      currentWorkspaceId: "workspace-a",
+      error: null,
+      index: [
+        { id: "alpha", title: "Alpha", tags: ["shared"], updated: "2026-08-01T00:00:00.000Z", path: "wiki/alpha.md" },
+        { id: "beta", title: "Beta", tags: ["other"], updated: "2026-08-02T00:00:00.000Z", path: "wiki/beta.md" },
+      ],
+      loading: false,
+      pendingPatchCount: 0,
+      schemaCatalog: { schema: { ref: "schema/wiki-schema.md", exists: true, summary: "s" }, templates: [] },
+    });
+    const root = document.body.appendChild(document.createElement("div"));
+    const controller = mountNavigatorInto(root, { initialTheaterId: "workspace-a", onRequest: vi.fn() });
+
+    controller.setActiveTag("shared");
+    expect(root.querySelectorAll("[data-entry-id]")).toHaveLength(1);
+
+    // 스키마 탭으로 옮겨간 뒤 문서 헤더에서 같은 태그를 다시 눌러도,
+    // 광고된 액션(카탈로그 필터)대로 항목 목록으로 복귀해야 한다.
+    root.querySelector<HTMLButtonElement>('[data-mode="schema"]')!.click();
+    expect(root.querySelector<HTMLElement>(".codex-nav-search-input")?.hidden).toBe(true);
+
+    controller.setActiveTag("shared");
+    expect(root.querySelector<HTMLElement>(".codex-nav-search-input")?.hidden).toBe(false);
+    expect([...root.querySelectorAll<HTMLElement>("[data-entry-id]")].map((entry) => entry.dataset.entryId)).toEqual(["alpha"]);
+    expect(root.querySelector("[data-clear-tag]")?.textContent).toContain("shared");
+    controller.destroy();
+  });
+
 });
 
 function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {

--- a/runtime/fleet-console/tests/codex-schema-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-schema-ui.test.ts
@@ -391,8 +391,8 @@ describe("Codex schema UI contract", () => {
     const controller = mountNavigatorInto(root, { initialTheaterId: "workspace-a", onRequest });
 
     expect([...root.querySelectorAll<HTMLElement>("[data-entry-id]")].map((entry) => entry.dataset.entryId)).toEqual(["newer", "older"]);
-    expect(root.querySelector<HTMLElement>('[data-entry-id="newer"] .meta')?.textContent).toContain("Today");
-    expect(root.querySelector<HTMLElement>('[data-entry-id="older"] .meta')?.title).toBe("2024-01-01T00:00:00.000Z");
+    expect(root.querySelector<HTMLElement>('[data-entry-id="newer"] .when')?.textContent).toContain("Today");
+    expect(root.querySelector<HTMLElement>('[data-entry-id="older"] .when')?.title).toBe("2024-01-01T00:00:00.000Z");
 
     root.querySelector<HTMLButtonElement>('[data-sort="name"]')!.click();
     expect(localStorage.getItem("fleet.codex.navigator.sort")).toBe("name");


### PR DESCRIPTION
## Summary
- Codex 정독 정비 D1~D4 (실측 제안 재가분: https://claude.ai/code/artifact/4de84ff5-2f84-442e-924c-f6fe2ac14878)
- **D1 분할 정독 문법**: 문서 타이포를 리더 스크롤포트 기준 `@container` 문법으로 승격(분할·덱·리사이즈가 한 규칙 공유, 특정성 0 함정은 `.codex-reader-host` 선택자 승급으로 방어). 분할 아웃라인은 기본 접힌 한 줄 스파인이 되어 스크롤 스파이의 현재 섹션명을 되비춘다. 실측: 분할 h1 60px·5줄(306px)→26px·2줄, 열림 직후 본문 0줄→첫 화면에서 Overview 가독.
- **D2 도크 프레임 경계**: Cowork 도크를 본문 위 sticky 부유에서 스크롤포트 밖 컴포저 행(`.codex-reader-composer`)으로 정박(분할·덱 공통, 채팅 컴포저와 동형). 유령 padding-bottom 128px 제거. `✦0` 주석 칩은 주석이 있을 때만 렌더. 대기열·충돌·스키마 화면에서는 행 자체가 접힘.
- **D3 카탈로그 밀도**: 행에서 무정보 `current ·` 접두 제거, 상대시간 우측 정렬(tabular), 예외 상태(draft·deprecated·superseded·낡음)만 배지로 승격, 태그 1줄 클램프 + `+N` 표식, 짜부라진 칩은 말줄임. 실측: 행 75px→57px, 화면당 9→12건.
- **D4 살아있는 메타 칩**: 문서 헤더 태그 칩을 버튼화해 클릭 시 카탈로그 태그 필터 실행(내비게이터 기존 액션 재사용). 갱신 시각 문법을 카탈로그와 단일 출처(`formatRelativeUpdated`)로 통일하고 절대 날짜는 툴팁에 보존. 5개 초과 태그는 `+N ↔ −` 토글로 접힘.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` green
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run` — 192 files / 2369 tests green (분리 도크 회귀 테스트 신규, 기존 cowork·host-state·panel-state·schema-ui 단언 스펙 변경 반영)
- [x] 격리 콘솔 실측(agent-browser, 시드 32건): 분할 h1 26px/2줄·전주 스파인 34px·첫 본문 top 372px(<뷰포트), 도크 스크롤포트 밖·패딩 40px·✦0 숨김, 카탈로그 화면당 12건·낡음/draft 배지, 헤더 칩 클릭→필터 7건·`+5↔−` 토글·`업데이트 1달 전`(title=절대날짜), 덱 520px→26px·799px→30px, Esc 복귀, 대기열 컴포저 접힘, 페이지 오류 0