### PR TITLE
fix(fleet-console): keep dimmed terminal cells on the dark glass field

### DIFF
--- a/.changelog.d/terminal-glass-black-cells.md
+++ b/.changelog.d/terminal-glass-black-cells.md
@@ -1,0 +1,8 @@
+---
+branch: terminal-glass-black-cells
+---
+
+### fleet-console
+#### Fixed
+- Keep dimmed terminal output on the glass surface in the dark themes, so diff gutters and faded lines no longer print as solid black blocks.
+  ko: 다크 테마의 리퀴드 글래스에서 흐리게 출력된 터미널 내용이 유리 면을 그대로 유지합니다. diff 줄 번호와 흐린 줄이 검은 덩어리로 찍히지 않습니다.

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -191,6 +191,11 @@
      terminal은 유리 루트가 없는 레일 Shell 카드의 면이며, xterm이 계산값을 읽어 간다. */
   --glass-tint-field: var(--surface-panel);
   --glass-tint-terminal: var(--surface-panel);
+  /* floor는 유리가 만든 유효색의 **불투명 근사**다. xterm은 dim(SGR 2) 셀을 만나면 기본 배경
+     셀에도 배경 사각형을 그리면서 알파를 1로 강제하므로(WebGL RectangleRenderer), 필드를
+     완전히 비운 값의 RGB가 그대로 칠해진다. RGB를 유리 톤으로 채워 두면 그 사각형이 필드와
+     같은 색이 되어 보이지 않는다 — 알파는 terminal-surface가 0으로 눕혀 유리를 그대로 통과시킨다. */
+  --glass-tint-terminal-floor: var(--glass-tint-terminal);
   --glass-tint-band: var(--surface-band);
   /* 패널 광원(pane-light) — 유리 뒤가 앱에서 가장 어두운 캔버스라 blur가 굴절시킬 빛이 없다.
      그래서 다크 유리는 자기 위쪽에 광원을 하나 얹어 재질을 명도가 아니라 기울기로 말한다.
@@ -230,6 +235,7 @@
   --canvas-on-ambience: oklch(16% 0.022 245);
   --glass-on-tint-caption: oklch(17% 0.018 245 / 82%);
   --glass-on-tint-terminal: oklch(18.5% 0.028 245 / 83%);
+  --glass-on-tint-terminal-floor: oklch(18.1% 0.027 245);
   --glass-on-tint-band: oklch(13% 0.018 245 / 55%);
   --glass-on-backdrop-strong: blur(24px) saturate(1.7);
   --glass-on-backdrop-soft: blur(12px) saturate(1.5);
@@ -424,6 +430,7 @@
   --canvas-on-ambience: oklch(18% 0.035 235);
   --glass-on-tint-caption: oklch(21% 0.03 248 / 82%);
   --glass-on-tint-terminal: oklch(25% 0.05 248 / 83%);
+  --glass-on-tint-terminal-floor: oklch(23.9% 0.047 247);
   --glass-on-tint-band: oklch(19% 0.045 248 / 50%);
   --glass-on-rim: oklch(96% 0.012 88 / 18%);
 
@@ -500,6 +507,7 @@
   --canvas-on-ambience: oklch(18% 0.014 250);
   --glass-on-tint-caption: oklch(19% 0.008 252 / 84%);
   --glass-on-tint-terminal: oklch(21% 0.013 252 / 83%);
+  --glass-on-tint-terminal-floor: oklch(20.5% 0.013 252);
   --glass-on-tint-band: oklch(17% 0.007 255 / 50%);
   --glass-on-rim: oklch(95% 0.003 250 / 16%);
 
@@ -648,6 +656,7 @@
   /* 라이트 필드는 불투명 종이 — mCR(가독 보정)이 배경 실색을 요구하고, 종이 위 젖빛 유리는
      어차피 지각 불가 수준이다. 필드·거터가 같은 불투명 값으로 만나 격자 경계 띠가 없다. */
   --glass-on-tint-terminal: oklch(98.2% 0.004 100);
+  --glass-on-tint-terminal-floor: var(--glass-on-tint-terminal);
   --glass-on-tint-field: var(--glass-on-tint-terminal);
   /* 라이트는 유리 뒤가 이미 밝다 — 굴절할 빛이 부족한 문제가 없으므로 광원도 대기광도 얹지 않는다.
      백지 위에 광원을 더하면 종이가 평평해지고 최명면 극성만 흐려진다. */
@@ -708,6 +717,7 @@
     --glass-tint-caption: var(--glass-on-tint-caption);
     --glass-tint-field: var(--glass-on-tint-field);
     --glass-tint-terminal: var(--glass-on-tint-terminal);
