### PR TITLE
fix(fleet-console): lift the dark liquid-glass terminal off the canvas

### DIFF
--- a/.changelog.d/dark-glass-terminal-surface.md
+++ b/.changelog.d/dark-glass-terminal-surface.md
@@ -1,0 +1,8 @@
+---
+branch: dark-glass-terminal-surface
+---
+
+### fleet-console
+#### Fixed
+- Liquid glass no longer sinks the terminal into the canvas on the dark themes: the reading field rises back above the sidebar and rail, the pane carries a light of its own, and terminal black stays darker than the field it is drawn on.
+  ko: 리퀴드 글래스를 켜도 다크 테마의 터미널이 캔버스로 가라앉지 않습니다. 읽는 면이 사이드바·레일 위로 돌아오고, 패널이 자체 광원을 얻으며, 터미널 검정이 필드보다 어둡게 유지됩니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3123,7 +3123,7 @@
 
 .operations-canvas.is-formation-view {
   background:
-    radial-gradient(100% 80% at 50% 42%, var(--canvas-sea-core), var(--canvas-sea-mid) 78%),
+    radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-sea-mid) 78%),
     var(--canvas-abyss);
   cursor: default;
 }
@@ -3147,7 +3147,7 @@
 
 .operations-canvas-sea {
   background:
-    radial-gradient(ellipse at 48% 42%, color-mix(in oklch, var(--canvas-sea-core) 82%, transparent), transparent 38%),
+    radial-gradient(ellipse at 48% 42%, color-mix(in oklch, var(--canvas-ambience) 82%, transparent), transparent 38%),
     radial-gradient(circle at 18% 18%, color-mix(in oklch, var(--aurora) 7%, transparent), transparent 34%),
     radial-gradient(circle at 84% 76%, color-mix(in oklch, var(--brass) 5%, transparent), transparent 36%),
     linear-gradient(145deg, var(--canvas-sea-near), var(--canvas-sea-mid) 58%, var(--canvas-sea-far));
@@ -4563,9 +4563,16 @@
   border: 1px solid var(--surface-rim);
   /* 상단 모서리는 캡션이 잇는다 — 본문이 따로 둥글면 두 개의 창처럼 읽힌다. */
   border-radius: 0 0 var(--radius-md) var(--radius-md);
-  /* 패널의 유일한 면 — 루트가 panel 유리 틴트를 칠하고, 캡션·본문 팬은 panel-face(게이트
-     열림 시 transparent)를 칠해 유리 한 장으로 읽힌다. xterm 필드만 원 토큰의 불투명을 지킨다. */
-  background: var(--glass-tint-panel);
+  /* 패널의 유일한 면 — 루트가 panel 유리 틴트를 칠하고, 박스 안의 본문 팬은 panel-face(게이트
+     열림 시 transparent)를 칠해 유리 한 장으로 읽힌다. 틴트 아래의 pane-light는 창 위쪽에 놓인
+     광원 한 겹이다: 유리 뒤가 캔버스(앱에서 가장 어두운 면)라 blur가 굴절시킬 빛이 없으므로,
+     재질은 명도가 아니라 이 기울기가 말한다. 게이트가 닫히면 광원은 투명, 틴트는 불투명
+     --surface-panel이라 목록 전체가 오늘의 한 겹으로 축약된다. */
+  --pane-light-origin: -12px;
+  background:
+    linear-gradient(var(--glass-tint-panel), var(--glass-tint-panel)),
+    radial-gradient(150% 420px at 50% var(--pane-light-origin), var(--glass-pane-light) 0%, transparent 62%),
+    var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-panel);
   backdrop-filter: var(--glass-backdrop-panel);
   box-shadow: inset 0 1px 0 var(--glass-rim), var(--shadow-soft);
@@ -6121,6 +6128,16 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-top-style: none;
 }
 
