### PR TITLE
feat(fleet-console): unify interactive control states

### DIFF
--- a/.changelog.d/fleet-console-control-grammar-p2.md
+++ b/.changelog.d/fleet-console-control-grammar-p2.md
@@ -1,0 +1,8 @@
+---
+branch: fleet-console-control-grammar-p2
+---
+
+### fleet-console
+#### Changed
+- Unify hover, focus, selection, disabled, and form control feedback across Console chrome, settings, and built-in file and repository tools, with keyboard navigation and an undimmed current row in the Host picker.
+  ko: Console 크롬, 설정, 내장 파일 및 저장소 도구의 호버, 포커스, 선택, 비활성화, 폼 컨트롤 피드백을 통일하고 Host 선택기에 키보드 탐색과 흐려지지 않는 현재 행을 제공합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -36,7 +36,7 @@ const GITHUB_STARGAZERS_URL = "https://github.com/sbluemin/fleet-harness/stargaz
 const GITHUB_STARS_API_URL = "https://api.github.com/repos/sbluemin/fleet-harness";
 const GITHUB_STARS_CACHE_KEY = "fleet-console.github-stars";
 const GITHUB_STARS_TTL_MS = 6 * 60 * 60 * 1000;
-const ENABLED_MENU_ITEM_SELECTOR = '[role="menuitem"]:not([disabled])';
+const ENABLED_MENU_ITEM_SELECTOR = '[role="menuitem"]:not([disabled]), [role="menuitemradio"]:not([disabled])';
 
 /**
  * Desktop 셸과의 계약 리터럴 — 셸이 이 항해를 가로채므로 요청은 기계를 떠나지 않는다.
@@ -149,6 +149,7 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
   const [reach, setReach] = useState<Readonly<Record<string, RemoteHostReach>>>({});
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const menuItems = () => Array.from(panelRef.current?.querySelectorAll<HTMLButtonElement>(ENABLED_MENU_ITEM_SELECTOR) ?? []);
   /**
    * 목록을 접는 일. 집이 펼친 판은 이 화면의 상태가 아니라 셸이 얹은 덮개라, 접겠다는 말도
    * 셸에게 가야 한다 — 여기서 state만 내리면 빈 덮개가 콘솔을 가린 채 남는다.
@@ -189,20 +190,89 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
   }, [open, hosts, servedFromLoopback]);
 
   // 판을 닫는 길은 목록을 어디서 읽어 왔는지와 무관하다 — 묻지 않는 콘솔에서도 판은 닫혀야 한다.
+  // 열리면 현재 행(없으면 첫 행)으로 포커스를 옮기고, 같은 밴드의 Theater 메뉴와 같은 방향키
+  // 문법을 쓴다. 현재 행은 선택 대상은 아니어도 위치 기준이므로 focus 목록에는 남는다.
   useEffect(() => {
-    if (!open) return;
+    // Add Host는 자기 모달·키 문법을 소유한다. 덮개 picker는 그 뒤에서도 open이므로 여기서
+    // 명시적으로 물러나지 않으면 입력의 Home/End와 모달의 Escape를 메뉴가 가로챈다.
+    if (!open || addOpen) return;
+    const panel = panelRef.current;
+    if (panel === null) return;
+    let initialFocusPending = true;
+    let fallbackFocus: HTMLButtonElement | null = null;
+    let focusedCurrent: HTMLButtonElement | null = null;
+    const focusInitialItem = () => {
+      const items = menuItems();
+      const current = items.find((item) => item.getAttribute("aria-checked") === "true");
+      // 목록 응답이 늦으면 임시 current 행이 실제 저장 행으로 교체된다. 사용자가 아직 움직이지
+      // 않았다면 끊긴 기준점을 새 current로 이어 주되, 한 번 직접 이동한 포커스는 덮어쓰지 않는다.
+      if (current && (initialFocusPending || (focusedCurrent !== null && !focusedCurrent.isConnected))) {
+        initialFocusPending = false;
+        fallbackFocus = null;
+        focusedCurrent = current;
+        current.focus();
+        return;
+      }
+      if (!current && initialFocusPending && items[0] && !panel.contains(document.activeElement)) {
+        fallbackFocus = items[0];
+        fallbackFocus.focus();
+      }
+    };
+    const frame = window.requestAnimationFrame(focusInitialItem);
+    const observer = new MutationObserver(focusInitialItem);
+    observer.observe(panel, { childList: true, subtree: true, attributes: true, attributeFilter: ["aria-checked", "disabled"] });
     const onPointer = (event: PointerEvent) => {
       const target = event.target as Node;
-      if (!panelRef.current?.contains(target) && !triggerRef.current?.contains(target)) dismiss();
+      if (panel.contains(target)) {
+        initialFocusPending = false;
+        fallbackFocus = null;
+        focusedCurrent = null;
+        return;
+      }
+      if (!triggerRef.current?.contains(target)) dismiss();
     };
-    const onKey = (event: KeyboardEvent) => { if (event.key === "Escape") { dismiss(); triggerRef.current?.focus(); } };
+    const onFocus = (event: FocusEvent) => {
+      const target = event.target as Node;
+      if (target === fallbackFocus || target === focusedCurrent) return;
+      initialFocusPending = false;
+      fallbackFocus = null;
+      focusedCurrent = null;
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        dismiss();
+        triggerRef.current?.focus();
+        return;
+      }
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp" && event.key !== "Home" && event.key !== "End") return;
+      if (!panel.contains(document.activeElement) && !panel.contains(event.target as Node)) return;
+      const items = menuItems();
+      if (items.length === 0) return;
+      event.preventDefault();
+      initialFocusPending = false;
+      fallbackFocus = null;
+      focusedCurrent = null;
+      const current = items.findIndex((item) => item === document.activeElement);
+      const next = event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? items.length - 1
+          : event.key === "ArrowDown"
+            ? (current + 1) % items.length
+            : current <= 0 ? items.length - 1 : current - 1;
+      items[next]?.focus();
+    };
     document.addEventListener("pointerdown", onPointer, true);
+    document.addEventListener("focusin", onFocus);
     document.addEventListener("keydown", onKey);
     return () => {
+      window.cancelAnimationFrame(frame);
+      observer.disconnect();
       document.removeEventListener("pointerdown", onPointer, true);
+      document.removeEventListener("focusin", onFocus);
       document.removeEventListener("keydown", onKey);
     };
-  }, [open]);
+  }, [addOpen, open]);
 
   /**
    * 어느 콘솔에 서 있는가. 집이 펼친 목록에서는 이 화면(집)이 아니라 목록을 부른 콘솔이
@@ -327,6 +397,7 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
           className={`host-switcher-chip${state.controlHolder !== null ? " is-shared" : ""}`}
           aria-haspopup="menu"
           aria-expanded={pickerHome === null && open}
+          data-open={pickerHome === null && open ? "true" : undefined}
           aria-label={`${t("chrome.hosts.aria")}: ${chipLabel}`}
           title={chipLabel}
           onClick={() => {
@@ -429,8 +500,9 @@ function HostRow({
       role="menuitemradio"
       aria-checked={current}
       className={`${current ? "is-current" : ""} ${compact ? "is-home" : ""}`.trim()}
-      disabled={current || disabled === true || onOpen === undefined}
-      onClick={onOpen}
+      disabled={!current && (disabled === true || onOpen === undefined)}
+      aria-disabled={current || disabled === true || onOpen === undefined}
+      onClick={current || disabled === true ? undefined : onOpen}
     >
       <span className={`host-switcher-dot ${live ? "is-live" : ""}`} aria-hidden="true" />
       <span className="host-switcher-entry">

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -80,7 +80,11 @@
   border-radius: var(--radius-xs);
   padding: 8px 14px;
   cursor: pointer;
-  transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
+  transition:
+    background var(--duration-fast),
+    border-color var(--duration-fast),
+    color var(--duration-fast),
+    transform var(--duration-fast) var(--ease-spring);
 }
 .fc-btn--primary {
   background: var(--brass);
@@ -121,8 +125,11 @@
   background: color-mix(in oklch, var(--coral) 10%, transparent);
 }
 
+.fc-btn:active:not(:disabled) { transform: translateY(1px); }
+.fc-btn:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); transform: none; }
+
 .fc-btn:focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
+  outline: 2px solid var(--control-focus-ring);
   outline-offset: 2px;
 }
 /* ===== Global Settings — 전역 옵션(시스템 프롬프트 주입 + 메타포) 표면 ===== */
@@ -216,15 +223,21 @@
 .global-settings-nav-item:nth-child(3) { animation-delay: 80ms; }
 .global-settings-nav-item:nth-child(4) { animation-delay: 120ms; }
 
-.global-settings-nav-item:hover {
-  background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
+.global-settings-nav-item:hover:not([aria-pressed="true"]) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   transform: translateX(2px);
 }
 
-.global-settings-nav-item.is-active {
-  border-color: color-mix(in oklch, var(--brass) 30%, transparent);
-  background: var(--surface-glass-strong);
-  box-shadow: var(--shadow-anchor);
+.global-settings-nav-item:active:not([aria-pressed="true"]) {
+  transform: translateX(2px) translateY(1px);
+}
+
+.global-settings-nav-item.is-active,
+.global-settings-nav-item[aria-pressed="true"] {
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
+  box-shadow: var(--shadow-anchor), inset 3px 0 0 var(--brass);
 }
 
 .global-settings-nav-label {
@@ -240,7 +253,8 @@
 }
 
 .global-settings-nav-item:hover .global-settings-nav-label,
-.global-settings-nav-item.is-active .global-settings-nav-label {
+.global-settings-nav-item.is-active .global-settings-nav-label,
+.global-settings-nav-item[aria-pressed="true"] .global-settings-nav-label {
   color: var(--text-primary);
 }
 
@@ -255,7 +269,8 @@
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
-.global-settings-nav-item.is-active .global-settings-nav-eyebrow {
+.global-settings-nav-item.is-active .global-settings-nav-eyebrow,
+.global-settings-nav-item[aria-pressed="true"] .global-settings-nav-eyebrow {
   color: var(--brass-bright);
 }
 
@@ -454,14 +469,15 @@
   background: var(--ink-rim);
 }
 
-.global-settings-toggle:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+.global-settings-toggle:hover:not(:disabled):not(.is-on) {
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
 .global-settings-toggle.is-on {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--control-selected-fill);
   color: var(--aurora-ink);
+  box-shadow: inset 0 -2px 0 var(--brass);
 }
 
 .global-settings-toggle.is-on::before {
@@ -477,7 +493,7 @@
 
 .global-settings-toggle:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: var(--control-disabled-opacity);
   transform: none;
 }
 
@@ -759,18 +775,25 @@
 }
 
 .host-switcher-chip:hover,
-.host-switcher-chip:focus-visible,
+.host-switcher-chip:focus-visible {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
+}
+
 .host-switcher-chip[aria-expanded="true"] {
-  border-color: color-mix(in oklch, var(--ink-fog) 30%, transparent);
-  background: color-mix(in oklch, var(--ink-spectral) 10%, transparent);
-  color: var(--text-secondary);
-  outline: none;
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
+  color: var(--text-primary);
 }
 
 .host-switcher-chip .host-switcher-name { color: inherit; }
-.host-switcher-chip:hover .host-switcher-name,
-.host-switcher-chip[aria-expanded="true"] .host-switcher-name { color: var(--text-primary); }
-.host-switcher-chip svg { width: 10px; height: 10px; }
+.host-switcher-chip svg {
+  width: 10px;
+  height: 10px;
+  transition: transform var(--duration-fast) var(--ease-spring);
+}
+.host-switcher-chip[aria-expanded="true"] > svg:last-child { transform: rotate(180deg); }
 
 .host-switcher-dot {
   flex: none;
@@ -819,11 +842,12 @@
 }
 
 .host-switcher-panel > button {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-3);
   padding: var(--space-2) var(--space-3);
-  border: 0;
+  border: 1px solid transparent;
   border-radius: var(--radius-xs);
   background: none;
   color: var(--text-secondary);
@@ -831,10 +855,32 @@
   text-align: left;
 }
 
