### PR TITLE
fix(fleet-console): free Codex health details from rail

### DIFF
--- a/runtime/fleet-console/core/client/src/codex/components/navigator.ts
+++ b/runtime/fleet-console/core/client/src/codex/components/navigator.ts
@@ -317,11 +317,16 @@ export function mountNavigatorInto(
     const left = Math.min(maxLeft, Math.max(HEALTH_POPOVER_VIEWPORT_GUTTER, triggerRect.right - popoverRect.width));
     const below = triggerRect.bottom + HEALTH_POPOVER_TRIGGER_GAP;
     const above = triggerRect.top - popoverRect.height - HEALTH_POPOVER_TRIGGER_GAP;
-    const top = below + popoverRect.height <= viewportHeight - HEALTH_POPOVER_VIEWPORT_GUTTER || above < HEALTH_POPOVER_VIEWPORT_GUTTER
+    const preferredTop = below + popoverRect.height <= viewportHeight - HEALTH_POPOVER_VIEWPORT_GUTTER || above < HEALTH_POPOVER_VIEWPORT_GUTTER
       ? below
       : above;
+    const maxTop = Math.max(
+      HEALTH_POPOVER_VIEWPORT_GUTTER,
+      viewportHeight - popoverRect.height - HEALTH_POPOVER_VIEWPORT_GUTTER,
+    );
+    const top = Math.min(maxTop, Math.max(HEALTH_POPOVER_VIEWPORT_GUTTER, preferredTop));
     healthPopoverElement.style.left = `${Math.round(left)}px`;
-    healthPopoverElement.style.top = `${Math.round(Math.max(HEALTH_POPOVER_VIEWPORT_GUTTER, top))}px`;
+    healthPopoverElement.style.top = `${Math.round(top)}px`;
   }
 
   function startHealthPopoverTracking(): void {

--- a/runtime/fleet-console/core/client/src/codex/components/navigator.ts
+++ b/runtime/fleet-console/core/client/src/codex/components/navigator.ts
@@ -44,6 +44,8 @@ type SortOrder = "updated" | "name";
 
 const SEARCH_DEBOUNCE_MS = 120;
 const SORT_STORAGE_KEY = "fleet.codex.navigator.sort";
+const HEALTH_POPOVER_VIEWPORT_GUTTER = 12;
+const HEALTH_POPOVER_TRIGGER_GAP = 6;
 
 function resolveActiveLocale() {
   const preference = getGlobalSettingsStoreState().state?.language ?? "auto";
@@ -214,6 +216,9 @@ export function mountNavigatorInto(
   let searchController: AbortController | null = null;
   let searchEpoch = 0;
   let healthPopoverOpen = false;
+  let healthPopoverElement: HTMLElement | null = null;
+  let healthPopoverTrigger: HTMLButtonElement | null = null;
+  let healthPopoverResizeObserver: ResizeObserver | null = null;
   // 대기 수가 늘어난 순간에만 도착 표식을 켠다 — 줄어드는 변화(승인·반려)는 알림이 아니다.
   let lastSeenPendingCount: number | null = null;
 
@@ -271,6 +276,107 @@ export function mountNavigatorInto(
   const sortControls = root.querySelector<HTMLElement>(".codex-nav-sort")!;
   const healthStrip = root.querySelector<HTMLElement>(".codex-nav-health")!;
 
+  function stopHealthPopoverTracking(): void {
+    healthPopoverResizeObserver?.disconnect();
+    healthPopoverResizeObserver = null;
+    window.removeEventListener("resize", positionHealthPopover);
+    window.removeEventListener("scroll", positionHealthPopover, true);
+  }
+
+  function isHealthPopoverTriggerVisible(trigger: HTMLButtonElement): boolean {
+    if (!trigger.isConnected) return false;
+    if (typeof trigger.checkVisibility === "function") {
+      return trigger.checkVisibility({ checkOpacity: false, checkVisibilityCSS: true });
+    }
+    const style = getComputedStyle(trigger);
+    return style.display !== "none" && style.visibility !== "hidden";
+  }
+
+  function closeHealthPopover(restoreFocus = false): void {
+    healthPopoverOpen = false;
+    stopHealthPopoverTracking();
+    healthPopoverElement?.remove();
+    healthPopoverElement = null;
+    const trigger = healthPopoverTrigger;
+    healthPopoverTrigger = null;
+    trigger?.setAttribute("aria-expanded", "false");
+    if (restoreFocus && trigger && isHealthPopoverTriggerVisible(trigger)) trigger.focus();
+  }
+
+  function positionHealthPopover(): void {
+    if (!healthPopoverElement || !healthPopoverTrigger) return;
+    if (!isHealthPopoverTriggerVisible(healthPopoverTrigger)) {
+      closeHealthPopover();
+      return;
+    }
+    const triggerRect = healthPopoverTrigger.getBoundingClientRect();
+    const popoverRect = healthPopoverElement.getBoundingClientRect();
+    const viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+    const viewportHeight = document.documentElement.clientHeight || window.innerHeight;
+    const maxLeft = Math.max(HEALTH_POPOVER_VIEWPORT_GUTTER, viewportWidth - popoverRect.width - HEALTH_POPOVER_VIEWPORT_GUTTER);
+    const left = Math.min(maxLeft, Math.max(HEALTH_POPOVER_VIEWPORT_GUTTER, triggerRect.right - popoverRect.width));
+    const below = triggerRect.bottom + HEALTH_POPOVER_TRIGGER_GAP;
+    const above = triggerRect.top - popoverRect.height - HEALTH_POPOVER_TRIGGER_GAP;
+    const top = below + popoverRect.height <= viewportHeight - HEALTH_POPOVER_VIEWPORT_GUTTER || above < HEALTH_POPOVER_VIEWPORT_GUTTER
+      ? below
+      : above;
+    healthPopoverElement.style.left = `${Math.round(left)}px`;
+    healthPopoverElement.style.top = `${Math.round(Math.max(HEALTH_POPOVER_VIEWPORT_GUTTER, top))}px`;
+  }
+
+  function startHealthPopoverTracking(): void {
+    positionHealthPopover();
+    if (!healthPopoverOpen) return;
+    window.addEventListener("resize", positionHealthPopover);
+    window.addEventListener("scroll", positionHealthPopover, true);
+    if (typeof ResizeObserver !== "undefined" && healthPopoverTrigger && healthPopoverElement) {
+      healthPopoverResizeObserver = new ResizeObserver(positionHealthPopover);
+      healthPopoverResizeObserver.observe(root);
+      healthPopoverResizeObserver.observe(healthPopoverTrigger);
+      healthPopoverResizeObserver.observe(healthPopoverElement);
+    }
+  }
+
+  function openHealthPopover(trigger: HTMLButtonElement): void {
+    const state = getState();
+    const health = state.health;
+    if (!health) return;
+    const t = consoleT();
+    const drydock = health.lastDrydock ?? null;
+    const logUnreadable = health.logUnreadable === true;
+    const timestamp = drydock ? new Date(drydock.at).toLocaleString(resolveActiveLocale()) : t("codex.nav.healthNever");
+    closeHealthPopover();
+    healthPopoverOpen = true;
+    healthPopoverTrigger = trigger;
+    trigger.setAttribute("aria-expanded", "true");
+    const popover = document.createElement("div");
+    popover.className = "codex-nav-health-popover";
+    popover.setAttribute("role", "dialog");
+    popover.setAttribute("aria-label", t("codex.nav.healthDetailsAria"));
+    popover.innerHTML = `
+      ${logUnreadable ? `<div><span>${escapeHtml(t("codex.nav.healthLogUnreadable"))}</span><strong>${escapeHtml(t("codex.nav.healthAttention"))}</strong></div>` : ""}
+      <div><span>${escapeHtml(t("codex.nav.healthErrors"))}</span><strong>${drydock?.errorCount ?? 0}</strong></div>
+      <div><span>${escapeHtml(t("codex.nav.healthWarnings"))}</span><strong>${drydock?.warningCount ?? 0}</strong></div>
+      <div><span>${escapeHtml(t("codex.nav.healthInfos"))}</span><strong>${drydock?.infoCount ?? 0}</strong></div>
+      <div><span>${escapeHtml(t("codex.nav.healthConflicts"))}</span><strong>${health.conflictCount}</strong></div>
+      <div><span>${escapeHtml(t("codex.nav.healthPending"))}</span><strong>${health.pendingCount}</strong></div>
+      <div><span>${escapeHtml(t("codex.nav.healthWatch"))}</span><strong>${escapeHtml(
+        state.liveState === "live"
+          ? t("codex.nav.healthWatchLive")
+          : state.liveState === "polling"
+            ? t("codex.nav.healthWatchPolling")
+            : t("codex.nav.healthWatchUnknown"),
+      )}</strong></div>
+      <p>${escapeHtml(t("codex.nav.healthRanAt", { at: timestamp }))}</p>
+      <p>${escapeHtml(state.lastCheckedAt === null
+        ? t("codex.nav.healthCheckedNever")
+        : t("codex.nav.healthCheckedAt", { at: new Date(state.lastCheckedAt).toLocaleTimeString(resolveActiveLocale()) }))}</p>
+    `;
+    (document.getElementById("app") ?? document.body).appendChild(popover);
+    healthPopoverElement = popover;
+    startHealthPopoverTracking();
+  }
+
   function renderHealth(): void {
     const t = consoleT();
     const state = getState();
@@ -279,11 +385,12 @@ export function mountNavigatorInto(
     const issueCount = drydock?.issueCount ?? 0;
     const logUnreadable = health?.logUnreadable === true;
     // 문장형 스트립은 좁은 폭에서 잘려 나갔다 — 항상 보이는 응축 칩으로 바꾸고
-    // 세부는 팝오버가 계속 담당한다. 충돌 수는 충돌 칩의 배지로 옮긴다.
+    // 세부는 뷰포트 레이어가 담당한다. 충돌 수는 충돌 칩의 배지로 옮긴다.
     conflictBadge.textContent = String(health?.conflictCount ?? 0);
     conflictBadge.hidden = (health?.conflictCount ?? 0) === 0;
     healthStrip.hidden = health === null;
     if (!health) {
+      closeHealthPopover();
       healthStrip.innerHTML = "";
       return;
     }
@@ -294,31 +401,15 @@ export function mountNavigatorInto(
       : attention
         ? t("codex.nav.healthIssues", { count: issueCount })
         : t("codex.nav.healthOk");
-    const timestamp = drydock ? new Date(drydock.at).toLocaleString(resolveActiveLocale()) : t("codex.nav.healthNever");
     healthStrip.innerHTML = `
-      <button class="codex-nav-health-chip" data-health-detail type="button" aria-expanded="${String(healthPopoverOpen)}" aria-label="${escapeHtml(t("codex.nav.healthDetailsAria"))}">
+      <button class="codex-nav-health-chip" data-health-detail type="button" aria-expanded="false" aria-label="${escapeHtml(t("codex.nav.healthDetailsAria"))}">
         <span class="codex-nav-health-dot is-${tone}" aria-hidden="true"></span>${escapeHtml(label)}
       </button>
-      ${healthPopoverOpen ? `<div class="codex-nav-health-popover" role="dialog" aria-label="${escapeHtml(t("codex.nav.healthDetailsAria"))}">
-        ${logUnreadable ? `<div><span>${escapeHtml(t("codex.nav.healthLogUnreadable"))}</span><strong>${escapeHtml(t("codex.nav.healthAttention"))}</strong></div>` : ""}
-        <div><span>${escapeHtml(t("codex.nav.healthErrors"))}</span><strong>${drydock?.errorCount ?? 0}</strong></div>
-        <div><span>${escapeHtml(t("codex.nav.healthWarnings"))}</span><strong>${drydock?.warningCount ?? 0}</strong></div>
-        <div><span>${escapeHtml(t("codex.nav.healthInfos"))}</span><strong>${drydock?.infoCount ?? 0}</strong></div>
-        <div><span>${escapeHtml(t("codex.nav.healthConflicts"))}</span><strong>${health.conflictCount}</strong></div>
-        <div><span>${escapeHtml(t("codex.nav.healthPending"))}</span><strong>${health.pendingCount}</strong></div>
-        <div><span>${escapeHtml(t("codex.nav.healthWatch"))}</span><strong>${escapeHtml(
-          state.liveState === "live"
-            ? t("codex.nav.healthWatchLive")
-            : state.liveState === "polling"
-              ? t("codex.nav.healthWatchPolling")
-              : t("codex.nav.healthWatchUnknown"),
-        )}</strong></div>
-        <p>${escapeHtml(t("codex.nav.healthRanAt", { at: timestamp }))}</p>
-        <p>${escapeHtml(state.lastCheckedAt === null
-          ? t("codex.nav.healthCheckedNever")
-          : t("codex.nav.healthCheckedAt", { at: new Date(state.lastCheckedAt).toLocaleTimeString(resolveActiveLocale()) }))}</p>
-      </div>` : ""}
     `;
+    if (healthPopoverOpen) {
+      const trigger = healthStrip.querySelector<HTMLButtonElement>("[data-health-detail]");
+      if (trigger) openHealthPopover(trigger);
+    }
   }
 
   function loadHealth(): void {
@@ -451,11 +542,11 @@ export function mountNavigatorInto(
     const target = event.target;
     if (!(target instanceof Element)) return;
 
-    const healthDetail = target.closest<HTMLElement>("[data-health-detail]");
+    const healthDetail = target.closest<HTMLButtonElement>("[data-health-detail]");
     if (healthDetail) {
       event.stopPropagation();
-      healthPopoverOpen = !healthPopoverOpen;
-      renderHealth();
+      if (healthPopoverOpen) closeHealthPopover();
+      else openHealthPopover(healthDetail);
       return;
     }
 
@@ -510,16 +601,15 @@ export function mountNavigatorInto(
   }
 
   function handleDocumentClick(event: MouseEvent): void {
-    if (!healthPopoverOpen || healthStrip.contains(event.target as Node)) return;
-    healthPopoverOpen = false;
-    renderHealth();
+    if (!healthPopoverOpen) return;
+    const target = event.target as Node;
+    if (healthStrip.contains(target) || healthPopoverElement?.contains(target)) return;
+    closeHealthPopover();
   }
 
   function handleDocumentKeyDown(event: KeyboardEvent): void {
     if (event.key !== "Escape" || !healthPopoverOpen) return;
-    healthPopoverOpen = false;
-    renderHealth();
-    root.querySelector<HTMLButtonElement>("[data-health-detail]")?.focus();
+    closeHealthPopover(true);
   }
 
   function handleSearchInput(): void {
@@ -554,6 +644,7 @@ export function mountNavigatorInto(
       searchInput.removeEventListener("input", handleSearchInput);
       document.removeEventListener("click", handleDocumentClick);
       document.removeEventListener("keydown", handleDocumentKeyDown);
+      closeHealthPopover();
       if (debounceTimer !== null) clearTimeout(debounceTimer);
       searchController?.abort();
       root.innerHTML = "";

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -2569,10 +2569,11 @@ button.chip:focus-visible {
 }
 
 /* 레일은 의도적으로 overflow:hidden인 유리 프레임이다. 헬스 상세는 app의 루트 레이어로
-   이식해 그 프레임과 인접 레일에 갇히지 않고, 트리거 좌표를 따라 뷰포트 안에서 배치한다. */
+   이식해 그 프레임과 인접 레일에 갇히지 않고, 트리거 좌표를 따라 뷰포트 안에서 배치한다.
+   다만 일반 팝오버이므로 전역 모달(80+) 아래에 머물러 입력 격리를 침범하지 않는다. */
 .codex-nav-health-popover {
   position: fixed;
-  z-index: var(--z-overlay);
+  z-index: 70;
   display: grid;
   min-width: min(190px, calc(100vw - 24px));
   max-width: calc(100vw - 24px);

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -2568,17 +2568,30 @@ button.chip:focus-visible {
   box-shadow: 0 0 8px color-mix(in oklch, var(--positive) 45%, transparent);
 }
 
+/* 레일은 의도적으로 overflow:hidden인 유리 프레임이다. 헬스 상세는 app의 루트 레이어로
+   이식해 그 프레임과 인접 레일에 갇히지 않고, 트리거 좌표를 따라 뷰포트 안에서 배치한다. */
 .codex-nav-health-popover {
-  position: absolute;
-  z-index: 8;
-  top: calc(100% + var(--space-1));
-  right: 0;
+  position: fixed;
+  z-index: var(--z-overlay);
   display: grid;
-  min-width: 190px;
+  min-width: min(190px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
+  max-height: calc(100vh - 24px);
+  max-height: calc(100dvh - 24px);
+  overflow-y: auto;
   padding: var(--space-3);
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-md);
-  background: var(--ink-deep);
+  /* 팝업 판독성 계약: glass 틴트 아래 불투명 fallback 언더레이를 유지하고,
+     유리 게이트가 열릴 때만 body 뒤의 화면을 흐린다. */
+  background:
+    linear-gradient(
+      color-mix(in oklch, var(--glass-tint-strong) 94%, var(--ink-deep)),
+      color-mix(in oklch, var(--glass-tint-strong) 94%, var(--ink-deep))
+    ),
+    var(--glass-underlay);
+  -webkit-backdrop-filter: var(--glass-backdrop-strong);
+  backdrop-filter: var(--glass-backdrop-strong);
   box-shadow: var(--shadow-soft);
   color: var(--text-secondary);
 }

--- a/runtime/fleet-console/tests/codex-schema-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-schema-ui.test.ts
@@ -164,7 +164,7 @@ describe("Codex schema UI contract", () => {
     expect(strip.textContent).toContain("Wiki log unreadable");
     expect(strip.querySelector(".codex-nav-health-dot")?.classList.contains("is-coral")).toBe(false);
     strip.querySelector<HTMLButtonElement>("[data-health-detail]")?.click();
-    expect(strip.querySelector(".codex-nav-health-popover")?.textContent).toContain("Wiki log unreadableCheck");
+    expect(document.body.querySelector(".codex-nav-health-popover")?.textContent).toContain("Wiki log unreadableCheck");
     controller.destroy();
   });
 
@@ -197,13 +197,70 @@ describe("Codex schema UI contract", () => {
     const detail = strip.querySelector<HTMLButtonElement>("[data-health-detail]")!;
     detail.click();
     expect(strip.querySelector("[data-health-detail]")?.getAttribute("aria-expanded")).toBe("true");
-    expect(strip.querySelector(".codex-nav-health-popover")?.textContent).toContain("Errors1");
+    expect(document.body.querySelector(".codex-nav-health-popover")?.textContent).toContain("Errors1");
+    expect(strip.contains(document.body.querySelector(".codex-nav-health-popover"))).toBe(false);
     expect(onRequest).not.toHaveBeenCalled();
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-    expect(strip.querySelector(".codex-nav-health-popover")).toBeNull();
+    expect(document.body.querySelector(".codex-nav-health-popover")).toBeNull();
+    expect(detail.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(detail);
     expect(onRequest).not.toHaveBeenCalled();
     controller.destroy();
+  });
+
+  it("keeps health details inside the viewport when the rail trigger hugs an edge", async () => {
+    vi.resetModules();
+    apiMocks.fetchHealth.mockResolvedValue({
+      lastDrydock: {
+        at: "2026-08-03T02:03:04.000Z",
+        ok: false,
+        errorCount: 1,
+        warningCount: 2,
+        infoCount: 3,
+        issueCount: 6,
+      },
+      conflictCount: 1,
+      pendingCount: 2,
+    });
+    const state = await import("../core/client/src/codex/state.js");
+    const { mountNavigatorInto } = await import("../core/client/src/codex/components/navigator.js");
+    Object.assign(state.getState(), { error: null, index: [], loading: false, pendingPatchCount: 2 });
+    const clientWidth = Object.getOwnPropertyDescriptor(document.documentElement, "clientWidth");
+    const clientHeight = Object.getOwnPropertyDescriptor(document.documentElement, "clientHeight");
+    const originalRect = HTMLElement.prototype.getBoundingClientRect;
+    Object.defineProperty(document.documentElement, "clientWidth", { configurable: true, value: 668 });
+    Object.defineProperty(document.documentElement, "clientHeight", { configurable: true, value: 734 });
+    const root = document.body.appendChild(document.createElement("div"));
+    const controller = mountNavigatorInto(root, { initialTheaterId: "workspace-a", onRequest: vi.fn() });
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const detail = root.querySelector<HTMLButtonElement>("[data-health-detail]")!;
+      detail.getBoundingClientRect = () => new DOMRect(500, 250, 150, 32);
+      detail.getClientRects = () => ({ length: 1 }) as DOMRectList;
+      HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+        if (this.classList.contains("codex-nav-health-popover")) return new DOMRect(0, 0, 190, 312);
+        return originalRect.call(this);
+      };
+
+      detail.click();
+      const popover = document.body.querySelector<HTMLElement>(".codex-nav-health-popover")!;
+      expect(popover.style.left).toBe("460px");
+      expect(popover.style.top).toBe("288px");
+
+      detail.style.visibility = "hidden";
+      window.dispatchEvent(new Event("resize"));
+      expect(document.body.querySelector(".codex-nav-health-popover")).toBeNull();
+    } finally {
+      controller.destroy();
+      HTMLElement.prototype.getBoundingClientRect = originalRect;
+      if (clientWidth) Object.defineProperty(document.documentElement, "clientWidth", clientWidth);
+      else delete (document.documentElement as unknown as Record<string, unknown>).clientWidth;
+      if (clientHeight) Object.defineProperty(document.documentElement, "clientHeight", clientHeight);
+      else delete (document.documentElement as unknown as Record<string, unknown>).clientHeight;
+    }
   });
 
   it("keeps the latest entry when an older request resolves last", async () => {

--- a/runtime/fleet-console/tests/codex-schema-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-schema-ui.test.ts
@@ -234,8 +234,7 @@ describe("Codex schema UI contract", () => {
     const root = document.body.appendChild(document.createElement("div"));
     const controller = mountNavigatorInto(root, { initialTheaterId: "workspace-a", onRequest: vi.fn() });
     try {
-      await Promise.resolve();
-      await Promise.resolve();
+      await state.revalidateScopes(["queue"]);
 
       const detail = root.querySelector<HTMLButtonElement>("[data-health-detail]")!;
       detail.getBoundingClientRect = () => new DOMRect(500, 250, 150, 32);

--- a/runtime/fleet-console/tests/codex-schema-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-schema-ui.test.ts
@@ -250,6 +250,10 @@ describe("Codex schema UI contract", () => {
       expect(popover.style.left).toBe("460px");
       expect(popover.style.top).toBe("288px");
 
+      Object.defineProperty(document.documentElement, "clientHeight", { configurable: true, value: 300 });
+      window.dispatchEvent(new Event("resize"));
+      expect(popover.style.top).toBe("12px");
+
       detail.style.visibility = "hidden";
       window.dispatchEvent(new Event("resize"));
       expect(document.body.querySelector(".codex-nav-health-popover")).toBeNull();

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -479,6 +479,14 @@ function findRawProductSelectsInSourceFile(
 }
 
 describe("Instrument core design contract", () => {
+  it("keeps the Codex health popover below blocking modal layers", () => {
+    const codexComponents = source("codex/styles/components.css");
+    const popover = codexComponents.match(/\.codex-nav-health-popover \{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(popover).toContain("position: fixed;");
+    expect(popover).toContain("z-index: 70;");
+    expect(popover).not.toContain("var(--z-overlay)");
+  });
+
   it("collapses backend API rows against their Settings card width", () => {
     const components = source("styles/components.css");
     const section = components.match(/\.backend-api-section \{[^}]*\}/)?.[0] ?? "";


### PR DESCRIPTION
## Summary
- mount Codex Wiki health details in the application overlay layer instead of the clipping rail
- keep the popup inside the viewport and dismiss it when the trigger becomes hidden
- preserve glass readability, focus restoration, and add positioning regressions

## Test Plan
- [x] `corepack pnpm --dir runtime/fleet-console exec vitest run tests/codex-schema-ui.test.ts tests/codex-panel-state.test.tsx tests/codex-refit-routes.test.ts tests/instrument-design-contract.test.ts`
- [x] `corepack pnpm --dir runtime/fleet-console typecheck`
- [x] `corepack pnpm --dir runtime/fleet-console build`
- [x] Verify in an isolated Console that the popup remains fully visible outside the rail and closes when the rail collapses