+/* 떠 있는 캡션(Cruise·Tactical·War Room·최대화)과 companion 캡션은 top:-32px로 루트 박스 밖에
+   선다 — 창의 꼭대기가 본문이 아니라 그 캡션이라는 뜻이다. 광원 원점을 캡션 높이만큼 위로 밀어
+   본문이 창 전체를 비추는 한 줄기 빛의 아래쪽을 받게 한다. 각자 자기 박스 기준으로 그리면
+   본문 상단이 한 번 더 밝아져 캡션과의 이음새에 계단이 생긴다.
+   덱 타일과 상단 접힘 캡션(is-top-edge)은 흐름 안이라 루트의 top이 곧 창의 꼭대기다. */
+.canvas-operation:not(.is-deck-tile):not(.is-top-edge):has(> .canvas-operation-titlebar),
+.canvas-operation:has(> .canvas-companion-caption) {
+  --pane-light-origin: -44px;
+}
+
 /* 덱 타일만 그 면제에서 빠진다 — 카드뷰 캡션은 흐름 안으로 들어오며 자기 보더를 내려놓으므로
    (.canvas-operation.is-deck-tile > .canvas-operation-titlebar { border: 0 }) 윗변을 이을 주체가
    패널밖에 없다. is-deck-tile 블록이 이미 border-top 1px을 적어 두었지만 그 선택자는 위 이음새
@@ -6948,8 +6965,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   overflow: hidden;
   border-radius: 0 0 calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px);
   /* terminal-shell의 8px 패딩이 xterm 뷰포트를 사방에서 감싸므로 이 면은 실제로 보이는 띠다 —
-     캡션·작업면과 다른 값을 주면 창 안에 액자 테가 생긴다. 패널 면 하나를 그대로 쓴다. */
-  background: var(--glass-tint-terminal);
+     캡션·작업면과 다른 값을 주면 창 안에 액자 테가 생긴다. field 채널 하나를 그대로 쓴다:
+     다크+게이트 열림에서는 비어(transparent) 패널 루트의 유리 한 장이 필드와 거터를 함께 칠하고,
+     라이트·게이트 닫힘에서는 xterm이 받는 불투명 실색과 같은 값을 칠해 격자 경계 띠를 없앤다.
+     여기서 자기 틴트를 들면 루트 유리와 겹쳐 창 안이 두 값이 된다(이중 알파). */
+  background: var(--glass-tint-field);
 }
 
 .canvas-operation-terminal .terminal-stage,

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -185,8 +185,19 @@
   --glass-tint-panel: var(--surface-panel);
   --glass-tint-panel-face: var(--surface-panel);
   --glass-tint-caption: var(--surface-panel);
+  /* field는 터미널 필드와 그것을 감싸는 거터가 **함께** 칠하는 값이다. 다크+열림에서는 패널
+     루트의 유리 한 장이 둘 다 칠하므로 여기서는 비우고(덧칠하면 창 안이 두 값이 된다),
+     라이트·닫힘에서는 xterm이 요구하는 불투명 실색을 그대로 칠해 격자 경계 띠를 없앤다.
+     terminal은 유리 루트가 없는 레일 Shell 카드의 면이며, xterm이 계산값을 읽어 간다. */
+  --glass-tint-field: var(--surface-panel);
   --glass-tint-terminal: var(--surface-panel);
   --glass-tint-band: var(--surface-band);
+  /* 패널 광원(pane-light) — 유리 뒤가 앱에서 가장 어두운 캔버스라 blur가 굴절시킬 빛이 없다.
+     그래서 다크 유리는 자기 위쪽에 광원을 하나 얹어 재질을 명도가 아니라 기울기로 말한다.
+     이 채널은 광원의 **색**만 진다 — 기하(반경·중심)는 창의 구조라 components.css가 쓴다. */
+  --glass-pane-light: transparent;
+  /* 캔버스 대기광 — 유리가 실제로 굴절할 것을 뒤에 놓는다. 닫히면 원래의 심해 계조. */
+  --canvas-ambience: var(--canvas-sea-core);
   --glass-backdrop-strong: none;
   --glass-backdrop-soft: none;
   --glass-backdrop-panel: none;
@@ -207,12 +218,18 @@
   --glass-on-tint-deep: oklch(16.5% 0.016 245 / 48%);
   --glass-on-tint-abyss: oklch(13% 0.014 245 / 50%);
   --glass-on-tint-chrome: oklch(19% 0.018 245 / 50%);