-.host-switcher-panel > button:hover:not(:disabled) { background: color-mix(in oklch, var(--ink-deep) 80%, transparent); }
-.host-switcher-panel > button.is-current { background: color-mix(in oklch, var(--ink-deep) 90%, transparent); }
+.host-switcher-panel > button:hover:not(:disabled):not(.is-current),
+.host-switcher-panel > button:focus-visible:not(.is-current) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
+}
+
+.host-switcher-panel > button.is-current {
+  background: var(--control-selected-fill);
+  color: var(--text-primary);
+  cursor: default;
+}
+
+.host-switcher-panel > button.is-current::before {
+  position: absolute;
+  top: var(--space-2);
+  bottom: var(--space-2);
+  left: 0;
+  width: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  content: "";
+}
+
 .host-switcher-panel > button.is-current svg { margin-left: auto; color: var(--brass-bright); }
-.host-switcher-panel > button:disabled { cursor: not-allowed; opacity: 0.55; }
+.host-switcher-panel > button:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 /* 이 앱이 띄운 콘솔은 한 줄로 접고 강조한다 — 목록에서 유일하게 언제나 거기 있는 기준점이다. */
 .host-switcher-panel > button.is-home { padding-block: 6px; }
@@ -881,7 +927,9 @@
 .host-switcher-entry { display: flex; min-width: 0; flex-direction: column; }
 .host-switcher-entry small { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }
 .host-switcher-divider { height: 1px; margin: var(--space-2) var(--space-3); background: var(--surface-rim); }
-.host-switcher-link { color: var(--aurora-ink); font-size: var(--t-md); }
+.host-switcher-link { color: var(--text-secondary); font-size: var(--t-md); }
+.host-switcher-link:hover:not(:disabled),
+.host-switcher-link:focus-visible { color: var(--brass-ink); }
 
 /* ── 집이 펼친 호스트 목록 표면 ────────────────────────────────────────
    원격 콘솔을 보고 있을 때 목록은 집이 그려 이 위에 얹힌다. 판 자체는 위와 같은 문법을 쓰고,
@@ -990,16 +1038,23 @@
   min-width: 0;
   min-height: 40px;
   padding: 8px var(--space-3);
-  border: 1px solid color-mix(in oklch, var(--brass) 45%, transparent);
+  border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-abyss) 70%, transparent);
-  color: var(--brass-bright);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: var(--t-sm);
+  transition:
+    border-color var(--duration-fast) var(--ease-spring),
+    box-shadow var(--duration-fast) var(--ease-spring);
 }
 
 .add-host-field input::placeholder { color: var(--text-tertiary); }
-.add-host-field input:disabled { cursor: not-allowed; opacity: 0.6; }
+.add-host-field input:focus-visible {
+  border-color: var(--brass);
+  box-shadow: 0 0 0 3px var(--brass-glow);
+}
+.add-host-field input:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 .add-host-actions { display: flex; justify-content: flex-end; gap: var(--space-2); }
 
@@ -1324,6 +1379,75 @@
 .remote-card-help { margin: 0; color: var(--text-secondary); font-size: var(--t-md); line-height: 1.55; }
 .remote-card-alert { margin: 0; color: var(--warn-ink); font-family: var(--font-mono); font-size: var(--t-sm); }
 
+/* 폼 선택 컨트롤은 브라우저 기본 외형을 빌리지 않는다 — 같은 Console 안에서 OS마다
+   checkbox/radio의 크기·stroke·focus가 갈리면 나머지 instrument 문법과 한 제품으로 읽히지 않는다. */
+.theme-liquid-glass input[type="checkbox"],
+.remote-acknowledgment input[type="checkbox"],
+.remote-monitoring input[type="checkbox"],
+.remote-port-control input[type="radio"] {
+  appearance: none;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  border: 1px solid var(--surface-rim-strong);
+  background: color-mix(in oklab, var(--ink-deep) 82%, transparent);
+  transition:
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    box-shadow var(--duration-fast) var(--ease-spring);
+}
+
+.theme-liquid-glass input[type="checkbox"],
+.remote-acknowledgment input[type="checkbox"],
+.remote-monitoring input[type="checkbox"] { border-radius: calc(var(--radius-xs) - 2px); }
+.remote-port-control input[type="radio"] { border-radius: var(--radius-pill); }
+
+.theme-liquid-glass input[type="checkbox"]:hover:not(:disabled):not(:checked),
+.remote-acknowledgment input[type="checkbox"]:hover:not(:disabled):not(:checked),
+.remote-monitoring input[type="checkbox"]:hover:not(:disabled):not(:checked),
+.remote-port-control input[type="radio"]:hover:not(:disabled):not(:checked) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+}
+
+.theme-liquid-glass input[type="checkbox"]:checked,
+.remote-acknowledgment input[type="checkbox"]:checked,
+.remote-monitoring input[type="checkbox"]:checked {
+  border-color: var(--brass);
+  background:
+    linear-gradient(135deg, transparent 45%, var(--text-on-brass) 45% 55%, transparent 55%) 2px 4px / 5px 8px no-repeat,
+    linear-gradient(45deg, transparent 38%, var(--text-on-brass) 38% 54%, transparent 54%) 6px 1px / 8px 11px no-repeat,
+    var(--brass);
+}
+
+.theme-liquid-glass input[type="checkbox"]:active:not(:disabled),
+.remote-acknowledgment input[type="checkbox"]:active:not(:disabled),
+.remote-monitoring input[type="checkbox"]:active:not(:disabled),
+.remote-port-control input[type="radio"]:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.remote-port-control input[type="radio"]:checked {
+  border-color: var(--brass);
+  background: radial-gradient(circle, var(--brass) 0 42%, transparent 46%);
+  box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--ink-deep) 82%, transparent);
+}
+
+.theme-liquid-glass input:disabled,
+.remote-acknowledgment input:disabled,
+.remote-monitoring input:disabled,
+.remote-port-control input[type="radio"]:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
+
+/* 강제 색상에서는 배경 이미지가 사라질 수 있다. 네이티브 외형으로 돌아가 checked 표시를
+   시스템 팔레트에 맡기되, Console의 16px 격자는 그대로 유지한다. */
+@media (forced-colors: active) {
+  .theme-liquid-glass input[type="checkbox"],
+  .remote-acknowledgment input[type="checkbox"],
+  .remote-monitoring input[type="checkbox"],
+  .remote-port-control input[type="radio"] { appearance: auto; }
+}
+
 /* 켜고 끄는 스위치는 상태 하나만 말한다 — 세그먼트 두 칸보다 이쪽이 시안의 문법이다. */
 .remote-switch {
   flex: none;
@@ -1345,9 +1469,11 @@
   transition: transform var(--duration-fast) var(--ease-spring), background var(--duration-fast) var(--ease-spring);
 }
 
-.remote-switch.is-on { border-color: color-mix(in oklch, var(--brass) 60%, transparent); background: color-mix(in oklch, var(--brass) 22%, transparent); }
+.remote-switch:hover:not(:disabled):not(.is-on) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
+.remote-switch.is-on { border-color: var(--control-selected-rim); background: var(--control-selected-fill); }
 .remote-switch.is-on .remote-switch-knob { transform: translateX(20px); background: var(--brass-bright); }
-.remote-switch:disabled { cursor: not-allowed; opacity: 0.5; }
+.remote-switch:active:not(:disabled) { transform: translateY(1px); }
+.remote-switch:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 /* 한 단으로 흐른다. 옆 칸에 세우면 그리드 행 높이를 따라 늘어나, 짧은 쪽이 제 legend에서 100px 넘게 떨어진다. */
 .remote-endpoint-grid { display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--space-3); }
@@ -1360,8 +1486,10 @@
 .remote-interface-presets { display: grid; grid-template-columns: repeat(auto-fit, minmax(196px, 1fr)); gap: var(--space-2); }
 .remote-interface-preset { display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-1); min-width: 0; padding: var(--space-2) var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 32%, transparent); color: var(--text-secondary); text-align: left; }
 .remote-interface-preset code { color: var(--text-primary); font-family: var(--font-mono); font-size: var(--t-sm); overflow-wrap: anywhere; }
-.remote-interface-preset:hover, .remote-interface-preset.is-selected { border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); background: color-mix(in oklch, var(--brass) 10%, transparent); }
-.remote-interface-preset.is-selected { box-shadow: inset 3px 0 0 var(--brass); }
+.remote-interface-preset:hover:not(:disabled):not(.is-selected) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
+.remote-interface-preset.is-selected { border-color: var(--control-selected-rim); background: var(--control-selected-fill); box-shadow: inset 3px 0 0 var(--brass); }
+.remote-interface-preset:active:not(:disabled) { transform: translateY(1px); }
+.remote-interface-preset:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 .remote-field input, .remote-port-control input[type="number"] {
   min-width: 0;
   min-height: 36px;
@@ -1372,13 +1500,19 @@
   color: var(--text-primary);
   font-family: var(--font-mono);
 }
