### PR TITLE
fix(fleet-console): let the Settings theme preview fill its column

### DIFF
--- a/.changelog.d/settings-theme-preview-balance.md
+++ b/.changelog.d/settings-theme-preview-balance.md
@@ -1,0 +1,8 @@
+---
+branch: settings-theme-preview-balance
+---
+
+### fleet-console
+#### Fixed
+- The console preview in Settings -> Appearance now runs the full height of the theme controls beside it, instead of sitting as a small box pinned to the top of its column with a third of that column empty. The preview terminal fills the taller frame and the floating menu stays over its output, so liquid glass still reads as glass.
+  ko: 설정 -> 겉모습의 콘솔 미리보기가 옆의 테마 컨트롤과 같은 높이로 섭니다. 예전에는 작은 상자가 열 꼭대기에 붙고 그 아래 3분의 1이 늘 비어 있었습니다. 커진 프레임은 터미널이 채우고 떠 있는 메뉴는 그 글줄 위에 남아, 리퀴드 글래스가 계속 유리로 읽힙니다.

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -537,18 +537,32 @@ function AppearancePreview() {
               <p className="appearance-preview-panel-title">{t("settings.preview.panel.title")}</p>
               <p className="appearance-preview-panel-value">{t("settings.preview.panel.value")}</p>
             </div>
-            <pre className="appearance-preview-terminal">
-              <span className="is-prompt">$</span> fleet status{"\n"}
-              <span className="is-good">ready</span> 3 operations{"\n"}
-              <span className="is-busy">running</span> rebuild-index{"\n"}
-              <span className="is-prompt">$</span> fleet logs
-            </pre>
+            {/* 글줄은 프레임 높이보다 넉넉히 둔다 — 넘친 줄은 흐려지며 잘리므로, 축소판이
+                자라도 터미널이 반쯤 빈 상자로 보이지 않는다. */}
+            <div className="appearance-preview-terminal-slot">
+              <div className="appearance-preview-terminal">
+                <pre className="appearance-preview-terminal-flow">
+                  <span className="is-prompt">$</span> fleet status{"\n"}
+                  <span className="is-good">ready</span> 3 operations{"\n"}
+                  <span className="is-busy">running</span> rebuild-index{"\n"}
+                  <span className="is-prompt">$</span> fleet logs rebuild-index{"\n"}
+                  scan 2481 files{"\n"}
+                  index 18 packages{"\n"}
+                  <span className="is-warn">warn</span> 2 stale entries{"\n"}
+                  <span className="is-good">done</span> in 6.4s{"\n"}
+                  <span className="is-prompt">$</span> fleet open rebuild-index{"\n"}
+                  attach terminal{"\n"}
+                  watch 4 sources{"\n"}
+                  sync repository
+                </pre>
+              </div>
+              {/* 겹침이 핵심이다 — 이 메뉴가 터미널 글줄 위에 떠 있어야 유리가 읽힌다. */}
+              <div className="appearance-preview-menu">
+                <p>{t("settings.preview.menu.first")}<span>↵</span></p>
+                <p>{t("settings.preview.menu.second")}<span>F2</span></p>
+              </div>
+            </div>
           </div>
-        </div>
-        {/* 겹침이 핵심이다 — 이 메뉴가 터미널 위에 떠 있어야 유리가 읽힌다. */}
-        <div className="appearance-preview-menu">
-          <p>{t("settings.preview.menu.first")}<span>↵</span></p>
-          <p>{t("settings.preview.menu.second")}<span>F2</span></p>
         </div>
       </div>
       <figcaption>{t("settings.preview.caption.help")}</figcaption>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -439,12 +439,15 @@
 .settings-scope.is-sessions i { background: var(--aurora); }
 
 /* 겉모습은 고르는 자리에서 보여야 한다. 컨트롤과 축소판이 한 행에 서고, 좁아지면 축소판이
-   컨트롤 아래로 내려간다. */
+   컨트롤 아래로 내려간다.
+
+   축소판은 컨트롤 열의 높이를 그대로 받는다(align-items 기본값 stretch). 예전에는 208px
+   프레임이 열 꼭대기에 못박혀 폭과 무관하게 아래 126px가 늘 비었고, 바로 아래 타이포그래피
+   카드의 같은 문법(글꼴 목록과 미리보기가 같은 높이)과도 어긋났다. */
 .appearance-split {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 340px);
   gap: var(--space-5);
-  align-items: start;
 }
 
 .appearance-controls {
@@ -455,6 +458,7 @@
 
 .appearance-preview {
   display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
   gap: var(--space-2);
   margin: 0;
   min-width: 0;
@@ -556,10 +560,12 @@
   font-weight: var(--weight-medium);
 }
 
+/* 터미널이 남는 높이를 흡수한다 — 패널은 제 크기를 지키고, 프레임이 자라도 빈 바닥이
+   생기지 않는다. */
 .appearance-preview-stage {
   display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 6px;
-  align-content: start;
   min-width: 0;
 }
 
@@ -588,28 +594,49 @@
   line-height: 1.3;
 }
 
