### PR TITLE
feat(fleet-console): make liquid glass legible on the light theme

### DIFF
--- a/.changelog.d/light-glass-refit.md
+++ b/.changelog.d/light-glass-refit.md
@@ -1,0 +1,13 @@
+---
+branch: light-glass-refit
+---
+
+### fleet-console
+#### Changed
+- Make Liquid Glass legible on the light theme. The glass now carries color, a shadowed lower bevel, and a contact shadow, and the canvas behind it gained the same chroma budget the dark themes already used, so turning the setting on and off is a visible change instead of a 2 percent shift in brightness.
+  ko: 라이트 테마에서 리퀴드 글래스가 보이도록 정비했습니다. 유리가 색과 아래쪽 그늘, 접촉 그림자를 갖고, 뒤의 캔버스도 다크 테마와 같은 채도 예산을 쓰게 되어 설정을 켜고 끄는 차이가 명도 2퍼센트가 아니라 눈에 보이는 변화가 됩니다.
+- Let the settings page scroll behind the command band so the glass has something to refract.
+  ko: 설정 화면이 커맨드 밴드 뒤로 스크롤되어, 유리가 굴절할 내용을 갖습니다.
+#### Fixed
+- Give the environment popover in the command band the same glass surface as the menu beside it.
+  ko: 커맨드 밴드의 환경 팝오버가 옆의 메뉴와 같은 유리 표면을 쓰도록 맞췄습니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -330,9 +330,18 @@ export function App() {
     });
   }, [canUndoLastClose, navigate, resolvePanelShortcut, undoLastClose]);
 