+.remote-field input:hover:not(:disabled):not([aria-invalid="true"]),
+.remote-port-control input[type="number"]:hover:not(:disabled):not([aria-invalid="true"]),
+.remote-link-field input:hover {
+  border-color: var(--control-hover-rim);
+}
+.remote-field input:focus-visible, .remote-port-control input[type="number"]:focus-visible, .remote-link-field input:focus-visible { border-color: var(--control-hover-rim); }
+.remote-field input:disabled, .remote-port-control input[type="number"]:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 .remote-field input[aria-invalid="true"], .remote-port-control input[aria-invalid="true"] { border-color: color-mix(in oklch, var(--coral) 55%, var(--surface-rim-strong)); }
 
 /* 내용 높이만 차지한다 — 이웃 칸을 따라 늘어나지 않으므로 legend와 컨트롤이 붙어 있다. */
 .remote-port-control { display: flex; flex-direction: column; gap: var(--space-2); align-self: start; margin: 0; padding: var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); }
 .remote-port-control legend { padding: 0 var(--space-1); color: var(--text-secondary); font-size: var(--t-sm); }
 .remote-port-control label { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--text-secondary); font-size: var(--t-sm); }
-.remote-port-control input[type="radio"], .remote-acknowledgment input { accent-color: var(--brass); }
 .remote-port-control input[type="number"] { width: 110px; }
 .remote-port-modes { display: flex; flex-wrap: wrap; gap: var(--space-3); }
 .remote-port-value { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
@@ -1426,8 +1560,9 @@
 .remote-actions-note { min-width: 0; color: var(--text-secondary); font-size: var(--t-sm); }
 .remote-actions-buttons { display: flex; flex-wrap: wrap; gap: var(--space-2); }
 .remote-create.is-quiet { border-color: var(--surface-rim-strong); background: transparent; color: var(--text-primary); }
-.remote-create.is-quiet:hover:not(:disabled) { border-color: color-mix(in oklch, var(--brass) 55%, transparent); }
-.remote-create.is-danger { border-color: color-mix(in oklch, var(--coral) 55%, transparent); background: color-mix(in oklch, var(--coral) 12%, transparent); color: var(--coral-ink); }
+.remote-create.is-quiet:hover:not(:disabled) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
+.remote-create.is-danger { border-color: color-mix(in oklab, var(--coral) 55%, transparent); background: color-mix(in oklab, var(--coral) 12%, transparent); color: var(--coral-ink); }
+.remote-create.is-danger:hover:not(:disabled) { border-color: color-mix(in oklab, var(--coral) 72%, var(--surface-rim)); background: color-mix(in oklab, var(--coral) 18%, transparent); }
 
 .remote-fingerprint {
   overflow-wrap: anywhere;
@@ -1450,9 +1585,12 @@
   font-size: var(--t-sm);
 }
 
-.remote-create { border-color: color-mix(in oklch, var(--brass) 55%, transparent); background: color-mix(in oklch, var(--brass) 16%, transparent); color: var(--brass-bright); }
-.remote-rotate.is-armed, .remote-rotate:hover:not(:disabled) { border-color: color-mix(in oklch, var(--warn) 55%, transparent); background: var(--warn-glow); color: var(--warn-ink); }
-.remote-rotate:disabled, .remote-create:disabled { cursor: not-allowed; opacity: 0.55; }
+.remote-create { border-color: var(--control-selected-rim); background: var(--control-selected-fill); color: var(--brass-bright); }
+.remote-create:hover:not(:disabled):not(.is-quiet):not(.is-danger) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); color: var(--text-primary); }
+.remote-rotate.is-armed { border-color: color-mix(in oklch, var(--warn) 55%, transparent); background: var(--warn-glow); color: var(--warn-ink); }
+.remote-rotate:hover:not(:disabled):not(.is-armed) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); color: var(--text-primary); }
+.remote-rotate:active:not(:disabled), .remote-create:active:not(:disabled) { transform: translateY(1px); }
+.remote-rotate:disabled, .remote-create:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 .remote-link-field { display: flex; gap: var(--space-2); }
 .remote-link-field input {
@@ -1478,6 +1616,15 @@
   font-family: var(--font-mono);
   font-size: var(--t-xs);
 }
+
+.remote-link-field button:hover:not(:disabled) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
+}
+
+.remote-link-field button:active:not(:disabled) { transform: translateY(1px); }
+.remote-link-field button:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 /* 다른 콘솔 목록 — 고르는 것은 연결 방식이 아니라 콘솔이므로 각 줄이 하나의 호스트다. */
 .remote-hosts { display: flex; flex-direction: column; gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
@@ -1508,7 +1655,9 @@
   font-size: var(--t-base);
 }
 
-.remote-host-name:focus { outline: 1px solid color-mix(in oklch, var(--brass) 55%, transparent); outline-offset: 3px; }
+.remote-host-name:hover:not(:disabled) { background: var(--control-hover-fill); }
+.remote-host-name:focus-visible { outline: 2px solid var(--control-focus-ring); outline-offset: 3px; }
+.remote-host-name:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 .remote-host-text small { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }
 
 .remote-host-open {
@@ -1521,10 +1670,11 @@
   font-size: var(--t-xs);
 }
 
-.remote-host-open:disabled { cursor: not-allowed; opacity: 0.5; }
+.remote-host-open:hover:not(:disabled) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); color: var(--text-primary); }
+.remote-host-open:active:not(:disabled) { transform: translateY(1px); }
+.remote-host-open:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 .remote-monitoring { display: flex; align-items: center; gap: var(--space-3); color: var(--text-secondary); font-size: var(--t-md); }
-.remote-monitoring input { accent-color: var(--brass); }
 
 .remote-table { width: 100%; border-collapse: collapse; font-size: var(--t-md); }
 .remote-table th {
@@ -1565,7 +1715,9 @@
   font-size: var(--t-sm);
 }
 
-.remote-revoke:disabled { cursor: not-allowed; opacity: 0.5; }
+.remote-revoke:hover:not(:disabled) { background: color-mix(in oklab, var(--coral) 10%, transparent); color: var(--coral); }
+.remote-revoke:active:not(:disabled) { transform: translateY(1px); }
+.remote-revoke:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 .remote-row-actions { display: flex; gap: var(--space-4); justify-content: flex-end; }
 
@@ -1581,7 +1733,9 @@
   font-size: var(--t-sm);
 }
 
-.remote-disconnect:disabled { cursor: not-allowed; opacity: 0.5; }
+.remote-disconnect:hover:not(:disabled) { background: var(--control-hover-fill); color: var(--text-primary); }
+.remote-disconnect:active:not(:disabled) { transform: translateY(1px); }
+.remote-disconnect:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 @media (prefers-reduced-motion: reduce) {
   .remote-switch, .remote-switch-knob { transition: none; }
@@ -1597,7 +1751,7 @@
 .typography-reset:disabled,
 .font-card:disabled {
   cursor: not-allowed;
-  opacity: 0.52;
+  opacity: var(--control-disabled-opacity);
 }
 
 /* Theme selection: Light|Dark mode switch. Light은 Whites(오트밀) 단일이라 카드가 없고,
@@ -1647,18 +1801,34 @@
 
 .theme-mode-seg button:disabled {
   cursor: not-allowed;
-  opacity: 0.52;
+  opacity: var(--control-disabled-opacity);
 }
 
-.theme-mode-seg button:hover:not(:disabled):not(.is-active) {
+.theme-mode-seg button:hover:not(:disabled):not(.is-active),
+.theme-mode-seg button:focus-visible:not(.is-active) {
   color: var(--text-primary);
+  background: var(--control-hover-fill);
 }
 
 .theme-mode-seg button.is-active {
+  position: relative;
   color: var(--text-primary);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent);
+  background: var(--control-selected-fill);
+  box-shadow: inset 0 0 0 1px var(--control-selected-rim);
 }
+
+.theme-mode-seg button.is-active::after {
+  position: absolute;
+  right: var(--space-2);
+  bottom: 0;
+  left: var(--space-2);
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  content: "";
+}
+
+.theme-mode-seg button:active:not(:disabled) { transform: translateY(1px); }
 
 .theme-dark-tray {
   display: flex;
@@ -1718,10 +1888,7 @@
   user-select: none;
 }
 
-.theme-liquid-glass input {
-  accent-color: var(--brass);
-  margin-top: 3px;
-}
+.theme-liquid-glass input { margin-top: 3px; }
 
 .theme-liquid-glass-text {
   display: flex;
@@ -1760,16 +1927,17 @@
     transform var(--duration-fast) var(--ease-spring);
 }
 
-.theme-card:hover:not(:disabled) {
+.theme-card:hover:not(:disabled):not(.is-active) {
   color: var(--text-primary);
-  border-color: color-mix(in oklch, var(--brass) 40%, var(--surface-rim));
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
 }
 
 .theme-card.is-active {
   color: var(--text-primary);
-  border-color: color-mix(in oklch, var(--brass) 70%, transparent);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent), var(--shadow-soft);
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
+  box-shadow: 0 0 0 1px var(--control-selected-rim), var(--shadow-soft);
 }
 
 .theme-card:active:not(:disabled) {
@@ -1827,9 +1995,13 @@
 }
 
 .typography-reset:hover:not(:disabled) {
-  border-color: color-mix(in oklch, var(--brass) 56%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   color: var(--text-primary);
+}
+
+.typography-reset:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .global-settings-row.is-stack {
@@ -2140,14 +2312,25 @@
     background var(--duration-fast) var(--ease-spring);
 }
 
-.segmented-option:hover:not(.is-active) {
+.segmented-option:hover:not(:disabled):not(.is-active) {
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
 .segmented-option.is-active {
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 38%, transparent);
+  box-shadow: inset 0 0 0 1px var(--control-selected-rim), inset 0 -2px 0 var(--brass);
+}
+
+.segmented-option:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.segmented-option:disabled {
+  cursor: not-allowed;
+  opacity: var(--control-disabled-opacity);
+  transform: none;
 }
 
 /* Kimi provider API key registration. The Terminal plugin owns behavior; the Console shell supplies shared settings visuals. */
@@ -2232,14 +2415,19 @@
   color: var(--text-tertiary);
 }
 
-.model-auth-input:focus {
-  outline: none;
-  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+.model-auth-input:hover:not(:disabled) {
+  border-color: var(--control-hover-rim);
+}
+
+.model-auth-input:focus-visible {
+  border-color: var(--control-hover-rim);
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
 }
 
 .model-auth-input:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: var(--control-disabled-opacity);
 }
 
 .model-auth-actions {
@@ -2269,18 +2457,21 @@
     transform var(--duration-fast) var(--ease-spring);
 }
 
