### PR TITLE
feat(fleet-console): join chat work to its answer

### DIFF
--- a/.changelog.d/chat-completion-seam.md
+++ b/.changelog.d/chat-completion-seam.md
@@ -1,0 +1,8 @@
+---
+branch: chat-completion-seam
+---
+
+### fleet-console
+#### Changed
+- Join each completed Chat turn's work summary directly to its final answer, while keeping the process expandable in place.
+  ko: 완료된 각 채팅 턴의 작업 요약을 최종 응답에 바로 이어 붙이고, 과정은 그 자리에서 계속 펼쳐 볼 수 있게 합니다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2075,6 +2075,25 @@ describe("Instrument core design contract", () => {
     for (const signal of ["--aurora", "--positive", "--warn", "--coral", "--brass"]) {
       expect(composerWorkRestBlock).not.toContain(signal);
     }
+    // 완료 과정과 Answer는 한 이음새다. 별도 Answer kicker를 다시 세우지 않고, details가 닫히든
+    // 열리든 Answer 표식은 과정과 실제 응답 사이의 경계를 지킨다. 과정이 없는 답만 기존 kicker다.
+    expect(chatView0).toContain('className={`agent-chat-fold${leadsToAnswer ? " leads-to-answer" : ""}`}');
+    // summary의 실제 소요·결말·백그라운드 작업 수·문맥 증가량을 접근성 이름으로 보존한다.
+    // 고정 aria-label을 씌우면 이 가시 상태가 전부 가려진다.
+    expect(chatView0).not.toContain('<summary aria-label={t("terminal.chat.foldAria")}>');
+    expect(chatView0).toContain('className="agent-chat-completion-handoff"');
+    expect(chatView0).toContain('className={`agent-chat-answer${hasSettledWork ? " has-seam" : ""}`}');
+    expect(chatView0).toContain('? <span className="agent-chat-sr-only">{t("terminal.chat.answerLabel")}</span>');
+    const completionSummaryBlock = chat.match(/^\.agent-chat-fold\.leads-to-answer > summary \{[^}]*\}/m)?.[0] ?? "";
+    expect(completionSummaryBlock).toContain("display: flex;");
+    expect(completionSummaryBlock).toContain("width: 100%;");
+    const completionNodeBlock = chat.match(/^\.agent-chat-completion-node \{[^}]*\}/m)?.[0] ?? "";
+    expect(completionNodeBlock).toContain("background: var(--positive);");
+    expect(completionNodeBlock).not.toContain("--brass");
+    const completionRunningNodeBlock = chat.match(/^\.agent-chat-completion-node\.is-running \{[^}]*\}/m)?.[0] ?? "";
+    expect(completionRunningNodeBlock).toContain("background: var(--aurora);");
+    const completionRuleBlock = chat.match(/^\.agent-chat-completion-rule \{[^}]*\}/m)?.[0] ?? "";
+    expect(completionRuleBlock).toContain("background: var(--hairline);");
     // 중지는 실패가 아니다 — 사용자가 스스로 끊은 결말에 coral을 붙이면 자기가 누른 버튼의
     // 결과를 고장으로 읽는다. 성공도 아니므로 positive도 아니고, 남는 것은 중립 잉크다.
     const chatFoldStoppedBlock = chat.match(/^\.agent-chat-fold-stopped \{[^}]*\}/m)?.[0] ?? "";

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-ledger-note.test.tsx
@@ -106,7 +106,7 @@ describe("chat ledger commentary", () => {
     expect(el?.textContent ?? "").not.toContain("`Fable`");
   });
 