+/* 떠 있는 메뉴는 이 칸을 기준으로 앉는다. 프레임 바닥이 아니라 터미널 글줄 위여야 뒤가
+   비지 않고, 그래야 블러가 블러로 보인다. */
+.appearance-preview-terminal-slot {
+  position: relative;
+  display: grid;
+  min-height: 0;
+}
+
 .appearance-preview-terminal {
-  margin: 0;
+  position: relative;
   overflow: hidden;
-  padding: 7px 8px;
+  min-height: 0;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-abyss) 72%, transparent);
+}
+
+/* 글줄은 흐름에서 빼 둔다. 흐름 안에 두면 줄 수가 프레임의 최소 높이를 정해 버리고,
+   "축소판은 컨트롤 열 높이를 따른다"는 규칙이 글줄 수와의 우연에 기대게 된다.
+   마스킹도 상자가 아니라 글줄에만 건다 — 상자째 흐리면 테두리와 바탕까지 사라진다.
+   덕분에 높이가 얼마든 터미널은 차 있는 것처럼 보이고, 넘친 줄은 잘린 글자 대신 사그라든다. */
+.appearance-preview-terminal-flow {
+  position: absolute;
+  inset: 7px 8px;
+  margin: 0;
   color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: calc(var(--font-body-size) - 3px);
   line-height: 1.7;
   white-space: pre;
+  mask-image: linear-gradient(to bottom, oklch(0% 0 0) calc(100% - 18px), transparent);
+  -webkit-mask-image: linear-gradient(to bottom, oklch(0% 0 0) calc(100% - 18px), transparent);
 }
 