-.model-auth-button:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+.model-auth-button:hover:not(:disabled):not(.is-primary) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
 .model-auth-button.is-primary {
-  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
 }
 
 .model-auth-button.is-primary:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
@@ -2290,7 +2481,7 @@
 
 .model-auth-button:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: var(--control-disabled-opacity);
 }
 
 @media (max-width: 720px) {
@@ -2364,17 +2555,27 @@
   cursor: pointer;
 }
 
-.backend-api-core-toggle:hover,
-.backend-api-core-toggle:focus-visible,
-.backend-api-plugin-toggle:hover,
-.backend-api-plugin-toggle:focus-visible {
+.backend-api-core-toggle:hover:not(:disabled):not([aria-expanded="true"]),
+.backend-api-plugin-toggle:hover:not(:disabled):not([aria-expanded="true"]) {
+  background: var(--control-hover-fill);
+  color: var(--brass-bright);
+}
+
+.backend-api-core-toggle[aria-expanded="true"],
+.backend-api-plugin-toggle[aria-expanded="true"] {
+  background: var(--control-selected-fill);
   color: var(--brass-bright);
 }
 
 .backend-api-core-toggle:focus-visible,
 .backend-api-plugin-toggle:focus-visible {
-  outline: 1px solid var(--brass);
+  outline: 2px solid var(--control-focus-ring);
   outline-offset: 5px;
+}
+
+.backend-api-core-toggle:active:not(:disabled),
+.backend-api-plugin-toggle:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .backend-api-core-group {
@@ -2543,25 +2744,25 @@
     transform var(--duration-fast) var(--ease-spring);
 }
 
-.settings-disclosure-toggle:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 8%, transparent);
+.settings-disclosure-toggle:hover:not(:disabled):not([aria-expanded="true"]) {
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
 .settings-disclosure-toggle[aria-expanded="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--control-selected-fill);
   color: var(--brass-bright);
+  box-shadow: inset 0 -2px 0 var(--brass);
 }
 
 .settings-disclosure-toggle:active:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
   color: var(--text-primary);
   transform: translateY(1px);
 }
 
 .settings-disclosure-toggle:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: var(--control-disabled-opacity);
   transform: none;
 }
 
@@ -4951,8 +5152,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .operations-side-bar-axis-seg:focus-visible {
-  outline: 2px solid var(--aurora);
-  outline-offset: 1px;
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
 }
 
 .operations-side-bar-chips {
@@ -6433,27 +6634,28 @@ body[data-side-bar-animating="true"] .canvas-operation {
     background var(--duration-fast) var(--ease-spring);
 }
 
-/* 믹스는 oklab이다 — oklch는 hue를 극좌표 호로 보간하므로 brass(78)와 중립 rim(245)의 믹스가
-   엉뚱한 hue에 착지한다(실측: instrument·maritime 테두리 hue 144 초록, carbon 354 자홍,
-   채움 208~289 청록·보라). 위치 채널이 신호 채널 옆으로 새던 자리이고, 같은 함정을 채팅 좌표
-   칩에서 한 번 치렀다. 투명과 섞는 outline만 hue가 하나뿐이라 호가 생기지 않는다. */
-.canvas-operation-icon-button:hover,
-.canvas-operation-icon-button:focus-visible,
-.fleet-caption-action:hover:not(:disabled),
-.fleet-caption-action:focus-visible {
+/* 포인터 hover는 내부 rim+wash만, 키보드 focus는 전역 외곽 링을 보존한다. 둘을 한
+   선택자에 두면 마우스를 스치기만 해도 focus ring이 떠 입력 수단의 고유 신호가 사라진다. */
+.canvas-operation-icon-button:hover:not(.is-active),
+.fleet-caption-action:hover:not(:disabled):not([aria-pressed="true"]) {
   color: var(--brass-bright);
-  border-color: color-mix(in oklab, var(--brass) 45%, var(--surface-rim));
-  background: color-mix(in oklab, var(--brass) 12%, var(--surface-glass));
-  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
-  outline-offset: 2px;
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+}
+
+.canvas-operation-icon-button:focus-visible:not(.is-active),
+.fleet-caption-action:focus-visible:not([aria-pressed="true"]) {
+  color: var(--brass-bright);
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
 }
 
 .canvas-operation-icon-button.is-active,
 .fleet-caption-action[aria-pressed="true"] {
   color: var(--brass-bright);
-  border-color: color-mix(in oklab, var(--brass) 60%, var(--surface-rim));
-  background: color-mix(in oklab, var(--brass) 22%, var(--surface-glass));
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 30%, transparent);
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
+  box-shadow: inset 0 -2px 0 var(--brass);
 }
 
 .canvas-operation-icon-button svg,
@@ -11438,10 +11640,28 @@ body[data-codex-side="true"] .command-card {
   background: var(--aurora);
 }
 
-.fc-settings-toggle:focus-within .fc-settings-toggle__control,
-.fc-settings-field__control:focus {
-  outline: 2px solid color-mix(in oklch, var(--brass) 70%, transparent);
+.fc-settings-toggle:hover:not(:has(.fc-settings-toggle__input:disabled)) .fc-settings-toggle__control {
+  border-color: var(--control-hover-rim);
+}
+
+.fc-settings-toggle:has(.fc-settings-toggle__input:disabled) {
+  cursor: not-allowed;
+  opacity: var(--control-disabled-opacity);
+}
+
+.fc-settings-toggle:has(.fc-settings-toggle__input:focus-visible) .fc-settings-toggle__control,
+.fc-settings-field__control:focus-visible {
+  outline: 2px solid var(--control-focus-ring);
   outline-offset: 2px;
+}
+
+.fc-settings-field__control:hover:not(:disabled):not(:focus-visible) {
+  border-color: var(--control-hover-rim);
+}
+
+.fc-settings-field__control:disabled {
+  cursor: not-allowed;
+  opacity: var(--control-disabled-opacity);
 }
 
 .fc-settings-select,
@@ -11515,6 +11735,22 @@ body[data-codex-side="true"] .command-card {
   .fc-settings-toggle__control::after {
     transition: none;
   }
+}
+
+@media (forced-colors: active) {
+  .fc-settings-toggle__input {
+    appearance: auto;
+    position: static;
+    width: 16px;
+    height: 16px;
+    clip: auto;
+  }
+
+  .fc-settings-toggle__control { display: none; }
+
+  .fc-select__trigger:disabled,
+  .fc-select__option[aria-disabled="true"],
+  .fc-settings-toggle:has(.fc-settings-toggle__input:disabled) { opacity: 1; }
 }
 
 @media (max-width: 720px) {
@@ -12158,10 +12394,11 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
   box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);
   transition: border-color var(--duration-fast) var(--ease-glide);
 }
-.fc-select__trigger:hover { border-color: var(--surface-rim-strong); }
-.fc-select__trigger:focus-visible { outline: none; border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); }
-.fc-select__trigger[aria-expanded="true"] { border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); }
-.fc-select__trigger:disabled { opacity: 0.45; cursor: default; }
+.fc-select__trigger:hover:not(:disabled):not([aria-expanded="true"]) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
+.fc-select__trigger:focus-visible { border-color: var(--control-hover-rim); outline: 2px solid var(--control-focus-ring); outline-offset: 2px; }
+.fc-select__trigger[aria-expanded="true"] { border-color: var(--control-selected-rim); background: var(--control-selected-fill); }
+.fc-select__trigger:active:not(:disabled) { transform: translateY(1px); }
+.fc-select__trigger:disabled { opacity: var(--control-disabled-opacity); cursor: not-allowed; }
 .fc-select__caret { color: var(--text-tertiary); font-size: var(--t-xs); transition: transform var(--duration-fast) var(--ease-glide); }
 .fc-select__trigger[aria-expanded="true"] .fc-select__caret { transform: rotate(180deg); }
 .fc-select__popup {
@@ -12178,15 +12415,15 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
 .fc-select__popup[data-open="true"] { opacity: 1; transform: translateY(0); pointer-events: auto; }
 .fc-select__option {
   display: flex; align-items: center; justify-content: space-between; gap: var(--space-2);
-  padding: 8px 10px; border-radius: var(--radius-xs);
+  padding: 8px 10px; border: 1px solid transparent; border-radius: var(--radius-xs);
   color: var(--text-secondary); font-weight: var(--weight-medium); font-size: var(--t-md); line-height: 1.3; font-family: var(--font-body); cursor: pointer;
-  transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
+  transition: background var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
-.fc-select__option[data-active="true"] { background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--text-primary); }
-.fc-select__option[aria-selected="true"] { color: var(--brass-bright); }
+.fc-select__option[data-active="true"]:not([aria-disabled="true"]):not([aria-selected="true"]) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); color: var(--text-primary); }
+.fc-select__option[aria-selected="true"] { border-color: var(--control-selected-rim); background: var(--control-selected-fill); color: var(--brass-bright); }
 .fc-select__option[aria-selected="true"]::after { content: "✓"; font-size: var(--t-xs); color: var(--brass-bright); }
-.fc-select__option[aria-disabled="true"] { color: var(--text-tertiary); cursor: default; font-style: italic; }
-.fc-select__option[aria-disabled="true"][data-active="true"] { background: transparent; color: var(--text-tertiary); }
+.fc-select__option[aria-disabled="true"] { color: var(--text-tertiary); cursor: not-allowed; font-style: italic; opacity: var(--control-disabled-opacity); }
+.fc-select__option[aria-disabled="true"][data-active="true"] { background: transparent; border-color: transparent; color: var(--text-tertiary); }
 
 .fc-select--compact { min-width: 0; }
 /* compact 트리거는 칩 문법의 모노 티어를 쓴다 — 콘솔 본문 14px 옆에서 9px는 라벨이 아니라 흔적이 된다.

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -530,12 +530,16 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   height: 16px;
 }
 
-.command-band-button:hover,
+.command-band-button:hover {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
+}
+
 .command-band-button:focus-visible {
-  border-color: color-mix(in oklch, var(--ink-fog) 30%, transparent);
-  background: color-mix(in oklch, var(--ink-spectral) 10%, transparent);
-  color: var(--text-secondary);
-  outline: none;
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
 }
 
 /* 눌린 아이콘 버튼은 밴드의 다른 토글과 같은 문법으로 말한다 — .command-band-mode-seg·
@@ -543,7 +547,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
    이미 이 문법을 입고 있다. 이 규칙이 없던 동안 aria-pressed는 접근성 트리에만 존재하고
    화면에는 아무 흔적도 남기지 않았다. */
 .command-band-button[aria-pressed="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
 }
 
