### PR TITLE
feat(fleet-console): move the focus mark from the caption to the board

### DIFF
--- a/.changelog.d/panel-focus-visibility.md
+++ b/.changelog.d/panel-focus-visibility.md
@@ -4,5 +4,5 @@ branch: panel-focus-visibility
 
 ### fleet-console
 #### Changed
-- Make the focused panel stand out on the Map. The panel holding keyboard focus now carries a deeper caption wash and sits one step above the board, while the other panels' captions and names step back toward the canvas - so moving focus with the arrow shortcuts is visible where the panels are, not only in the sidebar. Panels recede only while a panel is focused, and their status rails and terminal bodies stay untouched.
-  ko: Map에서 포커스한 패널이 눈에 띄게 했습니다. 키보드 포커스를 가진 패널은 캡션 워시가 진해지고 한 단 올라서며, 나머지 패널의 캡션과 이름은 캔버스 쪽으로 물러납니다. 화살표 단축키로 포커스를 옮길 때 사이드바가 아니라 패널이 있는 자리에서 그 변화가 보입니다. 후퇴는 포커스한 패널이 있을 때만 일어나고, 상태 레일과 터미널 본문은 그대로 둡니다.
+- Show where keyboard focus went on the Map. The panels you are not working in now fade back a little while one panel holds focus, that panel sits one step above the board, and a brass ring runs around it once at the moment focus arrives - so an arrow-key move reads on the panels themselves instead of only in the sidebar. Captions keep the look they always had, a faded panel keeps its status rail and stays readable, and the ring is skipped entirely when the system asks for reduced motion.
+  ko: Map에서 키보드 포커스가 어디로 갔는지 보이게 했습니다. 한 패널이 포커스를 쥐고 있는 동안 나머지 패널의 본문이 조금 물러나고, 그 패널은 한 단 올라서며, 포커스가 옮겨 앉는 순간 창 둘레를 brass 링이 한 번 지나갑니다. 화살표로 옮긴 결과가 사이드바가 아니라 패널이 있는 자리에서 읽힙니다. 캡션은 늘 쓰던 모습 그대로이고, 물러난 패널도 상태 레일을 유지하며 읽을 수 있습니다. 시스템이 모션 최소화를 요청하면 링은 돌지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -83,6 +83,9 @@ const CLOSE_ARM_DURATION_MS = 1500;
 const DRAG_THRESHOLD_PX = 3;
 // 캡션 상태 레일의 도착 플래시 길이 — CSS의 var(--duration-slow)와 한 값이다.
 const ARRIVAL_FLASH_DURATION_MS = 360;
+// 포커스 도착 링의 수명 — CSS --duration-slow(0.36s)와 같은 값이다. 링은 전이 전용이라
+// 애니메이션이 끝나면 클래스를 거둔다.
+const FOCUS_ARRIVAL_DURATION_MS = 360;
 // 위상을 한 박자로 묶는 레일 애니메이션 — components.css의 상태 레일 선언과 한 벌이다.
 const PHASE_LOCKED_RAIL_ANIMATIONS = new Set(["caption-rail-flow", "caption-rail-call", "caption-rail-tide"]);
 
@@ -95,13 +98,18 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
   const resizeRef = useRef<ResizeState | null>(null);
   const closeArmTimeoutRef = useRef<number | null>(null);
   const arrivalFlashTimeoutRef = useRef<number | null>(null);
+  const focusArrivalTimeoutRef = useRef<number | null>(null);
   // 마운트 시점의 unseen을 이전 값으로 삼는다 — 이미 미확인인 채로 되살아난 프레임(Theater 재진입 등)은
   // 새 도착이 아니므로 플래시하지 않는다.
   const previousUnseenRef = useRef(unseen);
+  // 마운트 시점의 active를 이전 값으로 삼는다 — 이미 포커스를 쥔 채 되살아난 프레임(Theater
+  // 재진입·보기 모드 전환)은 이동이 아니므로 링을 돌리지 않는다.
+  const previousActiveRef = useRef(active);
   const lastVisibleGeometryRef = useRef(geometry);
   const restoreIdentityFocusRef = useRef(false);
   const [isCloseArmed, setIsCloseArmed] = useState(false);
   const [arrivalFlash, setArrivalFlash] = useState(false);