-  /* 다크 유리는 Ghostty 문법이다 — 틴트는 원 면보다 오히려 어둡게, 밀도(α)는 높게, 블러는
-     무겁게. 필드가 거의 검게 남아 대비를 지키고, 뒤 콘텐츠는 블러 너머 희미한 유령빛으로만
-     비친다. 명도를 올려 잿빛 워시를 만드는 방향은 실측 기각됐다. */
-  --glass-on-tint-panel: oklch(15% 0.018 245 / 55%);
+  /* 다크 유리의 밀도 문법 — 뒤에 비칠 빛이 없는 유리에서 투과는 재질감을 만들지 못하고 명도를
+     빼기만 한다(실측: 필드가 패널 면보다 3.1~6.1 L 아래로 내려앉아 사이드바·레일보다 어두워졌고,
+     ANSI black이 필드와 같거나 오히려 밝아졌다). 그래서 틴트는 원 면보다 살짝 위(+2 L)에 서고
+     밀도를 0.83으로 모은다. 명도만 올리면 잿빛 워시가 되므로 채도를 함께 1.7배로 싣고, 재질은
+     명도가 아니라 pane-light의 기울기가 말한다. 알파·명도를 다시 만지면 ANSI black과의 부호
+     (필드보다 어두울 것)를 반드시 재실측할 것. */
+  --glass-on-tint-panel: oklch(18.5% 0.028 245 / 83%);
+  --glass-on-tint-field: transparent;
+  --glass-on-pane-light: oklch(25% 0.032 245);
+  --canvas-on-ambience: oklch(16% 0.022 245);
   --glass-on-tint-caption: oklch(17% 0.018 245 / 82%);
-  --glass-on-tint-terminal: oklch(13% 0.015 245 / 62%);
+  --glass-on-tint-terminal: oklch(18.5% 0.028 245 / 83%);
   --glass-on-tint-band: oklch(13% 0.018 245 / 55%);
   --glass-on-backdrop-strong: blur(24px) saturate(1.7);
   --glass-on-backdrop-soft: blur(12px) saturate(1.5);
@@ -401,9 +418,12 @@
   --glass-on-tint-deep: oklch(20% 0.045 248 / 46%);
   --glass-on-tint-abyss: oklch(15% 0.04 250 / 48%);
   --glass-on-tint-chrome: oklch(27% 0.04 248 / 45%);
-  --glass-on-tint-panel: oklch(20% 0.04 248 / 55%);
+  --glass-on-tint-panel: oklch(25% 0.05 248 / 83%);
+  --glass-on-tint-field: transparent;
+  --glass-on-pane-light: oklch(32% 0.055 248);
+  --canvas-on-ambience: oklch(18% 0.035 235);
   --glass-on-tint-caption: oklch(21% 0.03 248 / 82%);
-  --glass-on-tint-terminal: oklch(17% 0.035 248 / 62%);
+  --glass-on-tint-terminal: oklch(25% 0.05 248 / 83%);
   --glass-on-tint-band: oklch(19% 0.045 248 / 50%);
   --glass-on-rim: oklch(96% 0.012 88 / 18%);
 
@@ -474,9 +494,12 @@
   --glass-on-tint-deep: oklch(18% 0.007 255 / 46%);
   --glass-on-tint-abyss: oklch(14% 0.006 255 / 48%);
   --glass-on-tint-chrome: oklch(24% 0.006 252 / 45%);
-  --glass-on-tint-panel: oklch(17% 0.008 252 / 55%);
+  --glass-on-tint-panel: oklch(21% 0.013 252 / 83%);
+  --glass-on-tint-field: transparent;
+  --glass-on-pane-light: oklch(28% 0.014 252);
+  --canvas-on-ambience: oklch(18% 0.014 250);
   --glass-on-tint-caption: oklch(19% 0.008 252 / 84%);
-  --glass-on-tint-terminal: oklch(15% 0.007 252 / 62%);
+  --glass-on-tint-terminal: oklch(21% 0.013 252 / 83%);
   --glass-on-tint-band: oklch(17% 0.007 255 / 50%);
   --glass-on-rim: oklch(95% 0.003 250 / 16%);
 
@@ -625,6 +648,11 @@
   /* 라이트 필드는 불투명 종이 — mCR(가독 보정)이 배경 실색을 요구하고, 종이 위 젖빛 유리는
      어차피 지각 불가 수준이다. 필드·거터가 같은 불투명 값으로 만나 격자 경계 띠가 없다. */
   --glass-on-tint-terminal: oklch(98.2% 0.004 100);