@@ -594,6 +598,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   padding: 2px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--surface-glass) 62%, transparent);
 }
 
 .command-band-mode-seg {
@@ -603,7 +608,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   height: 24px;
   padding: 0 9px;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   white-space: nowrap;
   font-family: var(--font-mono);
@@ -611,19 +616,35 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   font-weight: var(--weight-bold);
 }
 
-/* hover는 이웃 command-band-button과 동일한 링 문법 — brass 채움은 활성(pressed) 상태 전용. */
-.command-band-mode-seg:hover:not(:disabled),
-.command-band-mode-seg:focus-visible {
-  border-color: var(--hairline-strong);
+/* hover는 경계와 낮은 wash로 다음 행동만 예고하고, focus는 전역 외곽 링을 보존한다.
+   활성 모드는 wash 아래 짧은 datum을 더해 인접 도구의 pressed 면과 형상으로 갈린다. */
+.command-band-mode-seg:hover:not(:disabled):not([aria-pressed="true"]),
+.command-band-mode-seg:focus-visible:not([aria-pressed="true"]) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
 .command-band-mode-seg[aria-pressed="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  position: relative;
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
 }
 
-.command-band-mode-seg:disabled { cursor: not-allowed; opacity: 0.55; }
+.command-band-mode-seg[aria-pressed="true"]::after {
+  position: absolute;
+  right: var(--space-2);
+  bottom: -3px;
+  left: var(--space-2);
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  content: "";
+}
+
+.command-band-mode-seg:active:not(:disabled) { transform: translateY(1px); }
+.command-band-mode-seg:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 .command-band-mode-tray {
   display: flex;
@@ -648,7 +669,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   height: 24px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-xs);
   color: var(--text-tertiary);
 }
 
@@ -670,18 +691,21 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   font-variant-numeric: tabular-nums;
 }
 
-.command-band-mode-tool:hover:not(:disabled),
-.command-band-mode-tool:focus-visible {
-  border-color: var(--hairline-strong);
+.command-band-mode-tool:hover:not(:disabled):not([aria-pressed="true"]),
+.command-band-mode-tool:focus-visible:not([aria-pressed="true"]) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
 .command-band-mode-tool[aria-pressed="true"] {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
 }
 
-.command-band-mode-tool:disabled { cursor: not-allowed; opacity: 0.55; }
+.command-band-mode-tool:active:not(:disabled) { transform: translateY(1px); }
+.command-band-mode-tool:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 .command-band-theater-cluster {
   display: flex;
@@ -755,16 +779,25 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   gap: 6px;
   min-width: 0;
   padding: 2px 6px;
+  border: 1px solid transparent;
   border-radius: var(--radius-xs);
   cursor: pointer;
-  transition: background var(--duration-fast) var(--ease-spring), color var(--duration-fast) var(--ease-spring);
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring);
 }
 
-.command-band-segment-trigger:hover,
-.command-band-segment-trigger:focus-visible,
+.command-band-segment-trigger:hover:not(.is-open),
+.command-band-segment-trigger:focus-visible:not(.is-open) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+}
+
 .command-band-segment-trigger.is-open {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  outline: none;
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
+  color: var(--text-primary);
 }
 
 .command-band-segment-label {
@@ -780,8 +813,10 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   flex: none;
   color: var(--text-tertiary);
   opacity: 0.75;
+  transition: transform var(--duration-fast) var(--ease-spring);
 }
 
+.command-band-segment-trigger.is-open .command-band-trigger-caret { transform: rotate(180deg); }
 .command-band-trigger-caret svg { display: block; width: 10px; height: 10px; }
 
 .command-band-operation-placeholder {
@@ -818,11 +853,13 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 }
 
 .command-band-menu-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-2);
   width: 100%;
   padding: var(--space-2);
+  border: 1px solid transparent;
   border-radius: var(--radius-xs);
   color: var(--text-tertiary);
   font-family: var(--font-mono);
@@ -834,20 +871,32 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
     background var(--duration-fast) var(--ease-spring);
 }
 
-.command-band-menu-item:hover:not(:disabled),
-.command-band-menu-item:focus-visible {
+.command-band-menu-item:hover:not(:disabled):not(.is-active),
+.command-band-menu-item:focus-visible:not(.is-active) {
+  border-color: var(--control-hover-rim);
   color: var(--text-primary);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  outline: none;
+  background: var(--control-hover-fill);
 }
 
 .command-band-menu-item.is-active {
-  color: var(--brass-bright);
+  color: var(--text-primary);
+  background: var(--control-selected-fill);
 }
 
-.command-band-menu-action {
-  color: var(--brass-bright);
+.command-band-menu-item.is-active::before {
+  position: absolute;
+  top: var(--space-2);
+  bottom: var(--space-2);
+  left: 0;
+  width: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  content: "";
 }
+
+.command-band-menu-action { color: var(--text-secondary); }
+.command-band-menu-action:hover:not(:disabled),
+.command-band-menu-action:focus-visible { color: var(--brass-ink); }
 
 .command-band-menu-action:disabled {
   color: color-mix(in oklch, var(--brass-bright) 45%, transparent);

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -315,6 +315,16 @@
   --duration-base: 220ms;
   --duration-slow: 360ms;
 
+  /* 상호작용 컨트롤의 상태 recipe — 색 역할을 새로 만들지 않고 위치 채널(brass)을
+     한 강도 사다리로 묶는다. rest는 각 소비처의 중립 면이 맡고, hover는 예고,
+     selected는 지속 위치, focus는 입력 수단의 별도 외곽 링이다. */
+  --control-hover-fill: color-mix(in oklab, var(--brass) 8%, transparent);
+  --control-hover-rim: color-mix(in oklab, var(--brass) 42%, var(--surface-rim));
+  --control-selected-fill: color-mix(in oklab, var(--brass) 12%, transparent);
+  --control-selected-rim: color-mix(in oklab, var(--brass) 56%, var(--surface-rim));
+  --control-focus-ring: var(--brass);
+  --control-disabled-opacity: 0.5;
+
 }
 
 
@@ -769,7 +779,7 @@ a {
 }
 
 :focus-visible {
-  outline: 2px solid var(--brass);
+  outline: 2px solid var(--control-focus-ring);
   outline-offset: 2px;
   border-radius: var(--radius-xs);
 }

--- a/runtime/fleet-console/font-picker/styles.css
+++ b/runtime/fleet-console/font-picker/styles.css
@@ -51,12 +51,16 @@
   color: var(--text-primary);
 }
 
+.fc-font-browser__search:hover:not(:disabled):not(:focus-visible) {
+  border-color: var(--control-hover-rim);
+}
+
 .fc-font-browser__search:focus-visible,
 .fc-font-browser__listbox:focus-visible,
 .fc-font-browser__row:focus-visible,
 .fc-font-browser__stepper:focus-visible,
 .fc-font-browser__range:focus-visible {
-  outline: 2px solid var(--brass);
+  outline: 2px solid var(--control-focus-ring);
   outline-offset: 2px;
 }
 
@@ -71,26 +75,30 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-1, 4px) var(--space-2, 8px);
   padding: var(--space-2, 8px);
-  border: 0;
+  border: 1px solid transparent;
   border-radius: var(--radius-xs, 8px);
   background: transparent;
   color: var(--text-primary);
   text-align: left;
 }
 
-.fc-font-browser__row:hover,
-.fc-font-browser__row.is-active { background: color-mix(in oklab, var(--surface-rim) 38%, transparent); }
+.fc-font-browser__row:hover:not(:disabled):not(.is-active):not([aria-selected="true"]),
+.fc-font-browser__row.is-active:not(:disabled):not([aria-selected="true"]) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+}
 /* The chosen font stays marked with a soft brass fill (brass = current selection)
    even when keyboard focus moves elsewhere, so a click highlights it immediately. */
 .fc-font-browser__row[aria-selected="true"] {
-  background: color-mix(in oklab, var(--brass) 14%, transparent);
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
 }
 .fc-font-browser__row.is-unavailable,
-.fc-font-browser[data-disabled="true"] { opacity: 0.56; }
+.fc-font-browser[data-disabled="true"] { opacity: var(--control-disabled-opacity); }
 .fc-font-browser__row:disabled,
 .fc-font-browser__stepper:disabled,
 .fc-font-browser__range:disabled,
-.fc-font-browser__search:disabled { cursor: not-allowed; opacity: 0.56; }
+.fc-font-browser__search:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 .fc-font-browser__row-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .fc-font-browser__row-status { grid-column: 2; }
 
@@ -101,10 +109,25 @@
 .fc-font-browser__availability--unavailable { color: var(--warn-ink); }
 .fc-font-browser__preview-copy { min-height: 5em; margin: 0; color: var(--text-primary); overflow-wrap: anywhere; }
 .fc-font-browser__stepper { min-width: 2.2em; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs, 8px); background: color-mix(in oklab, var(--surface-glass-strong) 78%, transparent); color: var(--text-primary); }
+.fc-font-browser__stepper:hover:not(:disabled) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
+.fc-font-browser__stepper:active:not(:disabled) { transform: translateY(1px); }
 .fc-font-browser__size-value { color: var(--text-secondary); }
 .fc-font-browser__range { width: 100%; accent-color: var(--brass); }
 .fc-font-browser__state { margin: var(--space-2, 8px) 0; color: var(--text-tertiary); }
 .fc-font-browser__state--error { color: var(--coral-ink); }
+
+@media (forced-colors: active) {
+  .fc-font-browser__search,
+  .fc-font-browser__row,
+  .fc-font-browser__stepper,
+  .fc-font-browser__range { appearance: auto; }
+
+  .fc-font-browser[data-disabled="true"],
+  .fc-font-browser__row:disabled,
+  .fc-font-browser__stepper:disabled,
+  .fc-font-browser__range:disabled,
+  .fc-font-browser__search:disabled { opacity: 1; }
+}
 
 @media (prefers-reduced-motion: reduce) {
   .fc-font-browser *, .fc-font-browser *::before, .fc-font-browser *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }

--- a/runtime/fleet-console/font-picker/tests/browser.test.tsx
+++ b/runtime/fleet-console/font-picker/tests/browser.test.tsx
@@ -119,6 +119,26 @@ describe("FontPicker", () => {
     expect(container.textContent).toContain("Unavailable");
   });
 
