### PR TITLE
feat(fleet-console): give each dark theme its own Map terrain

### DIFF
--- a/.changelog.d/map-terrain-channel.md
+++ b/.changelog.d/map-terrain-channel.md
@@ -1,0 +1,8 @@
+---
+branch: map-terrain-channel
+---
+
+### fleet-console
+#### Changed
+- Give the Maritime and Carbon dark themes their own Map ground across Cruise, Tactical, and War Room, instead of the single Instrument-shaped field all three dark themes shared. Maritime reads as a chart table with a teal graticule, depth contours, and one warm lamp; Carbon reads as a machined graphite deck with an achromatic lattice, planar light, and a single copper bevel. Instrument keeps its existing Map exactly.
+  ko: 다크 테마 Maritime과 Carbon이 Cruise, Tactical, War Room 세 화면 모두에서 자기 Map 바닥을 갖습니다. 이전에는 다크 3종이 Instrument 형태의 바닥 하나를 함께 썼습니다. Maritime은 청록 경위선과 등심선, 따뜻한 등불 하나로 해도대처럼 읽히고, Carbon은 무채 격자와 평면광, 구리 베벨 하나로 가공된 흑연 갑판처럼 읽힙니다. Instrument의 Map은 그대로입니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-overlays.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-overlays.tsx
@@ -1,3 +1,5 @@
+import { type CSSProperties } from "react";
+
 import { useT } from "../i18n/index.js";
 import { canvasRectToScreen, type CanvasRect, type CanvasViewport } from "./coordinates.js";
 
@@ -13,8 +15,11 @@ export function CanvasGrid({ viewport }: CanvasGridProps) {
         className="operations-canvas-grid"
         style={{
           backgroundPosition: `${viewport.x}px ${viewport.y}px`,
-          backgroundSize: `${48 * viewport.zoom}px ${48 * viewport.zoom}px, ${12 * viewport.zoom}px ${12 * viewport.zoom}px`,
-        }}
+          /* 격자 피치는 테마가 --canvas-weave-major/minor로 소유한다. 여기서 넘기는 것은 줌뿐이고,
+             곱셈은 components.css가 이 요소에서 한다 — 상수를 여기 두면 Map 형상이 Instrument
+             하나로 고정된다. 모드(Tactical·War Room)는 그 CSS가 이 값을 덮어 줌을 따르지 않는다. */
+          "--canvas-weave-zoom": viewport.zoom,
+        } as CSSProperties}
       />
     </div>
   );

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3254,9 +3254,7 @@
 }
 
 .operations-canvas.is-triage {
-  background:
-    radial-gradient(66% 52% at 50% 46%, var(--canvas-wash-mid), var(--canvas-wash-far) 74%),
-    var(--canvas-abyss);
+  background: var(--canvas-field-triage);
   cursor: default;
 }
 
@@ -3274,15 +3272,21 @@
   display: none;
 }
 
+/* 모드 격자는 뷰포트 줌을 따르지 않는다 — 그래서 컴포넌트가 넘긴 --canvas-weave-zoom을
+   여기서 덮어쓴다(구 `background-size: … !important`와 같은 자리, 같은 이유). 성김은 테마
+   피치에 대한 배수로, 진하기는 테마 진하기에 대한 배수로 말해야 테마별 결이 모드에서도 산다.
+   보조 슬롯을 주선 피치로 합치는 것은 연출이다 — 구 단일값 background-size가 모든 레이어에
+   걸리며 만들던 결과이고, 모드의 성긴 판이 그 결과에 기대고 있어 그대로 보존한다.
+   배수는 1.3333이 아니라 calc(4 / 3)이어야 한다: 48 × 1.3333 = 63.9984px이라 여덟 칸째에서
+   누적 반올림이 1px을 넘겨 격자선이 통째로 밀린다(실측 확인). */
 .operations-canvas.is-triage .operations-canvas-grid {
-  opacity: 0.3;
-  background-size: 64px 64px !important;
+  --canvas-weave-zoom: calc(4 / 3) !important;
+  --canvas-weave-minor: var(--canvas-weave-major) !important;
+  opacity: calc(var(--canvas-weave-opacity) * 0.7143);
 }
 
 .operations-canvas.is-formation-view {
-  background:
-    radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-wash-mid) 78%),
-    var(--canvas-abyss);
+  background: var(--canvas-field-formation);
   cursor: default;
 }
 
