### PR TITLE
feat(fleet-console): make the focused panel stand out on the Map

### DIFF
--- a/.changelog.d/panel-focus-visibility.md
+++ b/.changelog.d/panel-focus-visibility.md
@@ -1,0 +1,8 @@
+---
+branch: panel-focus-visibility
+---
+
+### fleet-console
+#### Changed
+- Make the focused panel stand out on the Map. The panel holding keyboard focus now carries a deeper caption wash and sits one step above the board, while the other panels' captions and names step back toward the canvas - so moving focus with the arrow shortcuts is visible where the panels are, not only in the sidebar. Panels recede only while a panel is focused, and their status rails and terminal bodies stay untouched.
+  ko: Map에서 포커스한 패널이 눈에 띄게 했습니다. 키보드 포커스를 가진 패널은 캡션 워시가 진해지고 한 단 올라서며, 나머지 패널의 캡션과 이름은 캔버스 쪽으로 물러납니다. 화살표 단축키로 포커스를 옮길 때 사이드바가 아니라 패널이 있는 자리에서 그 변화가 보입니다. 후퇴는 포커스한 패널이 있을 때만 일어나고, 상태 레일과 터미널 본문은 그대로 둡니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4094,8 +4094,8 @@
   box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent);
 }
 
-/* 겨눈 카드의 캡션은 포커스 패널과 같은 워시를 입는다 — 새 값이 아니라
-   .canvas-operation.is-active > .canvas-operation-titlebar와 같은 한 값이다. */
+/* 겨눈 카드의 캡션은 같은 brass 워시를 옅게 입는다. 포커스(28%)보다 낮은 10%인 것은
+   제어 문법의 hover < selected 위계 그대로다 — 겨눔은 지목이지 자리가 아니다. */
 .canvas-triage-deck-cell:hover .canvas-operation.is-deck-tile > .canvas-operation-titlebar,
 .canvas-triage-deck-cell:has(> .canvas-triage-deck-pick:focus-visible) .canvas-operation.is-deck-tile > .canvas-operation-titlebar {
   background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption));