+  it("keeps search, listbox, disabled, and size controls explicitly labeled", () => {
+    const container = renderPicker({ disabled: true, loading: true });
+    const root = container.querySelector<HTMLElement>(".fc-font-browser");
+    const search = container.querySelector<HTMLInputElement>(".fc-font-browser__search");
+    const searchLabel = container.querySelector<HTMLLabelElement>(".fc-font-browser__search-label");
+    const listbox = container.querySelector<HTMLElement>(".fc-font-browser__listbox");
+    const sizeControl = container.querySelector<HTMLElement>(".fc-font-browser__size-control");
+
+    expect(root?.dataset.disabled).toBe("true");
+    expect(search?.disabled).toBe(true);
+    expect(searchLabel?.htmlFor).toBe(search?.id);
+    expect(listbox?.getAttribute("role")).toBe("listbox");
+    expect(listbox?.getAttribute("aria-label")).toBeTruthy();
+    expect(listbox?.getAttribute("aria-busy")).toBe("true");
+    expect(sizeControl?.getAttribute("role")).toBe("group");
+    expect(sizeControl?.getAttribute("aria-label")).toBeTruthy();
+    expect([...container.querySelectorAll<HTMLButtonElement>(".fc-font-browser__stepper")].every((button) => button.disabled && Boolean(button.getAttribute("aria-label")))).toBe(true);
+    expect(container.querySelector(".fc-font-browser__range")?.getAttribute("aria-label")).toBeTruthy();
+  });
+
   it("keeps slider draft local and commits once when its interaction ends", async () => {
     const onSizeCommit = vi.fn();
     const container = renderPicker({ onSizeCommit });

--- a/runtime/fleet-console/tests/host-picker-surface.test.tsx
+++ b/runtime/fleet-console/tests/host-picker-surface.test.tsx
@@ -168,7 +168,8 @@ describe("the list home unfolds", () => {
     expect(rowText().join("\n")).toContain("SBLUEMIN2C23");
     const current = rows().find((row) => row.getAttribute("aria-checked") === "true");
     expect(current?.textContent).toContain("dotobokuliui-Macmini");
-    expect((current as HTMLButtonElement).disabled).toBe(true);
+    expect((current as HTMLButtonElement).disabled).toBe(false);
+    expect(current?.getAttribute("aria-disabled")).toBe("true");
   });
 
   it("opens with the list already unfolded and no chip of its own", async () => {
@@ -178,6 +179,78 @@ describe("the list home unfolds", () => {
 
     expect(rows().length).toBeGreaterThan(0);
     expect(document.querySelector(".host-switcher-chip")).toBeNull();
+  });
+
+  it("keeps the picker keyboard behind the Add Host modal", async () => {
+    stubHomeConsole();
+    await mount(createElement(HostPickerScreen, { surface: { at: HERE } }));
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+
+    const add = document.querySelector<HTMLButtonElement>('.host-switcher-link[role="menuitem"]')!;
+    await act(async () => { add.click(); });
+    const input = document.querySelector<HTMLInputElement>(".add-host-field input")!;
+    expect(document.activeElement).toBe(input);
+
+    for (const key of ["ArrowDown", "Home", "End"]) {
+      await act(async () => { input.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true })); });
+      expect(document.activeElement).toBe(input);
+    }
+
+    await act(async () => { input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })); });
+    expect(document.querySelector('[aria-modal="true"]')).toBeNull();
+    expect(rows().length).toBeGreaterThan(0);
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("moves initial focus to a current saved host that arrives after the first frame", async () => {
+    standOn(HOME);
+    let releaseHosts = (_: Response) => {};
+    vi.stubGlobal("fetch", vi.fn(async (input: string) => {
+      const path = new URL(input, HOME).pathname;
+      if (path === "/api/v1/desktop/shell") return Response.json({ homeOrigin: HOME });
+      if (path === "/api/v1/local-consoles") return Response.json({ consoles: [scanned(HOME)] });
+      if (path === "/api/v1/remote-hosts") return new Promise<Response>((resolve) => { releaseHosts = resolve; });
+      return Response.json({ reachable: true, trusted: true });
+    }));
+
+    await mount(createElement(HostPickerScreen, { surface: { at: THERE } }));
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+    const fallback = rows().find((row) => row.getAttribute("aria-checked") === "true")!;
+    expect(document.activeElement).toBe(fallback);
+    expect((fallback as HTMLButtonElement).disabled).toBe(false);
+
+    await act(async () => {
+      releaseHosts(Response.json({
+        hosts: [{ id: "there", label: "SBLUEMIN2C23", origin: THERE, hostname: "10.211.55.3", port: 6186, fingerprint: "A".repeat(64), addedAt: 1, lastOpenedAt: null }],
+      }));
+      await Promise.resolve();
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const current = rows().find((row) => row.getAttribute("aria-checked") === "true")!;
+    expect(current.textContent).toContain("SBLUEMIN2C23");
+    expect(document.activeElement).toBe(current);
+  });
+
+  it("focuses the current row and moves through enabled actions with menu keys", async () => {
+    stubHomeConsole();
+
+    await mount(createElement(HostPickerScreen, { surface: { at: HERE } }));
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+
+    const items = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"], [role="menuitem"]')]
+      .filter((item) => !item.disabled);
+    const current = items.find((item) => item.getAttribute("aria-checked") === "true")!;
+    expect(document.activeElement).toBe(current);
+
+    await act(async () => { document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })); });
+    expect(document.activeElement).toBe(items[(items.indexOf(current) + 1) % items.length]);
+
+    await act(async () => { document.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })); });
+    expect(document.activeElement).toBe(items.at(-1));
+
+    await act(async () => { document.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true })); });
+    expect(document.activeElement).toBe(items[0]);
   });
 
   /** 판은 이 화면의 상태가 아니라 셸이 얹은 덮개라, 접겠다는 말도 셸에게 가야 한다. */

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -46,6 +46,9 @@ const TERMINAL_CHAT_COMPOSER_PATH = new URL("../../fleet-plugins/terminal/client
 const TERMINAL_CHAT_CSS_PATH = new URL("../../fleet-plugins/terminal/client/agent/chat/chat.css", import.meta.url);
 const QUOTA_CSS_PATH = new URL("../../fleet-plugins/quota/client/quota.css", import.meta.url);
 const QUOTA_PANEL_PATH = new URL("../../fleet-plugins/quota/client/rail-panel.tsx", import.meta.url);
+const FILE_EXPLORER_CSS_PATH = new URL("../../fleet-plugins/file-explorer/client/explorer.css", import.meta.url);
+const REPOSITORY_CSS_PATH = new URL("../../fleet-plugins/repository/client/repository.css", import.meta.url);
+const FONT_PICKER_CSS_PATH = new URL("../font-picker/styles.css", import.meta.url);
 const SDK_RAIL_TYPES_PATH = new URL("../sdk/rail/types.ts", import.meta.url);
 const SDK_CAPTION_ACTIONS_PATH = new URL("../sdk/components/caption-actions.tsx", import.meta.url);
 const SDK_VERSION_PATH = new URL("../sdk/version.ts", import.meta.url);
@@ -482,6 +485,74 @@ describe("Instrument core design contract", () => {
     expect(components).not.toMatch(/@media \(max-width: 720px\) \{\s*\.backend-api-row/);
   });
 
+  it("keeps the interaction control recipe theme-owned", () => {
+    const theme = source("styles/theme.css");
+    const root = theme.match(/^:root \{[\s\S]*?^\}/m)?.[0] ?? "";
+    for (const token of [
+      "--control-hover-fill",
+      "--control-hover-rim",
+      "--control-selected-fill",
+      "--control-selected-rim",
+      "--control-focus-ring",
+      "--control-disabled-opacity",
+    ]) expect(root).toContain(`${token}:`);
+    expect(root).toContain("--control-hover-fill: color-mix(in oklab, var(--brass) 8%, transparent);");
+    expect(root).toContain("--control-selected-rim: color-mix(in oklab, var(--brass) 56%, var(--surface-rim));");
+    expect(theme).toMatch(/:focus-visible \{[^}]*outline: 2px solid var\(--control-focus-ring\);/);
+  });
+
+  it("keeps selected controls stronger than hover and preserves forced-color form state", () => {
+    const components = source("styles/components.css");
+    const layout = source("styles/layout.css");
+    const explorer = externalSource(FILE_EXPLORER_CSS_PATH);
+    const repository = externalSource(REPOSITORY_CSS_PATH);
+
+    for (const selector of [
+      '.command-band-mode-seg:hover:not(:disabled):not([aria-pressed="true"])',
+      '.command-band-mode-tool:hover:not(:disabled):not([aria-pressed="true"])',
+      ".command-band-segment-trigger:hover:not(.is-open)",
+      ".command-band-menu-item:hover:not(:disabled):not(.is-active)",
+    ]) expect(layout).toContain(selector);
+    expect(components).toContain(".host-switcher-panel > button:hover:not(:disabled):not(.is-current)");
+    expect(components).toContain('.fleet-caption-action:hover:not(:disabled):not([aria-pressed="true"])');
+    expect(explorer).toContain('.fexp-view-mode button:hover:not(:disabled):not([aria-pressed="true"])');
+    expect(repository).toContain(".repository-toggle-btn:hover:not(.is-active)");
+
+    for (const css of [components, repository]) {
+      expect(css).toContain("@media (forced-colors: active)");
+      expect(css).toContain("appearance: auto;");
+    }
+  });
+
+  it("keeps Settings, SDK Select, and Font Picker on the shared control recipe", () => {
+    const components = source("styles/components.css");
+    const terminalSettings = externalSource(TERMINAL_AGENT_CLI_CSS_PATH);
+    const fontPicker = externalSource(FONT_PICKER_CSS_PATH);
+
+    for (const selector of [
+      '.global-settings-nav-item:hover:not([aria-pressed="true"])',
+      ".segmented-option:hover:not(:disabled):not(.is-active)",
+      '.fc-select__trigger:hover:not(:disabled):not([aria-expanded="true"])',
+      '.fc-select__option[data-active="true"]:not([aria-disabled="true"]):not([aria-selected="true"])',
+    ]) expect(components).toContain(selector);
+    for (const token of [
+      "var(--control-hover-fill)",
+      "var(--control-hover-rim)",
+      "var(--control-selected-fill)",
+      "var(--control-selected-rim)",
+      "var(--control-focus-ring)",
+      "var(--control-disabled-opacity)",
+    ]) {
+      expect(components).toContain(token);
+      expect(terminalSettings).toContain(token);
+      expect(fontPicker).toContain(token);
+    }
+    expect(fontPicker).toContain('.fc-font-browser__row:hover:not(:disabled):not(.is-active):not([aria-selected="true"])');
+    expect(fontPicker).toContain('@media (forced-colors: active)');
+    expect(components).toContain('.fc-settings-toggle:has(.fc-settings-toggle__input:focus-visible)');
+    expect(components).toContain('.fc-settings-toggle:has(.fc-settings-toggle__input:disabled)');
+  });
+
   it("keeps one control grammar on the caption band", () => {
     const components = source("styles/components.css");
     const frame = source("canvas/operation-frame.tsx");
@@ -495,13 +566,19 @@ describe("Instrument core design contract", () => {
     const svgSize = components.match(/\.canvas-operation-icon-button svg,\n\.fleet-caption-action svg \{[^}]*\}/)?.[0] ?? "";
     expect(svgSize).toContain("width: 14px;");
 
-    // 위치 채널은 oklab으로만 섞는다 — oklch의 hue 호가 brass를 초록·자홍에 내려놓았다(실측).
+    // 선택·hover는 theme.css의 oklab control recipe 하나를 소비한다. hover와 focus를 한
+    // 선택자로 합치면 마우스를 스칠 때도 외곽 focus ring이 떠 입력 수단의 신호가 사라진다.
     const pressed = components.match(/\.canvas-operation-icon-button\.is-active,\n\.fleet-caption-action\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(pressed).toContain("color-mix(in oklab, var(--brass) 60%, var(--surface-rim))");
-    expect(pressed).toContain("color-mix(in oklab, var(--brass) 22%, var(--surface-glass))");
-    expect(pressed).not.toContain("color-mix(in oklch, var(--brass) 60%");
-    const hover = components.match(/\.canvas-operation-icon-button:hover,[\s\S]{0,200}?\.fleet-caption-action:focus-visible \{[^}]*\}/)?.[0] ?? "";
-    expect(hover).toContain("color-mix(in oklab, var(--brass) 45%, var(--surface-rim))");
+    expect(pressed).toContain("border-color: var(--control-selected-rim);");
+    expect(pressed).toContain("background: var(--control-selected-fill);");
+    expect(pressed).toContain("box-shadow: inset 0 -2px 0 var(--brass);");
+    const hover = components.match(/\.canvas-operation-icon-button:hover:not\(\.is-active\),\n\.fleet-caption-action:hover:not\(:disabled\):not\(\[aria-pressed="true"\]\) \{[^}]*\}/)?.[0] ?? "";
+    expect(hover).toContain("border-color: var(--control-hover-rim);");
+    expect(hover).toContain("background: var(--control-hover-fill);");
+    expect(hover).not.toContain("outline:");
+    const focus = components.match(/\.canvas-operation-icon-button:focus-visible:not\(\.is-active\),\n\.fleet-caption-action:focus-visible:not\(\[aria-pressed="true"\]\) \{[^}]*\}/)?.[0] ?? "";
+    expect(focus).toContain("border-color: var(--control-hover-rim);");
+    expect(focus).not.toContain("outline: none;");
 
     // 진행은 aurora(상태)로, 위치는 brass로 — 한 버튼 위에서도 두 채널이 겹치지 않는다.
     const live = components.match(/\.fleet-caption-action-live \{[^}]*\}/)?.[0] ?? "";
@@ -1107,9 +1184,9 @@ describe("Instrument core design contract", () => {
     // 켜진 단계는 사다리 위의 위치이지 Operation 상태가 아니다 — 신호색을 빌리면 같은 카드의
     // 활동 축과 충돌하므로, 코어 segmented와 같은 brass 워시+brass ink+inset 링만 쓴다.
     const on = css.match(/\.ai-gateway-effort-level\.is-on \{[^}]*\}/)?.[0] ?? "";
-    expect(on).toContain("background: color-mix(in oklch, var(--brass) 16%, transparent);");
+    expect(on).toContain("background: var(--control-selected-fill);");
     expect(on).toContain("color: var(--brass-ink);");
-    expect(on).toContain("box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 38%, transparent);");
+    expect(on).toContain("box-shadow: inset 0 0 0 1px var(--control-selected-rim);");
     for (const [, , body] of css.matchAll(/([^{}]*\.ai-gateway-effort[^{}]*)\{([^}]*)\}/g)) {
       expect(body).not.toMatch(/var\(--(aurora|warn|coral|positive)[a-z-]*\)/);
     }
@@ -1797,8 +1874,18 @@ describe("Instrument core design contract", () => {
     expect(layout).toContain('body:has([aria-modal="true"]:not([hidden])) .command-band.is-fullscreen:not(.is-docked),');
     // aria-pressed가 화면에 흔적을 남기지 않던 회귀를 막는다 — 밴드 토글의 눌림은 brass 채움이다.
     const pressedBandButtonBlock = layout.match(/\.command-band-button\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(pressedBandButtonBlock).toContain("background: color-mix(in oklch, var(--brass) 12%, transparent);");
+    expect(pressedBandButtonBlock).toContain("background: var(--control-selected-fill);");
     expect(pressedBandButtonBlock).toContain("color: var(--brass-ink);");
+    // 캔버스 모드는 선택 datum을 가져 인접 도구의 pressed 면과 형상으로 갈린다.
+    const modePressedBlock = layout.match(/\.command-band-mode-seg\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
+    expect(modePressedBlock).toContain("border-color: var(--control-selected-rim);");
+    expect(modePressedBlock).toContain("background: var(--control-selected-fill);");
+    expect(layout).toMatch(/\.command-band-mode-seg\[aria-pressed="true"\]::after \{[^}]*background: var\(--brass\);/);
+    expect(layout).toContain('.command-band-mode-seg:hover:not(:disabled):not([aria-pressed="true"])');
+    // 열린 스위처는 hover보다 지속적인 selected 면을 갖고 caret이 방향을 바꾼다.
+    const openTriggerBlock = layout.match(/\.command-band-segment-trigger\.is-open \{[^}]*\}/)?.[0] ?? "";
+    expect(openTriggerBlock).toContain("border-color: var(--control-selected-rim);");
+    expect(layout).toContain(".command-band-segment-trigger.is-open .command-band-trigger-caret { transform: rotate(180deg); }");
   });
 
   it("keeps long What's new content inside the scrollable body without shrinking controls", () => {
@@ -2793,8 +2880,8 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain("font-weight: var(--weight-medium); font-size: var(--t-md); line-height: 1.2; font-family: var(--font-body);");
     expect(selectBlock).toContain("padding: 0 13px;");
     expect(selectBlock).toContain("box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);");
-    expect(selectBlock).toContain("border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));");
-    expect(selectBlock).toContain("background: color-mix(in oklch, var(--brass) 12%, transparent);");
+    expect(selectBlock).toContain("border-color: var(--control-selected-rim);");
+    expect(selectBlock).toContain("background: var(--control-selected-fill);");
     expect(selectBlock).toContain('content: "✓";');
     expect(selectBlock).toContain("font-style: italic;");
     expect(selectBlock).toContain(".fc-select--compact .fc-select__trigger {");

--- a/runtime/fleet-console/tests/sdk-select.test.tsx
+++ b/runtime/fleet-console/tests/sdk-select.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Select, type SelectOption } from "@fleet-console/sdk/react/browser";
-import { SettingsSelect } from "@fleet-console/sdk/settings/browser";
+import { SettingsField, SettingsRow, SettingsSelect, SettingsToggle } from "@fleet-console/sdk/settings/browser";
 import { isSelectOwnedKeyEvent } from "../core/client/src/components/whatsnew-modal.js";
 
 let root: Root | null = null;
@@ -459,6 +459,54 @@ describe("SettingsSelect public contract", () => {
     const trigger = container.querySelector<HTMLButtonElement>(".fc-select__trigger");
     expect(trigger?.getAttribute("aria-label")).toBe("Select setting");
     expect(trigger?.disabled).toBe(true);
+  });
+});
+
+describe("Settings control public contract", () => {
+  it("keeps toggle semantics, labels, and disabled state on the native checkbox", () => {
+    const onChange = vi.fn<(next: boolean) => void>();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(SettingsToggle, {
+        label: "Departure bell",
+        checked: true,
+        disabled: false,
+        onChange,
+      }));
+    });
+
+    const input = container.querySelector<HTMLInputElement>(".fc-settings-toggle__input");
+    expect(input?.type).toBe("checkbox");
+    expect(input?.checked).toBe(true);
+    expect(input?.disabled).toBe(false);
+    expect(input?.getAttribute("aria-label")).toBeNull();
+    expect(container.querySelector(".fc-settings-toggle__control")?.getAttribute("aria-hidden")).toBe("true");
+
+    act(() => input?.click());
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps row and field labels and hints associated with their groups", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement("div", null,
+        createElement(SettingsRow, { label: "Roster", hint: "Choose admirals" }, createElement("span", null, "Control")),
+        createElement(SettingsField, { label: "Path", hint: "Absolute path" }, createElement("input", null)),
+      ));
+    });
+
+    for (const selector of [".fc-settings-row", ".fc-settings-field"]) {
+      const group = container.querySelector<HTMLElement>(selector);
+      const labelId = group?.getAttribute("aria-labelledby") ?? "";
+      const hintId = group?.getAttribute("aria-describedby") ?? "";
+      expect(group?.getAttribute("role")).toBe("group");
+      expect(document.getElementById(labelId)).not.toBeNull();
+      expect(document.getElementById(hintId)).not.toBeNull();
+    }
   });
 });
 

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -410,21 +410,51 @@
 }
 
 .fexp-view-mode button {
+  position: relative;
+  min-height: 24px;
   padding: 1px 8px;
   background: none;
-  border: none;
+  border: 1px solid transparent;
   border-radius: calc(var(--radius-xs) - 2px);
   cursor: pointer;
   color: var(--text-tertiary);
-  font-family: var(--font-body);
+  font-family: var(--font-mono);
   font-size: var(--t-xs);
+  font-weight: var(--weight-bold);
   line-height: 1.5;
+  transition:
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.fexp-view-mode button:hover:not(:disabled):not([aria-pressed="true"]),
+.fexp-view-mode button:focus-visible:not([aria-pressed="true"]) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
 }
 
 .fexp-view-mode button[aria-pressed="true"] {
-  background: var(--surface-glass-strong);
-  color: var(--text-primary);
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
+  color: var(--brass-ink);
 }