+  // 밴드 유리 뒤로 본문을 흘리는 레이아웃(layout.css)은 라우트가 밴드에 실제로 붙어 있을 때만
+  // 성립한다. 흐름에 배너나 제어 반납 바가 서면 음수 마진이 그 바를 라우트로 덮어 Reconnect 같은
+  // 컨트롤의 히트 테스트를 가로채기 때문이다. CSS 인접 형제로는 이 조건을 말할 수 없어
+  // (항상 렌더되는 .floating-widget-layer가 흐름 밖 형제로 끼어 있다) 셸이 직접 알린다.
+  const linkBannerVisible = state.connection !== "live" && state.connectionLostAt !== null && !updateProgress.watching;
+  const runtimeBannerVisible = state.operationRuntimeHydration === "degraded" && !updateProgress.watching;
+  const controlBarVisible = state.controlHolder !== null && state.controlCurtainDismissed;
+  const bandUnderflowAvailable = !mobileLayout && !linkBannerVisible && !runtimeBannerVisible && !controlBarVisible;
+
   return (
     <ActiveCompanionShortcutsProvider value={companionShortcuts}>
-      <div className="console-shell">
+      <div className={bandUnderflowAvailable ? "console-shell has-band-underflow" : "console-shell"}>
         {/* The mobile layout carries its own header and tab bar, so the band would be a second,
             taller chrome on the axis a phone has least of. Its view-mode toggle moves to the
             mobile header and its settings entry becomes a tab, so nothing is stranded. */}
@@ -342,7 +351,7 @@ export function App() {
             배너째 언마운트되어, 눌린 버튼의 피드백까지 함께 사라진다(실브라우저 재현). */}
         {/* 업데이트 중에는 링크 상실이 고장이 아니라 진행이다. 같은 순간에 두 가지 이야기를
             내보내면 사용자는 더 무서운 쪽을 믿는다 — 커튼이 떠 있는 동안 배너는 침묵한다. */}
-        {state.connection !== "live" && state.connectionLostAt !== null && !updateProgress.watching ? (
+        {linkBannerVisible ? (
           <div className="console-link-banner" role="status" aria-live="polite">
             <span>{t(state.connection === "offline" ? "chrome.link.offline" : "chrome.link.reconnecting")}. {t("chrome.link.bannerDetail", { time: connectionLostTime })}</span>
             <ReconnectButton />
@@ -352,7 +361,7 @@ export function App() {
         {/* 런타임 축이 degraded면 화면의 활동 표시는 마지막으로 알던 값일 뿐 지금의 사실이 아니다.
             칩마다 물음표를 뿌리는 대신 배너 하나로만 말한다(제품 결정) — 어느 쪽이든 모르는 상태를
             유휴나 휴면으로 추정하지는 않는다. */}
-        {state.operationRuntimeHydration === "degraded" && !updateProgress.watching ? (
+        {runtimeBannerVisible ? (
           <div className="console-link-banner" role="status" aria-live="polite">
             <span>{t("chrome.runtime.degraded")}</span>
           </div>

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -330,43 +330,42 @@ export function App() {
     });
   }, [canUndoLastClose, navigate, resolvePanelShortcut, undoLastClose]);
 
-  // 밴드 유리 뒤로 본문을 흘리는 레이아웃(layout.css)은 라우트가 밴드에 실제로 붙어 있을 때만
-  // 성립한다. 흐름에 배너나 제어 반납 바가 서면 음수 마진이 그 바를 라우트로 덮어 Reconnect 같은
-  // 컨트롤의 히트 테스트를 가로채기 때문이다. CSS 인접 형제로는 이 조건을 말할 수 없어
-  // (항상 렌더되는 .floating-widget-layer가 흐름 밖 형제로 끼어 있다) 셸이 직접 알린다.
-  const linkBannerVisible = state.connection !== "live" && state.connectionLostAt !== null && !updateProgress.watching;
-  const runtimeBannerVisible = state.operationRuntimeHydration === "degraded" && !updateProgress.watching;
-  const controlBarVisible = state.controlHolder !== null && state.controlCurtainDismissed;
-  const bandUnderflowAvailable = !mobileLayout && !linkBannerVisible && !runtimeBannerVisible && !controlBarVisible;
-
   return (
     <ActiveCompanionShortcutsProvider value={companionShortcuts}>
-      <div className={bandUnderflowAvailable ? "console-shell has-band-underflow" : "console-shell"}>
+      <div className="console-shell">
         {/* The mobile layout carries its own header and tab bar, so the band would be a second,
             taller chrome on the axis a phone has least of. Its view-mode toggle moves to the
             mobile header and its settings entry becomes a tab, so nothing is stranded. */}
         {mobileLayout ? null : <CommandBand operationsViewVisible={operationsViewVisible} />}
         <FloatingWidgetLayer />
-        {/* 배너는 링크가 live가 아닌 동안 유지한다 — offline에만 걸면 재연결 시도가 시작되는 순간
-            배너째 언마운트되어, 눌린 버튼의 피드백까지 함께 사라진다(실브라우저 재현). */}
-        {/* 업데이트 중에는 링크 상실이 고장이 아니라 진행이다. 같은 순간에 두 가지 이야기를
-            내보내면 사용자는 더 무서운 쪽을 믿는다 — 커튼이 떠 있는 동안 배너는 침묵한다. */}
-        {linkBannerVisible ? (
-          <div className="console-link-banner" role="status" aria-live="polite">
-            <span>{t(state.connection === "offline" ? "chrome.link.offline" : "chrome.link.reconnecting")}. {t("chrome.link.bannerDetail", { time: connectionLostTime })}</span>
-            <ReconnectButton />
-          </div>
-        ) : null}
-        <UpdateCurtain />
-        {/* 런타임 축이 degraded면 화면의 활동 표시는 마지막으로 알던 값일 뿐 지금의 사실이 아니다.
-            칩마다 물음표를 뿌리는 대신 배너 하나로만 말한다(제품 결정) — 어느 쪽이든 모르는 상태를
-            유휴나 휴면으로 추정하지는 않는다. */}
-        {runtimeBannerVisible ? (
-          <div className="console-link-banner" role="status" aria-live="polite">
-            <span>{t("chrome.runtime.degraded")}</span>
-          </div>
-        ) : null}
-        <ControlBar />
+        {/* 밴드와 라우트 사이의 흐름 바는 전부 이 자리에 모은다. 밴드 유리 뒤로 본문을 흘리는
+            레이아웃(layout.css)은 라우트가 밴드에 실제로 붙어 있을 때만 성립하는데, 그 조건을
+            바 목록으로 열거하면 새 바가 생길 때마다 조용히 새어 나간다(연결·저하 배너와 제어 반납
+            바를 열거한 뒤 업데이트 결과 바가 남아 있었다). 이 자리를 한 곳으로 만들면 CSS가
+            :has(*) 하나로 "지금 흐름 바가 서 있는가"를 직접 물을 수 있고, 앞으로 여기에 무엇을
+            더 넣든 게이트가 저절로 닫힌다. 상자는 만들지 않는다(display: contents). */}
+        <div className="console-shell-bars">
+          {/* 배너는 링크가 live가 아닌 동안 유지한다 — offline에만 걸면 재연결 시도가 시작되는 순간
+              배너째 언마운트되어, 눌린 버튼의 피드백까지 함께 사라진다(실브라우저 재현). */}
+          {/* 업데이트 중에는 링크 상실이 고장이 아니라 진행이다. 같은 순간에 두 가지 이야기를
+              내보내면 사용자는 더 무서운 쪽을 믿는다 — 커튼이 떠 있는 동안 배너는 침묵한다. */}
+          {state.connection !== "live" && state.connectionLostAt !== null && !updateProgress.watching ? (
+            <div className="console-link-banner" role="status" aria-live="polite">
+              <span>{t(state.connection === "offline" ? "chrome.link.offline" : "chrome.link.reconnecting")}. {t("chrome.link.bannerDetail", { time: connectionLostTime })}</span>
+              <ReconnectButton />
+            </div>
+          ) : null}
+          <UpdateCurtain />
+          {/* 런타임 축이 degraded면 화면의 활동 표시는 마지막으로 알던 값일 뿐 지금의 사실이 아니다.
+              칩마다 물음표를 뿌리는 대신 배너 하나로만 말한다(제품 결정) — 어느 쪽이든 모르는 상태를
+              유휴나 휴면으로 추정하지는 않는다. */}
+          {state.operationRuntimeHydration === "degraded" && !updateProgress.watching ? (
+            <div className="console-link-banner" role="status" aria-live="polite">
+              <span>{t("chrome.runtime.degraded")}</span>
+            </div>
+          ) : null}
+          <ControlBar />
+        </div>
         {(() => {
           const routeContent = (
             <main className="console-route-content">

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -141,7 +141,11 @@
   min-height: 0;
   height: 100%;
   margin: 0 auto;
-  padding: var(--space-5) 0 var(--space-10);
+  /* --band-underflow는 스크롤포트가 밴드 유리 뒤까지 올라간 만큼이다(layout.css가 켠다).
+     첫 카드가 밴드에 가리지 않도록 같은 값을 위 패딩으로 돌려주고, 키보드 이동의 착지점도
+     같이 민다. 그 레이아웃이 아니면 0px이라 오늘의 여백 그대로다. */
+  padding: calc(var(--space-5) + var(--band-underflow, 0px)) 0 var(--space-10);
+  scroll-padding-top: var(--band-underflow, 0px);
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -184,7 +188,10 @@
 
 .global-settings-list {
   position: sticky;
-  top: var(--space-2);
+  /* 스크롤포트가 밴드 뒤까지 올라가면 sticky의 원점도 함께 올라간다 — 오프셋을 같이 밀지 않으면
+     상시 노출되어야 할 섹션 내비의 첫 그룹이 밴드 뒤에 붙어 잘리고 클릭까지 가로챈다.
+     --band-underflow가 꺼진 레이아웃에서는 0px이라 오늘의 위치 그대로다. */
+  top: calc(var(--space-2) + var(--band-underflow, 0px));
   align-self: start;
   display: flex;
   flex-direction: column;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -827,7 +827,7 @@
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: 0 14px 34px rgb(0 0 0 / 48%);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), 0 14px 34px rgb(0 0 0 / 48%);
 }
 
 .host-switcher-heading {
@@ -995,7 +995,7 @@
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: var(--shadow-floating), var(--shadow-anchor);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift), var(--shadow-anchor);
   animation: fleet-pop var(--duration-slow) var(--ease-spring) both;
 }
 
@@ -1127,7 +1127,7 @@
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: var(--shadow-floating), var(--shadow-anchor);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift), var(--shadow-anchor);
   animation: fleet-pop var(--duration-slow) var(--ease-spring) both;
 }
 
@@ -3097,7 +3097,7 @@
 
 .operations-canvas.is-triage {
   background:
-    radial-gradient(66% 52% at 50% 46%, var(--canvas-sea-mid), var(--canvas-sea-far) 74%),
+    radial-gradient(66% 52% at 50% 46%, var(--canvas-wash-mid), var(--canvas-wash-far) 74%),
     var(--canvas-abyss);
   cursor: default;
 }
@@ -3123,7 +3123,7 @@
 
 .operations-canvas.is-formation-view {
   background:
-    radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-sea-mid) 78%),
+    radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-wash-mid) 78%),
     var(--canvas-abyss);
   cursor: default;
 }
@@ -3148,9 +3148,9 @@
 .operations-canvas-sea {
   background:
     radial-gradient(ellipse at 48% 42%, color-mix(in oklch, var(--canvas-ambience) 82%, transparent), transparent 38%),
-    radial-gradient(circle at 18% 18%, color-mix(in oklch, var(--aurora) 7%, transparent), transparent 34%),
-    radial-gradient(circle at 84% 76%, color-mix(in oklch, var(--brass) 5%, transparent), transparent 36%),
-    linear-gradient(145deg, var(--canvas-sea-near), var(--canvas-sea-mid) 58%, var(--canvas-sea-far));
+    radial-gradient(circle at 18% 18%, color-mix(in oklch, var(--aurora) var(--canvas-bloom-aurora), transparent), transparent 34%),
+    radial-gradient(circle at 84% 76%, color-mix(in oklch, var(--brass) var(--canvas-bloom-brass), transparent), transparent 36%),
+    linear-gradient(145deg, var(--canvas-wash-near), var(--canvas-wash-mid) 58%, var(--canvas-wash-far));
 }
 
 .operations-canvas-grid {
@@ -4575,7 +4575,7 @@
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-panel);
   backdrop-filter: var(--glass-backdrop-panel);
-  box-shadow: inset 0 1px 0 var(--glass-rim), var(--shadow-soft);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--shadow-soft);
   /* 공통 geometry 모션 레이어 — formation/최대화/companion/복원의 재배치가 같은 물리로 움직인다.
      visibility는 0s 즉시(복원·focus layer 즉시 표시), 최소화 시에만 is-minimized가 지연을 소유한다.
      --panel-stagger-delay는 formation stagger 전용 채널로 geometry 4속성에만 걸린다 —
@@ -5008,8 +5008,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border-left: none;
   border-bottom: none;
   border-radius: 0 var(--radius-md) 0 0;
-  /* --glass-rim은 무채색 상단 하이라이트 전용 채널 — 기본 transparent라 게이트가 닫히면 소멸한다. */
-  box-shadow: inset 0 1px 0 var(--glass-rim), var(--shadow-soft);
+  /* --glass-rim은 무채색 상단 하이라이트 전용 채널 — 기본 transparent라 게이트가 닫히면 소멸한다.
+     --glass-bevel은 그 반대편(아래 모서리)의 그늘로, 라이트에서만 값을 갖는다. */
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--shadow-soft);
   transition: width 200ms ease, border-color 200ms ease, visibility 0s linear 0s;
 }
 
@@ -9338,7 +9339,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: var(--shadow-floating), var(--shadow-anchor);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift), var(--shadow-anchor);
 }
 
 .commissioning-header {
@@ -9595,7 +9596,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: var(--shadow-floating);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift);
   pointer-events: auto;
 }
 
