### PR TITLE
fix(fleet-console): keep reclaimed control disconnected

### DIFF
--- a/.changelog.d/remote-control-reclaim-fix.md
+++ b/.changelog.d/remote-control-reclaim-fix.md
@@ -1,0 +1,8 @@
+---
+branch: remote-control-reclaim-fix
+---
+
+### fleet-console
+#### Fixed
+- Keep remote control disconnected after the host takes it back or another device connects, until the remote user explicitly reconnects.
+  ko: 호스트가 제어권을 회수하거나 다른 기기가 접속한 뒤에는 원격 사용자가 명시적으로 다시 연결할 때까지 원격 제어 연결을 끊긴 상태로 유지합니다.

--- a/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
@@ -76,10 +76,10 @@ export const chromeEn = {
   "chrome.control.bar.joined": "Joined {time}",
   "chrome.control.reclaimed.eyebrow": "REMOTE CONTROL ENDED",
   "chrome.control.reclaimed.title": "Control was taken back",
-  "chrome.control.reclaimed.body": "Returning you to your own console…",
+  "chrome.control.reclaimed.body": "This session will stay disconnected. Open this host again when you want to reconnect.",
   "chrome.control.superseded.eyebrow": "REMOTE CONTROL ENDED",
   "chrome.control.superseded.title": "Another device connected",
-  "chrome.control.superseded.body": "A Console holds one remote connection at a time. Returning you to your own console…",
+  "chrome.control.superseded.body": "A Console holds one remote connection at a time. Open this host again when you want to reconnect.",
 
   // operation-search
   "chrome.operationSearch.commandsDialog": "Console commands",
@@ -435,10 +435,10 @@ export const chromeKo: Record<keyof typeof chromeEn, string> = {
   "chrome.control.bar.joined": "{time} 접속",
   "chrome.control.reclaimed.eyebrow": "원격 제어 종료",
   "chrome.control.reclaimed.title": "제어권이 회수되었습니다",
-  "chrome.control.reclaimed.body": "내 Console로 돌아가는 중…",
+  "chrome.control.reclaimed.body": "이 세션은 연결이 끊긴 상태로 유지됩니다. 다시 연결하려면 이 호스트를 다시 여세요.",
   "chrome.control.superseded.eyebrow": "원격 제어 종료",
   "chrome.control.superseded.title": "다른 기기가 접속했습니다",
-  "chrome.control.superseded.body": "Console은 한 번에 하나의 원격 접속만 유지합니다. 내 Console로 돌아가는 중…",
+  "chrome.control.superseded.body": "Console은 한 번에 하나의 원격 접속만 유지합니다. 다시 연결하려면 이 호스트를 다시 여세요.",
 
   "chrome.operationSearch.commandsDialog": "Console 명령",
   "chrome.operationSearch.quickSearchDialog": "Operation 빠른 검색",

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -78,6 +78,21 @@ export function connectOperationsSse(): void {
     try {
       const data = JSON.parse(msg.data) as { readonly reason?: unknown };
       if (!isSessionEnded(data)) return;
+      /**
+       * 서버는 이 프레임 뒤 스트림을 닫는다. 그 close가 onerror로 번지기 전에 이 source를 폐기해야
+       * 일반 단절로 오인한 자동 재합류가 호스트의 Take back을 곧바로 뒤집지 않는다.
+       *
+       * 페어링은 남기므로 Desktop의 호스트 목록처럼 사람이 명시적으로 다시 여는 길은 그대로다.
+       * 현재 문서의 401 자동 복구만 멈춘 뒤 reload한다. 새 문서는 일반 API의 401에서 pairing join을
+       * 시도하지 않고 종료 안내를 그대로 그리므로, 회수된 session이 같은 문서에서 되살아나지 않는다.
+       */
+      source.close();
+      if (activeSource === source) activeSource = null;
+      connectionGeneration += 1;
+      if (reconnectHandle !== null) {
+        clearTimeout(reconnectHandle);
+        reconnectHandle = null;
+      }
       // 사유를 실어 보낸다 — 안내 문구는 "주인이 되찾았다"와 "다른 기기가 이어받았다"로 갈린다.
       window.dispatchEvent(new CustomEvent<SessionEndedDetail>(CONTROL_RECLAIMED_EVENT, { detail: { reason: data.reason } }));
       window.setTimeout(() => location.reload(), CONTROL_RECLAIM_NAVIGATION_DELAY_MS);

--- a/runtime/fleet-console/tests/operations-sse.test.ts
+++ b/runtime/fleet-console/tests/operations-sse.test.ts
@@ -9,12 +9,22 @@ const mocks = vi.hoisted(() => ({
   getState: vi.fn(),
   hydrateOperations: vi.fn(),
   resetDesktopFullscreenSnapshot: vi.fn(),
+  resumeConsoleSession: vi.fn(),
   setConnectionState: vi.fn(),
 }));
 
 vi.mock("../core/client/src/api.js", () => ({
+  ApiError: class ApiError extends Error {
+    readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
   fetchObserverStatus: mocks.fetchObserverStatus,
   fetchOperations: mocks.fetchOperations,
+  resumeConsoleSession: mocks.resumeConsoleSession,
 }));
 
 vi.mock("../core/client/src/store.js", async (importOriginal) => {
@@ -78,6 +88,7 @@ describe("operations SSE update availability", () => {
     mocks.getState.mockReset();
     mocks.hydrateOperations.mockReset();
     mocks.resetDesktopFullscreenSnapshot.mockReset();
+    mocks.resumeConsoleSession.mockReset();
     mocks.setConnectionState.mockReset();
     vi.clearAllTimers();
     vi.useRealTimers();
@@ -250,6 +261,37 @@ describe("operations SSE update availability", () => {
     TestEventSource.instances[0]?.onerror?.();
     expect(actualState.getState().controlHolder).toEqual(holder);
     actualState.setState({ controlHolder: null, controlCurtainDismissed: false });
+  });
+
+  it.each(["reclaimed", "superseded"] as const)("keeps a %s session ended instead of automatically taking control again", async (reason) => {
+    vi.useFakeTimers();
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+
+    connectOperationsSse();
+    const endedSource = TestEventSource.instances[0]!;
+    endedSource.emit("control:reclaimed", JSON.stringify({ reason }));
+    endedSource.onerror?.();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(endedSource.closed).toBe(true);
+    expect(mocks.fetchOperations).not.toHaveBeenCalled();
+    expect(mocks.resumeConsoleSession).not.toHaveBeenCalled();
+    expect(TestEventSource.instances).toHaveLength(1);
+  });
+
+  it("keeps the explicit reconnect path available after a session ends", async () => {
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    mocks.fetchOperations.mockResolvedValue([]);
+
+    connectOperationsSse();
+    TestEventSource.instances[0]?.emit("control:reclaimed", JSON.stringify({ reason: "reclaimed" }));
+    reconnectOperationsSseNow();
+
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(2));
+    expect(mocks.fetchOperations).toHaveBeenCalledOnce();
+    expect(mocks.resumeConsoleSession).not.toHaveBeenCalled();
   });
 
   it("marks the retry attempt connecting while preserving the existing exponential retry path", async () => {


### PR DESCRIPTION
## Summary
- stop the reclaimed or superseded remote SSE generation before its close can enter the generic automatic session-resume path
- retain durable pairing and explicit reconnect behavior while keeping host Take back authoritative
- update the bilingual remote-ended notice and add regression coverage for both end reasons

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/operations-sse.test.ts tests/control-handover-client.test.tsx tests/i18n.test.ts tests/remote-access-listener.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`