+
+.fexp-view-mode button[aria-pressed="true"]::after {
+  position: absolute;
+  right: var(--space-2);
+  bottom: -3px;
+  left: var(--space-2);
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  content: "";
+}
+
+.fexp-view-mode button:active:not(:disabled) { transform: translateY(1px); }
+.fexp-view-mode button:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 .fexp-viewer-meta {
   display: flex;

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -161,26 +161,39 @@
 }
 
 .repository-toggle-btn {
+  position: relative;
   width: 24px;
   height: 24px;
   display: inline-grid;
   place-items: center;
   background: none;
-  border: none;
+  border: 1px solid transparent;
   cursor: pointer;
   color: var(--text-tertiary);
   border-radius: var(--radius-xs);
-  transition: color var(--duration-fast), background var(--duration-fast);
+  transition:
+    color var(--duration-fast),
+    border-color var(--duration-fast),
+    background var(--duration-fast),
+    transform var(--duration-fast) var(--ease-spring);
 }
 
-.repository-toggle-btn:hover {
-  color: var(--text-secondary);
+.repository-toggle-btn:hover:not(.is-active),
+.repository-toggle-btn:focus-visible:not(.is-active) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
 }
 
 .repository-toggle-btn.is-active {
+  border-color: var(--control-selected-rim);
   color: var(--brass-ink);
-  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  background: var(--control-selected-fill);
+  box-shadow: inset 0 -2px 0 var(--brass);
 }