+  --glass-on-tint-field: var(--glass-on-tint-terminal);
+  /* 라이트는 유리 뒤가 이미 밝다 — 굴절할 빛이 부족한 문제가 없으므로 광원도 대기광도 얹지 않는다.
+     백지 위에 광원을 더하면 종이가 평평해지고 최명면 극성만 흐려진다. */
+  --glass-on-pane-light: transparent;
+  --canvas-on-ambience: var(--canvas-sea-core);
   --glass-on-tint-band: oklch(92% 0.006 100 / 52%);
   --glass-on-backdrop-strong: blur(26px) saturate(1.45);
   --glass-on-backdrop-soft: blur(12px) saturate(1.25);
@@ -678,7 +706,10 @@
     --glass-tint-panel: var(--glass-on-tint-panel);
     --glass-tint-panel-face: transparent;
     --glass-tint-caption: var(--glass-on-tint-caption);
+    --glass-tint-field: var(--glass-on-tint-field);
     --glass-tint-terminal: var(--glass-on-tint-terminal);
+    --glass-pane-light: var(--glass-on-pane-light);
+    --canvas-ambience: var(--canvas-on-ambience);
     --glass-tint-band: var(--glass-on-tint-band);
     --glass-backdrop-strong: var(--glass-on-backdrop-strong);
     --glass-backdrop-soft: var(--glass-on-backdrop-soft);
@@ -701,7 +732,10 @@
       --glass-tint-panel: var(--surface-panel);
       --glass-tint-panel-face: var(--surface-panel);
       --glass-tint-caption: var(--surface-panel);
+      --glass-tint-field: var(--surface-panel);
       --glass-tint-terminal: var(--surface-panel);