@@ -3291,8 +3295,9 @@
 }
 
 .operations-canvas.is-formation-view .operations-canvas-grid {
-  opacity: 0.62;
-  background-size: 48px 48px !important;
+  --canvas-weave-zoom: 1 !important;
+  --canvas-weave-minor: var(--canvas-weave-major) !important;
+  opacity: calc(var(--canvas-weave-opacity) * 1.4762);
 }
 
 .operations-canvas-background,
@@ -3303,19 +3308,25 @@
   pointer-events: none;
 }
 
+/* Map의 두 바닥은 테마가 소유한다 — 색만이 아니라 연출까지. 세 다크가 같은 형상 하나를
+   공유하는 동안 Map은 테마를 말하지 못했고, 유리가 굴절할 구조도 없었다(실측: 배경 픽셀
+   평균 색차 0.42~2.44/255). 여기는 채널을 소비만 하며 테마 분기를 갖지 않는다.
+   field는 뷰포트에 고정된 대기라 레이어 수가 자유롭고, weave는 판과 함께 움직이는 격자라
+   주선 2슬롯 + 보조선 2슬롯의 고정 어휘를 쓴다(빈 슬롯은 투명 그라디언트로 채운다). */
 .operations-canvas-sea {
-  background:
-    radial-gradient(ellipse at 48% 42%, color-mix(in oklch, var(--canvas-ambience) 82%, transparent), transparent 38%),
-    radial-gradient(circle at 18% 18%, color-mix(in oklch, var(--aurora) var(--canvas-bloom-aurora), transparent), transparent 34%),
-    radial-gradient(circle at 84% 76%, color-mix(in oklch, var(--brass) var(--canvas-bloom-brass), transparent), transparent 36%),
-    linear-gradient(145deg, var(--canvas-wash-near), var(--canvas-wash-mid) 58%, var(--canvas-wash-far));
+  background: var(--canvas-field);
 }
 
 .operations-canvas-grid {
-  background-image:
-    linear-gradient(color-mix(in oklch, var(--brass) 9%, transparent) 1px, transparent 1px),
-    radial-gradient(circle, color-mix(in oklch, var(--aurora) 11%, transparent) 1px, transparent 1.4px);
-  opacity: 0.42;
+  background-image: var(--canvas-weave);
+  /* 줌 곱셈은 반드시 **이 요소**에서 일어나야 한다. :root 커스텀 속성 값 안에 중첩한 var()는
+     선언 지점인 :root에서 해석되므로, 컴포넌트가 격자 요소에 넘긴 줌을 영원히 보지 못한다. */
+  background-size:
+    calc(var(--canvas-weave-major) * var(--canvas-weave-zoom)) calc(var(--canvas-weave-major) * var(--canvas-weave-zoom)),
+    calc(var(--canvas-weave-major) * var(--canvas-weave-zoom)) calc(var(--canvas-weave-major) * var(--canvas-weave-zoom)),
+    calc(var(--canvas-weave-minor) * var(--canvas-weave-zoom)) calc(var(--canvas-weave-minor) * var(--canvas-weave-zoom)),
+    calc(var(--canvas-weave-minor) * var(--canvas-weave-zoom)) calc(var(--canvas-weave-minor) * var(--canvas-weave-zoom));
+  opacity: var(--canvas-weave-opacity);
 }
 
 .operations-canvas.is-formation-view .canvas-minimap,

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -95,6 +95,37 @@
   --canvas-sea-mid: oklch(10% 0.014 245);
   --canvas-sea-far: oklch(8.5% 0.012 245);
 
