### PR TITLE
fix(fleet-console): refine glass captions and command band

### DIFF
--- a/.changelog.d/glass-material-themes.md
+++ b/.changelog.d/glass-material-themes.md
@@ -1,0 +1,8 @@
+---
+branch: glass-material-themes
+---
+
+### fleet-console
+#### Changed
+- Improve Glass caption legibility and keep the Command Band visually seamless when routes or the sidebar change.
+  ko: Glass 캡션의 판독성을 높이고 라우트 또는 사이드바 상태가 바뀌어도 Command Band가 하나의 면으로 이어지게 합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -102,20 +102,18 @@ const COMMAND_BAND_CENTER_BREATHING_PX = 12;
 const COMMAND_BAND_CENTER_GUTTER_FLOOR_PX = 44;
 const COMMAND_BAND_CENTER_MIN_PX = 168;
 
-// 접힘 도킹 앵커 — 사이드바가 접히면 맵 컨트롤의 정박 경계(사이드바 우측 경계선)가 사라지므로,
+// 접힘 앵커 — 사이드바가 접히면 맵 컨트롤의 정박 경계(사이드바 우측 경계선)가 사라지므로,
 // 좌측 컨트롤군의 실측 콘텐츠 끝을 새 앵커로 쓴다(브레드크럼이 이미 쓰는 "정렬 앵커는 실제
-// 스테이지 경계" 원칙의 클러스터 판). CSS가 앵커에 INSET(--space-2)을 다시 더해 도킹 구분선이
-// 정확히 콘텐츠 끝 + DOCK_DIVIDER_LEAD에 놓인다. 미측정(0 이하)이면 사이드바 폭 앵커로
-// 폴백해 첫 페인트가 기존 문법과 동일하게 남는다.
-const COMMAND_BAND_DOCK_DIVIDER_LEAD_PX = 10;
-
+// 스테이지 경계" 원칙의 클러스터 판). CSS가 앵커에 INSET(--space-2)을 더해 펼침 상태와 같은
+// 단일 간격으로 클러스터를 잇는다. 미측정(0 이하)이면 사이드바 폭 앵커로 폴백해 첫 페인트가
+// 기존 문법과 동일하게 남는다.
 export function commandBandMapControlsAnchor(
   collapsed: boolean,
   sideBarWidth: number,
   leftContentEnd: number,
 ): number {
   if (!collapsed || leftContentEnd <= 0) return sideBarWidth;
-  return leftContentEnd + COMMAND_BAND_DOCK_DIVIDER_LEAD_PX - COMMAND_BAND_MAP_CONTROLS_INSET_PX;
+  return leftContentEnd;
 }
 
 // Activity Rail의 고정 스트립 폭. 패널 폭은 포함하지 않는다 — PR #302가 밴드를 레일

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -550,8 +550,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           <SearchIcon />
         </button>
       </div>
-      {operationsViewVisible ? <div ref={mapControlsRef} className={`command-band-map-controls${sideBar.collapsed ? " is-docked" : ""}`}>
-        <span className="command-band-dock-divider" aria-hidden="true" />
+      {operationsViewVisible ? <div ref={mapControlsRef} className="command-band-map-controls">
         <div className="command-band-mode-switch" role="group" aria-label={t("chrome.commandBand.canvasMode")}>
           {CANVAS_MODES.map((mode) => (
             <button

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3701,7 +3701,7 @@
    .canvas-operation.is-active > .canvas-operation-titlebar와 같은 한 값이다. */
 .canvas-triage-deck-cell:hover .canvas-operation.is-deck-tile > .canvas-operation-titlebar,
 .canvas-triage-deck-cell:has(> .canvas-triage-deck-pick:focus-visible) .canvas-operation.is-deck-tile > .canvas-operation-titlebar {
-  background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-panel-face));
+  background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption));
   /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
   background-clip: padding-box;
 }
@@ -3942,7 +3942,7 @@
    베이스는 반드시 --surface-panel이다(반투명 잉크 티어를 깔면 셸 패널만 이음새가 되살아난다).
    background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
 .canvas-operation--shell .canvas-operation-titlebar {
-  background: color-mix(in oklch, var(--aurora) 9%, var(--glass-tint-panel-face));
+  background: color-mix(in oklch, var(--aurora) 9%, var(--glass-tint-caption));
   background-clip: padding-box;
 }
 
@@ -4628,7 +4628,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-bottom-width: 0;
   border-bottom-style: none;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
-  background: var(--glass-tint-panel-face);
+  background: var(--glass-tint-caption);
   background-clip: padding-box;
   color: var(--text-tertiary);
   cursor: default;
@@ -5899,7 +5899,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-bottom-style: none;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
   overflow: visible;
-  background: var(--glass-tint-panel-face);
+  background: var(--glass-tint-caption);
   background-clip: padding-box;
   cursor: grab;
   touch-action: none;
@@ -5939,7 +5939,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
    워시는 캡션만 진다. 채팅·터미널 본문은 --surface-panel에 남아, 포커스가 로그 전체를
    다른 면으로 다시 칠하지 않는다. */
 .canvas-operation.is-active > .canvas-operation-titlebar {
-  background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-panel-face));
+  background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption));
   /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
   background-clip: padding-box;
 }

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -341,10 +341,10 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   box-shadow: none;
 }
 