+
+.repository-toggle-btn:active:not(:disabled) { transform: translateY(1px); }
+.repository-toggle-btn:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 /* ── 섹션 스크롤 컨테이너 ── */
 .repository-sections {
@@ -1987,6 +2000,31 @@
    줄바꿈을 허용하고 버튼이 남은 줄을 통째로 갖게 한다 — 컨트롤은 눌리는 대신 내려간다. */
 .repository-commit-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 10px; margin-top: 8px; }
 .repository-commit-amend { display: inline-flex; align-items: center; gap: 5px; font-size: var(--t-sm); color: var(--text-tertiary); }
+.repository-commit-amend input[type="checkbox"] {
+  appearance: none;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: calc(var(--radius-xs) - 2px);
+  background: color-mix(in oklab, var(--ink-deep) 82%, transparent);
+  transition:
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    box-shadow var(--duration-fast) var(--ease-spring);
+}
+.repository-commit-amend input[type="checkbox"]:checked {
+  border-color: var(--brass);
+  background:
+    linear-gradient(135deg, transparent 45%, var(--text-on-brass) 45% 55%, transparent 55%) 2px 4px / 5px 8px no-repeat,
+    linear-gradient(45deg, transparent 38%, var(--text-on-brass) 38% 54%, transparent 54%) 6px 1px / 8px 11px no-repeat,
+    var(--brass);
+}
+.repository-commit-amend input[type="checkbox"]:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
+@media (forced-colors: active) {
+  .repository-commit-amend input[type="checkbox"] { appearance: auto; }
+}
 .repository-commit-target {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--t-xs);

--- a/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
+++ b/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
@@ -111,9 +111,19 @@
   font-family: var(--font-mono);
 }
 
-.agent-cli-path-input:focus {
-  border-color: var(--brass);
-  outline: 1px solid var(--brass);
+.agent-cli-path-input:hover:not(:disabled) {
+  border-color: var(--control-hover-rim);
+}
+
+.agent-cli-path-input:focus-visible {
+  border-color: var(--control-hover-rim);
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+}
+
+.agent-cli-path-input:disabled {
+  cursor: not-allowed;
+  opacity: var(--control-disabled-opacity);
 }
 
 .agent-cli-path-actions {
@@ -134,19 +144,29 @@
   cursor: pointer;
 }
 
-.agent-cli-path-button:hover:not(:disabled),
-.agent-cli-path-button:focus-visible {
-  border-color: var(--brass);
+.agent-cli-path-button:hover:not(:disabled) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
+.agent-cli-path-button:focus-visible {
+  border-color: var(--control-hover-rim);
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+}
+
 .agent-cli-path-button.is-primary {
-  border-color: var(--brass);
+  border-color: var(--control-selected-rim);
+}
+
+.agent-cli-path-button:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .agent-cli-path-button:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: var(--control-disabled-opacity);
 }
 
 .agent-cli-path-error {
@@ -163,7 +183,17 @@
 
 .agent-cli-searched-paths summary {
   width: fit-content;
+  border-radius: var(--radius-xs);
   cursor: pointer;
+}
+
+.agent-cli-searched-paths summary:hover {
+  color: var(--text-primary);
+}
+
+.agent-cli-searched-paths summary:focus-visible {
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
 }
 
 .agent-cli-searched-paths ul {
@@ -386,14 +416,24 @@
     color var(--duration-fast) var(--ease-spring);
 }
 
-.ai-gateway-priority-toggle:hover:not(:disabled) {
-  border-color: var(--surface-rim-strong);
+.ai-gateway-priority-toggle:hover:not(:disabled):not(.is-ranked) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   color: var(--text-secondary);
 }
 
+.ai-gateway-priority-toggle:focus-visible {
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+}
+
+.ai-gateway-priority-toggle:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
 .ai-gateway-priority-toggle:disabled {
-  cursor: default;
-  opacity: 0.6;
+  cursor: not-allowed;
+  opacity: var(--control-disabled-opacity);
 }
 
 .ai-gateway-priority-toggle.is-ranked {
@@ -470,20 +510,30 @@
     color var(--duration-fast) var(--ease-spring);
 }
 
-.ai-gateway-host-only:hover:not(:disabled) {
-  border-color: var(--surface-rim-strong);
+.ai-gateway-host-only:hover:not(:disabled):not(.is-on) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
+.ai-gateway-host-only:focus-visible {
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+}
+
 .ai-gateway-host-only.is-on {
-  border-color: color-mix(in oklch, var(--brass) 40%, transparent);
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
+}
+
+.ai-gateway-host-only:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .ai-gateway-host-only:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: var(--control-disabled-opacity);
 }
 
 /* 라벨 두 단어로는 "와이어에는 남고 로스터에서만 빠진다"를 읽을 수 없으므로, 한 줄 요약
@@ -532,7 +582,17 @@
 }
 
 .ai-gateway-remove:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--coral) 10%, transparent);
   color: var(--coral);
+}
+
+.ai-gateway-remove:focus-visible {
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+}
+
+.ai-gateway-remove:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 /* 강도 노출 편집 — 속성 칩과 같은 알약 안에서 사다리를 펼친 배지다. 강도는 이 카드에서
@@ -581,13 +641,23 @@
 }
 
 .ai-gateway-effort-level:hover:not(:disabled):not(.is-on) {
+  background: var(--control-hover-fill);
   color: var(--text-primary);
 }
 
+.ai-gateway-effort-level:focus-visible {
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+}
+
 .ai-gateway-effort-level.is-on {
-  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 38%, transparent);
+  box-shadow: inset 0 0 0 1px var(--control-selected-rim);
+}
+
+.ai-gateway-effort-level:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 /* 마지막 한 단계는 끌 수 없다. 켜진 채로 잠긴 상태이므로 흐리게 만들지 않는다 —
@@ -598,7 +668,7 @@
 
 .ai-gateway-effort-level:disabled:not(.is-on) {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: var(--control-disabled-opacity);
 }
 
 .ai-gateway-composer {
@@ -635,13 +705,30 @@
   transition: background var(--duration-fast) var(--ease-spring);
 }
 
+.ai-gateway-axis-toggle:hover:not(:disabled):not(.is-on) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
+}
+
+.ai-gateway-axis-toggle:focus-visible {
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+}
+
 .ai-gateway-axis-toggle.is-on {
-  border-color: color-mix(in oklch, var(--brass) 40%, transparent);
+  border-color: var(--control-selected-rim);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
 }
 
 .ai-gateway-axis-toggle.is-on::before {
   background: var(--brass);
+}
+
+.ai-gateway-axis-toggle:active:not(:disabled),
+.ai-gateway-add-button:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .ai-gateway-composer-note {
@@ -653,9 +740,9 @@
 .ai-gateway-add-button {
   margin-left: auto;
   padding: var(--space-2) var(--space-4);
-  border: 1px solid color-mix(in oklch, var(--brass) 40%, var(--surface-rim));
+  border: 1px solid var(--control-selected-rim);
   border-radius: var(--radius-xs);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  background: var(--control-selected-fill);
   color: var(--brass-ink);
   font-family: var(--font-mono);
   font-size: var(--t-xs);
@@ -665,10 +752,21 @@
   cursor: pointer;
 }
 
+.ai-gateway-add-button:hover:not(:disabled) {
+  border-color: var(--control-hover-rim);
+  background: var(--control-hover-fill);
+  color: var(--text-primary);
+}
+
+.ai-gateway-add-button:focus-visible {
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+}
+
 .ai-gateway-add-button:disabled,
 .ai-gateway-axis-toggle:disabled,
 .ai-gateway-remove:disabled {
-  opacity: 0.45;
+  opacity: var(--control-disabled-opacity);
   cursor: not-allowed;
 }
 
@@ -698,6 +796,12 @@
 
 .compact-timing-track.is-live {
   cursor: ew-resize;
+}
+
+.compact-timing-track:has(.compact-timing-sr:focus-visible) {
+  outline: 2px solid var(--control-focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .compact-timing-bar {


### PR DESCRIPTION
## Summary
- establish a shared hover, focus, selected, active, disabled, and destructive control recipe across all Console themes
- apply the interaction grammar to Console chrome, Settings, Font Picker, and built-in Terminal, File Explorer, and Repository surfaces
- keep the current Host row legible and focusable while adding menu keyboard navigation, async focus correction, and modal keyboard isolation

## Test Plan
- [x] `corepack pnpm --dir <worktree> --filter @dotobokuri/fleet-console test` (192 files passed, 1 skipped; 2,377 tests passed, 24 skipped)
- [x] `corepack pnpm --dir <worktree> --filter @dotobokuri/fleet-console typecheck`
- [x] `corepack pnpm --dir <worktree> --filter @dotobokuri/fleet-console build`
- [x] `corepack pnpm --dir <worktree> --filter @fleet-plugins/terminal typecheck`
- [x] `corepack pnpm --dir <worktree> --filter @fleet-plugins/terminal test` (93 files, 1,000 tests passed)
- [x] `corepack pnpm --dir <worktree> --filter @fleet-plugins/terminal build`
- [x] `corepack pnpm --dir <worktree> --filter @fleet-console/font-picker test` (3 files, 16 tests passed)
- [x] `corepack pnpm --dir <worktree> --filter @fleet-console/font-picker typecheck`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`
- [x] isolated browser verification across Instrument, Maritime, Carbon, and Whites; Liquid Glass on/off; desktop and mobile Settings surfaces; zero page errors, unhandled rejections, and horizontal overflow