-.appearance-preview-terminal .is-prompt { color: var(--brass-bright); }
-.appearance-preview-terminal .is-good { color: var(--positive); }
-.appearance-preview-terminal .is-busy { color: var(--aurora); }
+.appearance-preview-terminal-flow .is-prompt { color: var(--brass-bright); }
+.appearance-preview-terminal-flow .is-good { color: var(--positive); }
+.appearance-preview-terminal-flow .is-busy { color: var(--aurora); }
+.appearance-preview-terminal-flow .is-warn { color: var(--warn); }
 
 .appearance-preview-menu {
   position: absolute;
-  right: 10px;
-  bottom: 18px;
+  top: 26px;
+  right: 6px;
   z-index: 2;
   display: grid;
   gap: 3px;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -841,6 +841,38 @@ describe("Instrument core design contract", () => {
     expect(css).toMatch(/\.fc-btn--primary \{[^}]*color: var\(--text-on-brass\);/);
   });
 
+  /* 겉모습 축소판은 자기가 고르게 하는 화면을 대신 보여 준다. 계약은 둘이다. 축소판은 컨트롤
+     열의 높이를 따라야 하고(예전에는 208px 프레임이 열 꼭대기에 못박혀 폭과 무관하게 아래
+     126px가 늘 비었다 — 바로 아래 타이포그래피 카드의 목록/미리보기 동일 높이 문법과도 어긋난다),
+     떠 있는 메뉴는 터미널 글줄 위에 얹혀야 한다(유리 뒤가 비면 backdrop-filter는 블러 없음과
+     똑같은 픽셀을 그린다). */
+  it("lets the appearance preview follow its controls column and keep glass over text", () => {
+    const components = source("styles/components.css");
+    const settings = source("pages/global-settings.tsx");
+    const split = components.match(/\.appearance-split \{[^}]*\}/)?.[0] ?? "";
+    const preview = components.match(/\.appearance-preview \{[^}]*\}/)?.[0] ?? "";
+    const stage = components.match(/\.appearance-preview-stage \{[^}]*\}/)?.[0] ?? "";
+    const flow = components.match(/\.appearance-preview-terminal-flow \{[^}]*\}/)?.[0] ?? "";
+    const menu = components.match(/\.appearance-preview-menu \{[^}]*\}/)?.[0] ?? "";
+
+    // 상단 고정이 곧 예전 결함이다 — 열이 아무리 길어져도 축소판만 제 크기로 남았다.
+    expect(split).not.toContain("align-items: start;");
+    expect(preview).toContain("grid-template-rows: minmax(0, 1fr) auto;");
+    // 남는 높이는 터미널이 흡수한다 — 패널이 늘어나면 두 줄짜리 카드가 빈 상자가 된다.
+    expect(stage).toContain("grid-template-rows: auto minmax(0, 1fr);");
+    expect(stage).not.toContain("align-content: start;");
+    // 글줄은 흐름 밖에 둔다. 흐름 안이면 줄 수가 프레임의 최소 높이를 정해 버려 위 규칙이
+    // "컨트롤 열 높이"가 아니라 "글줄 수와의 우연"에 기대게 된다.
+    expect(flow).toContain("position: absolute;");
+    expect(flow).toContain("mask-image: linear-gradient(to bottom, oklch(0% 0 0) calc(100% - 18px), transparent);");
+    // 메뉴는 프레임 바닥이 아니라 터미널 칸을 기준으로 앉는다 — 바닥에 매달면 프레임이 자랄수록
+    // 글줄에서 멀어져 빈 바탕 위로 떠오르고, 그때 유리는 유리로 읽히지 않는다.
+    expect(settings).toContain('<div className="appearance-preview-terminal-slot">');
+    expect(menu).toContain("position: absolute;");
+    expect(menu).toContain("top: 26px;");
+    expect(menu).not.toContain("bottom:");
+  });
+
   // 다크 유리의 판독 계약 — 유리 뒤가 앱에서 가장 어두운 캔버스라 투과는 명도를 빼기만 한다.
   it("keeps the dark glass pane lit and the terminal field single-layered", () => {
     const components = source("styles/components.css");


### PR DESCRIPTION
## Summary
- 설정 → 겉모습 카드의 콘솔 미리보기가 옆 컨트롤 열과 같은 높이로 선다. 실측상 208px 프레임이 열 꼭대기에 고정돼 폭(1200/1440/1920)과 무관하게 아래 126px — 열의 33% — 가 늘 비어 있었고, 바로 아래 타이포그래피 카드의 `목록 | 미리보기` 분할(391/391 동일 높이)과도 문법이 어긋나 있었다.
- 남는 높이는 터미널이 흡수한다. 글줄은 흐름 밖(`position: absolute`)에 두어 줄 수가 프레임의 최소 높이를 정하지 못하게 했고, 넘친 꼬리는 글자가 잘리는 대신 마스크로 사그라든다 — 프레임이 어떤 높이든 터미널이 차 보인다.
- 떠 있는 메뉴를 프레임 바닥이 아니라 터미널 칸 기준으로 앉혔다. 프레임이 자라면 바닥 고정 메뉴는 글줄에서 멀어져 빈 바탕 위로 떠오르고, 그 순간 backdrop-filter는 블러 없음과 똑같은 픽셀을 그린다.
- 두 구조 규칙(축소판=컨트롤 열 높이, 메뉴=글줄 위)을 `instrument-design-contract` 테스트에 고정했다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 192 파일 / 2390 통과, 1 스킵
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과 (boundary guard 포함)
- [x] `pnpm check:localized-attributes`, `pnpm check:core-boundary` — 위반 없음
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 프래그먼트 1건 검증
- [x] 신설 계약 단언 red 확인 — `align-items: start` 복구 시 1 failed, 원복 후 87 passed
- [x] 격리 Console 헤드리스 실측 — 1680/1200 두 열 레이아웃에서 미리보기 열 378px = 컨트롤 열 378px, 아래 공백 0px(이전 126px), 프레임 340×334
- [x] 접힘 레이아웃(1100) — 프레임 420×208 유지, 터미널 5줄 + 페이드, 페이지 오류 0
- [x] 테마 4종(Instrument·Maritime·Carbon·Whites) 및 리퀴드 글래스 ON/OFF 스크린샷 확인 — 메뉴가 모든 상태에서 글줄 위 유지