-/* Utility route에는 아래로 이어질 사이드바가 없다. chrome cap을 남기면 좌측 컨트롤 폭만큼
-   별도 판이 생겨 밴드가 어긋나 보이므로, 이때만 전체 band tint로 합친다. */
+/* Utility route에는 아래로 이어질 사이드바가 없다. band 루트가 이미 전체 Glass 면을 칠하므로
+   좌측 cap을 다시 그리면 같은 반투명 tint가 겹쳐 별도 판으로 보인다. 좌표만 남기고 paint는 끈다. */
 .command-band.is-utility .command-band-left::before {
-  background: var(--glass-tint-band);
+  display: none;
 }
 
 .command-band-brand {

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -325,16 +325,26 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 
 .command-band-left.is-collapsed {
   border-color: transparent;
+  box-shadow: none;
 }
 
+/* 접힌 캡은 좌표만 유지하고 그리지 않는다. band tint를 다시 칠하거나 backdrop-filter를 남기면
+   280px 캡 끝이 모드 스위치 안을 가르는 재질 이음선으로 드러난다. */
 .command-band-left.is-collapsed::before {
-  background: var(--glass-tint-band);
+  display: none;
 }
 
 .command-band.is-utility .command-band-left {
   width: fit-content;
   border-right-color: transparent;
   background: transparent;
+  box-shadow: none;
+}
+
+/* Utility route에는 아래로 이어질 사이드바가 없다. chrome cap을 남기면 좌측 컨트롤 폭만큼
+   별도 판이 생겨 밴드가 어긋나 보이므로, 이때만 전체 band tint로 합친다. */
+.command-band.is-utility .command-band-left::before {
+  background: var(--glass-tint-band);
 }
 
 .command-band-brand {
@@ -564,25 +574,6 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls { transition: none; }
-
-/* 접힘 도킹 구분선 — 클러스터가 좌측 컨트롤군에 붙을 때만 나타나는 hairline(formation-divider 문법).
-   플로우 형제라 도킹 해제 시 display로 제거해야 gap이 유령 폭을 남기지 않는다. */
-.command-band-dock-divider {
-  display: none;
-  align-self: stretch;
-  flex: none;
-  width: 1px;
-  background: var(--surface-rim);
-}
-
-.command-band-map-controls.is-docked .command-band-dock-divider {
-  display: block;
-  animation: command-band-dock-divider-in 200ms ease;
-}
-
-@keyframes command-band-dock-divider-in {
-  from { opacity: 0; }
-}
 
 /* Cruise / Tactical / War Room — 캔버스 모드는 이 세그먼트 스위치 하나만 소유한다.
    모드 전용 도구는 오른쪽 트레이에 붙으므로, 다른 모드의 도구는 애초에 존재하지 않는다. */
@@ -960,6 +951,5 @@ html[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-le
   }
 
   .right-rail-stale-veil { animation: none !important; }
-  .command-band-dock-divider { animation: none !important; }
   .command-band.is-fullscreen { transition: none !important; }
 }

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -184,6 +184,7 @@
      닫히면 채널 기본값이 --surface-panel 불투명이라 구 판독 계약으로 돌아간다. */
   --glass-tint-panel: var(--surface-panel);
   --glass-tint-panel-face: var(--surface-panel);
+  --glass-tint-caption: var(--surface-panel);
   --glass-tint-terminal: var(--surface-panel);
   --glass-tint-band: var(--surface-band);
   --glass-backdrop-strong: none;
@@ -210,6 +211,7 @@
      무겁게. 필드가 거의 검게 남아 대비를 지키고, 뒤 콘텐츠는 블러 너머 희미한 유령빛으로만
      비친다. 명도를 올려 잿빛 워시를 만드는 방향은 실측 기각됐다. */
   --glass-on-tint-panel: oklch(15% 0.018 245 / 55%);
+  --glass-on-tint-caption: oklch(17% 0.018 245 / 82%);
   --glass-on-tint-terminal: oklch(13% 0.015 245 / 62%);
   --glass-on-tint-band: oklch(13% 0.018 245 / 55%);
   --glass-on-backdrop-strong: blur(24px) saturate(1.7);
@@ -379,6 +381,7 @@
   --glass-on-tint-abyss: oklch(15% 0.04 250 / 48%);
   --glass-on-tint-chrome: oklch(27% 0.04 248 / 45%);
   --glass-on-tint-panel: oklch(20% 0.04 248 / 55%);
+  --glass-on-tint-caption: oklch(21% 0.03 248 / 82%);
   --glass-on-tint-terminal: oklch(17% 0.035 248 / 62%);
   --glass-on-tint-band: oklch(19% 0.045 248 / 50%);
   --glass-on-rim: oklch(96% 0.012 88 / 18%);
@@ -451,6 +454,7 @@
   --glass-on-tint-abyss: oklch(14% 0.006 255 / 48%);
   --glass-on-tint-chrome: oklch(24% 0.006 252 / 45%);
   --glass-on-tint-panel: oklch(17% 0.008 252 / 55%);
+  --glass-on-tint-caption: oklch(19% 0.008 252 / 84%);
   --glass-on-tint-terminal: oklch(15% 0.007 252 / 62%);
   --glass-on-tint-band: oklch(17% 0.007 255 / 50%);
   --glass-on-rim: oklch(95% 0.003 250 / 16%);
@@ -596,6 +600,7 @@
   --glass-on-tint-abyss: oklch(94% 0.004 100 / 52%);
   --glass-on-tint-chrome: oklch(92% 0.005 100 / 52%);
   --glass-on-tint-panel: oklch(98.2% 0.004 100 / 60%);
+  --glass-on-tint-caption: oklch(96% 0.006 100 / 88%);
   /* 라이트 필드는 불투명 종이 — mCR(가독 보정)이 배경 실색을 요구하고, 종이 위 젖빛 유리는
      어차피 지각 불가 수준이다. 필드·거터가 같은 불투명 값으로 만나 격자 경계 띠가 없다. */
   --glass-on-tint-terminal: oklch(98.2% 0.004 100);
@@ -651,6 +656,7 @@
     --glass-tint-chrome: var(--glass-on-tint-chrome);
     --glass-tint-panel: var(--glass-on-tint-panel);
     --glass-tint-panel-face: transparent;
+    --glass-tint-caption: var(--glass-on-tint-caption);
     --glass-tint-terminal: var(--glass-on-tint-terminal);
     --glass-tint-band: var(--glass-on-tint-band);
     --glass-backdrop-strong: var(--glass-on-backdrop-strong);
@@ -673,6 +679,7 @@
       --glass-tint-chrome: var(--surface-chrome);
       --glass-tint-panel: var(--surface-panel);
       --glass-tint-panel-face: var(--surface-panel);
+      --glass-tint-caption: var(--surface-panel);
       --glass-tint-terminal: var(--surface-panel);
       --glass-tint-band: var(--surface-band);
       --glass-backdrop-strong: none;

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -153,10 +153,10 @@ describe("Command Band center visibility measurements", () => {
   it("docks the map controls to the measured left-cluster end only while collapsed", () => {
     // 펼침: 앵커 = 사이드바 폭(경계선 옆) — 기존 문법 그대로.
     expect(commandBandMapControlsAnchor(false, 280, 183)).toBe(280);
-    // 접힘: 앵커 = 콘텐츠 끝 + 구분선 리드(10) - CSS 인셋(8) → 구분선이 정확히 콘텐츠 끝 + 10에 놓인다.
-    expect(commandBandMapControlsAnchor(true, 280, 183)).toBe(183 + 10 - 8);
+    // 접힘: 앵커 = 콘텐츠 끝. CSS 인셋(8)이 펼침 상태와 같은 단일 간격을 만든다.
+    expect(commandBandMapControlsAnchor(true, 280, 183)).toBe(183);
     // 사이드바를 넓혀도 접힘 앵커는 사이드바 폭과 무관하다 — 넓힌-뒤-접기 부유가 소멸한다.
-    expect(commandBandMapControlsAnchor(true, 460, 183)).toBe(183 + 10 - 8);
+    expect(commandBandMapControlsAnchor(true, 460, 183)).toBe(183);
     // 미측정(0 이하) 폴백: 기존 사이드바 폭 앵커를 유지해 첫 페인트가 흔들리지 않는다.
     expect(commandBandMapControlsAnchor(true, 280, 0)).toBe(280);
   });

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1595,10 +1595,10 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain("{panelTogglesVisible ? <button type=\"button\" className=\"command-band-button command-band-sidebar-toggle\"");
     expect(commandBand).toContain("{panelTogglesVisible ? <button type=\"button\" className=\"command-band-button command-band-rail-toggle\"");
     expect(commandBand).toContain(`      </div>
-      {operationsViewVisible ? <div ref={mapControlsRef} className={\`command-band-map-controls\${sideBar.collapsed ? " is-docked" : ""}\`}>`);
-    // 접힘 도킹 구분선은 맵 컨트롤의 첫 플로우 자식이다 — 도킹 상태에서만 display로 나타나
-    // 좌측 컨트롤군과 클러스터를 formation-divider 문법의 hairline으로 잇는다.
-    expect(commandBand).toContain('<span className="command-band-dock-divider" aria-hidden="true" />');
+      {operationsViewVisible ? <div ref={mapControlsRef} className="command-band-map-controls">`);
+    // 접힘 상태도 펼침 상태와 같은 단일 간격으로 잇는다. 별도 구분선과 캡 표면은 사라진
+    // 사이드바 경계를 다시 만들어 Command Band를 두 판처럼 보이게 하므로 두지 않는다.
+    expect(commandBand).not.toContain("command-band-dock-divider");
     expect(commandBand).toContain('aria-label={t("chrome.commandBand.resetCanvasView")}');
     expect(commandBand).toContain("<ResetViewIcon />");
     expect(commandBand).toContain("onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })}");
@@ -1658,8 +1658,7 @@ describe("Instrument core design contract", () => {
     // 글라이드는 접힘/펼침 앵커 전환 전용 — 드래그 리사이즈는 :has 게이트로 즉시 추종을 유지한다.
     expect(layout).toContain("transition: left 200ms ease;");
     expect(layout).toContain('body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls { transition: none; }');
-    expect(layout).toContain(".command-band-dock-divider {");
-    expect(layout).toContain(".command-band-map-controls.is-docked .command-band-dock-divider {");
+    expect(layout).not.toContain("command-band-dock-divider");
     expect(layout).not.toContain(".command-band-mode-switch {\n  position: absolute;");
     // 구 문법(모드 전용 도구를 밴드에 상시 노출)의 잔재는 남기지 않는다.
     expect(layout).not.toContain(".command-band-formation-group {");
@@ -1728,6 +1727,8 @@ describe("Instrument core design contract", () => {
     const commandBandLeftBlock = layout.match(/\.command-band-left \{[^}]*\}/)?.[0] ?? "";
     expect(commandBandLeftBlock).toContain("border-right: 1px solid var(--surface-rim);");
     expect(layout).toMatch(/\.command-band-left::before \{[^}]*background: var\(--glass-tint-chrome\);/);
+    // 아래 사이드바가 없는 utility route는 좌측 chrome cap을 band에 합쳐 한 면으로 읽힌다.
+    expect(layout).toMatch(/\.command-band\.is-utility \.command-band-left::before \{[^}]*background: var\(--glass-tint-band\);/);
     // 사이드바도 같은 크롬 표면을 소비해야 캡과 한 열로 읽힌다 — glass 회귀를 여기서 잡는다.
     const sideBarBlock = components.match(/^\.operations-side-bar \{[^}]*\}/m)?.[0] ?? "";
     expect(components).toMatch(/\.operations-side-bar::before \{[^}]*background: var\(--glass-tint-chrome\);/);
@@ -1738,7 +1739,7 @@ describe("Instrument core design contract", () => {
     expect(operationBlock).toContain("backdrop-filter: var(--glass-backdrop-panel);");
     expect(operationBlock).not.toContain("--surface-window");
     const titlebarBlock = components.match(/^\.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
-    expect(titlebarBlock).toContain("background: var(--glass-tint-panel-face);");
+    expect(titlebarBlock).toContain("background: var(--glass-tint-caption);");
     expect(titlebarBlock).toContain("background var(--duration-base) var(--ease-spring)");
     // 캡션 아웃라인은 본문과 같은 --surface-rim이다. inherit는 본문 윗변을 비운 뒤
     // 계산색이 갈라져 캡션만 선이 빠진다.
@@ -1768,7 +1769,8 @@ describe("Instrument core design contract", () => {
     expect(layout).toContain(".command-band.is-fullscreen {");
     // 접거나 풀스크린이면 상단 캡이 없으므로 부유 카드 문법이 그대로 남는다.
     expect(components).toContain("border-radius: 0 var(--radius-md) 0 0;");
-    expect(layout).toContain(".command-band-left.is-collapsed {");
+    expect(layout).toMatch(/\.command-band-left\.is-collapsed \{[^}]*box-shadow: none;/);
+    expect(layout).toMatch(/\.command-band-left\.is-collapsed::before \{[^}]*display: none;/);
     expect(components).not.toContain(".float-handle");
     expect(components).not.toContain("focus-mode-reveal");
     expect(rail).toContain(".right-rail.is-closed");
@@ -1853,11 +1855,11 @@ describe("Instrument core design contract", () => {
     expect(navigatorScrollBlock).toContain("overflow-y: auto;");
   });
 
-  it("locks Command Band coordinate invariance to tint-only state changes", () => {
+  it("locks Command Band coordinate invariance to paint-only state changes", () => {
     const layout = source("styles/layout.css");
     const components = source("styles/components.css");
     const rail = source("styles/rail.css");
-    // .command-band-left.is-collapsed 블록은 톤 전환(배경·경계색)만 가진다 —
+    // .command-band-left.is-collapsed 블록은 페인트 전환(배경·경계·그림자)만 가진다 —
     // 위치·크기·여백 속성이 들어오는 순간 좌표 불변 계약이 깨진다.
     const collapsedBlocks = layout.match(/^\.command-band-left\.is-collapsed \{[^}]*\}/gm) ?? [];
     expect(collapsedBlocks).toHaveLength(1);
@@ -1869,8 +1871,10 @@ describe("Instrument core design contract", () => {
       .filter((line) => line.length > 0);
     expect(collapsedDeclarations.length).toBeGreaterThan(0);
     for (const declaration of collapsedDeclarations) {
-      expect(declaration).toMatch(/^(?:background|border-color):/);
+      expect(declaration).toMatch(/^(?:background|border-color|box-shadow):/);
     }
+    const collapsedBeforeBlock = layout.match(/^\.command-band-left\.is-collapsed::before \{[^}]*\}/m)?.[0] ?? "";
+    expect(collapsedBeforeBlock).toContain("display: none;");
     // 어떤 상태 셀렉터도 밴드 버튼의 기하를 조건부로 겨냥하지 못한다.
     const statefulBandButtonRule =
       /(?:is-closed|is-collapsed|data-sidebar|data-rail)[^{]*\.command-band-(?:button|sidebar-toggle|search|rail-toggle)|\.command-band-(?:button|sidebar-toggle|search|rail-toggle)[^{]*(?:is-closed|is-collapsed)/;
@@ -1884,7 +1888,6 @@ describe("Instrument core design contract", () => {
     expect(reducedMotionBlock).toContain(".command-band-map-controls,");
     expect(reducedMotionBlock).toContain(".command-band-left {");
     expect(reducedMotionBlock).toContain("transition: none !important;");
-    expect(reducedMotionBlock).toContain(".command-band-dock-divider { animation: none !important; }");
   });
 
   it("keeps the Instrument base tokens and selector while blocking legacy palette escapes", () => {
@@ -2646,7 +2649,7 @@ describe("Instrument core design contract", () => {
     // warn과 brass가 한 덩어리 금색으로 읽힌다. 워시는 캡션만 진다 — 채팅 본문까지
     // 따라가면 활성 패널 전체가 다른 면으로 바뀐다.
     expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar {");
-    expect(components).toContain("color-mix(in oklab, var(--brass) 10%, var(--glass-tint-panel-face))");
+    expect(components).toContain("color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption))");
     expect(components).not.toContain("--surface-window");
     expect(components).not.toContain(".canvas-operation-titlebar::before");
     expect(components).toContain("background: var(--caption-rail, transparent);");
@@ -3491,7 +3494,7 @@ describe("War Room deck panel grammar", () => {
     expect(components).toContain(".canvas-triage-deck-pick:focus-visible {");
     // 겨눈 카드의 캡션 워시는 포커스 패널과 같은 한 값이다 — 새 값을 만들지 않는다.
     const wash = components.match(/\.canvas-triage-deck-cell:hover \.canvas-operation\.is-deck-tile > \.canvas-operation-titlebar,\n[^{]*\{[^}]*\}/)?.[0] ?? "";
-    expect(wash).toContain("background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-panel-face));");
+    expect(wash).toContain("background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption));");
     expect(wash).toContain("background-clip: padding-box;");
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1727,8 +1727,9 @@ describe("Instrument core design contract", () => {
     const commandBandLeftBlock = layout.match(/\.command-band-left \{[^}]*\}/)?.[0] ?? "";
     expect(commandBandLeftBlock).toContain("border-right: 1px solid var(--surface-rim);");
     expect(layout).toMatch(/\.command-band-left::before \{[^}]*background: var\(--glass-tint-chrome\);/);
-    // 아래 사이드바가 없는 utility route는 좌측 chrome cap을 band에 합쳐 한 면으로 읽힌다.
-    expect(layout).toMatch(/\.command-band\.is-utility \.command-band-left::before \{[^}]*background: var\(--glass-tint-band\);/);
+    // 아래 사이드바가 없는 utility route는 band 루트가 이미 전체 Glass 면을 칠하므로,
+    // 좌측 cap을 다시 합성하지 않고 paint를 끈다.
+    expect(layout).toMatch(/\.command-band\.is-utility \.command-band-left::before \{[^}]*display: none;/);
     // 사이드바도 같은 크롬 표면을 소비해야 캡과 한 열로 읽힌다 — glass 회귀를 여기서 잡는다.
     const sideBarBlock = components.match(/^\.operations-side-bar \{[^}]*\}/m)?.[0] ?? "";
     expect(components).toMatch(/\.operations-side-bar::before \{[^}]*background: var\(--glass-tint-chrome\);/);


### PR DESCRIPTION
## Summary
- give Operation and companion captions a denser, theme-aware Glass tint without changing the existing theme optical recipes
- unify utility-route Command Band surfaces and remove the stale collapsed-sidebar cap seam
- dock map controls with one consistent gap and no synthetic divider

## Test Plan
- [x] `pnpm --dir runtime/fleet-console test`
- [x] `pnpm --dir runtime/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Browser-check expanded, collapsed, utility-route, Glass-off, and four-theme caption states