@@ -10095,7 +10096,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: var(--shadow-floating), var(--shadow-anchor);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift), var(--shadow-anchor);
 }
 
 .directory-browser-header {
@@ -11021,7 +11022,7 @@ body[data-codex-side="true"] .command-card {
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: inset 0 1px 0 var(--glass-rim), var(--shadow-floating), 0 0 44px -30px var(--brass);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift), 0 0 44px -30px var(--brass);
   text-align: center;
   animation: whatsnew-card-in var(--duration-slow) var(--ease-spring) both;
 }
@@ -11103,7 +11104,7 @@ body[data-codex-side="true"] .command-card {
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: var(--shadow-floating), 0 0 44px -30px var(--brass);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift), 0 0 44px -30px var(--brass);
   animation: whatsnew-card-in var(--duration-slow) var(--ease-spring) both;
 }
 
@@ -12323,7 +12324,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: var(--shadow-floating);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift);
 }
 
 /* 메뉴 항목은 theater-menu-item과 같은 mono 대문자 문법을 쓴다 — 콘솔 메뉴 단일 방언. */
@@ -12540,7 +12541,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
     var(--glass-underlay);
   -webkit-backdrop-filter: var(--glass-backdrop-strong);
   backdrop-filter: var(--glass-backdrop-strong);
-  box-shadow: var(--shadow-floating);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift);
   color: var(--text-primary);
   pointer-events: auto;
   animation: feature-tour-enter var(--duration-slow) var(--ease-glide) both;
@@ -14096,7 +14097,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
   overflow: hidden;
   border: 1px solid color-mix(in oklch, var(--warn) 48%, var(--surface-rim));
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-floating), 0 0 44px -24px var(--warn-glow);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift), 0 0 44px -24px var(--warn-glow);
   animation: fleet-pop var(--duration-slow) var(--ease-spring) both;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -26,6 +26,13 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
   pointer-events: none;
 }
 