+  /* ── Map 지형 채널 ────────────────────────────────────────────────────────
+     Map의 연출은 색과 함께 테마가 소유한다. 이 채널이 생기기 전에는 형상이 components.css와
+     canvas-overlays.tsx에 Instrument 하나로 굳어 있어, 다크 3종이 색만 갈린 같은 판을 썼다.
+     Instrument = SOUNDING(유리 아래 심해 측심): 구형 심도 + 48px 눈금 + 12px 점 격자.
+     weave는 판과 함께 움직이므로 주선 2슬롯 + 보조선 2슬롯의 **고정 어휘**를 지킨다 —
+     레이어 수가 테마마다 달라지면 줌 계산을 컴포넌트가 다시 알아야 한다. 빈 슬롯은
+     투명 그라디언트로 채운다(Instrument는 가로 눈금과 점 격자 둘뿐이라 두 칸이 빈다). */
+  --canvas-weave-major: 48px;
+  --canvas-weave-minor: 12px;
+  --canvas-weave-opacity: 0.42;
+  /* 계조·블룸은 워시/블룸 채널을 통해 읽는다 — 유리 게이트가 라이트에서 이 둘을 재조율하고,
+     채널 기본값이 현행 sea라 게이트가 닫히면 원래 픽셀로 돌아간다. 지형이 채널로 옮겨 와도
+     그 간접은 그대로 유지되어야 한다. */
+  --canvas-field:
+    radial-gradient(ellipse at 48% 42%, color-mix(in oklch, var(--canvas-ambience) 82%, transparent), transparent 38%),
+    radial-gradient(circle at 18% 18%, color-mix(in oklch, var(--aurora) var(--canvas-bloom-aurora), transparent), transparent 34%),
+    radial-gradient(circle at 84% 76%, color-mix(in oklch, var(--brass) var(--canvas-bloom-brass), transparent), transparent 36%),
+    linear-gradient(145deg, var(--canvas-wash-near), var(--canvas-wash-mid) 58%, var(--canvas-wash-far));
+  --canvas-weave:
+    linear-gradient(color-mix(in oklch, var(--brass) 9%, transparent) 1px, transparent 1px),
+    linear-gradient(transparent, transparent),
+    radial-gradient(circle, color-mix(in oklch, var(--aurora) 11%, transparent) 1px, transparent 1.4px),
+    linear-gradient(transparent, transparent);
+  /* 두 모드는 sea 층을 숨기고 캔버스가 직접 칠한다 — 그래서 자기 field를 따로 갖는다. */
+  --canvas-field-formation:
+    radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-wash-mid) 78%),
+    var(--canvas-abyss);
+  --canvas-field-triage:
+    radial-gradient(66% 52% at 50% 46%, var(--canvas-wash-mid), var(--canvas-wash-far) 74%),
+    var(--canvas-abyss);
+
   /* 캐리어 시그니처 색 — 콘솔 팔레트에서 재정의한 provider 정체성 축. */
   --provider-claude: oklch(78% 0.15 62);
   --provider-kimi: oklch(75% 0.15 315);
@@ -422,6 +453,39 @@
   --canvas-sea-mid: oklch(7% 0.015 246);
   --canvas-sea-far: oklch(6% 0.012 250);
 
