### PR TITLE
feat(fleet-console): decouple Theater accordion controls

### DIFF
--- a/.changelog.d/theater-accordion-direct-toggle.md
+++ b/.changelog.d/theater-accordion-direct-toggle.md
@@ -1,0 +1,8 @@
+---
+branch: theater-accordion-direct-toggle
+---
+
+### fleet-console
+#### Changed
+- Let every Theater sidebar section expand or collapse without first switching the active Theater.
+  ko: 활성 Theater를 먼저 전환하지 않아도 사이드바의 모든 Theater 섹션을 접거나 펼칠 수 있습니다.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -1436,24 +1436,19 @@ function TheaterSectionHeader({
     if (dragging) suppressClickRef.current = true;
   };
 
-  // 행 클릭은 ▾ 버튼을 흡수한 단일 제스처다. 비활성 Theater는 선택만 하고(영속 접힘 선호를
-  // 건드리지 않는다), 이미 활성인 Theater에서만 접기/펼치기를 토글한다.
-  // 행 title도 이 결과와 일치시킨다: 비활성 행은 "Switch to …", 활성 행만 Expand/Collapse를 광고한다.
-  const activateOrToggle = () => {
-    if (!active) {
-      onSelectTheater(theater.id);
-      return;
-    }
-    onToggleCollapsed(theater.id);
-  };
-
+  // Theater 선택과 아코디언은 서로 다른 동작이다. 이름은 Theater를 마운트하고 chevron은
+  // 활성 여부와 무관하게 이 섹션만 접는다. 둘을 한 버튼에 합치면 같은 위치의 동작이
+  // 활성 상태에 따라 바뀌고, 비활성 Theater는 접으려 해도 먼저 마운트해야 한다.
   const select = () => {
     if (suppressClickRef.current) {
       suppressClickRef.current = false;
       return;
     }
-    activateOrToggle();
+    if (!active) onSelectTheater(theater.id);
   };
+  const collapseLabel = collapsed
+    ? t("sidebar.theater.expand", { theater: theater.label })
+    : t("sidebar.theater.collapse", { theater: theater.label });
 
   return (
     // 행 자체가 role="button"이면서 상태 정렬·새 Operation·액션 버튼을 품고 있어, 활성화
@@ -1473,8 +1468,7 @@ function TheaterSectionHeader({
         onClick={select}
         onKeyDown={handleKeyDown}
         aria-current={active ? "true" : undefined}
-        aria-expanded={!collapsed}
-        title={active ? (collapsed ? t("sidebar.theater.expand", { theater: theater.label }) : t("sidebar.theater.collapse", { theater: theater.label })) : t("sidebar.theater.switchTo", { theater: theater.label })}
+        title={active ? theater.label : t("sidebar.theater.switchTo", { theater: theater.label })}
       >
         <span className="side-bar-theater-anchor" aria-hidden="true">
           {theaterInitials(theater.label)}
@@ -1483,9 +1477,18 @@ function TheaterSectionHeader({
           {showStatusLiveTick ? <span className="side-bar-status-axis-live-tick" aria-hidden="true" /> : null}
         </span>
         <span className="side-bar-theater-name">{theater.label}</span>
-        <ChevronIcon collapsed={collapsed} />
       </button>
       <span className="side-bar-theater-row-controls" role="group" aria-label={t("sidebar.theater.controlsAria", { theater: theater.label })}>
+        <button
+          type="button"
+          className="side-bar-theater-row-btn side-bar-theater-collapse-btn"
+          aria-expanded={!collapsed}
+          aria-label={collapseLabel}
+          title={collapseLabel}
+          onClick={() => onToggleCollapsed(theater.id)}
+        >
+          <ChevronIcon collapsed={collapsed} />
+        </button>
         {/* 축 토글이 빠지면서 이 묶음과 바깥 행 컨트롤이 같은 범위가 됐다. 겹친 두 group을
             그대로 두면 보조기술이 분할 버튼 하나를 두 겹으로 읽으므로, 바깥 하나만 남긴다
             (플러스는 Operation, 케밥은 Theater 동작이라 바깥 라벨이 둘을 함께 덮는다). */}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5197,8 +5197,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: transparent;
 }
 
-/* 행 안의 활성화 버튼. 예전에는 행 자체가 버튼 역할을 겸하면서 컨트롤 버튼들을 품고 있었다 —
-   남은 자리를 채워 클릭 영역은 그대로 두고, 활성화 대상만 하나로 되돌린다. */
+/* 행 안의 Theater 선택 버튼. 남은 자리를 채우되 아코디언은 오른쪽의 독립 버튼이 맡는다. */
 .side-bar-theater-activate {
   display: flex;
   align-items: center;
@@ -5352,27 +5351,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
   white-space: nowrap;
 }
 
-.side-bar-theater-chevron {
-  box-sizing: border-box;
-  flex: none;
+.side-bar-theater-collapse-btn {
   width: 22px;
-  height: 22px;
-  padding: 4px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-xs);
-  color: var(--text-tertiary);
-  transition:
-    border-color var(--duration-fast) var(--ease-spring),
-    color var(--duration-fast) var(--ease-spring),
-    transform 0.15s ease;
 }
 
-/* 활성 Theater의 본문 전체가 접기/펼치기 버튼이므로 포인터가 그 표면에 들어오면 chevron도
-   + / …와 같은 보더 링으로 응답한다. 비활성 Theater는 클릭 결과가 "전환"이므로 링을 켜지 않는다. */
-.side-bar-theater-header.is-active .side-bar-theater-activate:hover .side-bar-theater-chevron,
-.side-bar-theater-header.is-active .side-bar-theater-activate:focus-visible .side-bar-theater-chevron {
-  border-color: var(--hairline-strong);
-  color: var(--text-primary);
+.side-bar-theater-chevron {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.15s ease;
 }
 
 .side-bar-theater-chevron.is-collapsed {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1518,16 +1518,16 @@ describe("Instrument core design contract", () => {
     expect(components).not.toContain(".side-bar-status-header__dot");
     expect(components).toContain("background: var(--group-mark);");
     // 세 단계 아코디언(Theater / Group / Status)은 + / … 액션과 같은 보더 링으로 hover에
-    // 응답한다. 화살표 색만 바꾸면 포인터 아래 표면의 버튼 경계가 드러나지 않는다.
+    // 응답한다. Theater의 chevron도 독립 버튼이라 같은 공통 링 선언을 소비한다.
     const theaterActivate = components.match(/\.side-bar-theater-activate \{[^}]*\}/)?.[0] ?? "";
     const theaterDraggingActivate = components.match(/\.side-bar-theater-header--dragging \.side-bar-theater-activate \{[^}]*\}/)?.[0] ?? "";
-    const theaterChevronHover = components.match(/\.side-bar-theater-header\.is-active \.side-bar-theater-activate:hover \.side-bar-theater-chevron,[\s\S]*?\}/)?.[0] ?? "";
+    const theaterCollapse = components.match(/\.side-bar-theater-collapse-btn \{[^}]*\}/)?.[0] ?? "";
     const sharedIconHover = components.match(/\.side-bar-theater-row-btn:hover,[\s\S]*?\.side-bar-group-header__toggle:focus-visible \{[^}]*\}/)?.[0] ?? "";
     const statusToggleHover = components.match(/\.side-bar-status-header__toggle:hover \{[^}]*\}/)?.[0] ?? "";
     expect(theaterActivate).toContain("cursor: pointer;");
     expect(theaterActivate).not.toContain("cursor: inherit;");
     expect(theaterDraggingActivate).toContain("cursor: grabbing;");
-    expect(theaterChevronHover).toContain("border-color: var(--hairline-strong);");
+    expect(theaterCollapse).toContain("width: 22px;");
     expect(sharedIconHover).toContain("border-color: var(--hairline-strong);");
     expect(components).toMatch(/\.side-bar-group-header__toggle:focus-visible \{\s*outline: 2px solid var\(--brass\);/);
     expect(statusToggleHover).toContain("border-color: var(--hairline-strong);");

--- a/runtime/fleet-console/tests/operations-side-bar-inactive-theater.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-inactive-theater.test.tsx
@@ -70,6 +70,29 @@ describe("inactive Theater sidebar hierarchy", () => {
     expect(JSON.parse(window.localStorage.getItem("fleet-console.canvas.theater-b") ?? "{}").collapsedGroups).toEqual([]);
   });
 
+  it("toggles the inactive Theater directly without selecting it", () => {
+    const onSelectTheater = vi.fn();
+    writeTheaterBSnapshot();
+    renderSideBar(undefined, onSelectTheater);
+
+    const inactive = findInactiveSection();
+    const collapse = inactive.querySelector<HTMLButtonElement>(".side-bar-theater-collapse-btn");
+    expect(collapse?.getAttribute("aria-label")).toBe("Collapse Bravo");
+
+    act(() => collapse?.click());
+
+    expect(onSelectTheater).not.toHaveBeenCalled();
+    expect(collapse?.getAttribute("aria-label")).toBe("Expand Bravo");
+    expect(inactive.querySelector(".side-bar-group-header")).toBeNull();
+    expect(inactive.querySelector("[data-side-bar-chip-id]")).toBeNull();
+
+    act(() => collapse?.click());
+
+    expect(onSelectTheater).not.toHaveBeenCalled();
+    expect(inactive.querySelector(".side-bar-group-header")).not.toBeNull();
+    expect(inactive.querySelectorAll("[data-side-bar-chip-id]")).toHaveLength(6);
+  });
+
   it("hides inactive Group headers and Operations when the Theater section is collapsed", () => {
     writeTheaterBSnapshot();
     setTheaterCollapsed("theater-b", true);
@@ -81,7 +104,7 @@ describe("inactive Theater sidebar hierarchy", () => {
   });
 });
 
-function renderSideBar(onFocus = vi.fn()): void {
+function renderSideBar(onFocus = vi.fn(), onSelectTheater = vi.fn()): void {
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
@@ -113,7 +136,7 @@ function renderSideBar(onFocus = vi.fn()): void {
     onReorderGroups: () => {},
     onReorderTheaters: () => {},
     onUngroupAll: () => {},
-    onSelectTheater: () => {},
+    onSelectTheater,
     onAddTheater: () => {},
     onCancelAddTheater: () => {},
     onForgetTheater: () => {},

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -644,29 +644,30 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-header__count").textContent).toBe("1");
   });
 
-  it("uses the Theater name row for persisted collapse and exposes the split control accessibility contract", () => {
+  it("separates Theater selection from persisted collapse and exposes the split control accessibility contract", () => {
     const onSelectTheater = vi.fn();
     renderSideBar([makeOperation("only", null)], [], onSelectTheater);
 
     expect(container?.querySelector(".side-bar-theater-count")).toBeNull();
-    expect(container?.querySelector(".side-bar-theater-collapse-btn")).toBeNull();
     expect(required<HTMLButtonElement>(".side-bar-theater-split-plus").getAttribute("aria-label")).toBe("New Operation in Alpha");
+    const collapse = required<HTMLButtonElement>(".side-bar-theater-collapse-btn");
+    expect(collapse.getAttribute("aria-label")).toBe("Collapse Alpha");
+    expect(collapse.getAttribute("aria-expanded")).toBe("true");
     const caret = required<HTMLButtonElement>(".side-bar-theater-split-caret");
     expect(caret.getAttribute("aria-haspopup")).toBe("menu");
     expect(caret.getAttribute("aria-expanded")).toBe("false");
     expect(caret.querySelectorAll("circle")).toHaveLength(3);
     expect(caret.querySelector("path")).toBeNull();
 
-    act(() => required<HTMLElement>(".side-bar-theater-activate").click());
+    act(() => collapse.click());
 
-    // 활성 Theater 행 클릭은 접기 토글만 수행한다 — 재선택하지 않는다.
-    // (비활성 Theater 클릭은 선택만 하고 접기 상태를 건드리지 않는 것이 행 제스처 계약이다.)
     expect(onSelectTheater).not.toHaveBeenCalled();
-    expect(required<HTMLElement>(".side-bar-theater-activate").getAttribute("aria-expanded")).toBe("false");
+    expect(collapse.getAttribute("aria-label")).toBe("Expand Alpha");
+    expect(collapse.getAttribute("aria-expanded")).toBe("false");
     expect(window.localStorage.getItem("fleet-console.operations.theater-collapsed")).toBe('["theater-a"]');
   });
 
-  it("selects an inactive Theater on row click without mutating its persisted collapse preference", () => {
+  it("selects an inactive Theater by name without mutating its persisted collapse preference", () => {
     setTheaterCollapsed("theater-a", true);
     const onSelectTheater = vi.fn();
     renderSideBar([makeOperation("only", null)], [], onSelectTheater, "theater-other");
@@ -674,7 +675,6 @@ describe("OperationsSideBar STATUS axis", () => {
     act(() => required<HTMLElement>(".side-bar-theater-activate").click());
 
     expect(onSelectTheater).toHaveBeenCalledWith("theater-a");
-    // 비활성 클릭=선택만 — 접힘 영속 키는 그대로 남는다.
     expect(window.localStorage.getItem("fleet-console.operations.theater-collapsed")).toBe('["theater-a"]');
   });
 


### PR DESCRIPTION
## Summary
- Separate Theater selection from the sidebar accordion control.
- Allow inactive Theater sections to expand or collapse without mounting them first.
- Preserve persisted collapse state, accessibility labels, and the existing sidebar control grammar.

## Test Plan
- [x] `corepack pnpm --dir runtime/fleet-console test`
- [x] `corepack pnpm --dir runtime/fleet-console typecheck`
- [x] `corepack pnpm --dir runtime/fleet-console build`
- [x] Headed browser E2E with two registered Theaters
- [x] `node scripts/compile-changelog-fragments.mjs --check`