+/* 흐름 바 자리. 상자를 만들지 않으므로 자식이 그대로 .console-shell의 플렉스 아이템이 되고
+   레이아웃은 이 래퍼가 없던 때와 같다 — 이 요소는 오직 "지금 흐름 바가 서 있는가"를
+   :has(*)로 물을 수 있게 하려고 존재한다(밴드 언더플로 게이트). */
+.console-shell-bars {
+  display: contents;
+}
+
 .console-route-content {
   flex: 1;
   min-width: 0;
@@ -252,23 +259,26 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
    현재 문서 스크롤을 갖는 데스크톱 라우트는 설정 하나뿐이다. Operations 캔버스는 스크롤이
    아니라 고정 프레임이라 이 규칙의 대상이 아니다. */
 @supports (selector(:has(*)) and ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)))) {
-  /* 셸은 밴드와 라우트 사이에 연결 배너·저하 배너·제어 반납 바를 조건부로 끼운다. 그 바가
-     하나라도 서면 음수 마진은 밴드가 아니라 그 바를 라우트로 덮어 Reconnect·제어 되찾기의
-     히트 테스트를 가로챈다. 본문이 유리 뒤로 가는 일은 라우트가 실제로 밴드에 붙어 있을
-     때만 성립한다.
-     CSS 인접 형제로는 이 조건을 말할 수 없다 — 항상 렌더되는 .floating-widget-layer(fixed,
-     흐름 밖)가 사이에 있어 인접 형제 셀렉터가 영영 매칭되지 않는다. 그래서 흐름 바의 유무는 셸이
-     .has-band-underflow로 알린다.
+  /* 셸은 밴드와 라우트 사이에 흐름 바(연결·저하 배너, 업데이트 결과 바, 제어 반납 바)를
+     조건부로 끼운다. 그 바가 하나라도 서면 음수 마진은 밴드가 아니라 그 바를 라우트로 덮어
+     Reconnect·Dismiss·제어 되찾기의 히트 테스트를 가로챈다. 본문이 유리 뒤로 가는 일은
+     라우트가 실제로 밴드에 붙어 있을 때만 성립한다.
+     조건을 바 목록으로 열거하지 않는다 — 두 번 새어 나갔다. app.tsx가 흐름 바를 전부
+     .console-shell-bars 한 자리에 모으므로, 여기서는 그 자리가 비었는지만 묻는다.
+     :has()는 중첩할 수 없어 :has(... :not(:has(*)))는 셀렉터째 무효가 된다(실측) — 자식
+     결합자를 :has() 안에 두고 바깥에서 부정한다.
+     인접 형제 셀렉터는 쓸 수 없다: 항상 렌더되는 .floating-widget-layer(fixed, 흐름 밖)가
+     사이에 있어 영영 매칭되지 않는다.
      --band-underflow는 그 자리에서만 켜지고 자손이 상속한다 — 조건이 깨지면 0px 기본값으로
      떨어져 페이지 패딩과 sticky 오프셋이 함께 원래 레이아웃으로 돌아간다. */
-  :root:not([data-glass="off"]) .console-shell.has-band-underflow:has(.global-settings-page) .console-route-content {
+  :root:not([data-glass="off"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .console-route-content {
     --band-underflow: var(--chrome-band-height);
     margin-top: calc(-1 * var(--band-underflow));
   }
 
   /* 밴드는 라우트 본문(위치 없음, z:auto)만 이기면 된다. 값을 키우면 What's new(35) 같은
      낮은 오버레이 위로 밴드가 올라서므로(기존 is-docked 주석의 실측 회귀) 사다리의 맨 아래에 둔다. */
-  :root:not([data-glass="off"]) .console-shell.has-band-underflow:has(.global-settings-page) .command-band {
+  :root:not([data-glass="off"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .command-band {
     --z-band-underflow: 2;
     isolation: isolate;
     z-index: var(--z-band-underflow);
@@ -277,12 +287,12 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
   /* 유리 게이트의 셋째 조건. 투명도 축소를 선호하면 밴드는 불투명 실색으로 돌아가므로,
      본문을 그 뒤로 보내면 굴절 대신 가려지기만 한다 — 공간 예약 레이아웃으로 되돌린다. */
   @media (prefers-reduced-transparency: reduce) {
-    :root:not([data-glass="off"]) .console-shell.has-band-underflow:has(.global-settings-page) .console-route-content {
+    :root:not([data-glass="off"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .console-route-content {
       --band-underflow: 0px;
       margin-top: 0;
     }
 
-    :root:not([data-glass="off"]) .console-shell.has-band-underflow:has(.global-settings-page) .command-band {
+    :root:not([data-glass="off"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .command-band {
       isolation: auto;
       z-index: auto;
     }

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -257,7 +257,7 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
      히트 테스트를 가로챈다. 본문이 유리 뒤로 가는 일은 라우트가 실제로 밴드에 붙어 있을
      때만 성립한다.
      CSS 인접 형제로는 이 조건을 말할 수 없다 — 항상 렌더되는 .floating-widget-layer(fixed,
-     흐름 밖)가 사이에 있어 가 영영 매칭되지 않는다. 그래서 흐름 바의 유무는 셸이
+     흐름 밖)가 사이에 있어 인접 형제 셀렉터가 영영 매칭되지 않는다. 그래서 흐름 바의 유무는 셸이
      .has-band-underflow로 알린다.
      --band-underflow는 그 자리에서만 켜지고 자손이 상속한다 — 조건이 깨지면 0px 기본값으로
      떨어져 페이지 패딩과 sticky 오프셋이 함께 원래 레이아웃으로 돌아간다. */

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -234,6 +234,60 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
   pointer-events: none;
 }
 
+/* ── 본문이 밴드 유리 뒤로 지나가게 한다 ─────────────────────────────────────
+   유리는 뒤에 있는 것을 흐릴 뿐이라, 뒤가 비어 있으면 blur는 항등함수다. 실측에서 모든
+   스크롤 컨테이너의 상단이 밴드의 하단과 같은 좌표(top: 44)에 있어, 밴드의 blur(16px)가
+   평평한 면을 흐려 평평한 면을 만들고 있었다. 본문 잉크(L*23)가 밴드 유리(L*93) 뒤로
+   들어가면 블러는 70포인트의 대비를 얻는다.
+
+   음수 마진은 페이지가 아니라 라우트 컨테이너에 준다 — .console-route-content가
+   overflow:hidden이라, 페이지만 끌어올리면 밴드 뒤로 들어간 부분이 그대로 잘린다.
+
+   밴드의 z-index/isolation이 함께 필요한 이유: 밴드 유리는 자식 없는 ::before(z-index:-1)라
+   밴드가 스태킹 컨텍스트를 갖지 않으면 그 유리가 끌어올린 본문보다 아래로 내려간다.
+   isolation은 스태킹 컨텍스트만 만들고 containing block은 만들지 않으므로, 밴드에 앵커된
+   드롭다운의 위치 계산은 그대로다(루트 backdrop-filter의 함정과 다른 지점).
+
+   게이트 뒤에 둔다 — 유리를 끄면 공간 예약 레이아웃이 정확히 돌아온다.
+   현재 문서 스크롤을 갖는 데스크톱 라우트는 설정 하나뿐이다. Operations 캔버스는 스크롤이
+   아니라 고정 프레임이라 이 규칙의 대상이 아니다. */
+@supports (selector(:has(*)) and ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)))) {
+  :root:not([data-glass="off"]) .console-shell:has(.global-settings-page) .console-route-content {
+    margin-top: calc(-1 * var(--chrome-band-height));
+  }
+
+  /* 밴드는 라우트 본문(위치 없음, z:auto)만 이기면 된다. 값을 키우면 What's new(35) 같은
+     낮은 오버레이 위로 밴드가 올라서므로(기존 is-docked 주석의 실측 회귀) 사다리의 맨 아래에 둔다. */
+  :root:not([data-glass="off"]) .console-shell:has(.global-settings-page) .command-band {
+    --z-band-underflow: 2;
+    isolation: isolate;
+    z-index: var(--z-band-underflow);
+  }
+
+  :root:not([data-glass="off"]) .global-settings-page {
+    padding-top: calc(var(--space-5) + var(--chrome-band-height));
+    scroll-padding-top: var(--chrome-band-height);
+  }
+
+  /* 유리 게이트의 셋째 조건. 투명도 축소를 선호하면 밴드는 불투명 실색으로 돌아가므로,
+     본문을 그 뒤로 보내면 굴절 대신 가려지기만 한다 — 공간 예약 레이아웃으로 되돌린다. */
+  @media (prefers-reduced-transparency: reduce) {
+    :root:not([data-glass="off"]) .console-shell:has(.global-settings-page) .console-route-content {
+      margin-top: 0;
+    }
+
+    :root:not([data-glass="off"]) .console-shell:has(.global-settings-page) .command-band {
+      isolation: auto;
+      z-index: auto;
+    }
+
+    :root:not([data-glass="off"]) .global-settings-page {
+      padding-top: var(--space-5);
+      scroll-padding-top: 0;
+    }
+  }
+}
+
 .command-band.is-fullscreen {
   position: fixed;
   inset: 0 0 auto;
@@ -307,7 +361,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   /* 사이드바 상단 캡 — 같은 크롬 표면(chrome 틴트 채널)을 ::before로 공유해야 한 열로 읽힌다. */
   position: relative;
   background: none;
-  box-shadow: inset 0 1px 0 var(--glass-rim);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel);
   transition: border-color 200ms ease;
 }
 
@@ -459,8 +513,16 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   padding: var(--space-3);
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-md);
-  background: var(--surface-band);
-  box-shadow: 0 12px 30px color-mix(in oklch, var(--ink-deep) 70%, transparent);
+  /* 떠 있는 면이므로 형제인 .command-band-system-menu와 같은 strong 계열 유리를 쓴다.
+     유리 전환(PR #888)에서 이 규칙만 --surface-band 불투명으로 남아, 밴드에 앵커된
+     같은 종류의 메뉴 둘이 서로 다른 재질이었다. */
+  background:
+    var(--glass-sheen),
+    linear-gradient(var(--glass-tint-strong), var(--glass-tint-strong)),
+    var(--glass-underlay);
+  -webkit-backdrop-filter: var(--glass-backdrop-strong);
+  backdrop-filter: var(--glass-backdrop-strong);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift);
   color: var(--text-primary);
   font-size: var(--t-xs);
 }

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -252,38 +252,39 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
    현재 문서 스크롤을 갖는 데스크톱 라우트는 설정 하나뿐이다. Operations 캔버스는 스크롤이
    아니라 고정 프레임이라 이 규칙의 대상이 아니다. */
 @supports (selector(:has(*)) and ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)))) {
-  :root:not([data-glass="off"]) .console-shell:has(.global-settings-page) .console-route-content {
-    margin-top: calc(-1 * var(--chrome-band-height));
+  /* 셸은 밴드와 라우트 사이에 연결 배너·저하 배너·제어 반납 바를 조건부로 끼운다. 그 바가
+     하나라도 서면 음수 마진은 밴드가 아니라 그 바를 라우트로 덮어 Reconnect·제어 되찾기의
+     히트 테스트를 가로챈다. 본문이 유리 뒤로 가는 일은 라우트가 실제로 밴드에 붙어 있을
+     때만 성립한다.
+     CSS 인접 형제로는 이 조건을 말할 수 없다 — 항상 렌더되는 .floating-widget-layer(fixed,
+     흐름 밖)가 사이에 있어 가 영영 매칭되지 않는다. 그래서 흐름 바의 유무는 셸이
+     .has-band-underflow로 알린다.
+     --band-underflow는 그 자리에서만 켜지고 자손이 상속한다 — 조건이 깨지면 0px 기본값으로
+     떨어져 페이지 패딩과 sticky 오프셋이 함께 원래 레이아웃으로 돌아간다. */
+  :root:not([data-glass="off"]) .console-shell.has-band-underflow:has(.global-settings-page) .console-route-content {
+    --band-underflow: var(--chrome-band-height);
+    margin-top: calc(-1 * var(--band-underflow));
   }
 
   /* 밴드는 라우트 본문(위치 없음, z:auto)만 이기면 된다. 값을 키우면 What's new(35) 같은
      낮은 오버레이 위로 밴드가 올라서므로(기존 is-docked 주석의 실측 회귀) 사다리의 맨 아래에 둔다. */
-  :root:not([data-glass="off"]) .console-shell:has(.global-settings-page) .command-band {
+  :root:not([data-glass="off"]) .console-shell.has-band-underflow:has(.global-settings-page) .command-band {
     --z-band-underflow: 2;
     isolation: isolate;
     z-index: var(--z-band-underflow);
   }
 
-  :root:not([data-glass="off"]) .global-settings-page {
-    padding-top: calc(var(--space-5) + var(--chrome-band-height));
-    scroll-padding-top: var(--chrome-band-height);
-  }
-
   /* 유리 게이트의 셋째 조건. 투명도 축소를 선호하면 밴드는 불투명 실색으로 돌아가므로,
      본문을 그 뒤로 보내면 굴절 대신 가려지기만 한다 — 공간 예약 레이아웃으로 되돌린다. */
   @media (prefers-reduced-transparency: reduce) {
-    :root:not([data-glass="off"]) .console-shell:has(.global-settings-page) .console-route-content {
+    :root:not([data-glass="off"]) .console-shell.has-band-underflow:has(.global-settings-page) .console-route-content {
+      --band-underflow: 0px;
       margin-top: 0;
     }
 
-    :root:not([data-glass="off"]) .console-shell:has(.global-settings-page) .command-band {
+    :root:not([data-glass="off"]) .console-shell.has-band-underflow:has(.global-settings-page) .command-band {
       isolation: auto;
       z-index: auto;
-    }
-
-    :root:not([data-glass="off"]) .global-settings-page {
-      padding-top: var(--space-5);
-      scroll-padding-top: 0;
     }
   }
 }

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -23,7 +23,7 @@
   border-right: none;
   border-bottom: none;
   background: none;
-  box-shadow: inset 0 1px 0 var(--glass-rim), var(--shadow-floating);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift);
   overflow: hidden;
   transition: width 200ms ease, border-color 200ms ease, visibility 0s linear 0s;
 }

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -203,11 +203,25 @@
   --glass-pane-light: transparent;
   /* 캔버스 대기광 — 유리가 실제로 굴절할 것을 뒤에 놓는다. 닫히면 원래의 심해 계조. */
   --canvas-ambience: var(--canvas-sea-core);
+  /* 캔버스 워시·블룸 — 대기광과 같은 일을 계조와 방위 라디알에서 한다. 유리는 뒤에 있는 것을
+     흐리고 채도를 올릴 뿐이라, 뒤가 무채색 평면이면 blur도 saturate도 항등함수가 된다.
+     기본값이 현행 sea·현행 혼합률이라 게이트가 닫히면 지금 화면 그대로다. */
+  --canvas-wash-near: var(--canvas-sea-near);
+  --canvas-wash-mid: var(--canvas-sea-mid);
+  --canvas-wash-far: var(--canvas-sea-far);
+  --canvas-bloom-aurora: 7%;
+  --canvas-bloom-brass: 5%;
   --glass-backdrop-strong: none;
   --glass-backdrop-soft: none;
   --glass-backdrop-panel: none;
   --glass-backdrop-scrim: none;
   --glass-rim: transparent;
+  /* 아래쪽 어두운 베벨. 밝은 바탕에서는 흰 하이라이트에 여유가 없어(라이트 유리 본체 L*94.7,
+     흰 천장까지 5.3포인트) 판의 두께를 그늘 쪽이 말한다. 다크는 위쪽 rim이 이미 이기므로
+     값을 두지 않고, 기본 transparent라 게이트가 닫히면 소멸한다. */
+  --glass-bevel: transparent;
+  /* 떠 있는 유리의 부양. 기본값이 곧 현행 계약이라 게이트가 닫히면 --shadow-floating 그대로다. */
+  --glass-lift: var(--shadow-floating);
   --glass-sheen: linear-gradient(transparent, transparent);
   /* 게이트가 켜질 때 채널에 실릴 테마별 유리 재료 — 여기(base)와 각 테마 블록에만
      리터럴을 둔다. 게이트 블록은 값 없이 이 재료를 채널로 옮기기만 한다.
@@ -643,16 +657,20 @@
   /* 라이트 유리는 종이보다 살짝 어두운 스모크드 밀크다 — 백지 위 백유리는 지각 불가라서
      틴트를 L92~94 대역으로 내리고 채도 증폭을 올려야 부유층이 종이와 분리되어 읽힌다
      (실측 피드백). 텍스트 잉크(L22~37)는 L93 합성 위에서 AA를 유지하고, 패널만은
-     "종이가 최명면" 극성 계약 때문에 밝은 틴트를 지킨다. */
-  --glass-on-tint-strong: oklch(93% 0.006 100 / 58%);
-  --glass-on-tint-soft: oklch(93.5% 0.005 100 / 52%);
-  --glass-on-tint-pillar: oklch(94% 0.005 100 / 55%);
-  --glass-on-tint-raised: oklch(92.5% 0.006 100 / 52%);
-  --glass-on-tint-deep: oklch(92.5% 0.006 100 / 52%);
-  --glass-on-tint-abyss: oklch(94% 0.004 100 / 52%);
-  --glass-on-tint-chrome: oklch(92% 0.005 100 / 52%);
+     "종이가 최명면" 극성 계약 때문에 밝은 틴트를 지킨다.
+     명도 대역과 알파는 출시값 그대로 두고 chroma만 0.005 -> 0.015 대역으로 올린다.
+     명도 이동은 라이트에서 상대 1.5~2.2%라 지각 문턱 아래이지만(실측), 같은 자리의 chroma는
+     3 -> 12(RGB 스프레드)로 문턱을 넘는다. 명도를 손대면 잉크 대비가 함께 움직이므로
+     더하는 축은 색 하나뿐이다. hue는 대기광(84)과 한 가족이 되도록 100 -> 90으로 당긴다. */
+  --glass-on-tint-strong: oklch(93% 0.016 90 / 58%);
+  --glass-on-tint-soft: oklch(93.5% 0.015 90 / 52%);
+  --glass-on-tint-pillar: oklch(94% 0.015 90 / 55%);
+  --glass-on-tint-raised: oklch(92.5% 0.016 90 / 52%);
+  --glass-on-tint-deep: oklch(92.5% 0.016 90 / 52%);
+  --glass-on-tint-abyss: oklch(94% 0.014 90 / 52%);
+  --glass-on-tint-chrome: oklch(92% 0.015 90 / 52%);
   --glass-on-tint-panel: oklch(98.2% 0.004 100 / 60%);
-  --glass-on-tint-caption: oklch(96% 0.006 100 / 88%);
+  --glass-on-tint-caption: oklch(96% 0.014 90 / 88%);
   /* 라이트 필드는 불투명 종이 — mCR(가독 보정)이 배경 실색을 요구하고, 종이 위 젖빛 유리는
      어차피 지각 불가 수준이다. 필드·거터가 같은 불투명 값으로 만나 격자 경계 띠가 없다. */
   --glass-on-tint-terminal: oklch(98.2% 0.004 100);
@@ -661,13 +679,31 @@
   /* 라이트는 유리 뒤가 이미 밝다 — 굴절할 빛이 부족한 문제가 없으므로 광원도 대기광도 얹지 않는다.
      백지 위에 광원을 더하면 종이가 평평해지고 최명면 극성만 흐려진다. */
   --glass-on-pane-light: transparent;
-  --canvas-on-ambience: var(--canvas-sea-core);
-  --glass-on-tint-band: oklch(92% 0.006 100 / 52%);
-  --glass-on-backdrop-strong: blur(26px) saturate(1.45);
-  --glass-on-backdrop-soft: blur(12px) saturate(1.25);
-  --glass-on-backdrop-panel: blur(30px) saturate(1.35);
-  --glass-on-rim: oklch(100% 0 0 / 75%);
-  --glass-on-sheen: linear-gradient(118deg, oklch(100% 0 0 / 55%) 0%, transparent 34%, transparent 78%, oklch(100% 0 0 / 28%) 100%);
+  /* 대기광·워시·블룸이 Move A다. 라이트 캔버스의 chroma는 0.003~0.006으로 다크 3종의
+     0.005~0.030 대비 1/3~1/5 예산이었고, saturate가 0에 걸려 항등함수였다(실측).
+     명도는 그대로 두고 chroma만 다크와 같은 예산으로 올린다 — 눈에는 여전히 흰 책상이다.
+     베이스 계조에서 hue를 벌리면 보간이 초록을 통과해 종이가 상해 보이므로(실측),
+     한랭/온난 두 극은 이미 sea에 있던 aurora·brass 라디알의 혼합률로 만든다. */
+  --canvas-on-ambience: oklch(95.4% 0.016 84);
+  --canvas-on-wash-near: oklch(95.3% 0.011 88);
+  --canvas-on-wash-mid: oklch(96.5% 0.008 94);
+  --canvas-on-wash-far: oklch(97.4% 0.006 98);
+  --canvas-on-bloom-aurora: 12%;
+  --canvas-on-bloom-brass: 8%;
+  --glass-on-tint-band: oklch(92% 0.016 90 / 52%);
+  /* 입력이 0이 아니게 된 뒤의 증폭이다. 입력과 증폭을 함께 올리면 곱해져서,
+     saturate(2.2)에서는 사이드바가 RGB 스프레드 27의 베이지로 넘어갔다(실측). */
+  --glass-on-backdrop-strong: blur(30px) saturate(1.75);
+  --glass-on-backdrop-soft: blur(16px) saturate(1.6);
+  --glass-on-backdrop-panel: blur(32px) saturate(1.5);
+  --glass-on-rim: oklch(100% 0 0 / 92%);
+  /* 라이트 유리의 두께는 그늘 쪽이 말한다 — 흰 하이라이트는 본체 L*94.7 위로 4.2포인트를
+     얻는 데 그치지만, 어두운 쪽으로는 74포인트가 비어 있다(모서리 단면 실측). */
+  --glass-on-bevel: oklch(34% 0.03 92 / 30%);
+  /* 접촉 + 대기 두 겹. 밝은 바탕에서 부유를 만드는 것은 명도차가 아니라 그림자다.
+     색을 중성 회색에서 brass 쪽으로 기울여 먼지가 아니라 따뜻한 재질을 통과한 빛으로 읽힌다. */
+  --glass-on-lift: 0 2px 5px -1px oklch(34% 0.035 88 / 22%), 0 20px 46px -18px oklch(32% 0.04 88 / 30%);
+  --glass-on-sheen: linear-gradient(118deg, oklch(100% 0 0 / 72%) 0%, transparent 30%, transparent 74%, oklch(100% 0 0 / 34%) 100%);
   /* 라이트에서 패널은 종이다 — 크롬(96%)보다 밝은 최명면이어야 시선이 작업면에 남는다.
      캔버스는 base 색이 아니라 그 위에 칠하는 sea 그라디언트가 실제 픽셀을 정하며 패널 둘레에서
      L 94.9~96.6으로 실측된다. 그래서 프레임 톤(ink-deep 95.5%)으로 통일하면 패널이 책상과
@@ -726,6 +762,15 @@
     --glass-backdrop-panel: var(--glass-on-backdrop-panel);
     --glass-backdrop-scrim: var(--glass-on-backdrop-scrim);
     --glass-rim: var(--glass-on-rim);
+    /* 베벨·부양·워시·블룸은 라이트에만 재료가 있다. fallback이 곧 현행 계약이라
+       다크 3종은 이 다섯 줄이 있어도 한 픽셀도 바뀌지 않는다. */
+    --glass-bevel: var(--glass-on-bevel, transparent);
+    --glass-lift: var(--glass-on-lift, var(--shadow-floating));
+    --canvas-wash-near: var(--canvas-on-wash-near, var(--canvas-sea-near));
+    --canvas-wash-mid: var(--canvas-on-wash-mid, var(--canvas-sea-mid));
+    --canvas-wash-far: var(--canvas-on-wash-far, var(--canvas-sea-far));
+    --canvas-bloom-aurora: var(--canvas-on-bloom-aurora, 7%);
+    --canvas-bloom-brass: var(--canvas-on-bloom-brass, 5%);
     --glass-sheen: var(--glass-on-sheen);
   }
 
@@ -753,6 +798,13 @@
       --glass-backdrop-panel: none;
       --glass-backdrop-scrim: none;
       --glass-rim: transparent;
+      --glass-bevel: transparent;
+      --glass-lift: var(--shadow-floating);
+      --canvas-wash-near: var(--canvas-sea-near);
+      --canvas-wash-mid: var(--canvas-sea-mid);
+      --canvas-wash-far: var(--canvas-sea-far);
+      --canvas-bloom-aurora: 7%;
+      --canvas-bloom-brass: 5%;
       --glass-sheen: linear-gradient(transparent, transparent);
     }
   }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -737,9 +737,9 @@ describe("Instrument core design contract", () => {
     // 치워두기의 두 번 눌러 확정 안내는 패널 안 HUD가 소유한다 — 레일이 사라져도 이 기능은 그대로다.
     expect(canvas).toContain("setAsideArmed");
     expect(canvas).not.toMatch(/canvas-triage-(?:frame|bracket|hud(?:-eye|-name)?|curtain-kicker|curtain-ruler)/);
-    // Formation 판의 중앙은 대기광 채널이 정한다 — 유리가 굴절할 빛을 패널 뒤에 놓기 위해서다.
-    // 채널 기본값은 --canvas-sea-core이므로 게이트가 닫히면 원래 픽셀로 돌아간다.
-    expect(components).toContain("radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-sea-mid) 78%)");
+    // Formation 판의 중앙은 대기광 채널이, 둘레는 워시 채널이 정한다 — 유리가 굴절할 빛을
+    // 패널 뒤에 놓기 위해서다. 두 채널 모두 기본값이 현행 sea라 게이트가 닫히면 원래 픽셀이다.
+    expect(components).toContain("radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-wash-mid) 78%)");
     expect(components).toContain("background-size: 48px 48px !important;");
     expect(components).toContain(".canvas-formation-guide {");
     // 캡션은 순번을 싣지 않는다 — 번호는 빈 자리를 가리키는 가이드만 진다.
@@ -830,6 +830,56 @@ describe("Instrument core design contract", () => {
     expect(surface).toContain("readLiquidGlassPaneActive()) return glassFieldClearColor();");
     // 검정 리터럴을 그대로 돌려주면 dim 셀 회귀가 재발한다 — 반환은 폴백 두 곳뿐이다.
     expect((surface.match(/return "rgba\(0, 0, 0, 0\)";/g) ?? []).length).toBe(2);
+
+  // 라이트 유리는 명도가 아니라 색·그늘·부양으로 읽힌다. 밝은 바탕에서 명도 이동은 상대
+  // 1.5~2.2%로 지각 문턱 아래이고(실측), 흰 하이라이트는 본체 L*94.7 위로 4.2포인트밖에
+  // 얻지 못한다. 그래서 라이트에만 베벨(아래 그늘)·부양(접촉 그림자)·대기 채도가 실린다.
+  it("carries the light glass on chroma, bevel and lift instead of luminance", () => {
+    const theme = source("styles/theme.css");
+    const components = source("styles/components.css");
+    const layout = source("styles/layout.css");
+    const rail = source("styles/rail.css");
+
+    // 새 채널 넷의 닫힌-게이트 기본값이 곧 구 계약이다 — 하나라도 어긋나면 유리를 꺼도
+    // 화면이 돌아오지 않는다.
+    expect(theme).toContain("--glass-bevel: transparent;");
+    expect(theme).toContain("--glass-lift: var(--shadow-floating);");
+    expect(theme).toContain("--canvas-wash-near: var(--canvas-sea-near);");
+    expect(theme).toContain("--canvas-wash-mid: var(--canvas-sea-mid);");
+    expect(theme).toContain("--canvas-wash-far: var(--canvas-sea-far);");
+    expect(theme).toContain("--canvas-bloom-aurora: 7%;");
+    expect(theme).toContain("--canvas-bloom-brass: 5%;");
+
+    // 게이트는 라이트에만 있는 재료를 fallback으로 받는다 — 다크 3종이 값을 갖지 않아야
+    // 이 다섯 줄이 다크를 한 픽셀도 건드리지 않는다.
+    expect(theme).toContain("--glass-bevel: var(--glass-on-bevel, transparent);");
+    expect(theme).toContain("--glass-lift: var(--glass-on-lift, var(--shadow-floating));");
+    for (const material of [
+      "--glass-on-bevel",
+      "--glass-on-lift",
+      "--canvas-on-wash-near",
+      "--canvas-on-bloom-aurora",
+      "--canvas-on-bloom-brass",
+    ]) {
+      expect((theme.match(new RegExp(`${material}:`, "g")) ?? []).length).toBe(1);
+    }
+
+    // 라이트 틴트는 무채색이 아니다. chroma 0.005 대역에서는 saturate가 항등함수라
+    // 유리가 "약간 회색이 된 카드"로만 읽혔다(ON/OFF RGB 스프레드 3 대 3, 실측).
+    const whites = theme.match(/:root\[data-theme="whites"\] \{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(whites).not.toBe("");
+    const lightTints = [...whites.matchAll(/--glass-on-tint-(?:strong|soft|pillar|raised|deep|abyss|chrome|band): oklch\([\d.]+% ([\d.]+) /g)];
+    expect(lightTints.length).toBe(8);
+    for (const [, chroma] of lightTints) expect(Number(chroma)).toBeGreaterThanOrEqual(0.012);
+
+    // 소비처: 크롬·패널·떠 있는 면은 위 rim과 아래 bevel을 한 쌍으로 쓴다.
+    for (const css of [components, layout, rail]) {
+      const rims = (css.match(/inset 0 1px 0 var\(--glass-rim\)/g) ?? []).length;
+      const bevels = (css.match(/inset 0 -1px 0 var\(--glass-bevel\)/g) ?? []).length;
+      expect(bevels).toBeGreaterThanOrEqual(rims);
+    }
+    // 부양은 --shadow-floating을 그대로 두면 라이트에서 접촉면이 없다.
+    expect((components.match(/var\(--glass-lift\)/g) ?? []).length).toBeGreaterThanOrEqual(10);
   });
 
   // 텍스트 3티어만 대비를 통제하므로 원료 잉크를 color에 직접 쓰면 판독 하한을 한곳에서 보장할 수 없다.
@@ -1678,6 +1728,10 @@ describe("Instrument core design contract", () => {
       expect(components).toMatch(new RegExp(`${scoped} \\{[^}]*backdrop-filter: var\\(--glass-backdrop-strong\\);`));
     }
     expect(layout).toMatch(/\.command-band-menu \{[^}]*\),\s*var\(--glass-underlay\);/);
+    // 밴드에 앵커된 두 메뉴는 같은 재질이어야 한다 — 환경 팝오버만 --surface-band 불투명으로
+    // 남아 있던 유리 전환 누락(Move E)의 재발 방지.
+    expect(layout).toMatch(/\.command-band-environment-popover \{[^}]*\),\s*var\(--glass-underlay\);/);
+    expect(layout).toMatch(/\.command-band-environment-popover \{[^}]*backdrop-filter: var\(--glass-backdrop-strong\);/);
     expect(skillsCss).toMatch(/\.skills-overlay-dialog \{[^}]*\),\s*var\(--glass-underlay\);/);
     expect(skillsCss).toMatch(/\.skills-toast \{[^}]*\),\s*var\(--glass-underlay\);/);
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__artifact-menu \{[^}]*var\(--glass-underlay\);/);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -830,6 +830,7 @@ describe("Instrument core design contract", () => {
     expect(surface).toContain("readLiquidGlassPaneActive()) return glassFieldClearColor();");
     // 검정 리터럴을 그대로 돌려주면 dim 셀 회귀가 재발한다 — 반환은 폴백 두 곳뿐이다.
     expect((surface.match(/return "rgba\(0, 0, 0, 0\)";/g) ?? []).length).toBe(2);
+  });
 
   // 라이트 유리는 명도가 아니라 색·그늘·부양으로 읽힌다. 밝은 바탕에서 명도 이동은 상대
   // 1.5~2.2%로 지각 문턱 아래이고(실측), 흰 하이라이트는 본체 L*94.7 위로 4.2포인트밖에

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -882,6 +882,39 @@ describe("Instrument core design contract", () => {
     expect((components.match(/var\(--glass-lift\)/g) ?? []).length).toBeGreaterThanOrEqual(10);
   });
 
+  // 밴드 유리 뒤로 본문을 흘리는 레이아웃은 라우트가 밴드에 붙어 있을 때만 성립한다. 그 조건을
+  // 바 목록으로 열거하면 새 바가 생길 때마다 조용히 새어 나가 Reconnect·Dismiss·제어 되찾기의
+  // 히트 테스트를 라우트가 가로챈다(리뷰에서 두 번 적발). 그래서 흐름 바는 한 자리에 모으고,
+  // 게이트는 그 자리가 비었는지만 묻는다.
+  it("gates the band underflow on an empty shell-bar slot, not a list of bars", () => {
+    const layout = source("styles/layout.css");
+    const app = source("app.tsx");
+
+    // 래퍼는 상자를 만들지 않는다 — 있으나 없으나 레이아웃이 같아야 도입 비용이 0이다.
+    expect(layout).toMatch(/\.console-shell-bars \{[^}]*display: contents;/);
+
+    // 게이트 네 곳(마진·밴드 z·축소 투명도 되돌림 둘)이 모두 같은 구조 조건을 쓴다.
+    // :has()는 중첩할 수 없으므로 자식 결합자를 안에 두고 바깥에서 부정한다.
+    const gates = layout.match(/:not\(:has\(\.console-shell-bars > \*\)\)/g) ?? [];
+    expect(gates.length).toBe(4);
+    expect(layout).not.toContain(".console-shell-bars:not(:has(*))");
+
+    // 밴드와 라우트 사이에 흐름 바를 직접 두면 게이트를 우회한다. 그 구간에 남을 수 있는 것은
+    // 흐름 밖 오버레이 레이어와 바 자리뿐이다.
+    const between = app.slice(
+      app.indexOf("<CommandBand"),
+      app.indexOf('<main className="console-route-content"'),
+    );
+    expect(between).not.toBe("");
+    const elementsBetween = [...between.matchAll(/^\s{8}<([A-Za-z][\w.]*)/gm)].map((m) => m[1]);
+    expect(elementsBetween).toEqual(["FloatingWidgetLayer", "div"]);
+    expect(between).toContain('<div className="console-shell-bars">');
+    // 알려진 흐름 바 넷은 그 자리 안에 있어야 한다.
+    for (const bar of ["console-link-banner", "<UpdateCurtain />", "<ControlBar />"]) {
+      expect(between.slice(between.indexOf('<div className="console-shell-bars">'))).toContain(bar);
+    }
+  });
+
   // 텍스트 3티어만 대비를 통제하므로 원료 잉크를 color에 직접 쓰면 판독 하한을 한곳에서 보장할 수 없다.
   it("keeps text color on the semantic three-tier token grammar", () => {
     const violations: string[] = [];


### PR DESCRIPTION
## Summary

라이트 테마에서 리퀴드 글래스 체크박스를 켜고 꺼도 차이가 없다는 보고를 실측으로 확인하고, 원인을 재료 선택으로 규명해 전면 정비했습니다.

**실측된 문제.** 격리 콘솔에서 `data-glass`만 바꿔 같은 프레임을 두 번 캡처했을 때, 라이트 테마의 토글은 크롬 명도를 ΔL\* 1.4~2.1(상대 1.5~2.2%)만 움직였고 캔버스·패널·스크림·터미널은 한 픽셀도 바뀌지 않았습니다. 화면 전체 738,560px 중 6/255 이상 변한 픽셀은 289개였습니다. 같은 표면의 다크는 상대 44.3%로 움직입니다. 밝은 바탕에서는 흰 정반사에 남은 여유가 5.3 L\*뿐이라(모서리 단면 실측: 캔버스 96.1 → 보더 76.2 → 하이라이트 98.9 → 본체 94.7) 명도가 재질을 말할 수 없습니다.

- **채널 4종 신설** — `--glass-bevel`(아래 그늘), `--glass-lift`(접촉+대기 그림자), `--canvas-wash-*`, `--canvas-bloom-*`. 넷 다 닫힌-게이트 기본값이 곧 현행 계약이고, 다크 3종은 재료를 갖지 않아 fallback으로 현행을 그대로 씁니다.
- **whites 유리를 명도가 아니라 색으로** — 틴트의 L과 알파는 출시값 그대로 두고 chroma만 0.005 → 0.015 대역으로 올렸습니다. 명도 대역이 불변이라 본문 대비도 불변입니다(최저 6.27:1).
- **라이트 캔버스에 다크와 같은 채도 예산** — 한랭/온난 극은 `.operations-canvas-sea`에 이미 있던 aurora·brass 라디알의 혼합률로 만듭니다. 베이스 계조에서 hue를 벌리면 보간이 초록을 통과해 종이가 상해 보이는 것을 실측으로 확인했습니다.
- **본문이 밴드 유리 뒤로** — 모든 스크롤 컨테이너 상단이 밴드 하단과 같은 좌표(`top: 44`)라 blur가 항등함수였습니다. 설정 라우트를 밴드 뒤까지 늘려 굴절할 대비를 줍니다. 유리와 같은 세 조건(`@supports`·`prefers-reduced-transparency`·설정) 뒤에 둡니다.
- **누락 표면 1건** — `.command-band-environment-popover`만 `--surface-band` 불투명으로 남아, 밴드에 앵커된 같은 종류의 메뉴 둘이 서로 다른 재질이었습니다.

## Test Plan

- [x] `pnpm typecheck` (워크스페이스 전체)
- [x] `pnpm test` — console 2386 passed / 24 skipped, terminal 플러그인, desktop 302 passed
- [x] `pnpm build` (워크스페이스 전체) · `pnpm check:core-boundary` · `pnpm check:localized-attributes`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 계약 테스트 동시 갱신 — 새 채널 넷의 닫힌-게이트 기본값, 라이트 전용 재료가 정확히 1회만 선언될 것, 라이트 틴트 chroma 하한(8종 ≥ 0.012), rim/bevel 쌍 소비, 환경 팝오버의 유리 채널 소비
- [x] 격리 콘솔 실측 — 라이트 ON/OFF 차이 289px → **27,706px**(6/255 초과). 다크 3종 baseline: maritime 34,281 · carbon 22,946 · instrument 578
- [x] 회귀 검증 — 4테마 × 게이트 2상태의 계산된 유리 채널 25종을 canary 빌드와 대조: **`whites|on`만 변경**(의도한 15개 채널), 나머지 7개 조합은 완전 동일
- [x] 대비 — 유리 5면 × 뒤 배경 2종 × 잉크 3티어 = 30개 조합 전부 AA 통과(최저 6.27:1)
- [x] Move D 실측 — 밴드 뒤로 콘텐츠가 지날 때 밴드 내부 명도 표준편차 0.00 → 5.88, 팝오버 스태킹 정상(`elementFromPoint`가 팝오버 내부)