+  /* Map 지형 = CHART TABLE(해도대). Maritime은 다크 3종 중 채도가 가장 높은 테마이고, 밝은
+     청록(aurora 195)과 진한 호박색(brass 75)이 감청 잉크 위에 얹힌다 — 그 조합이 이미 야간
+     해도대다. 그래서 점 격자가 아니라 두 축의 경위선을 긋고, 중심에서 퍼지는 등심선으로
+     수심을 말하며, 좌상단 램프 하나가 Map에서 유일한 난색이 된다. 대각 심해(145deg) 대신
+     수평에 가까운 168deg를 쓰는 것도 같은 이유다 — 해구가 아니라 수면이어야 한다. */
+  --canvas-weave-major: 96px;
+  --canvas-weave-minor: 32px;
+  --canvas-weave-opacity: 0.5;
+  --canvas-field:
+    radial-gradient(124% 88% at 18% 2%, color-mix(in oklch, var(--brass) 11%, transparent), transparent 54%),
+    repeating-radial-gradient(ellipse 70% 58% at 50% 46%, transparent 0 54px, color-mix(in oklch, var(--aurora) 4.5%, transparent) 54px 55px),
+    radial-gradient(ellipse 84% 68% at 50% 46%, color-mix(in oklch, var(--canvas-sea-core) 94%, transparent), transparent 76%),
+    radial-gradient(96% 74% at 92% 98%, color-mix(in oklch, var(--aurora) 10%, transparent), transparent 58%),
+    linear-gradient(168deg, var(--canvas-wash-near), var(--canvas-wash-mid) 46%, var(--canvas-wash-far));
+  --canvas-weave:
+    linear-gradient(90deg, color-mix(in oklch, var(--aurora) 15%, transparent) 1px, transparent 1px),
+    linear-gradient(color-mix(in oklch, var(--aurora) 15%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in oklch, var(--aurora) 6%, transparent) 1px, transparent 1px),
+    linear-gradient(color-mix(in oklch, var(--aurora) 6%, transparent) 1px, transparent 1px);
+  /* Tactical = 정렬을 위해 치운 해도대. 등불이 띠로 넓어지고 등심선은 걷힌다 — 편대를 놓는
+     판이지 수심을 재는 판이 아니다. */
+  --canvas-field-formation:
+    linear-gradient(to bottom, color-mix(in oklch, var(--brass) 10%, transparent), transparent 28%),
+    radial-gradient(124% 64% at 50% 40%, color-mix(in oklch, var(--canvas-sea-core) 96%, transparent), transparent 78%),
+    radial-gradient(84% 52% at 50% 110%, color-mix(in oklch, var(--aurora) 10%, transparent), transparent 62%),
+    var(--canvas-abyss);
+  /* War Room = 야간 당직. 초점 모드라 밝기를 크게 벌릴 수 없어, 세 테마를 **빛의 자리**로
+     가른다 — Instrument는 가운데 우물, Maritime은 아래 수평선, Carbon은 위 작업등. */
+  --canvas-field-triage:
+    radial-gradient(150% 48% at 50% 114%, color-mix(in oklch, var(--aurora) 12%, transparent), transparent 66%),
+    radial-gradient(98% 36% at 50% 102%, color-mix(in oklch, var(--canvas-sea-core) 66%, transparent), transparent 70%),
+    var(--canvas-abyss);
+
   --surface-glass: oklch(28% 0.04 248 / 60%);
   /* 패널 면은 ink 스케일의 한 칸이 아니다 — deep(20%)과 veil(36%) 사이의 터미널 필드 톤이다. */
   --surface-panel: oklch(23% 0.03 248);
@@ -498,6 +562,38 @@
   --canvas-sea-near: oklch(10% 0.007 255);
   --canvas-sea-mid: oklch(8% 0.006 255);
   --canvas-sea-far: oklch(6% 0.005 258);
+
+  /* Map 지형 = MACHINED DECK(가공 갑판). Carbon의 정체성은 색을 쓰지 않는 것이다 — 잉크
+     스케일 전체가 채도 0.005~0.008이고 구리색 brass 하나만 난색이다. 그래서 눈금을 brass나
+     aurora가 아니라 --ink-rim으로 긋는다: 이 테마에서 그 토큰은 채도 0.005라 격자가 완전히
+     무채가 된다(실측 배경 채도 0.0067 -> 0.0041). 빛도 구형 radial이 아니라 위에서 떨어지는
+     평면광이다 — 작업대 조명이 판을 비추는 방식이지 물속에서 빛이 퍼지는 방식이 아니다. */
+  --canvas-weave-major: 64px;
+  --canvas-weave-minor: 16px;
+  --canvas-weave-opacity: 0.6;
+  --canvas-field:
+    linear-gradient(to bottom, color-mix(in oklch, var(--brass) 9%, transparent), transparent 24%),
+    linear-gradient(to bottom, color-mix(in oklch, var(--canvas-sea-core) 92%, transparent), transparent 58%),
+    linear-gradient(to top, color-mix(in oklch, var(--canvas-wash-far) 92%, transparent), transparent 40%),
+    var(--canvas-abyss);
+  --canvas-weave:
+    linear-gradient(90deg, color-mix(in oklch, var(--ink-rim) 26%, transparent) 1px, transparent 1px),
+    linear-gradient(color-mix(in oklch, var(--ink-rim) 26%, transparent) 1px, transparent 1px),
+    linear-gradient(color-mix(in oklch, var(--ink-rim) 9%, transparent) 1px, transparent 1px),
+    linear-gradient(transparent, transparent);
+  /* Tactical = 조명을 켠 지그판. 평면광을 위아래로 벌려 판 전체를 밝힌다 — 슬롯이 보여야
+     하는 모드다. */
+  --canvas-field-formation:
+    linear-gradient(to bottom, color-mix(in oklch, var(--brass) 9%, transparent), transparent 20%),
+    linear-gradient(to bottom, color-mix(in oklch, var(--canvas-sea-core) 98%, transparent), transparent 66%),
+    linear-gradient(to top, color-mix(in oklch, var(--canvas-wash-far) 90%, transparent), transparent 34%),
+    var(--canvas-abyss);
+  /* War Room = 머리 위 작업등 하나. 상단 띠에서만 빛이 떨어지고 아래는 전부 흑연으로 진다 —
+     Instrument의 가운데 우물과 분포가 최대로 갈리도록 radial이 아니라 선형 띠를 쓴다. */
+  --canvas-field-triage:
+    linear-gradient(to bottom, color-mix(in oklch, var(--brass) 12%, transparent), transparent 16%),
+    linear-gradient(to bottom, color-mix(in oklch, var(--canvas-sea-core) 74%, transparent), transparent 28%),
+    var(--canvas-abyss);
 
   --surface-glass: oklch(25% 0.006 252 / 62%);
   /* 패널 면은 ink 스케일의 한 칸이 아니다 — deep(18%)과 mid(25%) 사이의 터미널 필드 톤이다. */

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -203,6 +203,11 @@ function source(path: string): string {
   return fs.readFileSync(new URL(path, CLIENT_ROOT), "utf8").replace(/\r\n/g, "\n");
 }
 