@@ -5073,7 +5073,17 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .canvas-operation.is-running,
 .canvas-operation.is-unseen {
   border-color: var(--surface-rim);
-  box-shadow: var(--shadow-soft);
+  /* box-shadow는 베이스가 이미 소유한다. 여기서 --shadow-soft만 다시 적으면 유리 rim·bevel
+     inset이 함께 지워져, 상태가 켜지거나 포커스를 받은 패널만 윗변 광택을 잃었다(실측:
+     inset 16% → 6%). 이 규칙이 되돌려야 할 것은 옛 상시 aura의 색이지 유리의 두께가 아니다. */
+}
+
+/* 포커스한 패널은 한 단 올라선다 — 채움이 닿지 못하는 몫을 깊이가 진다. 어두운 테마에서
+   접지 그림자는 거의 보이지 않지만, 라이트 테마에서는 이 한 단이 채움보다 크게 읽힌다.
+   중립 rim 블록보다 뒤에 서서, 진행 중인 패널이 포커스를 받아도 깊이는 포커스가 소유한다.
+   색은 하나도 쓰지 않으므로 상태 채널과 겹칠 자리가 없다. */
+.canvas-operation.is-active {
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--shadow-floating);
 }
 
 /* 상태 레일 색 — OperationActivity 매핑 축(.tenant-beacon 선언)과 같은 토큰을 쓴다.
@@ -6347,15 +6357,37 @@ body[data-side-bar-animating="true"] .canvas-operation {
    믹스는 oklab이다 — oklch는 hue를 극좌표 호로 보간해 brass(78)와 ink-rim(245)의 62% 믹스가
    hue 141(초록)에 착지했고, 위치 채널이 신호 채널 positive(160) 옆에 앉았다.
    워시는 캡션만 진다. 채팅·터미널 본문은 --surface-panel에 남아, 포커스가 로그 전체를
-   다른 면으로 다시 칠하지 않는다. */
+   다른 면으로 다시 칠하지 않는다.
+   비율은 28%다. 10%는 실측에서 포커스/비포커스 캡션의 실렌더 대비가 1.14:1이었다 —
+   상태 표시가 인접색과 가져야 할 3:1의 절반에도 못 미쳐, 단축키로 패널을 옮겨도 캔버스에서
+   무엇이 바뀌었는지 보이지 않았다. 28%는 같은 측정에서 1.67:1이다. 그 위(50% = 3.01:1)로는
+   캡션이 금색 판이 되어 바로 아랫변의 warn 레일과 한 덩어리로 읽힌다 — 채움 채널의 상한은
+   기준선이 아니라 상태 채널과의 거리가 정한다. 남는 몫은 주변 후퇴가 진다. */
 .canvas-operation.is-active > .canvas-operation-titlebar {
-  background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption));
+  background: color-mix(in oklab, var(--brass) 28%, var(--glass-tint-caption));
   /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
   background-clip: padding-box;
 }
 
 .canvas-operation.is-active > .canvas-operation-titlebar .canvas-operation-identity-name {
   color: var(--text-primary);
+}
+
+/* 주변 후퇴 — 무대에 포커스가 서 있을 때만 나머지 캡션이 바탕 쪽으로 물러난다.
+   :has() 게이트가 없으면 포커스가 없는 화면에서도 모든 캡션이 어두워져, 물러설 기준이 없는
+   상태에서 기본 모습만 바뀐다. 후퇴는 캡션 면과 이름까지다 — 본문(터미널·채팅 로그)은 건드리지
+   않는다. 곁의 패널을 읽는 일은 포커스와 무관하게 계속된다. 상태 레일(::after)도 그대로 둔다:
+   비포커스 패널의 진행이 0픽셀이 되던 옛 실패로 되돌아가는 길이다.
+   덱 타일은 빠진다 — 카드의 위치 마크는 칸(.canvas-triage-deck-cell)이 이미 소유한다. */
+.operations-canvas:has(.canvas-operation.is-active) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar {
+  background: color-mix(in oklab, var(--canvas-abyss) 34%, var(--glass-tint-caption));
+  background-clip: padding-box;
+}
+
+/* 이름은 한 티어 내려간다. :hover 제외가 없으면 이 규칙이 특이도로 이름의 hover를 이겨,
+   비포커스 패널에서는 이름 위에 마우스를 얹어도 아무 반응이 없다(이름은 클릭하면 편집이다). */
+.operations-canvas:has(.canvas-operation.is-active) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar .canvas-operation-identity-name:not(:hover) {
+  color: var(--text-tertiary);
 }
 
 /* 캡션 아랫변 = 상태 채널. 포커스는 채움이 말하므로 선은 상태 하나만 소유한다. */

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6382,15 +6382,20 @@ body[data-side-bar-animating="true"] .canvas-operation {
    상태에서 기본 모습만 바뀐다. 후퇴는 캡션 면과 이름까지다 — 본문(터미널·채팅 로그)은 건드리지
    않는다. 곁의 패널을 읽는 일은 포커스와 무관하게 계속된다. 상태 레일(::after)도 그대로 둔다:
    비포커스 패널의 진행이 0픽셀이 되던 옛 실패로 되돌아가는 길이다.
-   덱 타일은 빠진다 — 카드의 위치 마크는 칸(.canvas-triage-deck-cell)이 이미 소유한다. */
-.operations-canvas:has(.canvas-operation.is-active) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar {
+   덱 타일은 후퇴 대상에서도, 게이트에서도 빠진다 — 카드의 위치 마크는
+   칸(.canvas-triage-deck-cell)이 소유하므로 카드는 표식을 받지 않고, 표식을 받지 않는 것은
+   남들을 물러서게 할 자격도 없다. 게이트가 표식보다 넓으면 아무것도 앞으로 나서지 않은 채
+   무대만 어두워진다: 대기 큐가 비어 있지 않으면 enterTriage가 활성 id를 카드에 남기고
+   (triage-store.ts), 무대의 자동 포커스는 모달·투어가 떠 있던 프레임에서 한 번 걸러지면
+   캐시 때문에 다시 시도되지 않는다(canvas.tsx). 게이트와 표식은 같은 것을 가리켜야 한다. */
+.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar {
   background: color-mix(in oklab, var(--canvas-abyss) 34%, var(--glass-tint-caption));
   background-clip: padding-box;
 }
 
 /* 이름은 한 티어 내려간다. :hover 제외가 없으면 이 규칙이 특이도로 이름의 hover를 이겨,
    비포커스 패널에서는 이름 위에 마우스를 얹어도 아무 반응이 없다(이름은 클릭하면 편집이다). */
-.operations-canvas:has(.canvas-operation.is-active) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar .canvas-operation-identity-name:not(:hover) {
+.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar .canvas-operation-identity-name:not(:hover) {
   color: var(--text-tertiary);
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5081,8 +5081,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
 /* 포커스한 패널은 한 단 올라선다 — 채움이 닿지 못하는 몫을 깊이가 진다. 어두운 테마에서
    접지 그림자는 거의 보이지 않지만, 라이트 테마에서는 이 한 단이 채움보다 크게 읽힌다.
    중립 rim 블록보다 뒤에 서서, 진행 중인 패널이 포커스를 받아도 깊이는 포커스가 소유한다.
-   색은 하나도 쓰지 않으므로 상태 채널과 겹칠 자리가 없다. */
-.canvas-operation.is-active {
+   색은 하나도 쓰지 않으므로 상태 채널과 겹칠 자리가 없다.
+   덱 타일은 워시와 함께 여기서도 빠진다 — 카드의 위치 마크는 칸이 소유한다. 활성 Operation이
+   덱에 남는 경로가 실제로 있다: 대기 큐가 비어 있지 않으면 enterTriage가 활성 id를 지우지 않고
+   돌아가므로(triage-store.ts), 대기가 아닌 활성 패널은 무대로 오르지도, 활성 표식을 놓지도 못한
+   채 카드가 된다. 그 카드만 부양하면 칸의 링 문법이 두 개로 갈린다. */
+.canvas-operation.is-active:not(.is-deck-tile) {
   box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--shadow-floating);
 }
 
@@ -6363,7 +6367,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
    무엇이 바뀌었는지 보이지 않았다. 28%는 같은 측정에서 1.67:1이다. 그 위(50% = 3.01:1)로는
    캡션이 금색 판이 되어 바로 아랫변의 warn 레일과 한 덩어리로 읽힌다 — 채움 채널의 상한은
    기준선이 아니라 상태 채널과의 거리가 정한다. 남는 몫은 주변 후퇴가 진다. */
-.canvas-operation.is-active > .canvas-operation-titlebar {
+.canvas-operation.is-active:not(.is-deck-tile) > .canvas-operation-titlebar {
   background: color-mix(in oklab, var(--brass) 28%, var(--glass-tint-caption));
   /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
   background-clip: padding-box;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6393,9 +6393,13 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background-clip: padding-box;
 }
 
-/* 이름은 한 티어 내려간다. :hover 제외가 없으면 이 규칙이 특이도로 이름의 hover를 이겨,
-   비포커스 패널에서는 이름 위에 마우스를 얹어도 아무 반응이 없다(이름은 클릭하면 편집이다). */
-.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar .canvas-operation-identity-name:not(:hover) {
+/* 이름은 한 티어 내려간다. 제외가 없으면 이 규칙이 특이도로 이름의 hover를 이겨, 비포커스
+   패널에서는 이름 위에 마우스를 얹어도 아무 반응이 없다(이름은 클릭하면 편집이다).
+   :focus-visible도 같은 이유로 함께 빠진다 — 그 초대는 마우스만의 것이 아니다. 이름의
+   focus-visible 규칙은 brass 아웃라인만 그리고 색은 건드리지 않아, 이 규칙을 그대로 두면
+   키보드로 이름에 닿은 사용자만 물러난 색에 머문다. 링은 어디에 있는지를 말하고 색은 무엇을
+   할 수 있는지를 말하므로, 두 입력 수단이 같은 초대를 받아야 한다. */
+.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar .canvas-operation-identity-name:not(:hover):not(:focus-visible) {
   color: var(--text-tertiary);
 }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2998,11 +2998,11 @@ describe("Instrument core design contract", () => {
     // 포커스는 선을 쓰지 않는다: 상태 레일과 같은 굵기의 brass 선이 캡션 위아래에 겹치면
     // warn과 brass가 한 덩어리 금색으로 읽힌다. 워시는 캡션만 진다 — 채팅 본문까지
     // 따라가면 활성 패널 전체가 다른 면으로 바뀐다.
-    expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar {");
+    expect(components).toContain(".canvas-operation.is-active:not(.is-deck-tile) > .canvas-operation-titlebar {");
     // 워시는 28%다. 10%는 실렌더 대비 1.14:1로 상태 표시의 3:1에 크게 못 미쳤고, 50%(3.01:1)는
     // 캡션을 금색 판으로 만들어 아랫변 warn 레일과 한 덩어리가 된다. 채움의 상한은 기준선이
     // 아니라 상태 채널과의 거리가 정하므로, 나머지 몫은 주변 후퇴와 융기가 나눠 진다.
-    const focusWash = components.match(/\.canvas-operation\.is-active > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
+    const focusWash = components.match(/\.canvas-operation\.is-active:not\(\.is-deck-tile\) > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
     expect(focusWash).toContain("background: color-mix(in oklab, var(--brass) 28%, var(--glass-tint-caption));");
     expect(focusWash).toContain("background-clip: padding-box;");
     // 후퇴는 무대에 포커스가 설 때만 일어난다 — :has() 게이트가 빠지면 포커스 없는 화면의
@@ -3016,10 +3016,14 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".canvas-operation-identity-name:not(:hover) {");
     // 포커스의 깊이는 색을 하나도 쓰지 않는다 — 상태 채널과 겹칠 자리가 없다. 중립 rim 블록보다
     // 뒤에 서서, 진행 중인 패널이 포커스를 받아도 깊이는 포커스가 소유한다.
-    const lift = components.match(/\n\.canvas-operation\.is-active \{[^}]*\}/)?.[0] ?? "";
+    const lift = components.match(/\n\.canvas-operation\.is-active:not\(\.is-deck-tile\) \{[^}]*\}/)?.[0] ?? "";
     expect(lift).toContain("var(--shadow-floating)");
     expect(lift).toContain("inset 0 1px 0 var(--glass-rim)");
     expect(lift).not.toMatch(/--(?:brass|warn|aurora|positive|coral)\b/);
+    // 덱 타일은 워시와 부양 둘 다에서 빠진다 — 카드의 위치 마크는 칸이 소유하고, 대기 큐가 비어
+    // 있지 않으면 enterTriage가 활성 id를 그대로 두어 활성 Operation이 카드로 남는 경로가 있다.
+    expect(components).not.toMatch(/\n\.canvas-operation\.is-active \{/);
+    expect(components).not.toMatch(/\.canvas-operation\.is-active > \.canvas-operation-titlebar \{/);
     // 중립 rim 블록은 색만 되돌린다. box-shadow를 다시 적으면 유리 rim·bevel inset이 함께
     // 지워져 상태가 켜진 패널만 윗변 광택을 잃는다(실측 inset 16% → 6%).
     const neutralRim = components.match(/\.canvas-operation\.is-active,\n\.canvas-operation\.is-running,\n\.canvas-operation\.is-unseen \{[^}]*\}/)?.[0] ?? "";

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -3008,7 +3008,7 @@ describe("Instrument core design contract", () => {
     // 후퇴는 무대에 포커스가 설 때만 일어난다 — :has() 게이트가 빠지면 포커스 없는 화면의
     // 기본 캡션까지 어두워진다. 본문과 상태 레일은 후퇴에서 빠지고, 덱 타일도 빠진다
     // (카드의 위치 마크는 칸이 소유한다).
-    const recede = components.match(/\.operations-canvas:has\(\.canvas-operation\.is-active\) \.canvas-operation:not\(\.is-active\):not\(\.is-deck-tile\) > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
+    const recede = components.match(/\.operations-canvas:has\(\.canvas-operation\.is-active:not\(\.is-deck-tile\)\) \.canvas-operation:not\(\.is-active\):not\(\.is-deck-tile\) > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
     expect(recede).toContain("background: color-mix(in oklab, var(--canvas-abyss) 34%, var(--glass-tint-caption));");
     expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*> \.canvas-operation-titlebar::after \{/);
     expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*\.canvas-operation-terminal \{/);
@@ -3024,6 +3024,10 @@ describe("Instrument core design contract", () => {
     // 있지 않으면 enterTriage가 활성 id를 그대로 두어 활성 Operation이 카드로 남는 경로가 있다.
     expect(components).not.toMatch(/\n\.canvas-operation\.is-active \{/);
     expect(components).not.toMatch(/\.canvas-operation\.is-active > \.canvas-operation-titlebar \{/);
+    // 게이트는 표식보다 넓어선 안 된다. 표식을 받지 않는 카드가 후퇴를 발화시키면 아무것도
+    // 앞으로 나서지 않은 채 무대만 어두워진다 — 활성 카드는 실제로 남는다(triage-store.ts의
+    // 조기 반환 + canvas.tsx의 무대 자동 포커스 1회 캐시).
+    expect(components).not.toMatch(/\.operations-canvas:has\(\.canvas-operation\.is-active\)/);
     // 중립 rim 블록은 색만 되돌린다. box-shadow를 다시 적으면 유리 rim·bevel inset이 함께
     // 지워져 상태가 켜진 패널만 윗변 광택을 잃는다(실측 inset 16% → 6%).
     const neutralRim = components.match(/\.canvas-operation\.is-active,\n\.canvas-operation\.is-running,\n\.canvas-operation\.is-unseen \{[^}]*\}/)?.[0] ?? "";

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -3012,8 +3012,11 @@ describe("Instrument core design contract", () => {
     expect(recede).toContain("background: color-mix(in oklab, var(--canvas-abyss) 34%, var(--glass-tint-caption));");
     expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*> \.canvas-operation-titlebar::after \{/);
     expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*\.canvas-operation-terminal \{/);
-    // 이름 티어 하강은 hover를 이기면 안 된다 — 이름은 클릭하면 편집이라 hover가 곧 그 초대다.
-    expect(components).toContain(".canvas-operation-identity-name:not(:hover) {");
+    // 이름 티어 하강은 편집 초대를 이기면 안 된다 — 이름은 눌러서 고치는 자리다. hover만 빼면
+    // 그 초대가 마우스만의 것이 된다: 이름의 focus-visible 규칙은 아웃라인만 그리고 색은
+    // 건드리지 않아, 키보드로 닿은 사용자만 물러난 색에 남는다.
+    expect(components).toContain(".canvas-operation-identity-name:not(:hover):not(:focus-visible) {");
+    expect(components).not.toMatch(/\.canvas-operation-identity-name:not\(:hover\) \{/);
     // 포커스의 깊이는 색을 하나도 쓰지 않는다 — 상태 채널과 겹칠 자리가 없다. 중립 rim 블록보다
     // 뒤에 서서, 진행 중인 패널이 포커스를 받아도 깊이는 포커스가 소유한다.
     const lift = components.match(/\n\.canvas-operation\.is-active:not\(\.is-deck-tile\) \{[^}]*\}/)?.[0] ?? "";

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2999,7 +2999,32 @@ describe("Instrument core design contract", () => {
     // warn과 brass가 한 덩어리 금색으로 읽힌다. 워시는 캡션만 진다 — 채팅 본문까지
     // 따라가면 활성 패널 전체가 다른 면으로 바뀐다.
     expect(components).toContain(".canvas-operation.is-active > .canvas-operation-titlebar {");
-    expect(components).toContain("color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption))");
+    // 워시는 28%다. 10%는 실렌더 대비 1.14:1로 상태 표시의 3:1에 크게 못 미쳤고, 50%(3.01:1)는
+    // 캡션을 금색 판으로 만들어 아랫변 warn 레일과 한 덩어리가 된다. 채움의 상한은 기준선이
+    // 아니라 상태 채널과의 거리가 정하므로, 나머지 몫은 주변 후퇴와 융기가 나눠 진다.
+    const focusWash = components.match(/\.canvas-operation\.is-active > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
+    expect(focusWash).toContain("background: color-mix(in oklab, var(--brass) 28%, var(--glass-tint-caption));");
+    expect(focusWash).toContain("background-clip: padding-box;");
+    // 후퇴는 무대에 포커스가 설 때만 일어난다 — :has() 게이트가 빠지면 포커스 없는 화면의
+    // 기본 캡션까지 어두워진다. 본문과 상태 레일은 후퇴에서 빠지고, 덱 타일도 빠진다
+    // (카드의 위치 마크는 칸이 소유한다).
+    const recede = components.match(/\.operations-canvas:has\(\.canvas-operation\.is-active\) \.canvas-operation:not\(\.is-active\):not\(\.is-deck-tile\) > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
+    expect(recede).toContain("background: color-mix(in oklab, var(--canvas-abyss) 34%, var(--glass-tint-caption));");
+    expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*> \.canvas-operation-titlebar::after \{/);
+    expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*\.canvas-operation-terminal \{/);
+    // 이름 티어 하강은 hover를 이기면 안 된다 — 이름은 클릭하면 편집이라 hover가 곧 그 초대다.
+    expect(components).toContain(".canvas-operation-identity-name:not(:hover) {");
+    // 포커스의 깊이는 색을 하나도 쓰지 않는다 — 상태 채널과 겹칠 자리가 없다. 중립 rim 블록보다
+    // 뒤에 서서, 진행 중인 패널이 포커스를 받아도 깊이는 포커스가 소유한다.
+    const lift = components.match(/\n\.canvas-operation\.is-active \{[^}]*\}/)?.[0] ?? "";
+    expect(lift).toContain("var(--shadow-floating)");
+    expect(lift).toContain("inset 0 1px 0 var(--glass-rim)");
+    expect(lift).not.toMatch(/--(?:brass|warn|aurora|positive|coral)\b/);
+    // 중립 rim 블록은 색만 되돌린다. box-shadow를 다시 적으면 유리 rim·bevel inset이 함께
+    // 지워져 상태가 켜진 패널만 윗변 광택을 잃는다(실측 inset 16% → 6%).
+    const neutralRim = components.match(/\.canvas-operation\.is-active,\n\.canvas-operation\.is-running,\n\.canvas-operation\.is-unseen \{[^}]*\}/)?.[0] ?? "";
+    expect(neutralRim).toContain("border-color: var(--surface-rim);");
+    expect(neutralRim).not.toContain("box-shadow:");
     expect(components).not.toContain("--surface-window");
     expect(components).not.toContain(".canvas-operation-titlebar::before");
     expect(components).toContain("background: var(--caption-rail, transparent);");


### PR DESCRIPTION
## Summary
- 포커스한 패널의 캡션 워시를 brass 10% → 28%로 올렸습니다. 격리 콘솔 실측에서 10%는 비포커스 캡션과의 실렌더 대비가 네 테마 모두 1.14:1 안팎(instrument 1.14 · maritime 1.17 · carbon 1.14 · whites 1.12)이었고, 상태 표시가 인접색과 가져야 할 3:1의 절반에도 못 미쳐 단축키로 포커스를 옮겨도 캔버스에서 변화가 보이지 않았습니다.
- 무대에 포커스가 서 있을 때만 나머지 패널이 물러납니다 — 캡션 채움이 캔버스 쪽으로 내려가고 이름이 한 티어 낮아집니다. `:has()` 게이트가 포커스 없는 화면을 그대로 두고, 후퇴는 터미널 본문과 캡션 아랫변 상태 레일을 건드리지 않습니다. 덱 타일은 칸이 위치 마크를 소유하므로 제외했습니다.
- 포커스한 패널은 `--shadow-floating`으로 한 단 올라섭니다. 색을 쓰지 않는 채널이라 상태 채널과 겹칠 자리가 없고, 채움만으로는 어떤 비율로도 기준선에 닿지 못하는 라이트 테마를 이 깊이가 메웁니다.
- 중립 rim 블록이 `box-shadow`를 다시 적으면서 유리 rim·bevel inset까지 지우던 문제를 함께 고쳤습니다(실측 inset 16% → 6%) — 상태가 켜지거나 포커스를 받은 패널만 윗변 광택을 잃고 있었습니다.
- 결과 실측: instrument 1.14 → **1.71:1**(ΔE 0.064 → 0.201), whites 1.12 → **1.45:1**(ΔE 0.042 → 0.124).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 192 files / 2390 tests passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] 격리 콘솔 헤디드 실측: Tactical에서 Alt+→ 포커스 이동 후 캡션 채움·이름·그림자 대조(instrument·whites 스크린샷)
- [x] 상태 레일 회귀 없음 — 후퇴한 패널에 `is-running--turn`을 걸어 `::after` opacity 1 · 2px · `caption-rail-travel` 확인
- [x] `:has()` 게이트 — 활성 패널이 없으면 캡션이 `oklch(0.17 0.018 245 / 0.82)`, 이름이 `--text-secondary`로 복귀
- [x] 이름 hover 유지 — 후퇴 규칙에 `:not(:hover)`를 두어 편집 초대가 살아 있음
- [x] War Room 회귀 없음 — 덱 타일 캡션은 기본값 유지 / Cruise에서 포커스 패널 z 승격·중심 이동 정상