+    --glass-tint-terminal-floor: var(--glass-on-tint-terminal-floor);
     --glass-pane-light: var(--glass-on-pane-light);
     --canvas-ambience: var(--canvas-on-ambience);
     --glass-tint-band: var(--glass-on-tint-band);
@@ -734,6 +744,7 @@
       --glass-tint-caption: var(--surface-panel);
       --glass-tint-field: var(--surface-panel);
       --glass-tint-terminal: var(--surface-panel);
+      --glass-tint-terminal-floor: var(--surface-panel);
       --glass-pane-light: transparent;
       --canvas-ambience: var(--canvas-sea-core);
       --glass-tint-band: var(--surface-band);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -808,6 +808,30 @@ describe("Instrument core design contract", () => {
     expect((theme.match(/--glass-on-tint-field: transparent;/g) ?? []).length).toBe(3);
   });
 
+  /* 비운 터미널 필드의 RGB는 검정이 아니라 유리 톤이어야 한다. xterm은 dim(SGR 2)을 배경 워드의
+     플래그로 실어 기본 배경 셀에도 배경 사각형을 만들고, 그 사각형만 알파를 1로 강제한다 —
+     RGB가 (0,0,0)이면 dim 셀이 유리 위에서 순수 검정으로 드러난다(Claude Code diff 거터 실측). */
+  it("clears the dark glass terminal field to a glass-toned floor", () => {
+    const theme = source("styles/theme.css");
+    const surface = fs.readFileSync(fileURLToPath(TERMINAL_SURFACE_PATH), "utf8");
+
+    // 닫힌 게이트의 기본값은 곧 현행 불투명 계약이다 — floor가 따로 놀면 게이트를 닫아도 색이 갈린다.
+    expect(theme).toContain("--glass-tint-terminal-floor: var(--glass-tint-terminal);");
+    expect(theme).toContain("--glass-tint-terminal-floor: var(--glass-on-tint-terminal-floor);");
+    // 다크 3종은 틴트(83%)를 캔버스 대기광 위에 합성한 불투명 근사를 재료로 둔다.
+    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(18.1% 0.027 245);");
+    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(23.9% 0.047 247);");
+    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(20.5% 0.013 252);");
+    // 라이트는 유리에서도 불투명 종이라 floor가 곧 그 값이다.
+    expect(theme).toContain("--glass-on-tint-terminal-floor: var(--glass-on-tint-terminal);");
+
+    // 필드를 비우는 경로는 floor 계산값을 읽어 알파만 0으로 눕힌다.
+    expect(surface).toContain('getPropertyValue("--glass-tint-terminal-floor")');
+    expect(surface).toContain("readLiquidGlassPaneActive()) return glassFieldClearColor();");
+    // 검정 리터럴을 그대로 돌려주면 dim 셀 회귀가 재발한다 — 반환은 폴백 두 곳뿐이다.
+    expect((surface.match(/return "rgba\(0, 0, 0, 0\)";/g) ?? []).length).toBe(2);
+  });
+
   // 텍스트 3티어만 대비를 통제하므로 원료 잉크를 color에 직접 쓰면 판독 하한을 한곳에서 보장할 수 없다.
   it("keeps text color on the semantic three-tier token grammar", () => {
     const violations: string[] = [];

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -741,9 +741,9 @@ function baseTerminalThemeFor(theme: TerminalThemeId): ITheme {
 
 /* 터미널 필드의 단일층 규약 — xterm 필드(cols×rows 격자)는 패널 본문을 꽉 채우지 못하므로,
    필드와 남는 거터가 서로 다른 층을 칠하면 경계 띠가 어긋난다(실측). 그래서:
-   - 다크 + 게이트 열림: xterm 배경은 완전 투명으로 비우고, 필드·거터를 컨테이너
-     (.canvas-operation-terminal/.terminal-shell)의 --glass-tint-terminal 한 겹이 칠한다.
-     다크는 minimumContrastRatio=1이라 투명 배경이 대비 보정에 관여하지 않는다.
+   - 다크 + 게이트 열림: xterm 배경은 알파 0으로 비우고(RGB는 아래 glassFieldClearColor 참조),
+     필드·거터를 컨테이너(.canvas-operation-terminal/.terminal-shell)의 --glass-tint-terminal
+     한 겹이 칠한다. 다크는 minimumContrastRatio=1이라 투명 배경이 대비 보정에 관여하지 않는다.
    - 라이트(Whites)와 게이트 닫힘: mCR이 배경 실색을 요구하므로 xterm은 채널 계산값
      (라이트 유리=불투명 종이, 게이트 닫힘=불투명 --surface-panel)을 그대로 받는다 —
      컨테이너도 같은 채널을 칠해 필드·거터가 같은 값으로 만난다.
@@ -752,10 +752,29 @@ function baseTerminalThemeFor(theme: TerminalThemeId): ITheme {
    위 ITheme의 background 리터럴은 토큰을 읽을 수 없는 환경(jsdom·SSR)의 폴백이다. */
 export function resolvePanelSurface(theme: TerminalThemeId, fallback: string): string {
   if (typeof document === "undefined") return fallback;
-  if (!LIGHT_TERMINAL_THEMES.has(theme) && readLiquidGlassPaneActive()) return "rgba(0, 0, 0, 0)";
+  if (!LIGHT_TERMINAL_THEMES.has(theme) && readLiquidGlassPaneActive()) return glassFieldClearColor();
   const resolved = getComputedStyle(document.documentElement).getPropertyValue("--glass-tint-terminal").trim();
   if (!resolved) return fallback;
   return normalizeCssColorToRgba(resolved) ?? fallback;
+}
+
+/* 다크 유리에서 필드를 비우는 값 — 알파는 0이지만 RGB는 검정이 아니라 유리 톤이어야 한다.
+   xterm은 dim(SGR 2)을 `BgFlags.DIM`, 즉 **배경 워드의 비트**로 싣는다. WebGL RectangleRenderer는
+   배경 사각형을 그릴지를 `bg !== 0` 하나로 판정하므로(updateBackgrounds), 배경이 default인 dim 셀도
+   사각형 대상이 되고, 그 사각형은 테마 배경색을 쓰면서 알파를 상수 1로 덮어쓴다(_updateRectangle).
+   화면 전체를 지우는 뷰포트 사각형만 알파를 보존하므로, 필드는 투명한데 dim 셀만 불투명해진다.
+   `rgba(0,0,0,0)`을 넘기면 그 셀이 순수 검정으로 칠해진다 — Claude Code가 diff 거터를 dim으로
+   찍는 것이 실측으로 확인됐고(PTY 원시 바이트), 유리 위에 검정 블록으로 드러났다.
+   그래서 RGB에는 유리 유효색의 불투명 근사(--glass-tint-terminal-floor)를 싣는다: 알파 0이라
+   필드 자체는 그대로 유리를 통과시키고, 알파가 1로 강제되는 dim 사각형만 필드와 같은 색이 된다.
+   유리는 뒤에 오는 것에 따라 유효색이 흔들리므로 이 값은 일치가 아니라 근사다. */
+function glassFieldClearColor(): string {
+  const floor = getComputedStyle(document.documentElement).getPropertyValue("--glass-tint-terminal-floor").trim();
+  // 빈 값을 프로브에 넘기면 fillStyle 할당이 무시되어 직전 색이 그대로 읽힌다 — 여기서 끊는다.
+  if (!floor) return "rgba(0, 0, 0, 0)";
+  const channels = /^rgba?\(([^)]+)\)$/i.exec(normalizeCssColorToRgba(floor) ?? "")?.[1]?.split(",");
+  if (!channels || channels.length < 3) return "rgba(0, 0, 0, 0)";
+  return `rgba(${channels[0]?.trim()}, ${channels[1]?.trim()}, ${channels[2]?.trim()}, 0)`;
 }
 
 let colorProbeCtx: CanvasRenderingContext2D | null | undefined;
@@ -799,8 +818,8 @@ export function terminalFieldIsTranslucent(background: string): boolean {
   const channels = /^rgba?\(([^)]+)\)$/i.exec(background.trim())?.[1]?.split(",");
   // rgba()가 아니면 resolvePanelSurface가 정규화를 못 한 환경이다(ITheme 폴백, 또는 canvas 프로브
   // 부재로 되돌아온 원문 oklch). 둘 다 xterm 자신도 알파를 파싱하지 못하는 환경이므로 불투명으로
-  // 읽는다. 알파가 실제로 필요한 유일한 경로(다크+게이트 열림)는 프로브를 거치지 않는
-  // "rgba(0, 0, 0, 0)" 리터럴이라 여기서 항상 검출된다.
+  // 읽는다. 알파가 실제로 필요한 유일한 경로(다크+게이트 열림)는 glassFieldClearColor()가 폴백까지
+  // 포함해 언제나 rgba() 형태로 돌려주므로 여기서 항상 검출된다.
   if (!channels) return false;
   return channels.length > 3 && Number.parseFloat(channels[3] ?? "1") < 1;
 }

--- a/runtime/fleet-plugins/terminal/tests/terminal-field-translucency.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-field-translucency.test.ts
@@ -13,10 +13,12 @@ import { resolvePanelSurface, terminalFieldIsTranslucent } from "../client/share
 const openGlassGate = () => document.documentElement.style.setProperty("--glass-backdrop-strong", "blur(24px) saturate(1.7)");
 const closeGlassGate = () => document.documentElement.style.setProperty("--glass-backdrop-strong", "none");
 const setTerminalTint = (value: string) => document.documentElement.style.setProperty("--glass-tint-terminal", value);
+const setTerminalFloor = (value: string) => document.documentElement.style.setProperty("--glass-tint-terminal-floor", value);
 
 afterEach(() => {
   document.documentElement.style.removeProperty("--glass-backdrop-strong");
   document.documentElement.style.removeProperty("--glass-tint-terminal");
+  document.documentElement.style.removeProperty("--glass-tint-terminal-floor");
 });
 
 describe("terminalFieldIsTranslucent", () => {
@@ -42,7 +44,27 @@ describe("resolved terminal field drives allowTransparency", () => {
   it("keeps the dark field translucent while the glass gate is open", () => {
     openGlassGate();
     setTerminalTint("rgb(17, 24, 33)");
+    setTerminalFloor("rgb(7, 19, 29)");
     expect(terminalFieldIsTranslucent(resolvePanelSurface("instrument", "oklch(16.5% 0.016 245)"))).toBe(true);
+  });
+
+  /* 비운 필드의 RGB는 검정이 아니라 유리 톤이어야 한다 — xterm이 dim(SGR 2) 셀에 그리는 배경
+     사각형은 알파를 1로 강제하므로, RGB가 (0,0,0)이면 그 셀만 순수 검정으로 칠해진다. */
+  it("clears the dark field to the glass floor color, not to black", () => {
+    openGlassGate();
+    setTerminalTint("rgb(17, 24, 33)");
+    setTerminalFloor("rgb(7, 19, 29)");
+    const cleared = resolvePanelSurface("instrument", "oklch(16.5% 0.016 245)");
+    expect(cleared).toBe("rgba(7, 19, 29, 0)");
+    expect(terminalFieldIsTranslucent(cleared)).toBe(true);
+  });
+
+  /* floor를 못 읽는 환경(토큰 부재·프로브 없음)은 완전 투명으로 물러난다 — 알파가 살아 있어야
+     필드가 유리를 통과시키고, 색을 지어내지 않는다. */
+  it("falls back to a fully transparent field when the floor token is missing", () => {
+    openGlassGate();
+    setTerminalTint("rgb(17, 24, 33)");
+    expect(resolvePanelSurface("instrument", "oklch(16.5% 0.016 245)")).toBe("rgba(0, 0, 0, 0)");
   });
 
   /* 라이트 필드는 유리가 켜져 있어도 불투명 종이다(--glass-on-tint-terminal에 알파가 없다).
@@ -50,6 +72,7 @@ describe("resolved terminal field drives allowTransparency", () => {
   it("keeps the light field opaque even while the glass gate is open", () => {
     openGlassGate();
     setTerminalTint("rgb(250, 249, 246)");
+    setTerminalFloor("rgb(250, 249, 246)");
     expect(terminalFieldIsTranslucent(resolvePanelSurface("whites", "oklch(98.2% 0.004 100)"))).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- 다크 리퀴드 글래스에서 xterm 필드를 비울 때 `rgba(0, 0, 0, 0)` 대신 **유리 톤 RGB + 알파 0**을 넘겨, dim(SGR 2)만 걸린 셀이 순수 검정 블록으로 칠해지던 문제를 없앱니다. Claude Code의 diff 줄 번호 거터가 대표 사례입니다.
- 네 테마 모두에 `--glass-tint-terminal-floor` 채널을 추가했습니다. 게이트가 닫히면 기본값이 곧 기존 불투명 계약이라 판독 동작이 그대로 되돌아갑니다.
- 원인: xterm은 dim을 배경 워드 플래그(`BgFlags.DIM`)로 실어서, WebGL `RectangleRenderer.updateBackgrounds()`의 `bg !== 0` 판정이 기본 배경 셀에도 배경 사각형을 만들고, `_updateRectangle()`이 그 사각형의 알파만 상수 1로 덮어씁니다. 화면 전체를 지우는 뷰포트 사각형만 알파를 보존하므로 필드는 투명한데 dim 셀만 불투명해집니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 1003 passed
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 2382 passed / 24 skipped
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`, `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 격리 콘솔 실측(게이트웨이 luna 모델로 Claude Code Edit 유도): instrument / maritime / carbon / whites 네 테마에서 diff 거터 검정 소멸 확인. instrument 거터 픽셀이 `rgb(0,0,0)` → 필드와 동일한 `rgb(8,22,32)`로, xterm 배경은 `rgba(7, 19, 29, 0)`, `allowTransparency`는 다크 true / 라이트 false 유지.