+      --glass-pane-light: transparent;
+      --canvas-ambience: var(--canvas-sea-core);
       --glass-tint-band: var(--surface-band);
       --glass-backdrop-strong: none;
       --glass-backdrop-soft: none;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -737,7 +737,9 @@ describe("Instrument core design contract", () => {
     // 치워두기의 두 번 눌러 확정 안내는 패널 안 HUD가 소유한다 — 레일이 사라져도 이 기능은 그대로다.
     expect(canvas).toContain("setAsideArmed");
     expect(canvas).not.toMatch(/canvas-triage-(?:frame|bracket|hud(?:-eye|-name)?|curtain-kicker|curtain-ruler)/);
-    expect(components).toContain("radial-gradient(100% 80% at 50% 42%, var(--canvas-sea-core), var(--canvas-sea-mid) 78%)");
+    // Formation 판의 중앙은 대기광 채널이 정한다 — 유리가 굴절할 빛을 패널 뒤에 놓기 위해서다.
+    // 채널 기본값은 --canvas-sea-core이므로 게이트가 닫히면 원래 픽셀로 돌아간다.
+    expect(components).toContain("radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-sea-mid) 78%)");
     expect(components).toContain("background-size: 48px 48px !important;");
     expect(components).toContain(".canvas-formation-guide {");
     // 캡션은 순번을 싣지 않는다 — 번호는 빈 자리를 가리키는 가이드만 진다.
@@ -777,6 +779,33 @@ describe("Instrument core design contract", () => {
     expect(css).toContain(":focus-visible");
     // brass 채움 버튼은 전용 on-brass 텍스트 티어를 소비한다 — abyss 재결합은 라이트 AA 회귀다.
     expect(css).toMatch(/\.fc-btn--primary \{[^}]*color: var\(--text-on-brass\);/);
+  });
+
+  // 다크 유리의 판독 계약 — 유리 뒤가 앱에서 가장 어두운 캔버스라 투과는 명도를 빼기만 한다.
+  it("keeps the dark glass pane lit and the terminal field single-layered", () => {
+    const components = source("styles/components.css");
+    const theme = source("styles/theme.css");
+
+    // 떠 있는 캡션을 가진 패널만 광원 원점을 캡션 높이만큼 위로 민다 — 창의 꼭대기가 본문이
+    // 아니라 그 캡션이기 때문이다. 덱 타일·상단 접힘 캡션은 흐름 안이라 루트가 곧 꼭대기다.
+    const floatingRoot =
+      components.match(
+        /\.canvas-operation:not\(\.is-deck-tile\):not\(\.is-top-edge\):has\(> \.canvas-operation-titlebar\),\n\.canvas-operation:has\(> \.canvas-companion-caption\) \{[^}]*\}/,
+      )?.[0] ?? "";
+    expect(floatingRoot).toContain("--pane-light-origin: -44px;");
+
+    // 새 채널 셋의 닫힌-게이트 기본값이 곧 구 불투명 계약이다.
+    expect(theme).toContain("--glass-tint-field: var(--surface-panel);");
+    expect(theme).toContain("--glass-pane-light: transparent;");
+    expect(theme).toContain("--canvas-ambience: var(--canvas-sea-core);");
+    // 다크 3종의 유리 재료는 밀도 문법이다 — 틴트가 원 면보다 어두우면 필드가 캔버스로 가라앉고
+    // ANSI black이 필드보다 밝아진다(실측 maritime +1.2 L·carbon +1.1 L 역전).
+    expect(theme).toContain("--glass-on-tint-panel: oklch(18.5% 0.028 245 / 83%);");
+    expect(theme).toContain("--glass-on-tint-panel: oklch(25% 0.05 248 / 83%);");
+    expect(theme).toContain("--glass-on-tint-panel: oklch(21% 0.013 252 / 83%);");
+    // 다크에서만 필드를 루트 유리에 넘긴다 — 라이트는 mCR이 불투명 실색을 요구한다.
+    expect(theme).toContain("--glass-on-tint-field: var(--glass-on-tint-terminal);");
+    expect((theme.match(/--glass-on-tint-field: transparent;/g) ?? []).length).toBe(3);
   });
 
   // 텍스트 3티어만 대비를 통제하므로 원료 잉크를 color에 직접 쓰면 판독 하한을 한곳에서 보장할 수 없다.
@@ -1807,7 +1836,12 @@ describe("Instrument core design contract", () => {
     // 패널은 하나의 면이다 — 루트가 panel 유리 틴트를, 캡션·본문 팬은 panel-face(게이트 열림 시
     // transparent)를 소비해 유리 한 장으로 읽힌다. 자식이 자기 틴트를 들면 이중 알파 얼룩이 된다.
     const operationBlock = components.match(/^\.canvas-operation \{[^}]*\}/m)?.[0] ?? "";
-    expect(operationBlock).toContain("background: var(--glass-tint-panel);");
+    expect(operationBlock).toContain("linear-gradient(var(--glass-tint-panel), var(--glass-tint-panel)),");
+    expect(operationBlock).toContain("var(--glass-underlay);");
+    // 유리 뒤가 캔버스(앱에서 가장 어두운 면)라 blur가 굴절시킬 빛이 없다 — 재질은 명도가 아니라
+    // 창 위쪽 광원의 기울기가 말한다. 기하는 절대 좌표라 떠 있는 캡션을 가진 패널은 원점을
+    // 캡션 높이만큼 위로 밀어 창 전체가 한 줄기 빛을 나눠 받는다.
+    expect(operationBlock).toContain("radial-gradient(150% 420px at 50% var(--pane-light-origin), var(--glass-pane-light) 0%, transparent 62%),");
     expect(operationBlock).toContain("backdrop-filter: var(--glass-backdrop-panel);");
     expect(operationBlock).not.toContain("--surface-window");
     const titlebarBlock = components.match(/^\.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
@@ -1821,7 +1855,9 @@ describe("Instrument core design contract", () => {
     expect(titlebarBlock).not.toContain("border-color: inherit;");
     expect(titlebarBlock).not.toContain("border-bottom: none;");
     const panelBodyBlock = components.match(/^\.canvas-operation-terminal \{[^}]*\}/m)?.[0] ?? "";
-    expect(panelBodyBlock).toContain("background: var(--glass-tint-terminal);");
+    // 터미널 필드·거터는 field 채널 하나로 만난다 — 다크+열림에서는 비어(transparent) 루트 유리
+    // 한 장이 둘 다 칠하고, 라이트·닫힘에서는 xterm이 받는 불투명 실색을 그대로 칠한다.
+    expect(panelBodyBlock).toContain("background: var(--glass-tint-field);");
     // 레일 Shell 카드도 같은 면이다 — xterm이 terminal 유리 채널을 따라 반투명해지므로
     // 카드 면도 panel-face로 물러나 유리 한 장으로 읽힌다(게이트가 닫히면 둘 다 불투명 복원).
     const terminalShellBlock = components.match(/^\.terminal-shell \{[^}]*\}/m)?.[0] ?? "";


### PR DESCRIPTION
## Summary
- 다크 테마에서 리퀴드 글래스를 켜면 Operation 터미널 면이 불투명 면보다 3.1~6.1 L 내려앉아 사이드바·레일보다 어두워지고, ANSI black이 필드와 같거나(instrument −0.4 L) 오히려 밝아지는(maritime +1.2 L·carbon +1.1 L) 문제를 고칩니다. 유리 뒤가 앱에서 가장 어두운 캔버스라 투과가 빛을 들이지 않고 빼기만 하던 것이 원인입니다.
- 다크 유리를 **밀도 문법**으로 재조율합니다: 패널 틴트가 면보다 2 L 위 + 채도 1.7배 + α 0.83에 서고, 재질은 명도가 아니라 창 위쪽에 놓은 광원(`--glass-pane-light`)의 기울기가 말합니다. 터미널 컨테이너는 다크에서 비는 `--glass-tint-field`를 소비해 루트 유리 한 장이 필드와 거터를 함께 칠하고(이중 틴트 제거), 캔버스에는 `--canvas-ambience`를 두어 블러가 굴절할 것을 뒤에 놓습니다.
- 새 채널 셋의 닫힌-게이트 기본값은 현행 불투명 계약 그대로라, 세 게이트(@supports 미달·prefers-reduced-transparency·설정 해제) 중 하나만 닫혀도 오늘의 픽셀로 복원됩니다.
- **캡션은 건드리지 않았습니다** — #904가 들여온 `--glass-tint-caption` 방식을 그대로 씁니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 192 passed / 1 skipped (2373 tests)
- [x] `pnpm --filter @fleet-plugins/terminal test` — 93 passed (1001 tests)
- [x] `pnpm typecheck` (workspace) · `pnpm build` (workspace) — green
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 8 entries validated
- [x] 격리 콘솔 헤디드 실측(1280×577, Tactical) — 4테마 × ON/OFF
  - ON 필드: instrument 17.6~18.7 / maritime 22.9~25.0 / carbon 19.7~21.5 (OFF 16.5 / 22.9 / 18.9)
  - 세 다크 테마 모두 패널이 크롬 위로 복귀, ANSI black −3.8~−4.9 L로 부호 정상화
  - whites는 필드 98.2 불변
- [x] **게이트 닫힘 원복 계약 픽셀 검증** — 브랜치와 canary 스타일시트를 동일 DOM 위에 각각 렌더해 프레임 diff: 741,000픽셀 중 14~88개(0.002~0.012%), 최대 채널차 2~8. 전부 `linear-gradient(틴트, 틴트)` 레이어의 ±1 디더링이며 이 관용구는 기존 팝업 25곳이 이미 씁니다.
- [x] 표면 순회(Tactical·War Room 덱 타일·최대화·companion·Cruise): 덱 타일은 캡션이 흐름 안이라 루트 유리 한 장을 그대로 받고 이중 알파가 없음을 DOM으로 확인
- [x] 페이지 위생: error 0 · unhandled rejection 0 · WebSocket 3개 전부 열린 상태 유지

## Notes
- #904의 캡션 틴트는 canary의 어두운 본문(L13.4/16.8/14.9)에 맞춰 잡힌 값이라, 본문이 올라온 뒤 **비포커스 캡션이 본문보다 1.6~5.5 L 어둡습니다**(maritime 최대). 포커스가 가면 brass 워시가 얹혀 본문 위로 올라옵니다. `--glass-on-tint-caption` 재조율은 이 PR 범위 밖으로 두었습니다.
- 레일 Shell 카드는 레일에 도킹된 상태로 띄우지 못해 렌더 확인은 못 했고, 그 카드가 소비하는 `--glass-tint-terminal`이 다크에서 비투명으로 해석되는 것만 확인했습니다.