-  it("keeps markdown on a settled turn inside the work fold", () => {
+  it("keeps markdown inside the completion seam that hands work to the answer", () => {
     // 끝난 턴은 과정을 접는다. 접힘 안에서도 같은 렌더 경로를 타야 한다 — 라이브에서만
     // 마크다운이고 접힘 안에서는 다시 italic 원문이 되면 같은 문장이 두 얼굴이 된다.
     // jsdom 의 details 는 닫혀도 자식을 돔에 남긴다. 여기서 묻는 것은 가시성이 아니라 경로다.
@@ -118,10 +118,36 @@ describe("chat ledger commentary", () => {
     mount();
     const fold = container?.querySelector("details.agent-chat-fold");
     expect(fold).not.toBeNull();
+    expect(fold?.classList.contains("leads-to-answer")).toBe(true);
+    expect(fold?.querySelector(".agent-chat-completion-node")).not.toBeNull();
+    const summary = fold?.querySelector("summary");
+    expect(summary?.querySelector(".agent-chat-completion-answer")?.textContent).toBe("응답");
+    // 이름을 고정 문구로 덮지 않는다. 소요·결말·백그라운드 작업 수·문맥 증가량이 summary의
+    // 실제 텍스트로 함께 읽혀야 한다.
+    expect(summary?.hasAttribute("aria-label")).toBe(false);
+    expect(summary?.textContent).toContain("74.0s 동안 작업함");
+    expect(container?.querySelector(".agent-chat-answer")?.classList.contains("has-seam")).toBe(true);
+    // 이음새가 Answer를 시각적으로 이미 부르므로 별도 kicker는 다시 세우지 않되, 본문 랜드마크의
+    // 접근성 이름은 숨은 텍스트로 보존한다.
+    expect(container?.querySelector(".agent-chat-answer-kicker")).toBeNull();
+    expect(container?.querySelector(".agent-chat-answer > .agent-chat-sr-only")?.textContent).toBe("응답");
     const el = fold?.querySelector<HTMLElement>(".agent-chat-ledger-note") ?? null;
     expect(el).not.toBeNull();
     expect(el?.className).toContain("markdown-body");
     expect(el?.querySelector("strong")?.textContent).toBe("최신 로스터");
     expect(el?.querySelector("code")?.textContent).toBe("Fable");
+  });
+
+  it("keeps the standalone Answer kicker when a turn has no process to fold", () => {
+    logState = stateWith([turn({
+      items: [],
+      state: "done",
+      durationMs: 2_000,
+      answer: "바로 답합니다.",
+    })]);
+    mount();
+    expect(container?.querySelector(".agent-chat-fold")).toBeNull();
+    expect(container?.querySelector(".agent-chat-answer")?.classList.contains("has-seam")).toBe(false);
+    expect(container?.querySelector(".agent-chat-answer-kicker")?.textContent).toBe("응답");
   });
 });

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -623,6 +623,7 @@ function ChatTurn({
   const contextGrew = turn.contextBefore !== undefined && nextContextBefore !== undefined
     ? nextContextBefore - turn.contextBefore
     : undefined;
+  const hasSettledWork = !working && (view.ledger.length > 0 || view.changes.length > 0);
   return (
     <>
       {turn.dispatch ? (
@@ -667,7 +668,7 @@ function ChatTurn({
                     && !view.awaiting}
                 />
               </>
-            ) : view.ledger.length > 0 || view.changes.length > 0 ? (
+            ) : hasSettledWork ? (
               <WorkFold
                 durationMs={turn.durationMs}
                 running={stillRunning}
@@ -675,6 +676,7 @@ function ChatTurn({
                 stopped={turn.state === "stopped"}
                 contextGrew={contextGrew}
                 language={language}
+                leadsToAnswer={view.answer !== null}
               >
                 <ChangeStrip changes={view.changes} language={language} />
                 <Ledger operationId={operationId} items={view.ledger} language={language} jobsByToolUse={jobsByToolUse} onOpenJob={onOpenJob} onAnswer={onAnswer} />
@@ -691,8 +693,10 @@ function ChatTurn({
               />
             ) : null}
             {!working && view.answer !== null ? (
-              <div className="agent-chat-answer">
-                <div className="agent-chat-answer-kicker">{t("terminal.chat.answerLabel")}</div>
+              <div className={`agent-chat-answer${hasSettledWork ? " has-seam" : ""}`}>
+                {hasSettledWork
+                  ? <span className="agent-chat-sr-only">{t("terminal.chat.answerLabel")}</span>
+                  : <div className="agent-chat-answer-kicker">{t("terminal.chat.answerLabel")}</div>}
                 <StreamedMarkdown
                   className="agent-chat-answer-body markdown-body"
                   text={view.answer}
@@ -1380,6 +1384,7 @@ function WorkFold({
   stopped,
   contextGrew,
   language,
+  leadsToAnswer,
   children,
 }: {
   readonly durationMs: number | undefined;
@@ -1392,6 +1397,8 @@ function WorkFold({
   /** 이 턴이 문맥 창에 더한 토큰. 앞 턴의 좌표가 없으면 undefined이고, 그때는 서지 않는다. */
   readonly contextGrew: number | undefined;
   readonly language: "en" | "ko";
+  /** 확정 응답이 바로 뒤에 서는가 — 그때만 접힘과 Answer를 한 완료 경계로 잇는다. */
+  readonly leadsToAnswer: boolean;
   readonly children: React.ReactNode;
 }) {
   const t = getT(language);
@@ -1399,8 +1406,11 @@ function WorkFold({
     ? t("terminal.chat.workedFor", { duration: formatDuration(durationMs) })
     : t("terminal.chat.workedLabel");
   return (
-    <details className="agent-chat-fold" {...(running > 0 ? { open: true } : {})}>
-      <summary aria-label={t("terminal.chat.foldAria")}>
+    <details className={`agent-chat-fold${leadsToAnswer ? " leads-to-answer" : ""}`} {...(running > 0 ? { open: true } : {})}>
+      <summary>
+        {leadsToAnswer ? (
+          <span className={`agent-chat-completion-node${running > 0 ? " is-running" : error ? " is-error" : stopped ? " is-stopped" : ""}`} aria-hidden="true" />
+        ) : null}
         <span className="agent-chat-fold-label">{label}</span>
         {running > 0 ? <span className="agent-chat-fold-running">{t("terminal.chat.foldRunning", { count: running })}</span> : null}
         {stopped ? <span className="agent-chat-fold-stopped">{t("terminal.chat.foldTurnStopped")}</span> : null}
@@ -1413,8 +1423,20 @@ function WorkFold({
           </span>
         ) : null}
         <span className="agent-chat-fold-chev" aria-hidden="true">⌄</span>
+        {leadsToAnswer ? (
+          <>
+            <span className="agent-chat-completion-rule" aria-hidden="true" />
+            <span className="agent-chat-completion-answer" aria-hidden="true">{t("terminal.chat.answerLabel")}</span>
+          </>
+        ) : null}
       </summary>
       <div className="agent-chat-fold-body">{children}</div>
+      {leadsToAnswer ? (
+        <div className="agent-chat-completion-handoff" aria-hidden="true">
+          <span className="agent-chat-completion-rule" />
+          <span className="agent-chat-completion-answer">{t("terminal.chat.answerLabel")}</span>
+        </div>
+      ) : null}
     </details>
   );
 }

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -817,9 +817,76 @@
 .agent-chat-ask-settled.is-open .agent-chat-ask-settled-value {
   color: var(--coral-ink);
 }
-/* 끝난 턴의 과정 접힘 — 요약 줄이 곧 소요 시간이고, 펼치기 아이콘은 문구 오른쪽에 선다. */
+/* 끝난 턴의 과정 접힘 — 요약 줄이 곧 소요 시간이고, 펼치기 아이콘은 문구 오른쪽에 선다.
+   바로 뒤에 Answer가 서면 같은 줄이 완료 이음새가 된다: 과정의 결말과 확정 응답이 별개 라벨 두
+   줄로 끊기지 않고, 한 경계의 양끝으로 읽힌다. 과정 자체와 펼침 계약은 그대로 details가 진다. */
 .agent-chat-fold {
   margin-top: var(--space-2);
+}
+
+.agent-chat-fold.leads-to-answer > summary {
+  display: flex;
+  width: 100%;
+}
+
+/* 완료점은 상태 채널을 쓴다. 접힘 안의 도구 실패가 아니라 턴이 어떤 결말로 Answer에 닿았는지를
+   말한다. 성공=positive, 턴 실패=coral, 사용자 중지=중립이다. 위치·hover 채널인 brass는 쓰지 않는다. */
+.agent-chat-completion-node {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  border-radius: var(--radius-pill);
+  background: var(--positive);
+  box-shadow: 0 0 0 4px var(--positive-glow);
+}
+
+.agent-chat-completion-node.is-running {
+  background: var(--aurora);
+  box-shadow: 0 0 0 4px var(--aurora-glow);
+}
+
+.agent-chat-completion-node.is-error {
+  background: var(--coral);
+  box-shadow: 0 0 0 4px var(--coral-glow);
+}
+
+.agent-chat-completion-node.is-stopped {
+  background: var(--text-tertiary);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--text-tertiary) 13%, transparent);
+}
+
+.agent-chat-completion-rule {
+  min-width: var(--space-4);
+  height: 1px;
+  flex: 1;
+  background: var(--hairline);
+}
+
+.agent-chat-completion-answer {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+/* 펼치면 과정이 이음새 안으로 들어온다. Answer 표식은 summary에 남아 과정을 건너뛰지 않고,
+   펼친 내용의 끝으로 내려가 실제 응답 바로 앞을 계속 가리킨다. */
+.agent-chat-completion-handoff {
+  display: none;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.agent-chat-fold.leads-to-answer[open] > summary > .agent-chat-completion-rule,
+.agent-chat-fold.leads-to-answer[open] > summary > .agent-chat-completion-answer {
+  display: none;
+}
+
+.agent-chat-fold.leads-to-answer[open] > .agent-chat-completion-handoff {
+  display: flex;
 }
 
 .agent-chat-fold > summary {
@@ -889,6 +956,12 @@
 /* Answer — 확정 응답의 전용 문법. 본문은 공유 마크다운 컴포넌트가 렌더한다. */
 .agent-chat-answer {
   margin-top: var(--space-3);
+}
+
+/* 과정 접힘이 완료 이음새를 지면 그 이음새가 이미 Answer의 시작을 말했다. 별도 kicker와 그 아래
+   여백을 다시 세우지 않고 본문을 경계 가까이 붙인다. 과정이 전혀 없는 답은 기존 kicker를 유지한다. */
+.agent-chat-answer.has-seam {
+  margin-top: var(--space-2);
 }
 
 .agent-chat-answer-kicker {


### PR DESCRIPTION
## Summary
- 완료된 Chat 턴의 과정 접힘과 최종 응답을 하나의 Completion Seam으로 연결합니다.
- 접힘을 펼치면 Answer 경계를 상세 과정의 끝으로 이동해 실제 응답 바로 앞을 계속 가리킵니다.
- 완료·백그라운드 실행·실패·중지 상태를 기존 색상 채널로 표현하고, 가시 결말 메타데이터를 접근성 이름에 보존합니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test`
- [x] `pnpm --filter @dotobokuri/fleet-console test`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 격리 Chat-born Opus 세션에서 닫힘·펼침·472px 패널 검증