+  const [focusArrival, setFocusArrival] = useState(false);
   const [dragging, setDragging] = useState(false);
   const displayTitle = operation.title;
   const rename = useInlineRename({
@@ -125,6 +133,7 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
     "canvas-operation",
     unseen ? "is-unseen" : "",
     arrivalFlash ? "is-unseen-arriving" : "",
+    focusArrival ? "is-focus-arriving" : "",
     active ? "is-active" : "",
     minimized ? "is-minimized" : "",
     maximized ? "is-maximized" : "",
@@ -138,7 +147,22 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
   useEffect(() => () => {
     if (closeArmTimeoutRef.current !== null) window.clearTimeout(closeArmTimeoutRef.current);
     if (arrivalFlashTimeoutRef.current !== null) window.clearTimeout(arrivalFlashTimeoutRef.current);
+    if (focusArrivalTimeoutRef.current !== null) window.clearTimeout(focusArrivalTimeoutRef.current);
   }, []);
+
+  // 포커스가 이 패널로 옮겨 앉는 순간에만 링을 돌린다 — 상태의 존재가 아니라 전이다.
+  // 포커스를 잃는 쪽은 아무것도 돌리지 않는다: 이동은 도착지 하나로 읽혀야 한다.
+  useEffect(() => {
+    const previous = previousActiveRef.current;
+    previousActiveRef.current = active;
+    if (previous || !active) return;
+    if (focusArrivalTimeoutRef.current !== null) window.clearTimeout(focusArrivalTimeoutRef.current);
+    setFocusArrival(true);
+    focusArrivalTimeoutRef.current = window.setTimeout(() => {
+      focusArrivalTimeoutRef.current = null;
+      setFocusArrival(false);
+    }, FOCUS_ARRIVAL_DURATION_MS);
+  }, [active]);
 
   // 도착은 상태의 전이이지 상태의 존재가 아니다 — false → true로 넘어가는 순간에만 플래시한다.
   useEffect(() => {

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -151,11 +151,22 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
   }, []);
 
   // 포커스가 이 패널로 옮겨 앉는 순간에만 링을 돌린다 — 상태의 존재가 아니라 전이다.
-  // 포커스를 잃는 쪽은 아무것도 돌리지 않는다: 이동은 도착지 하나로 읽혀야 한다.
+  // 포커스를 잃는 쪽은 링을 그 자리에서 거둔다. 타이머가 끝나기를 기다리면 링이 두 장 된다:
+  // 360ms 안에 한 번 더 옮기면 떠난 패널이 도착한 패널과 나란히 테두리를 두르고(실측 140ms
+  // 간격에서 14프레임 중첩), 그사이 되돌아오면 클래스가 한 번도 빠지지 않아 애니메이션이
+  // 다시 돌지도 않는다. 이동은 언제나 도착지 하나로 읽혀야 한다.
   useEffect(() => {
     const previous = previousActiveRef.current;
     previousActiveRef.current = active;
-    if (previous || !active) return;
+    if (!active) {
+      if (focusArrivalTimeoutRef.current !== null) {
+        window.clearTimeout(focusArrivalTimeoutRef.current);
+        focusArrivalTimeoutRef.current = null;
+      }
+      setFocusArrival(false);
+      return;
+    }
+    if (previous) return;
     if (focusArrivalTimeoutRef.current !== null) window.clearTimeout(focusArrivalTimeoutRef.current);
     setFocusArrival(true);
     focusArrivalTimeoutRef.current = window.setTimeout(() => {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5090,6 +5090,53 @@ body[data-side-bar-animating="true"] .canvas-operation {
   box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--shadow-floating);
 }
 
+/* 이동의 순간만 도는 테두리 — 포커스가 새로 앉을 때 창 둘레를 brass 링이 한 번 지나간다.
+   상주 표식(캡션 워시·본문 후퇴·융기)이 "지금 어디인가"를 말한다면 이 링은 "방금 저기로
+   갔다"를 말한다. 둘은 서로를 대신하지 못한다: 가만히 있는 표식은 눈길을 끌지 못하고,
+   지나간 신호는 남지 않는다.
+   전이 전용이므로 지속 상태(is-active)가 아니라 일시 클래스가 소유한다 — is-active에 걸면
+   Theater를 오갈 때마다 리마운트로 다시 돈다(도착 플래시 is-unseen-arriving의 선례와 같다).
+   기본 opacity가 0이라 애니메이션이 없으면 아무것도 그리지 않는다: reduced-motion은 이 링을
+   조용히 건너뛰고 상주 표식만 남긴다. 색은 위치 채널 brass 하나이며 상태 레일과 겹치는 자리가
+   없다 — 링은 창의 바깥선을 돌고, 레일은 캡션 안쪽 아랫변에 있다.
+   덱 타일은 여기서도 빠진다 — 카드의 위치는 칸이 소유하고, 카드로 남은 채 활성이 되는 경로가
+   실제로 있다(enterTriage의 조기 반환). 무대로 오른 패널은 덱 타일이 아니므로 링을 받는다.
+   링의 위쪽 끝은 캡션이 창의 꼭대기를 소유하는지에 달렸다: 떠 있는 캡션은 루트 박스 밖
+   -32px에 서므로 링도 그만큼(+캡션 보더 1px) 위에서 시작하고, 흐름 안 캡션(is-top-edge)은
+   루트의 top이 곧 꼭대기다. z는 캡션(7) 위에 서서 창 전체를 한 줄로 두른다. */
+.canvas-operation.is-focus-arriving:not(.is-deck-tile)::after {
+  content: "";
+  position: absolute;
+  top: var(--focus-ring-top, -33px);
+  right: -1px;
+  bottom: -1px;
+  left: -1px;
+  z-index: 8;
+  border: 2px solid var(--brass);
+  border-radius: var(--radius-md);
+  opacity: 0;
+  pointer-events: none;
+  animation: panel-focus-arrive var(--duration-slow) var(--ease-spring) 1;
+}
+
+.canvas-operation.is-top-edge {
+  --focus-ring-top: -1px;
+}
+
+@keyframes panel-focus-arrive {
+  0% {
+    opacity: 0;
+  }
+
+  25% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
 /* 상태 레일 색 — OperationActivity 매핑 축(.tenant-beacon 선언)과 같은 토큰을 쓴다.
    turn/background: warn(에이전트 턴·백그라운드 작업) · awaiting: aurora(운영자 입력 대기)
    · unseen: positive(미확인 완료). idle·dormant는 레일을 켜지 않는다. */
@@ -6362,13 +6409,11 @@ body[data-side-bar-animating="true"] .canvas-operation {
    hue 141(초록)에 착지했고, 위치 채널이 신호 채널 positive(160) 옆에 앉았다.
    워시는 캡션만 진다. 채팅·터미널 본문은 --surface-panel에 남아, 포커스가 로그 전체를
    다른 면으로 다시 칠하지 않는다.
-   비율은 28%다. 10%는 실측에서 포커스/비포커스 캡션의 실렌더 대비가 1.14:1이었다 —
-   상태 표시가 인접색과 가져야 할 3:1의 절반에도 못 미쳐, 단축키로 패널을 옮겨도 캔버스에서
-   무엇이 바뀌었는지 보이지 않았다. 28%는 같은 측정에서 1.67:1이다. 그 위(50% = 3.01:1)로는
-   캡션이 금색 판이 되어 바로 아랫변의 warn 레일과 한 덩어리로 읽힌다 — 채움 채널의 상한은
-   기준선이 아니라 상태 채널과의 거리가 정한다. 남는 몫은 주변 후퇴가 진다. */
+   비율은 10%다. 한때 28%까지 올렸으나(실렌더 대비 1.14 → 1.67:1) 캡션 혼자 화면에서 튀었고,
+   그 대비를 살 자리는 캡션이 아니었다 — 지금은 곁의 본문이 물러나서 포커스한 창을 세우고,
+   이동의 순간은 링이 말한다. 캡션은 오늘의 값 그대로 둔다. */
 .canvas-operation.is-active:not(.is-deck-tile) > .canvas-operation-titlebar {
-  background: color-mix(in oklab, var(--brass) 28%, var(--glass-tint-caption));
+  background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption));
   /* background 단축은 clip을 border-box로 되돌리므로 padding-box를 다시 적는다. */
   background-clip: padding-box;
 }
@@ -6377,30 +6422,21 @@ body[data-side-bar-animating="true"] .canvas-operation {
   color: var(--text-primary);
 }
 
-/* 주변 후퇴 — 무대에 포커스가 서 있을 때만 나머지 캡션이 바탕 쪽으로 물러난다.
-   :has() 게이트가 없으면 포커스가 없는 화면에서도 모든 캡션이 어두워져, 물러설 기준이 없는
-   상태에서 기본 모습만 바뀐다. 후퇴는 캡션 면과 이름까지다 — 본문(터미널·채팅 로그)은 건드리지
-   않는다. 곁의 패널을 읽는 일은 포커스와 무관하게 계속된다. 상태 레일(::after)도 그대로 둔다:
-   비포커스 패널의 진행이 0픽셀이 되던 옛 실패로 되돌아가는 길이다.
+/* 주변 후퇴 — 무대에 포커스가 서 있을 때만 곁의 본문이 물러난다. 캡션은 건드리지 않는다:
+   창의 머리는 어느 패널인지를 말하는 자리라 흐려지면 목록을 훑는 일이 함께 흐려진다.
+   물러나는 것은 읽던 내용 쪽이고, 그래서 포커스한 창의 본문만 또렷하게 남는다.
+   :has() 게이트가 없으면 포커스가 없는 화면에서도 모든 본문이 흐려져, 물러설 기준이 없는
+   상태에서 기본 모습만 바뀐다. 상태 레일(캡션 ::after)은 캡션 소속이라 자동으로 남는다 —
+   비포커스 패널의 진행이 0픽셀이 되던 옛 실패로 되돌아가지 않는다.
    덱 타일은 후퇴 대상에서도, 게이트에서도 빠진다 — 카드의 위치 마크는
    칸(.canvas-triage-deck-cell)이 소유하므로 카드는 표식을 받지 않고, 표식을 받지 않는 것은
    남들을 물러서게 할 자격도 없다. 게이트가 표식보다 넓으면 아무것도 앞으로 나서지 않은 채
    무대만 어두워진다: 대기 큐가 비어 있지 않으면 enterTriage가 활성 id를 카드에 남기고
    (triage-store.ts), 무대의 자동 포커스는 모달·투어가 떠 있던 프레임에서 한 번 걸러지면
    캐시 때문에 다시 시도되지 않는다(canvas.tsx). 게이트와 표식은 같은 것을 가리켜야 한다. */
-.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar {
-  background: color-mix(in oklab, var(--canvas-abyss) 34%, var(--glass-tint-caption));
-  background-clip: padding-box;
-}
-
-/* 이름은 한 티어 내려간다. 제외가 없으면 이 규칙이 특이도로 이름의 hover를 이겨, 비포커스
-   패널에서는 이름 위에 마우스를 얹어도 아무 반응이 없다(이름은 클릭하면 편집이다).
-   :focus-visible도 같은 이유로 함께 빠진다 — 그 초대는 마우스만의 것이 아니다. 이름의
-   focus-visible 규칙은 brass 아웃라인만 그리고 색은 건드리지 않아, 이 규칙을 그대로 두면
-   키보드로 이름에 닿은 사용자만 물러난 색에 머문다. 링은 어디에 있는지를 말하고 색은 무엇을
-   할 수 있는지를 말하므로, 두 입력 수단이 같은 초대를 받아야 한다. */
-.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-titlebar .canvas-operation-identity-name:not(:hover):not(:focus-visible) {
-  color: var(--text-tertiary);
+.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-terminal {
+  opacity: 0.72;
+  transition: opacity var(--duration-base) var(--ease-glide);
 }
 
 /* 캡션 아랫변 = 상태 채널. 포커스는 채움이 말하므로 선은 상태 하나만 소유한다. */

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -3022,6 +3022,12 @@ describe("Instrument core design contract", () => {
     expect(components).not.toMatch(/\.canvas-operation\.is-focus-arriving::after \{/);
     expect(operationFrame).toContain('focusArrival ? "is-focus-arriving" : ""');
     expect(operationFrame).toContain("previousActiveRef");
+    // 포커스를 잃는 쪽은 링을 그 자리에서 거둔다 — 타이머를 기다리면 360ms 안의 두 번째 이동에서
+    // 링이 두 장 되고(실측 중첩), 그사이 되돌아오면 클래스가 빠진 적이 없어 다시 돌지도 않는다.
+    const arrivalEffect = operationFrame.match(/useEffect\(\(\) => \{\n\s*const previous = previousActiveRef\.current;[\s\S]*?\}, \[active\]\);/)?.[0] ?? "";
+    expect(arrivalEffect).toContain("if (!active) {");
+    expect(arrivalEffect).toContain("setFocusArrival(false);");
+    expect(arrivalEffect).not.toMatch(/if \(previous \|\| !active\) return;/);
     // 포커스의 깊이는 색을 하나도 쓰지 않는다 — 상태 채널과 겹칠 자리가 없다. 중립 rim 블록보다
     // 뒤에 서서, 진행 중인 패널이 포커스를 받아도 깊이는 포커스가 소유한다.
     const lift = components.match(/\n\.canvas-operation\.is-active:not\(\.is-deck-tile\) \{[^}]*\}/)?.[0] ?? "";

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2999,24 +2999,29 @@ describe("Instrument core design contract", () => {
     // warn과 brass가 한 덩어리 금색으로 읽힌다. 워시는 캡션만 진다 — 채팅 본문까지
     // 따라가면 활성 패널 전체가 다른 면으로 바뀐다.
     expect(components).toContain(".canvas-operation.is-active:not(.is-deck-tile) > .canvas-operation-titlebar {");
-    // 워시는 28%다. 10%는 실렌더 대비 1.14:1로 상태 표시의 3:1에 크게 못 미쳤고, 50%(3.01:1)는
-    // 캡션을 금색 판으로 만들어 아랫변 warn 레일과 한 덩어리가 된다. 채움의 상한은 기준선이
-    // 아니라 상태 채널과의 거리가 정하므로, 나머지 몫은 주변 후퇴와 융기가 나눠 진다.
+    // 워시는 10%다. 한때 28%까지 올렸으나 캡션 혼자 화면에서 튀었다 — 대비를 살 자리는 캡션이
+    // 아니라 곁의 본문(후퇴)과 이동의 순간(링)이다. 캡션은 오늘의 값에 남는다.
     const focusWash = components.match(/\.canvas-operation\.is-active:not\(\.is-deck-tile\) > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
-    expect(focusWash).toContain("background: color-mix(in oklab, var(--brass) 28%, var(--glass-tint-caption));");
+    expect(focusWash).toContain("background: color-mix(in oklab, var(--brass) 10%, var(--glass-tint-caption));");
     expect(focusWash).toContain("background-clip: padding-box;");
-    // 후퇴는 무대에 포커스가 설 때만 일어난다 — :has() 게이트가 빠지면 포커스 없는 화면의
-    // 기본 캡션까지 어두워진다. 본문과 상태 레일은 후퇴에서 빠지고, 덱 타일도 빠진다
-    // (카드의 위치 마크는 칸이 소유한다).
-    const recede = components.match(/\.operations-canvas:has\(\.canvas-operation\.is-active:not\(\.is-deck-tile\)\) \.canvas-operation:not\(\.is-active\):not\(\.is-deck-tile\) > \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
-    expect(recede).toContain("background: color-mix(in oklab, var(--canvas-abyss) 34%, var(--glass-tint-caption));");
+    // 후퇴는 본문이 진다 — 캡션은 어느 패널인지를 말하는 자리라 흐려지면 목록을 훑는 일이 함께
+    // 흐려진다. 상태 레일은 캡션 소속이라 자동으로 남는다. 무대에 포커스가 설 때만 일어나며
+    // (:has() 게이트), 덱 타일은 대상에서도 게이트에서도 빠진다.
+    const recede = components.match(/\.operations-canvas:has\(\.canvas-operation\.is-active:not\(\.is-deck-tile\)\) \.canvas-operation:not\(\.is-active\):not\(\.is-deck-tile\) > \.canvas-operation-terminal \{[^}]*\}/)?.[0] ?? "";
+    expect(recede).toContain("opacity: 0.72;");
+    expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*> \.canvas-operation-titlebar \{/);
     expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*> \.canvas-operation-titlebar::after \{/);
-    expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*\.canvas-operation-terminal \{/);
-    // 이름 티어 하강은 편집 초대를 이기면 안 된다 — 이름은 눌러서 고치는 자리다. hover만 빼면
-    // 그 초대가 마우스만의 것이 된다: 이름의 focus-visible 규칙은 아웃라인만 그리고 색은
-    // 건드리지 않아, 키보드로 닿은 사용자만 물러난 색에 남는다.
-    expect(components).toContain(".canvas-operation-identity-name:not(:hover):not(:focus-visible) {");
-    expect(components).not.toMatch(/\.canvas-operation-identity-name:not\(:hover\) \{/);
+    // 이동의 순간은 링이 말한다 — 전이 전용이라 지속 상태가 아니라 일시 클래스가 소유하고,
+    // 기본 opacity 0이라 애니메이션이 없는 reduced-motion에서는 아무것도 그리지 않는다.
+    const ring = components.match(/\.canvas-operation\.is-focus-arriving:not\(\.is-deck-tile\)::after \{[^}]*\}/)?.[0] ?? "";
+    expect(ring).toContain("border: 2px solid var(--brass);");
+    expect(ring).toContain("opacity: 0;");
+    expect(ring).toContain("animation: panel-focus-arrive var(--duration-slow) var(--ease-spring) 1;");
+    expect(components).toContain("@keyframes panel-focus-arrive {");
+    expect(components).not.toContain(".canvas-operation.is-active::after {");
+    expect(components).not.toMatch(/\.canvas-operation\.is-focus-arriving::after \{/);
+    expect(operationFrame).toContain('focusArrival ? "is-focus-arriving" : ""');
+    expect(operationFrame).toContain("previousActiveRef");
     // 포커스의 깊이는 색을 하나도 쓰지 않는다 — 상태 채널과 겹칠 자리가 없다. 중립 rim 블록보다
     // 뒤에 서서, 진행 중인 패널이 포커스를 받아도 깊이는 포커스가 소유한다.
     const lift = components.match(/\n\.canvas-operation\.is-active:not\(\.is-deck-tile\) \{[^}]*\}/)?.[0] ?? "";


### PR DESCRIPTION
## Summary
- **A 롤백** — 포커스 캡션 워시를 brass 28% → 10%(원래 값)로 되돌렸습니다. 28%는 대비를 잘못된 자리에서 샀습니다: 캡션 혼자 화면에서 튀는 동안, 같은 캡션에 얹힌 후퇴는 다크에서 `(8,14,21) → (5,11,17)`로 거의 보이지 않았습니다.
- **후퇴를 본문으로** — 포커스한 패널이 있는 동안 나머지 Operation의 본문(`.canvas-operation-terminal`)이 `opacity: 0.72`로 물러납니다. 창의 머리(캡션)는 어느 패널인지를 말하는 자리라 그대로 두고, 물러나는 것은 읽던 내용 쪽입니다. 상태 레일은 캡션 소속이라 자동으로 남습니다.
- **도착 링(C 신설)** — 포커스가 새로 앉는 순간 창 둘레를 brass 링이 한 번(0.36s) 지나갑니다. 전이 전용이라 일시 클래스 `is-focus-arriving`이 소유하며(도착 플래시 `is-unseen-arriving` 선례와 같은 구조), 기본 `opacity: 0`이라 reduced-motion에서는 조용히 건너뜁니다.
- **덱 카드는 셋 다에서 제외** — 표식·후퇴·링 모두. 카드의 위치는 칸이 소유하고, Operation이 카드로 남은 채 활성이 되는 경로가 실제로 있습니다(`enterTriage` 조기 반환).

## 실측
| | 이전(#915) | 이번 |
|---|---|---|
| 포커스 캡션 | 28% 워시 | **10%(원복)** |
| 비포커스 캡션 | abyss 34% 혼합 | **손대지 않음** |
| 비포커스 본문 | 손대지 않음 | **opacity 0.72** |
| 이동 신호 | 없음 | **brass 링 1회 0.36s** |

- 후퇴한 이웃의 터미널 글자 대비: instrument **5.32:1**(포커스 9.22:1) — WCAG AA 4.5:1 위. whites는 1.61:1로 내려가지만 포커스 패널도 1.94:1이라 라이트 테마 터미널 팔레트의 선존 특성입니다.
- 링 발화: 실제 `Alt+→` 두 번에 링이 **도착지에서만** 47프레임(≈2×360ms) 관측, 포커스를 잃는 쪽은 0회.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 192 files / 2390 tests passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `build` — 통과
- [x] 격리 콘솔 헤디드: instrument·whites 두 테마 스크린샷 대조, 캡션 전 패널 동일·본문만 후퇴 확인
- [x] 링이 이동 순간에만·도착지에만 뜨는지 MutationObserver + 실제 키 입력으로 측정
- [x] `:has()` 게이트 — 포커스 없는 화면에서는 본문이 물러나지 않음
- [x] 디자인 계약을 같은 커밋에서 갱신(워시 10% · 본문 후퇴 · 링 문법 · 덱 제외 부정 단언)

Changelog-Amend: panel-focus-visibility.md