### PR TITLE
fix(fleet-console): refine Theater accordion controls

### DIFF
--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -1465,6 +1465,7 @@ function TheaterSectionHeader({
         type="button"
         className="side-bar-theater-activate"
         aria-haspopup="menu"
+        aria-disabled={active ? true : undefined}
         onClick={select}
         onKeyDown={handleKeyDown}
         aria-current={active ? "true" : undefined}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5220,6 +5220,10 @@ body[data-side-bar-animating="true"] .canvas-operation {
   outline-offset: 2px;
 }
 
+.side-bar-theater-activate[aria-disabled="true"] {
+  cursor: grab;
+}
+
 .side-bar-theater-header--dragging .side-bar-theater-activate {
   cursor: grabbing;
 }
@@ -5423,6 +5427,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
   height: 13px;
 }
 
+.side-bar-theater-collapse-btn .side-bar-theater-chevron {
+  width: 16px;
+  height: 16px;
+}
+
 .side-bar-theater-row-btn:hover,
 .side-bar-group-header__toggle:hover,
 .side-bar-theater-row-btn:focus-visible,
@@ -5432,7 +5441,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .side-bar-theater-row-btn:focus-visible {
-  outline: 2px solid var(--aurora);
+  outline: 2px solid var(--brass);
   outline-offset: -2px;
 }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1521,13 +1521,21 @@ describe("Instrument core design contract", () => {
     // 응답한다. Theater의 chevron도 독립 버튼이라 같은 공통 링 선언을 소비한다.
     const theaterActivate = components.match(/\.side-bar-theater-activate \{[^}]*\}/)?.[0] ?? "";
     const theaterDraggingActivate = components.match(/\.side-bar-theater-header--dragging \.side-bar-theater-activate \{[^}]*\}/)?.[0] ?? "";
+    const theaterCurrentActivate = components.match(/\.side-bar-theater-activate\[aria-disabled="true"\] \{[^}]*\}/)?.[0] ?? "";
     const theaterCollapse = components.match(/\.side-bar-theater-collapse-btn \{[^}]*\}/)?.[0] ?? "";
+    const theaterCollapseChevron = components.match(/\.side-bar-theater-collapse-btn \.side-bar-theater-chevron \{[^}]*\}/)?.[0] ?? "";
+    const theaterRowFocus = components.match(/\.side-bar-theater-row-btn:focus-visible \{[^}]*\}/)?.[0] ?? "";
     const sharedIconHover = components.match(/\.side-bar-theater-row-btn:hover,[\s\S]*?\.side-bar-group-header__toggle:focus-visible \{[^}]*\}/)?.[0] ?? "";
     const statusToggleHover = components.match(/\.side-bar-status-header__toggle:hover \{[^}]*\}/)?.[0] ?? "";
     expect(theaterActivate).toContain("cursor: pointer;");
     expect(theaterActivate).not.toContain("cursor: inherit;");
+    expect(theaterCurrentActivate).toContain("cursor: grab;");
     expect(theaterDraggingActivate).toContain("cursor: grabbing;");
     expect(theaterCollapse).toContain("width: 22px;");
+    expect(theaterCollapseChevron).toContain("width: 16px;");
+    expect(theaterCollapseChevron).toContain("height: 16px;");
+    expect(theaterRowFocus).toContain("outline: 2px solid var(--brass);");
+    expect(theaterRowFocus).not.toContain("--aurora");
     expect(sharedIconHover).toContain("border-color: var(--hairline-strong);");
     expect(components).toMatch(/\.side-bar-group-header__toggle:focus-visible \{\s*outline: 2px solid var\(--brass\);/);
     expect(statusToggleHover).toContain("border-color: var(--hairline-strong);");

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -649,6 +649,11 @@ describe("OperationsSideBar STATUS axis", () => {
     renderSideBar([makeOperation("only", null)], [], onSelectTheater);
 
     expect(container?.querySelector(".side-bar-theater-count")).toBeNull();
+    const activeTheater = required<HTMLButtonElement>(".side-bar-theater-activate");
+    expect(activeTheater.getAttribute("aria-current")).toBe("true");
+    expect(activeTheater.getAttribute("aria-disabled")).toBe("true");
+    act(() => activeTheater.click());
+    expect(onSelectTheater).not.toHaveBeenCalled();
     expect(required<HTMLButtonElement>(".side-bar-theater-split-plus").getAttribute("aria-label")).toBe("New Operation in Alpha");
     const collapse = required<HTMLButtonElement>(".side-bar-theater-collapse-btn");
     expect(collapse.getAttribute("aria-label")).toBe("Collapse Alpha");


### PR DESCRIPTION
## Summary
- Mark the current Theater selector as focusable `aria-disabled` while preserving row drag and context-menu behavior.
- Use the brass location channel for sidebar row-control keyboard focus.
- Preserve the authored 16px Theater chevron size against the shared icon rule.

## Test Plan
- [x] `corepack pnpm --dir runtime/fleet-console test`
- [x] `corepack pnpm --dir runtime/fleet-console typecheck`
- [x] `corepack pnpm --dir runtime/fleet-console build`
- [x] Headed browser measurement of focusability, focus ring token, and chevron size
- [x] `git diff --check`