+/* 선언 스캔용 — 콜론을 담은 주석 한 줄이 팔레트 선언으로 오독되는 것을 막는다. */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
 function externalSource(path: URL): string {
   return fs.readFileSync(path, "utf8");
 }
@@ -641,6 +646,61 @@ describe("Instrument core design contract", () => {
     expect(contextMenu).toContain("menuRef.current?.focus({ preventScroll: true });");
   });
 
+  it("lets each theme own the Map terrain while the canvas CSS stays theme-blind", () => {
+    const components = source("styles/components.css");
+    const theme = source("styles/theme.css");
+    const overlays = source("canvas/canvas-overlays.tsx");
+
+    // Map의 두 바닥은 채널을 소비만 한다 — 연출 리터럴이 여기로 돌아오면 세 다크가 다시 한 판을 쓴다.
+    expect(components).toContain(".operations-canvas-sea {\n  background: var(--canvas-field);\n}");
+    expect(components).toContain(".operations-canvas.is-triage {\n  background: var(--canvas-field-triage);");
+    expect(components).toContain(".operations-canvas.is-formation-view {\n  background: var(--canvas-field-formation);");
+
+    // 줌 곱셈은 격자 요소에서 일어나야 한다: :root 커스텀 속성 안에 중첩한 var()는 선언 지점인
+    // :root에서 해석돼 컴포넌트가 넘긴 줌을 영원히 보지 못한다.
+    // `.operations-canvas-grid`는 위치 선언을 sea와 공유하는 블록에도 등장한다 — 연출 블록만 고른다.
+    const gridBlock = (components.match(/\n\.operations-canvas-grid \{[\s\S]*?\n\}/g) ?? [])
+      .find((block) => block.includes("background-image")) ?? "";
+    expect(gridBlock).toContain("background-image: var(--canvas-weave);");
+    expect(gridBlock).toContain("calc(var(--canvas-weave-major) * var(--canvas-weave-zoom))");
+    expect(gridBlock).toContain("calc(var(--canvas-weave-minor) * var(--canvas-weave-zoom))");
+    expect(gridBlock).toContain("opacity: var(--canvas-weave-opacity);");
+    // 격자 어휘는 주선 2슬롯 + 보조선 2슬롯 고정이다 — 레이어 수가 테마마다 달라지면 줌 계산이 컴포넌트로 샌다.
+    expect(gridBlock.match(/--canvas-weave-major/g)).toHaveLength(4);
+    expect(gridBlock.match(/--canvas-weave-minor/g)).toHaveLength(4);
+
+    // 컴포넌트는 줌만 넘긴다. 피치 상수가 돌아오면 그 자리가 곧 테마 불변성이다.
+    expect(overlays).toContain('"--canvas-weave-zoom": viewport.zoom,');
+    expect(overlays).not.toMatch(/backgroundSize:/);
+
+    // 모드 격자는 줌을 따르지 않고 보조 슬롯을 주선 피치로 합친다.
+    // 배수는 calc(4 / 3)이어야 한다 — 1.3333은 48px 기준 63.9984px이라 여덟 칸째에 1px이 밀린다.
+    const triageGrid = components.match(/\.operations-canvas\.is-triage \.operations-canvas-grid \{[^}]*\}/)?.[0] ?? "";
+    expect(triageGrid).toContain("--canvas-weave-zoom: calc(4 / 3) !important;");
+    expect(triageGrid).toContain("--canvas-weave-minor: var(--canvas-weave-major) !important;");
+    expect(triageGrid).not.toMatch(/1\.3333/);
+    const formationGrid = components.match(/\.operations-canvas\.is-formation-view \.operations-canvas-grid \{[^}]*\}/)?.[0] ?? "";
+    expect(formationGrid).toContain("--canvas-weave-zoom: 1 !important;");
+    expect(formationGrid).toContain("--canvas-weave-minor: var(--canvas-weave-major) !important;");
+
+    // 세 다크가 각자의 지형을 선언한다 — base(Instrument) + maritime + carbon.
+    for (const token of ["--canvas-field:", "--canvas-weave:", "--canvas-field-formation:", "--canvas-field-triage:"]) {
+      expect(theme.match(new RegExp(`\\n  \\${token}`, "g"))).toHaveLength(3);
+    }
+    // Instrument 지형은 오늘의 화면 그대로다 — 이 값이 곧 Instrument 사양이다.
+    const base = theme.slice(0, theme.indexOf(':root[data-theme="'));
+    expect(base).toContain("--canvas-weave-major: 48px;");
+    expect(base).toContain("--canvas-weave-minor: 12px;");
+    expect(base).toContain("--canvas-weave-opacity: 0.42;");
+    // Carbon의 눈금은 신호색이 아니라 무채 --ink-rim이다 — 이 테마의 정체성은 색을 쓰지 않는 것이다.
+    // lastIndexOf여야 한다 — indexOf는 maritime과 carbon이 함께 선 공유 셀렉터를 먼저 집어
+    // Maritime 블록까지 삼킨다(그러면 이 단언이 Maritime의 aurora 눈금을 검사하게 된다).
+    const carbon = theme.slice(theme.lastIndexOf(':root[data-theme="carbon"] {'), theme.indexOf(':root[data-theme="whites"]'));
+    const carbonWeave = carbon.match(/--canvas-weave:[\s\S]*?;\n/)?.[0] ?? "";
+    expect(carbonWeave).toContain("var(--ink-rim)");
+    expect(carbonWeave).not.toMatch(/var\(--(?:brass|aurora)\)/);
+  });
+
   it("keeps the Map canvas out of the keyboard focus order", () => {
     const canvas = source("canvas/canvas.tsx");
     const theme = source("styles/theme.css");
@@ -739,8 +799,8 @@ describe("Instrument core design contract", () => {
     expect(canvas).not.toMatch(/canvas-triage-(?:frame|bracket|hud(?:-eye|-name)?|curtain-kicker|curtain-ruler)/);
     // Formation 판의 중앙은 대기광 채널이, 둘레는 워시 채널이 정한다 — 유리가 굴절할 빛을
     // 패널 뒤에 놓기 위해서다. 두 채널 모두 기본값이 현행 sea라 게이트가 닫히면 원래 픽셀이다.
-    expect(components).toContain("radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-wash-mid) 78%)");
-    expect(components).toContain("background-size: 48px 48px !important;");
+    // 연출 자체는 Map 지형 채널로 옮겨 갔으므로, 이 문장의 근거는 theme.css의 Instrument 사양이 진다.
+    expect(source("styles/theme.css")).toContain("radial-gradient(100% 80% at 50% 42%, var(--canvas-ambience), var(--canvas-wash-mid) 78%)");
     expect(components).toContain(".canvas-formation-guide {");
     // 캡션은 순번을 싣지 않는다 — 번호는 빈 자리를 가리키는 가이드만 진다.
     expect(components).not.toContain(".canvas-operation-formation-slot {");
@@ -2155,7 +2215,8 @@ describe("Instrument core design contract", () => {
     const darkVariantBlocks = theme.match(/^:root\[data-theme="(?:maritime|carbon)"\][^{]*\{[^}]*\}/gm) ?? [];
     expect(darkVariantBlocks).toHaveLength(3);
     for (const block of darkVariantBlocks) {
-      const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
+      // 주석은 선언이 아니다 — 콜론을 담은 설명 한 줄이 팔레트 이탈로 오독되면 안 된다.
+      const declarations = stripComments(block).match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
         expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|glass)[a-z-]*:$/);


### PR DESCRIPTION
## Summary

- Map의 연출이 `components.css`와 `canvas-overlays.tsx`에 Instrument 형상 하나로 굳어 있어, 다크 3종이 색만 갈린 같은 바닥을 썼습니다. 격리 콘솔 실측에서 Cruise·Tactical·War Room 세 뷰 모두 배경 픽셀 평균 색차가 **0.42~2.44 / 255**였고, 리퀴드 글래스가 굴절할 구조도 없었습니다.
- 연출을 테마가 이미 소유한 `--canvas-*` 채널로 옮겼습니다. field는 뷰포트 고정 대기라 레이어 수가 자유롭고, weave는 판과 함께 움직이는 격자라 **주선 2슬롯 + 보조선 2슬롯 고정 어휘**를 지켜 줌 계산이 CSS에 남습니다. `components.css`는 테마 분기 없이 채널만 소비하고, 컴포넌트는 줌만 넘깁니다.
- **Instrument는 오늘의 Map 그대로**입니다(배경 구역 변경 픽셀: Cruise 0/85,200, Tactical 0/101,200, War Room 151/101,200 최대 5 — War Room 잔차는 9초 주기 스캔선). Maritime은 해도대, Carbon은 가공 갑판이 되고 분리도가 1.4~9.2배로 올라갑니다.

### 배경 픽셀 평균 색차 (255단계, 동일 빌드 파이프라인 실측)

| 대조 | Cruise | Tactical | War Room |
|---|---|---|---|
| Instrument ↔ Maritime | 2.44 → **3.67** (1.5배) | 1.68 → **3.37** (2.0배) | 1.70 → **2.44** (1.4배) |
| Instrument ↔ Carbon | 1.96 → **5.79** (3.0배) | 1.91 → **4.32** (2.3배) | 1.75 → 2.00 (1.1배) |
| Maritime ↔ Carbon | 1.04 → **5.17** (5.0배) | 2.39 → **3.83** (1.6배) | **0.42 → 3.83** (9.2배) |

가장 붕괴돼 있던 칸은 War Room의 Maritime ↔ Carbon(0.42/255)이고, 가장 개선이 작은 칸은 War Room의 Instrument ↔ Carbon(1.1배)입니다. 초점 모드라 밝기를 크게 벌릴 수 없어 세 테마를 **빛의 자리**로 갈랐습니다 — Instrument는 가운데 우물, Maritime은 아래 수평선, Carbon은 위 작업등.

### 실측으로 확인한 구현 함정 3가지

- 줌 곱셈은 **격자 요소**에서 일어나야 합니다. `:root` 커스텀 속성 값 안에 중첩한 `var()`는 선언 지점인 `:root`에서 해석돼 컴포넌트가 넘긴 줌을 영원히 보지 못합니다.
- 성김 배수는 `1.3333`이 아니라 `calc(4 / 3)`이어야 합니다. 48 × 1.3333 = `63.9984px`이라 여덟 칸째에서 누적 반올림이 1px을 넘겨 War Room 격자선이 통째로 밀립니다.
- 모드 오버라이드는 보조 슬롯을 주선 피치로 합칩니다. 구 단일값 `background-size`가 모든 레이어에 걸리며 만들던 결과이고, 오늘의 성긴 모드 판이 거기 기대고 있어 **의도적으로 보존**했습니다. 재현하지 않으면 Instrument War Room이 5.53% 변합니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console test` — 192 파일 통과, 2387 테스트 통과 / 24 skip, 실패 0
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 4 fragment 검증 통과
- [x] 헤디드 실측: 격리 콘솔(전용 데이터 디렉토리)에서 동일 빌드 파이프라인으로 변경 전/후를 각각 빌드해 3테마 × 3뷰 = 9장 캡처 후 픽셀 비교. Instrument 불변 및 위 분리도 표 확인
- [x] 디자인 계약: `tests/instrument-design-contract.test.ts`에 Map 지형 채널 문법을 함께 고정(연출 리터럴 복귀 차단, 슬롯 어휘 4칸, 줌 곱셈 위치, `calc(4 / 3)`, Carbon 무채 눈금)