### PR TITLE
feat(fleet-console): fold quota provider cards without losing their reading

### DIFF
--- a/.changelog.d/quota-card-fold.md
+++ b/.changelog.d/quota-card-fold.md
@@ -1,0 +1,8 @@
+---
+branch: quota-card-fold
+---
+
+### fleet-console
+#### Added
+- Usage limits cards now collapse one at a time. A chevron in each card header folds that provider to a single row, and the row keeps reporting: the percentage of its most pressed window, a bar in the same severity colour the full meter uses, and the countdown to its reset. A provider that is collapsed while in trouble also carries a coloured rim, so a folded card is a density change rather than a blind spot. Cards with nothing to report say why instead - "Not connected", "No plan". Which cards are folded is remembered across restarts, next to the card order.
+  ko: 사용 한도 카드를 하나씩 접을 수 있습니다. 카드 머리의 화살표가 그 공급자를 한 줄로 접고, 접힌 줄은 계속 보고합니다 — 가장 급한 회차의 사용률, 펼친 미터와 같은 심각도 색의 막대, 리셋까지 남은 시간. 위험한 채로 접힌 카드는 테두리도 그 색을 입어, 접기가 사각지대가 아니라 밀도 전환이 됩니다. 보고할 것이 없는 카드는 이유를 대신 답니다 — "연결 안 됨", "구독 없음". 어떤 카드를 접었는지는 카드 순서와 함께 다시 켜도 유지됩니다.

--- a/runtime/fleet-console/tests/api-catalog.test.ts
+++ b/runtime/fleet-console/tests/api-catalog.test.ts
@@ -126,6 +126,7 @@ POST|/plugins/file-explorer/files/palette-search|http
 POST|/plugins/file-explorer/files/read|http
 POST|/plugins/file-explorer/files/reveal|http
 POST|/plugins/quota/connect|http
+POST|/plugins/quota/fold|http
 POST|/plugins/quota/order|http
 POST|/plugins/repository/changed|http
 POST|/plugins/repository/commit-create|http
@@ -215,7 +216,7 @@ describe("api catalog", () => {
 
     expect(response.status).toBe(200);
     expect(body.version).toBe("test");
-    expect(body.routes).toHaveLength(145);
+    expect(body.routes).toHaveLength(146);
     expect(body.routes).toEqual(expect.arrayContaining(buildApiCatalog()));
     const identities = body.routes.map(apiCatalogIdentity);
     expect(identities.slice().sort()).toEqual(EXPECTED_API_CATALOG_IDENTITIES);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1503,6 +1503,62 @@ describe("Instrument core design contract", () => {
     expect(panel).toContain('if (event.key === "Escape") setPinned(false);');
   });
 
+  it("pins the quota card fold — one severity channel, an honest hide, a sibling control", () => {
+    // 접기는 "치워두기"가 아니라 "밀도 바꾸기"다. 쿼터는 이 패널 밖에 신호가 하나도 없어
+    // 접힌 행이 그 공급자의 유일한 통로이기 때문에, 접힘이 신호를 삼키는 순간 사용자는
+    // 자기가 접어둔 공급자가 말라가는 것을 어디서도 듣지 못한다.
+    const css = externalSource(QUOTA_CSS_PATH).replace(/\r\n/g, "\n");
+    const panel = externalSource(QUOTA_PANEL_PATH).replace(/\r\n/g, "\n");
+
+    // (a) 접힌 행의 요약 막대는 미터와 같은 채널을 탄다 — 심각도가 두 문법으로 갈리면
+    // 한 공급자가 접힘과 펼침에서 서로 다른 판정을 말한다.
+    const spine = css.match(/^\.quota-fold-spine \{[^}]*\}/m)?.[0] ?? "";
+    expect(spine).toContain("--meter-accent: var(--ink-fog);");
+    expect(spine).toContain("--meter-weight: var(--gauge-weight-quiet);");
+    expect(css).toMatch(/\.quota-fold-spine--warning \{[^}]*--meter-accent: var\(--warn\);/);
+    expect(css).toMatch(/\.quota-fold-spine--warning \{[^}]*--meter-weight: var\(--gauge-weight-warn\);/);
+    expect(css).toMatch(/\.quota-fold-spine--critical \{[^}]*--meter-accent: var\(--coral\);/);
+    expect(css).toMatch(/\.quota-fold-spine--critical \{[^}]*--meter-weight: var\(--gauge-weight-critical\);/);
+    const spineFill = css.match(/\.quota-fold-spine__fill \{[^}]*\}/)?.[0] ?? "";
+    expect(spineFill).toContain("background: color-mix(in oklab, var(--meter-accent) var(--meter-weight), transparent);");
+    // 접힌 위험 카드의 테두리는 oklab에서 섞는다 — oklch는 coral(25°)과 hairline(245°)
+    // 사이의 짧은 호가 자주색을 지나, 실측에서 hue 309의 보라 테두리가 나왔다.
+    const alarm = css.match(/\.quota-card--alarm \{[^}]*\}/)?.[0];
+    expect(alarm).toBeDefined();
+    expect(alarm).toContain("color-mix(in oklab, var(--coral)");
+
+    // (b) 0fr은 상자를 없애지 않는다 — 높이 0의 내용은 접근성 트리에 그대로 남아
+    // 스크린리더에는 접은 적 없는 카드로 읽힌다. visibility가 눈과 트리를 맞춘다.
+    const rest = css.match(/\.quota-body--compact \.quota-card__rest,\n\.quota-card--folded \.quota-card__rest \{[^}]*\}/)?.[0] ?? "";
+    expect(rest).toContain("visibility: hidden;");
+    expect(css).toMatch(/\.quota-body--compact \.quota-card__collapse,\n\.quota-card--folded \.quota-card__collapse \{\n  grid-template-rows: 0fr;/);
+    // 접힌 밀도는 두 카드형을 이름으로 다 집어야 한다 — 한 클래스짜리 선택자는 파일 뒤쪽의
+    // `.quota-connect-card` 패딩과 특정성이 같아 연결 카드만 두꺼운 채로 접힌다.
+    expect(css).toMatch(/\.quota-provider\.quota-card--folded,\n\.quota-connect-card\.quota-card--folded \{\n  padding: 8px 12px;/);
+
+    // (c) 접기 컨트롤은 헤더의 형제다. 헤더 전체를 disclosure 버튼으로 만들면 이미 그
+    // 안에 사는 그립과 연결 해제 버튼이 접근성 트리에서 사라진다 — 버튼은 버튼을 품지 못한다.
+    expect(panel).toContain('className="quota-fold"');
+    expect(panel).toContain("aria-expanded={!folded}");
+    expect(panel).toContain("aria-controls={regionId}");
+    expect(panel).not.toMatch(/<button[^>]*className="quota-provider__header"/);
+
+    // (d) 헤더 우측 컨트롤은 여백을 다투지 않는다 — 각자 margin-left:auto를 집으면
+    // 접힘에서 display:none이 된 조각의 형제 선택자가 여전히 맞아 남은 컨트롤이 제목에 붙는다.
+    expect(css).toMatch(/\.quota-provider__header h3,\n\.quota-connect-card h3 \{\n  margin: 0 auto 0 0;/);
+    for (const selector of [".quota-plan", ".quota-disconnect"]) {
+      const block = css.match(new RegExp(`^\\${selector} \\{[^}]*\\}`, "m"))?.[0];
+      expect(block, selector).toBeDefined();
+      expect(block, selector).not.toContain("margin-left: auto;");
+    }
+
+    // (e) 좁은 레일은 패널의 폭이지 창의 폭이 아니다 — 미디어 쿼리로 물으면 240px 레일에서
+    // 넓은 화면의 답이 돌아와 헤더가 자기 컨트롤을 밀어낸다.
+    expect(css).toContain("container: quota-panel / inline-size;");
+    expect(css).toMatch(/@container quota-panel \(width < \d+px\) \{/);
+    expect(css).not.toMatch(/@media[^{]*\)\s*\{[^}]*\.quota-fold-spine/);
+  });
+
   it("pins the shared panel motion layer and existence choreography grammar", () => {
     const components = source("styles/components.css");
     // (a) 공통 모션 레이어의 duration/easing은 토큰 표기만 — 리터럴 ms 진입 금지.

--- a/runtime/fleet-plugins/quota/client/i18n/messages.ts
+++ b/runtime/fleet-plugins/quota/client/i18n/messages.ts
@@ -54,6 +54,17 @@ export const quotaEn = {
   "quota.reorder.handle": "Reorder {provider}. Use the arrow keys to move it.",
   "quota.reorder.moved": "{provider} moved to position {n}",
   "quota.reorder.error": "Couldn't save the order.",
+  "quota.fold.action": "Collapse {provider}",
+  "quota.unfold.action": "Expand {provider}",
+  "quota.fold.announced": "{provider} collapsed",
+  "quota.unfold.announced": "{provider} expanded",
+  "quota.fold.saveError": "Couldn't save which cards are collapsed.",
+  "quota.fold.summary": "{pct}% used, resets in {t}",
+  "quota.fold.notConnected": "Not connected",
+  "quota.fold.signedOut": "Not signed in",
+  "quota.fold.expired": "Sign-in expired",
+  "quota.fold.noSubscription": "No plan",
+  "quota.fold.unavailable": "Unavailable",
 } as const;
 
 export const quotaKo: Record<keyof typeof quotaEn, string> = {
@@ -112,6 +123,17 @@ export const quotaKo: Record<keyof typeof quotaEn, string> = {
   "quota.reorder.handle": "{provider} 순서 변경. 화살표 키로 이동합니다.",
   "quota.reorder.moved": "{provider} — {n}번째로 이동",
   "quota.reorder.error": "순서를 저장하지 못했습니다.",
+  "quota.fold.action": "{provider} 접기",
+  "quota.unfold.action": "{provider} 펼치기",
+  "quota.fold.announced": "{provider} 접힘",
+  "quota.unfold.announced": "{provider} 펼침",
+  "quota.fold.saveError": "접힌 카드를 저장하지 못했습니다.",
+  "quota.fold.summary": "{pct}% 사용, 리셋까지 {t}",
+  "quota.fold.notConnected": "연결 안 됨",
+  "quota.fold.signedOut": "로그인 없음",
+  "quota.fold.expired": "로그인 만료",
+  "quota.fold.noSubscription": "구독 없음",
+  "quota.fold.unavailable": "확인 불가",
 };
 
 export const QUOTA_MESSAGES = { en: quotaEn, ko: quotaKo } as const;

--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -9,11 +9,14 @@
 
 /* position: relative는 드롭 인디케이터의 기준 상자다 — 인디케이터는 스크롤 콘텐츠
    좌표(offsetTop)로 놓이므로 기준이 이 스크롤 컨테이너 자신이어야 한다. */
+/* 카드 밀도는 뷰포트가 아니라 이 패널의 폭이 정한다 — 레일은 240px까지 좁아지는데
+   창은 그대로다. 미디어 쿼리로 물으면 좁은 레일에서 넓은 화면의 답이 돌아온다. */
 .quota-body {
   position: relative;
   display: flex;
   flex: 1;
   flex-direction: column;
+  container: quota-panel / inline-size;
   gap: 14px;
   min-height: 0;
   padding: 16px;
@@ -212,25 +215,168 @@
 .quota-card__rest {
   overflow: hidden;
   min-height: 0;
+  /* 펼칠 때는 즉시 되살아나고, 접을 때만 전환이 끝난 뒤에 사라진다. */
+  transition: visibility 0s linear 0s;
 }
 
 .quota-body--compact {
   user-select: none;
 }
 
-.quota-body--compact .quota-card__collapse {
+/* 드래그 중의 일괄 접힘과 사용자가 고른 카드별 접힘은 같은 그림을 쓴다 — 하나가
+   다른 문법으로 접히면 드래그를 놓는 순간 카드가 다른 밀도로 착지한다. */
+.quota-body--compact .quota-card__collapse,
+.quota-card--folded .quota-card__collapse {
   grid-template-rows: 0fr;
 }
 
+/* 0fr은 상자를 없애지 않는다 — 높이 0의 내용은 화면에서만 사라지고 접근성 트리에는
+   그대로 남아, 스크린리더에는 접은 적 없는 카드로 읽힌다. visibility가 그 둘을 맞춘다. */
+.quota-body--compact .quota-card__rest,
+.quota-card--folded .quota-card__rest {
+  visibility: hidden;
+  transition: visibility 0s linear 180ms;
+}
+
+/* 두 카드형을 이름으로 다 적는다 — `.quota-card--folded` 한 클래스만으로는 파일 뒤쪽의
+   `.quota-connect-card { padding: 18px 16px }`와 특정성이 같아, 연결 카드만 20px 더
+   두꺼운 채로 접힌다. */
 .quota-body--compact .quota-provider,
-.quota-body--compact .quota-connect-card {
+.quota-body--compact .quota-connect-card,
+.quota-provider.quota-card--folded,
+.quota-connect-card.quota-card--folded {
   padding: 8px 12px;
 }
 
-/* 접힌 행에서는 헤더 우측 컨트롤을 치운다 — 드래그 중 남는 정보는 정체뿐이다. */
+/* 접힌 행에서는 헤더 우측 컨트롤을 치운다 — 한 줄로 접힌 카드에 남는 정보는 정체뿐이고,
+   연결 해제는 펼친 카드의 조작이다. */
 .quota-body--compact .quota-plan,
-.quota-body--compact .quota-disconnect {
+.quota-body--compact .quota-disconnect,
+.quota-card--folded .quota-plan,
+.quota-card--folded .quota-disconnect {
   display: none;
+}
+
+/* ── 카드별 접기 ───────────────────────────────
+   그립이 순서를 쥐듯 이 버튼은 밀도를 쥔다. 헤더 전체를 하나의 disclosure 버튼으로
+   만들지 않은 이유는 그 안에 이미 버튼이 둘 살기 때문이다 — 버튼은 버튼을 품지 못한다. */
+.quota-fold {
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  margin-right: -2px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-xs);
+  color: var(--text-tertiary);
+  background: transparent;
+  cursor: pointer;
+  transition: color 120ms ease, transform 180ms ease;
+}
+
+.quota-fold:hover,
+.quota-fold:focus-visible {
+  color: var(--brass);
+}
+
+.quota-fold:focus-visible {
+  outline: 1px solid var(--brass);
+  outline-offset: 1px;
+}
+
+.quota-fold[aria-expanded="false"] {
+  transform: rotate(-90deg);
+}
+
+/* 드래그 중에는 밀도를 쥐는 손이 둘일 수 없다 — 일괄 접힘 위에서 카드별 접기 버튼이
+   자기 상태를 그리면 화살표가 가리키는 방향과 실제 행이 어긋난다. */
+.quota-body--compact .quota-fold {
+  visibility: hidden;
+}
+
+/* 접힌 행에 남는 요약. 이 자리가 비면 90%를 넘긴 공급자를 접어둔 사용자는 그 사실을
+   어디서도 듣지 못한다 — 쿼터는 이 패널 밖에 신호가 없다. */
+.quota-fold-spine {
+  --meter-accent: var(--ink-fog);
+  --meter-weight: var(--gauge-weight-quiet);
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.quota-fold-spine--warning {
+  --meter-accent: var(--warn);
+  --meter-weight: var(--gauge-weight-warn);
+}
+
+.quota-fold-spine--critical {
+  --meter-accent: var(--coral);
+  --meter-weight: var(--gauge-weight-critical);
+}
+
+.quota-fold-spine__percent {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.quota-fold-spine--warning .quota-fold-spine__percent {
+  color: var(--warn-ink);
+}
+
+.quota-fold-spine--critical .quota-fold-spine__percent {
+  color: var(--coral-ink);
+}
+
+/* 미터와 같은 채널을 탄다 — 심각도가 두 문법으로 갈리면 한 공급자가 접힘과 펼침에서
+   서로 다른 판정을 말한다. */
+.quota-fold-spine__bar {
+  position: relative;
+  width: 40px;
+  height: 4px;
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: var(--ink-veil);
+}
+
+.quota-fold-spine__fill {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklab, var(--meter-accent) var(--meter-weight), transparent);
+}
+
+.quota-fold-spine__reset {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  white-space: nowrap;
+}
+
+.quota-fold-spine--quiet {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* 위험한 채로 접힌 카드는 테두리도 그 판정을 입는다. 40px 행 일곱 줄을 훑을 때
+   한 줄만 읽게 만드는 것은 스파인의 숫자가 아니라 이 테두리다.
+
+   섞는 공간은 oklab이다 — oklch는 두 색상각 사이의 짧은 호를 도는데, coral(25°)과
+   hairline(245°)은 그 호가 자주색을 지나 실측에서 hue 309의 보라 테두리가 나왔다.
+   직교 좌표에서 섞으면 채도만 빠진 coral로 착지한다. */
+.quota-card--alarm {
+  border-color: color-mix(in oklab, var(--coral) 46%, var(--hairline));
 }
 
 .quota-card--dragging {
@@ -289,9 +435,12 @@
   background: var(--aurora);
 }
 
+/* 헤더 오른쪽에는 상태 칩·연결 해제·접기가 조합에 따라 0~3개 선다. 각자 margin-left:auto를
+   집으면 조합마다 상쇄 규칙이 하나씩 늘고, 그중 하나가 접힘에서 display:none이 되는 순간
+   형제 선택자는 여전히 맞아 남은 컨트롤이 제목에 붙는다. 여백은 제목이 한 번만 가진다. */
 .quota-provider__header h3,
 .quota-connect-card h3 {
-  margin: 0;
+  margin: 0 auto 0 0;
   font-size: var(--t-base);
   font-weight: var(--weight-medium);
 }
@@ -337,7 +486,6 @@
 }
 
 .quota-plan {
-  margin-left: auto;
   border: 1px solid var(--hairline);
   border-radius: var(--radius-pill);
   padding: 2px 9px;
@@ -348,7 +496,6 @@
 }
 
 .quota-disconnect {
-  margin-left: auto;
   padding: 2px 4px;
   border: 0;
   color: var(--text-tertiary);
@@ -361,11 +508,6 @@
 .quota-disconnect:hover,
 .quota-disconnect:focus-visible {
   color: var(--brass);
-}
-
-.quota-plan + .quota-disconnect,
-.quota-disconnect:has(+ .quota-plan) {
-  margin-left: 0;
 }
 
 /* 심각도는 이 채널 하나로만 흐른다 — 채움과 예측 빗금이 각자 색을 집으면
@@ -644,10 +786,24 @@
   cursor: pointer;
 }
 
+/* 좁은 레일에서 헤더는 접기 버튼이 들어갈 28px을 갖고 있지 않다. 먼저 자리를 내주는
+   것은 정체를 말하는 조각들이다 — 상태 칩, 요약 막대, 리셋 시각, 사유 꼬리표가 빠지고
+   퍼센트만 남는다. 그 한 숫자가 접힌 행이 존재하는 이유이기 때문이다. */
+@container quota-panel (width < 300px) {
+  .quota-plan,
+  .quota-fold-spine__bar,
+  .quota-fold-spine__reset,
+  .quota-fold-spine--quiet {
+    display: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .quota-meter__fill,
   .quota-legend__bubble,
-  .quota-card__collapse {
+  .quota-card__collapse,
+  .quota-card__rest,
+  .quota-fold {
     transition: none;
   }
 }

--- a/runtime/fleet-plugins/quota/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/quota/client/rail-panel.tsx
@@ -98,6 +98,25 @@ export function isLatestRequestGeneration(generation: RequestGeneration, capture
   return generation.current === captured;
 }
 
+/**
+ * 응답이 실어온 접힘을 채택해도 되는가. 두 조건의 논리곱이며, 둘 중 하나만으로는
+ * 실측된 두 결함이 각각 남는다.
+ *
+ * - `revision === persisted` — 요청이 떠날 때 서버가 이미 우리가 든 것과 같은 집합을
+ *   들고 있었는가. 저장이 아직 도달하지 않은 채로 나간 요청은 그 이전 집합을 실어 온다.
+ * - `current === revision` — 떠난 뒤로 사용자가 카드를 접지 않았는가. 그 사이의 조작은
+ *   이 답보다 새롭다.
+ *
+ * 둘 다 아닐 때 채택하면 화면과 서버가 갈리고, 다음 토글이 그 옛 집합 위에서 계산되어
+ * 이미 저장된 접힘을 지운다.
+ */
+export function adoptsFoldedProviders(
+  captured: { readonly revision: number; readonly persisted: number },
+  current: number,
+): boolean {
+  return captured.revision === captured.persisted && current === captured.revision;
+}
+
 function elapsed(at: number | undefined, now: number): string {
   const delta = Math.max(0, now - (at ?? now));
   const days = Math.floor(delta / 86_400_000);
@@ -677,6 +696,9 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
      펼쳐졌는데 서버는 접힘이었고, 다음 토글이 그 옛 집합 위에서 계산되어 앞의 접힘을
      지웠다. 그래서 요청이 출발한 시점의 리비전을 들고 있다가 그때 그대로일 때만 채택한다. */
   const foldRevisionRef = useRef(0);
+  /* 서버가 들고 있다고 확인된 리비전. 토글은 리비전을 올리지만 저장은 foldSaveRef 뒤에
+     줄을 서므로, 둘이 어긋난 동안 떠난 요청은 아직 저장되지 않은 집합을 실어 온다. */
+  const foldPersistedRef = useRef(0);
 
   const adoptFolded = useCallback((next: readonly ProviderId[]) => {
     foldedRef.current = next;
@@ -690,7 +712,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
 
   const connect = useCallback((provider: ConnectableProviderId, connected: boolean) => {
     const generation = beginRequestGeneration(requestGenerationRef);
-    const foldRevision = foldRevisionRef.current;
+    const foldCapture = { persisted: foldPersistedRef.current, revision: foldRevisionRef.current };
     if (isLatestRequestGeneration(requestGenerationRef, generation)) setRequestError(false);
     ctx.api.fetch("quota", "connect", {
       method: "POST",
@@ -705,8 +727,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
         if (isLatestRequestGeneration(requestGenerationRef, generation)) {
           setData(result);
           setOrder(sanitizeProviderOrder(result.providerOrder));
-          // 요청이 출발한 뒤 사용자가 카드를 접었다면 이 답은 그 조작 이전의 것이다.
-          if (isLatestRequestGeneration(foldRevisionRef, foldRevision)) {
+          if (adoptsFoldedProviders(foldCapture, foldRevisionRef.current)) {
             adoptFolded(sanitizeFoldedProviders(result.foldedProviders));
           }
           setRequestError(false);
@@ -744,7 +765,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
       next.includes(id) ? "quota.fold.announced" : "quota.unfold.announced",
       { provider: PROVIDER_NAME[id] },
     ));
-    beginRequestGeneration(foldRevisionRef);
+    const revision = beginRequestGeneration(foldRevisionRef);
     const save = () => ctx.api.fetch("quota", "fold", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -753,12 +774,19 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
       .then((response) => {
         if (!response.ok) throw new Error("fold_failed");
       })
-      .catch(() => {
-        // 순서 저장과 같은 규칙 — 낙관 반영을 손으로 되돌리지 않고 서버 진실로 재동기화한다.
-        // 새로 나가는 요청은 지금 리비전을 들고 가므로 그 답은 채택된다.
-        setAnnouncement(t("quota.fold.saveError"));
-        refresh(false);
-      });
+      .then(
+        () => {
+          // 저장은 직렬화되어 순서대로 끝나지만, 이 값은 앞으로만 간다는 것이 계약이다.
+          foldPersistedRef.current = Math.max(foldPersistedRef.current, revision);
+        },
+        () => {
+          // 순서 저장과 같은 규칙 — 낙관 반영을 손으로 되돌리지 않고 서버 진실로 재동기화한다.
+          // 미저장 의도를 여기서 함께 접어야 그 재동기화 응답이 자기 검사에 걸리지 않는다.
+          foldPersistedRef.current = foldRevisionRef.current;
+          setAnnouncement(t("quota.fold.saveError"));
+          refresh(false);
+        },
+      );
     foldSaveRef.current = foldSaveRef.current.then(save, save);
   }, [ctx.api, adoptFolded, t, refresh]);
 
@@ -877,7 +905,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
 
   useEffect(() => {
     const generation = beginRequestGeneration(requestGenerationRef);
-    const foldRevision = foldRevisionRef.current;
+    const foldCapture = { persisted: foldPersistedRef.current, revision: foldRevisionRef.current };
     if (isLatestRequestGeneration(requestGenerationRef, generation)) setRequestError(false);
     const force = forceRef.current;
     forceRef.current = false;
@@ -890,8 +918,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
         if (isLatestRequestGeneration(requestGenerationRef, generation)) {
           setData(result);
           setOrder(sanitizeProviderOrder(result.providerOrder));
-          // 요청이 출발한 뒤 사용자가 카드를 접었다면 이 답은 그 조작 이전의 것이다.
-          if (isLatestRequestGeneration(foldRevisionRef, foldRevision)) {
+          if (adoptsFoldedProviders(foldCapture, foldRevisionRef.current)) {
             adoptFolded(sanitizeFoldedProviders(result.foldedProviders));
           }
           setRequestError(false);

--- a/runtime/fleet-plugins/quota/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/quota/client/rail-panel.tsx
@@ -4,18 +4,20 @@ import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerE
 import type { ConsoleLocale, Translate } from "@fleet-console/sdk/i18n";
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
 
-import type { ProviderDto, QuotaSummaryDto, QuotaWindow, ResetCredits } from "@dotobokuri/core-ai-gateway";
+import type { ProviderDto, ProviderStatus, QuotaSummaryDto, QuotaWindow, ResetCredits } from "@dotobokuri/core-ai-gateway";
 import {
   isProviderId,
   PROVIDER_ORDER_DEFAULT,
+  sanitizeFoldedProviders,
   sanitizeProviderOrder,
+  toggledFoldedProviders,
   type ProviderId,
 } from "../provider-order.js";
 import { providerGlyph } from "./cli-glyphs.js";
 import { getT, type QuotaMessageKey } from "./i18n/index.js";
 import "./quota.css";
 
-export { PROVIDER_ORDER_DEFAULT, sanitizeProviderOrder };
+export { PROVIDER_ORDER_DEFAULT, sanitizeFoldedProviders, sanitizeProviderOrder, toggledFoldedProviders };
 export type { ProviderId };
 
 type T = Translate<QuotaMessageKey>;
@@ -178,6 +180,12 @@ export function visibleCredits(credits: ResetCredits | undefined): ResetCredits 
   return credits !== undefined && credits.available > 0 ? credits : null;
 }
 
+const SEVERITY_RANK: Readonly<Record<"normal" | "warning" | "critical", number>> = {
+  critical: 2,
+  normal: 0,
+  warning: 1,
+};
+
 /**
  * The gateway's own verdict decides the meter's severity. Re-deriving one from
  * `usedPercent` alone is what let a window read calm here while the roster a
@@ -193,6 +201,39 @@ export function meterSeverity(window: QuotaWindow): "normal" | "warning" | "crit
     default: return window.usedPercent >= 90 ? "critical" : window.usedPercent >= 70 ? "warning" : "normal";
   }
 }
+
+/**
+ * 접힌 행이 대변할 창 하나.
+ *
+ * 집계 창(isAggregate)은 형제 창들의 합이라 개별 풀이 말라도 평온하게 읽힌다 —
+ * 실제 풀이 하나라도 있으면 집계는 후보에서 뺀다. 그다음 순위는 퍼센트가 아니라
+ * 게이트웨이의 압력 판정이 먼저다. 회차의 5분의 1 지점에서 44%를 쓴 창은 조용한
+ * 60% 창보다 급하고, 퍼센트만 보는 비교로는 그 사실을 볼 수 없다.
+ */
+export function foldedWindow(windows: readonly QuotaWindow[] | undefined): QuotaWindow | null {
+  if (windows === undefined || windows.length === 0) return null;
+  const pools = windows.filter((window) => window.isAggregate !== true);
+  const candidates = pools.length > 0 ? pools : windows;
+  return candidates.reduce((worst, window) => {
+    const rank = SEVERITY_RANK[meterSeverity(window)] - SEVERITY_RANK[meterSeverity(worst)];
+    if (rank !== 0) return rank > 0 ? window : worst;
+    return window.usedPercent > worst.usedPercent ? window : worst;
+  });
+}
+
+/**
+ * 읽을 수치가 없는 카드가 접혔을 때 그 자리에 남는 한 마디. 카드를 펼쳐야 알 수 있는
+ * 긴 안내를 줄이는 것이 아니라, "여기에는 볼 것이 없다"는 사실 자체를 행에 남긴다 —
+ * 없으면 접힌 행은 이름만 남아 아직 못 읽은 카드와 구분되지 않는다.
+ */
+export const FOLDED_STATUS_KEY: Readonly<Partial<Record<ProviderStatus, QuotaMessageKey>>> = {
+  error: "quota.fold.unavailable",
+  expired: "quota.fold.expired",
+  no_subscription: "quota.fold.noSubscription",
+  not_connected: "quota.fold.notConnected",
+  signed_out: "quota.fold.signedOut",
+  stale: "quota.fold.unavailable",
+};
 
 function clampPercent(value: number): number {
   return Math.min(100, Math.max(0, value));
@@ -401,6 +442,82 @@ function GripButton({ name, t }: { readonly name: string; readonly t: T }) {
   );
 }
 
+/* 카드 하나를 헤더 한 줄로 접었다 펴는 조작. 그립·연결 해제와 나란한 형제 버튼인
+   이유는 버튼이 버튼을 품을 수 없어서다 — 헤더 전체를 하나의 disclosure 버튼으로
+   만들면 이미 그 안에 사는 두 컨트롤이 접근성 트리에서 사라진다. */
+function FoldButton({
+  folded,
+  name,
+  regionId,
+  onToggle,
+  t,
+}: {
+  readonly folded: boolean;
+  readonly name: string;
+  readonly regionId: string;
+  readonly onToggle: () => void;
+  readonly t: T;
+}) {
+  return (
+    <button
+      type="button"
+      className="quota-fold"
+      aria-expanded={!folded}
+      aria-controls={regionId}
+      aria-label={t(folded ? "quota.unfold.action" : "quota.fold.action", { provider: name })}
+      onClick={onToggle}
+    >
+      <svg width="10" height="10" viewBox="0 0 10 10" stroke="currentColor" fill="none" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M1.5 3.5 L5 7 L8.5 3.5" />
+      </svg>
+    </button>
+  );
+}
+
+/**
+ * 접힌 행에 남는 요약. 접기가 "치워두기"가 아니라 "밀도 바꾸기"가 되는 지점이다 —
+ * 이 자리가 비면 90%를 넘긴 공급자를 접어둔 사용자는 그 사실을 어디서도 듣지 못한다.
+ * 패널 밖에 쿼터 신호가 하나도 없어 이 행이 유일한 통로이기 때문이다.
+ *
+ * 막대는 미터와 같은 채널을 탄다(--meter-accent/--meter-weight). 심각도가 두 문법으로
+ * 갈리면 같은 공급자가 접힘/펼침에서 서로 다른 판정을 말하게 된다.
+ */
+function FoldSpine({
+  provider,
+  now,
+  t,
+}: {
+  readonly provider: ProviderDto;
+  readonly now: number;
+  readonly t: T;
+}) {
+  const window = (provider.status === "ok" || provider.status === "stale")
+    ? foldedWindow(provider.windows)
+    : null;
+  if (window === null) {
+    const statusKey = FOLDED_STATUS_KEY[provider.status];
+    return statusKey === undefined
+      ? null
+      : <span className="quota-fold-spine quota-fold-spine--quiet">{t(statusKey)}</span>;
+  }
+  const severity = meterSeverity(window);
+  const countdown = window.resetsAt === undefined ? null : formatCountdown(window.resetsAt, now);
+  const used = t("quota.meter.used", { pct: window.usedPercent });
+  return (
+    <span
+      className={`quota-fold-spine quota-fold-spine--${severity}`}
+      role="img"
+      aria-label={countdown === null ? used : t("quota.fold.summary", { pct: window.usedPercent, t: countdown })}
+    >
+      <span className="quota-fold-spine__percent">{window.usedPercent}%</span>
+      <span className="quota-fold-spine__bar">
+        <span className="quota-fold-spine__fill" style={{ width: `${clampPercent(window.usedPercent)}%` }} />
+      </span>
+      {countdown === null ? null : <span className="quota-fold-spine__reset">{countdown}</span>}
+    </span>
+  );
+}
+
 /** 크레딧 칩의 표식. 미터의 리셋 카운트다운과 달리 "내가 당길 수 있는 리셋"이라 회전 화살표를 쓴다. */
 function ResetGlyph() {
   return (
@@ -429,6 +546,8 @@ function ProviderCard({
   t,
   connect,
   dragging,
+  folded,
+  toggleFold,
 }: {
   readonly id: ProviderId;
   readonly provider: ProviderDto;
@@ -437,20 +556,37 @@ function ProviderCard({
   readonly t: T;
   readonly connect: (provider: ConnectableProviderId, connected: boolean) => void;
   readonly dragging: boolean;
+  readonly folded: boolean;
+  readonly toggleFold: (provider: ProviderId) => void;
 }) {
   const name = PROVIDER_NAME[id];
+  const regionId = `quota-card-${id}`;
+  // 접힌 카드가 위험을 말하고 있으면 테두리도 그 판정을 입는다. 40px 행 일곱 줄을
+  // 훑을 때 한 줄만 읽게 만드는 것은 스파인의 숫자가 아니라 이 테두리다.
+  const summary = folded && (provider.status === "ok" || provider.status === "stale")
+    ? foldedWindow(provider.windows)
+    : null;
+  const alarm = summary !== null && meterSeverity(summary) === "critical";
+  const modifiers = `${dragging ? " quota-card--dragging" : ""}${folded ? " quota-card--folded" : ""}${alarm ? " quota-card--alarm" : ""}`;
+  const foldButton = (
+    <FoldButton folded={folded} name={name} regionId={regionId} onToggle={() => toggleFold(id)} t={t} />
+  );
   if (isConnectable(id) && provider.status === "not_connected") {
     const titleKey = id === "claude" ? "quota.connect.title" : "quota.connect.title.cursor";
     const bodyKey = id === "claude" ? "quota.connect.body" : "quota.connect.body.cursor";
     const actionKey = id === "claude" ? "quota.connect.action" : "quota.connect.action.cursor";
     return (
-      <section className={`quota-connect-card${dragging ? " quota-card--dragging" : ""}`} data-provider={id}>
+      <section className={`quota-connect-card${modifiers}`} data-provider={id}>
         <header className="quota-provider__header">
           <GripButton name={name} t={t} />
           <span className={`quota-provider__mark quota-provider__mark--${id}`}>{providerGlyph(id)}</span>
-          <h3>{t(titleKey)}</h3>
+          {/* 접힌 행은 목록의 한 줄이지 권유가 아니다 — 버튼이 사라진 자리에 "연결하세요"만
+              남으면 누를 곳 없는 지시가 된다. 그 자리에는 공급자 이름을 둔다. */}
+          <h3>{folded ? name : t(titleKey)}</h3>
+          {folded ? <FoldSpine provider={provider} now={now} t={t} /> : null}
+          {foldButton}
         </header>
-        <div className="quota-card__collapse">
+        <div className="quota-card__collapse" id={regionId}>
           <div className="quota-card__rest">
             <p>{t(bodyKey)}</p>
             {provider.method === "keychain" ? <p className="quota-connect-card__hint">{t("quota.connect.keychain")}</p> : null}
@@ -461,15 +597,17 @@ function ProviderCard({
     );
   }
   return (
-    <section className={`quota-provider${dragging ? " quota-card--dragging" : ""}`} data-provider={id}>
+    <section className={`quota-provider${modifiers}`} data-provider={id}>
       <header className="quota-provider__header">
         <GripButton name={name} t={t} />
         <span className={`quota-provider__mark quota-provider__mark--${id}`}>{providerGlyph(id)}</span>
         <h3>{name}</h3>
+        {folded ? <FoldSpine provider={provider} now={now} t={t} /> : null}
         {isConnectable(id) ? <button type="button" className="quota-disconnect" onClick={() => connect(id, false)}>{t("quota.disconnect.action")}</button> : null}
         {provider.plan ? <span className="quota-plan">{provider.plan}</span> : null}
+        {foldButton}
       </header>
-      <div className="quota-card__collapse">
+      <div className="quota-card__collapse" id={regionId}>
       <div className="quota-card__rest">
       {provider.status === "signed_out" ? <div className="quota-signed-out">{t(SIGNED_OUT_KEY[id])}</div> : null}
       {provider.status === "no_subscription" ? <div className="quota-signed-out">{t(NO_SUBSCRIPTION_KEY[id])}</div> : null}
@@ -503,8 +641,11 @@ function ProviderCard({
   );
 }
 
-/** summary 계열 응답은 코어 DTO에 플러그인 소유의 저장 순서를 얹어 온다. */
-type SummaryResponse = QuotaSummaryDto & { readonly providerOrder?: unknown };
+/** summary 계열 응답은 코어 DTO에 플러그인 소유의 패널 설정을 얹어 온다. */
+type SummaryResponse = QuotaSummaryDto & {
+  readonly providerOrder?: unknown;
+  readonly foldedProviders?: unknown;
+};
 
 function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   const t = useMemo(() => getT(ctx.language), [ctx.language]);
@@ -513,6 +654,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   const [now, setNow] = useState(Date.now());
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [order, setOrder] = useState<readonly ProviderId[]>(PROVIDER_ORDER_DEFAULT);
+  const [folded, setFolded] = useState<readonly ProviderId[]>([]);
   const [draggingId, setDraggingId] = useState<ProviderId | null>(null);
   const [announcement, setAnnouncement] = useState("");
   const forceRef = useRef(false);
@@ -523,6 +665,19 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   // 저장 요청 체인. 연속 이동의 POST가 서로를 추월하면 서버는 도착순으로 기록해
   // 옛 순열이 최종본이 될 수 있다 — 앞 요청이 끝난 뒤에만 다음을 보낸다.
   const orderSaveRef = useRef<Promise<void>>(Promise.resolve());
+  // 접힘도 같은 이유로 직렬화한다. 두 번 빠르게 누르면 두 POST가 서로를 추월해
+  // 화면은 펼쳐진 채 서버는 접힘으로 남을 수 있다.
+  const foldSaveRef = useRef<Promise<void>>(Promise.resolve());
+  /* 토글이 읽는 진실은 상태가 아니라 이 ref다. 같은 틱에 두 카드를 접으면 두 핸들러가
+     모두 렌더 전의 옛 집합을 읽어, 나중 것이 앞의 접힘을 지운 채로 저장된다. */
+  const foldedRef = useRef<readonly ProviderId[]>([]);
+  // 저장이 날아가 있는 동안 도착한 summary는 내 접힘보다 옛 진실을 싣고 있다.
+  const foldSavesInFlight = useRef(0);
+
+  const adoptFolded = useCallback((next: readonly ProviderId[]) => {
+    foldedRef.current = next;
+    setFolded(next);
+  }, []);
 
   const refresh = useCallback((forceRequest = false) => {
     forceRef.current = forceRequest;
@@ -545,6 +700,9 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
         if (isLatestRequestGeneration(requestGenerationRef, generation)) {
           setData(result);
           setOrder(sanitizeProviderOrder(result.providerOrder));
+          // 저장이 아직 날아가는 중이면 서버의 답은 내 조작 이전의 것이다 — 그대로
+          // 채택하면 방금 접은 카드가 스스로 펼쳐진다.
+          if (foldSavesInFlight.current === 0) adoptFolded(sanitizeFoldedProviders(result.foldedProviders));
           setRequestError(false);
           setNow(Date.now());
         }
@@ -572,6 +730,37 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
       });
     orderSaveRef.current = orderSaveRef.current.then(save, save);
   }, [ctx.api, t, refresh]);
+
+  const toggleFold = useCallback((id: ProviderId) => {
+    const next = toggledFoldedProviders(foldedRef.current, id);
+    adoptFolded(next);
+    setAnnouncement(t(
+      next.includes(id) ? "quota.fold.announced" : "quota.unfold.announced",
+      { provider: PROVIDER_NAME[id] },
+    ));
+    foldSavesInFlight.current += 1;
+    const save = () => ctx.api.fetch("quota", "fold", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ folded: next }),
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error("fold_failed");
+      })
+      .then(
+        () => {
+          foldSavesInFlight.current -= 1;
+        },
+        () => {
+          // 순서 저장과 같은 규칙 — 낙관 반영을 손으로 되돌리지 않고 서버 진실로 재동기화한다.
+          // 카운터를 먼저 내려야 그 재동기화가 자기 자신에게 막히지 않는다.
+          foldSavesInFlight.current -= 1;
+          setAnnouncement(t("quota.fold.saveError"));
+          refresh(false);
+        },
+      );
+    foldSaveRef.current = foldSaveRef.current.then(save, save);
+  }, [ctx.api, adoptFolded, t, refresh]);
 
   /* 드롭 판정은 상태가 아니라 DOM에서 읽는다. 카드가 order 상태를 그대로 그리는 동안은
      둘이 같지만, 드래그 중 도착한 connect 응답이 순서를 바꿔도 화면에 보이던 그대로가
@@ -700,6 +889,9 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
         if (isLatestRequestGeneration(requestGenerationRef, generation)) {
           setData(result);
           setOrder(sanitizeProviderOrder(result.providerOrder));
+          // 저장이 아직 날아가는 중이면 서버의 답은 내 조작 이전의 것이다 — 그대로
+          // 채택하면 방금 접은 카드가 스스로 펼쳐진다.
+          if (foldSavesInFlight.current === 0) adoptFolded(sanitizeFoldedProviders(result.foldedProviders));
           setRequestError(false);
           setNow(Date.now());
         }
@@ -765,6 +957,8 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
             t={t}
             connect={connect}
             dragging={draggingId === id}
+            folded={folded.includes(id)}
+            toggleFold={toggleFold}
           />
         )) : null}
         {draggingId !== null ? <span className="quota-drop-line" ref={dropLineRef} aria-hidden="true" /> : null}

--- a/runtime/fleet-plugins/quota/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/quota/client/rail-panel.tsx
@@ -671,8 +671,12 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   /* 토글이 읽는 진실은 상태가 아니라 이 ref다. 같은 틱에 두 카드를 접으면 두 핸들러가
      모두 렌더 전의 옛 집합을 읽어, 나중 것이 앞의 접힘을 지운 채로 저장된다. */
   const foldedRef = useRef<readonly ProviderId[]>([]);
-  // 저장이 날아가 있는 동안 도착한 summary는 내 접힘보다 옛 진실을 싣고 있다.
-  const foldSavesInFlight = useRef(0);
+  /* 응답이 실어온 접힘을 채택해도 되는지는 "지금 저장이 날아가는 중인가"로 판정할 수 없다.
+     서버는 요청을 받은 시점의 설정을 읽고, 그 답이 오는 사이에 사용자가 접은 카드의 저장은
+     이미 끝나 있을 수 있다 — 그 순간 카운터는 0이라 옛 집합이 통과한다. 실측에서 화면은
+     펼쳐졌는데 서버는 접힘이었고, 다음 토글이 그 옛 집합 위에서 계산되어 앞의 접힘을
+     지웠다. 그래서 요청이 출발한 시점의 리비전을 들고 있다가 그때 그대로일 때만 채택한다. */
+  const foldRevisionRef = useRef(0);
 
   const adoptFolded = useCallback((next: readonly ProviderId[]) => {
     foldedRef.current = next;
@@ -686,6 +690,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
 
   const connect = useCallback((provider: ConnectableProviderId, connected: boolean) => {
     const generation = beginRequestGeneration(requestGenerationRef);
+    const foldRevision = foldRevisionRef.current;
     if (isLatestRequestGeneration(requestGenerationRef, generation)) setRequestError(false);
     ctx.api.fetch("quota", "connect", {
       method: "POST",
@@ -700,9 +705,10 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
         if (isLatestRequestGeneration(requestGenerationRef, generation)) {
           setData(result);
           setOrder(sanitizeProviderOrder(result.providerOrder));
-          // 저장이 아직 날아가는 중이면 서버의 답은 내 조작 이전의 것이다 — 그대로
-          // 채택하면 방금 접은 카드가 스스로 펼쳐진다.
-          if (foldSavesInFlight.current === 0) adoptFolded(sanitizeFoldedProviders(result.foldedProviders));
+          // 요청이 출발한 뒤 사용자가 카드를 접었다면 이 답은 그 조작 이전의 것이다.
+          if (isLatestRequestGeneration(foldRevisionRef, foldRevision)) {
+            adoptFolded(sanitizeFoldedProviders(result.foldedProviders));
+          }
           setRequestError(false);
           setNow(Date.now());
         }
@@ -738,7 +744,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
       next.includes(id) ? "quota.fold.announced" : "quota.unfold.announced",
       { provider: PROVIDER_NAME[id] },
     ));
-    foldSavesInFlight.current += 1;
+    beginRequestGeneration(foldRevisionRef);
     const save = () => ctx.api.fetch("quota", "fold", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -747,18 +753,12 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
       .then((response) => {
         if (!response.ok) throw new Error("fold_failed");
       })
-      .then(
-        () => {
-          foldSavesInFlight.current -= 1;
-        },
-        () => {
-          // 순서 저장과 같은 규칙 — 낙관 반영을 손으로 되돌리지 않고 서버 진실로 재동기화한다.
-          // 카운터를 먼저 내려야 그 재동기화가 자기 자신에게 막히지 않는다.
-          foldSavesInFlight.current -= 1;
-          setAnnouncement(t("quota.fold.saveError"));
-          refresh(false);
-        },
-      );
+      .catch(() => {
+        // 순서 저장과 같은 규칙 — 낙관 반영을 손으로 되돌리지 않고 서버 진실로 재동기화한다.
+        // 새로 나가는 요청은 지금 리비전을 들고 가므로 그 답은 채택된다.
+        setAnnouncement(t("quota.fold.saveError"));
+        refresh(false);
+      });
     foldSaveRef.current = foldSaveRef.current.then(save, save);
   }, [ctx.api, adoptFolded, t, refresh]);
 
@@ -877,6 +877,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
 
   useEffect(() => {
     const generation = beginRequestGeneration(requestGenerationRef);
+    const foldRevision = foldRevisionRef.current;
     if (isLatestRequestGeneration(requestGenerationRef, generation)) setRequestError(false);
     const force = forceRef.current;
     forceRef.current = false;
@@ -889,9 +890,10 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
         if (isLatestRequestGeneration(requestGenerationRef, generation)) {
           setData(result);
           setOrder(sanitizeProviderOrder(result.providerOrder));
-          // 저장이 아직 날아가는 중이면 서버의 답은 내 조작 이전의 것이다 — 그대로
-          // 채택하면 방금 접은 카드가 스스로 펼쳐진다.
-          if (foldSavesInFlight.current === 0) adoptFolded(sanitizeFoldedProviders(result.foldedProviders));
+          // 요청이 출발한 뒤 사용자가 카드를 접었다면 이 답은 그 조작 이전의 것이다.
+          if (isLatestRequestGeneration(foldRevisionRef, foldRevision)) {
+            adoptFolded(sanitizeFoldedProviders(result.foldedProviders));
+          }
           setRequestError(false);
           setNow(Date.now());
         }

--- a/runtime/fleet-plugins/quota/provider-order.ts
+++ b/runtime/fleet-plugins/quota/provider-order.ts
@@ -22,3 +22,29 @@ export function sanitizeProviderOrder(value: unknown): ProviderId[] {
   }
   return order;
 }
+
+/**
+ * 접힘 집합도 릴리스 경계를 넘는다. 모르는 id를 버리고 중복을 걷어야 옛 설정 파일이
+ * 남아 있어도 접힘이 실재하는 카드에만 붙는다. 순서와 달리 빠진 id는 채우지 않는다 —
+ * 목록에 없다는 것이 곧 "펼침"이라는 뜻이기 때문이다. 반환은 늘 기본 순서로 정렬해
+ * 같은 집합이 늘 같은 페이로드가 되게 한다.
+ */
+export function sanitizeFoldedProviders(value: unknown): ProviderId[] {
+  const seen = new Set<ProviderId>();
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (isProviderId(entry)) seen.add(entry);
+    }
+  }
+  return PROVIDER_ORDER_DEFAULT.filter((id) => seen.has(id));
+}
+
+/** 한 공급자의 접힘을 뒤집는다. 결과는 sanitize와 같은 기본 순서를 유지한다. */
+export function toggledFoldedProviders(
+  folded: readonly ProviderId[],
+  id: ProviderId,
+): ProviderId[] {
+  const next = new Set(folded);
+  if (!next.delete(id)) next.add(id);
+  return PROVIDER_ORDER_DEFAULT.filter((entry) => next.has(entry));
+}

--- a/runtime/fleet-plugins/quota/routes.ts
+++ b/runtime/fleet-plugins/quota/routes.ts
@@ -5,7 +5,7 @@ import {
   createQuotaService,
 } from "@dotobokuri/core-ai-gateway";
 
-import { handleConnect, handleOrder, handleSummary } from "./server/handlers.js";
+import { handleConnect, handleFold, handleOrder, handleSummary } from "./server/handlers.js";
 
 export default definePlugin({
   id: "quota",
@@ -45,5 +45,9 @@ export default definePlugin({
       await handleOrder(req, res, ctx, serializeSettings);
       return true;
     }, { method: "POST", path: "", summary: "Persist the provider card order.", category: "Quota Plugin", gate: "origin-write", transport: "http" });
+    registerRouter(ctx, "fold", async ({ req, res }) => {
+      await handleFold(req, res, ctx, serializeSettings);
+      return true;
+    }, { method: "POST", path: "", summary: "Persist which provider cards are collapsed.", category: "Quota Plugin", gate: "origin-write", transport: "http" });
   },
 });

--- a/runtime/fleet-plugins/quota/server/handlers.ts
+++ b/runtime/fleet-plugins/quota/server/handlers.ts
@@ -6,18 +6,20 @@ import type { QuotaService } from "@dotobokuri/core-ai-gateway";
 import {
   isProviderId,
   PROVIDER_ORDER_DEFAULT,
+  sanitizeFoldedProviders,
   sanitizeProviderOrder,
   type ProviderId,
 } from "../provider-order.js";
 
 export type SettingsSerializer = <T>(operation: () => Promise<T>) => Promise<T>;
-export { PROVIDER_ORDER_DEFAULT, sanitizeProviderOrder };
+export { PROVIDER_ORDER_DEFAULT, sanitizeFoldedProviders, sanitizeProviderOrder };
 export type { ProviderId as OrderableProviderId };
 
 interface StoredSettings {
   readonly claudeConnected?: unknown;
   readonly cursorConnected?: unknown;
   readonly providerOrder?: unknown;
+  readonly foldedProviders?: unknown;
 }
 
 async function readStoredSettings(ctx: FleetPluginServerContext): Promise<StoredSettings> {
@@ -27,12 +29,26 @@ async function readStoredSettings(ctx: FleetPluginServerContext): Promise<Stored
     : {};
 }
 
-// connect와 order가 서로의 키를 보존하지 않으면 한쪽 저장이 다른 쪽 설정을 지운다.
+// 이 화이트리스트는 저장 경로가 늘 때마다 함께 늘어야 한다. 한 키라도 빠지면 다른
+// 경로의 저장이 그 설정을 조용히 지운다 — 카드를 한 번 끌어다 놓는 순간 접힘이 사라진다.
 function retainedSettings(settings: StoredSettings): Record<string, unknown> {
   return {
     ...(typeof settings.claudeConnected === "boolean" ? { claudeConnected: settings.claudeConnected } : {}),
     ...(typeof settings.cursorConnected === "boolean" ? { cursorConnected: settings.cursorConnected } : {}),
     ...(Array.isArray(settings.providerOrder) ? { providerOrder: sanitizeProviderOrder(settings.providerOrder) } : {}),
+    ...(Array.isArray(settings.foldedProviders) ? { foldedProviders: sanitizeFoldedProviders(settings.foldedProviders) } : {}),
+  };
+}
+
+/** summary 계열 응답이 코어 DTO에 얹어 보내는 플러그인 소유 설정. */
+async function panelSettings(ctx: FleetPluginServerContext): Promise<{
+  readonly providerOrder: ProviderId[];
+  readonly foldedProviders: ProviderId[];
+}> {
+  const stored = await readStoredSettings(ctx);
+  return {
+    providerOrder: sanitizeProviderOrder(stored.providerOrder),
+    foldedProviders: sanitizeFoldedProviders(stored.foldedProviders),
   };
 }
 
@@ -52,8 +68,7 @@ export async function handleSummary(
   }
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
   const summary = await service.getSummary({ force: url.searchParams.get("force") === "1" });
-  const providerOrder = sanitizeProviderOrder((await readStoredSettings(ctx)).providerOrder);
-  ctx.host.http.writeJson(res, 200, { ...summary, providerOrder });
+  ctx.host.http.writeJson(res, 200, { ...summary, ...(await panelSettings(ctx)) });
 }
 
 export async function handleConnect(
@@ -104,8 +119,7 @@ export async function handleConnect(
     await ctx.host.storage.writeJson("quota", "settings", next);
   });
   const summary = await service.getSummary({ forceProvider: body.provider });
-  const providerOrder = sanitizeProviderOrder((await readStoredSettings(ctx)).providerOrder);
-  ctx.host.http.writeJson(res, 200, { ...summary, providerOrder });
+  ctx.host.http.writeJson(res, 200, { ...summary, ...(await panelSettings(ctx)) });
 }
 
 export async function handleOrder(
@@ -159,4 +173,57 @@ export async function handleOrder(
     await ctx.host.storage.writeJson("quota", "settings", next);
   });
   ctx.host.http.writeJson(res, 200, { providerOrder });
+}
+
+export async function handleFold(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  ctx: FleetPluginServerContext,
+  serializeSettings: SettingsSerializer,
+): Promise<void> {
+  if (req.method !== "POST") {
+    ctx.host.http.writeJson(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+  if (!ctx.host.security.isTerminalAuthorized(req)) {
+    ctx.host.http.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const contentType = req.headers["content-type"];
+  const mediaType = typeof contentType === "string"
+    ? contentType.split(";", 1)[0]?.trim().toLowerCase()
+    : undefined;
+  if (mediaType !== "application/json") {
+    ctx.host.http.writeJson(res, 415, { error: "unsupported_media_type" });
+    return;
+  }
+  let body: { readonly folded?: unknown } | null;
+  try {
+    body = await ctx.host.http.readJsonBody(req);
+  } catch {
+    body = null;
+  }
+  // 순서와 달리 접힘은 부분집합이다 — 완전한 순열을 요구하면 "아무것도 접지 않음"을
+  // 보낼 길이 없다. 대신 알려진 id만, 중복 없이, 전체 수를 넘지 않게 받는다.
+  const folded = body?.folded;
+  if (
+    !body
+    || Object.keys(body).length !== 1
+    || !Array.isArray(folded)
+    || folded.length > PROVIDER_ORDER_DEFAULT.length
+    || !folded.every(isProviderId)
+    || new Set(folded).size !== folded.length
+  ) {
+    ctx.host.http.writeJson(res, 400, { error: "invalid_fold_request" });
+    return;
+  }
+  const foldedProviders = sanitizeFoldedProviders(folded);
+  await serializeSettings(async () => {
+    const next = {
+      ...retainedSettings(await readStoredSettings(ctx)),
+      foldedProviders,
+    };
+    await ctx.host.storage.writeJson("quota", "settings", next);
+  });
+  ctx.host.http.writeJson(res, 200, { foldedProviders });
 }

--- a/runtime/fleet-plugins/quota/tests/handlers.test.ts
+++ b/runtime/fleet-plugins/quota/tests/handlers.test.ts
@@ -4,7 +4,7 @@ import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import type { QuotaService } from "@dotobokuri/core-ai-gateway";
 import { describe, expect, it, vi } from "vitest";
 
-import { handleConnect, handleOrder, handleSummary } from "../server/handlers.js";
+import { handleConnect, handleFold, handleOrder, handleSummary } from "../server/handlers.js";
 import type { SettingsSerializer } from "../server/handlers.js";
 
 function createSerializer(): SettingsSerializer {
@@ -241,6 +241,94 @@ describe("quota route handlers", () => {
       claudeConnected: true,
       providerOrder: ["kimi", "claude", "codex", "xai", "cursor", "opencode", "antigravity"],
     });
+  });
+
+  it("appends the stored fold set to summary responses after sanitizing it", async () => {
+    const test = harness("GET", "/plugins/quota/summary");
+    test.readJson.mockResolvedValue({ foldedProviders: ["kimi", "bogus", "claude", "kimi"] });
+    await handleSummary(test.req, test.res, test.ctx, test.service);
+    expect((test.writes[0]?.payload as { foldedProviders: unknown }).foldedProviders)
+      .toEqual(["claude", "kimi"]);
+  });
+
+  it("persists a partial fold set while preserving connection flags", async () => {
+    const test = harness("POST", "/plugins/quota/fold", { folded: ["kimi", "claude"] });
+    await handleFold(test.req, test.res, test.ctx, test.serializeSettings);
+    expect(test.writeJson).toHaveBeenCalledWith("quota", "settings", {
+      claudeConnected: true,
+      cursorConnected: false,
+      foldedProviders: ["claude", "kimi"],
+    });
+    expect(test.writes).toEqual([{ status: 200, payload: { foldedProviders: ["claude", "kimi"] } }]);
+  });
+
+  // 접힘은 순서와 달리 부분집합이다 — 완전한 순열을 요구하면 "전부 펼침"을 보낼 길이 없다.
+  it("accepts an empty fold set as the way to expand everything", async () => {
+    const test = harness("POST", "/plugins/quota/fold", { folded: [] });
+    await handleFold(test.req, test.res, test.ctx, test.serializeSettings);
+    expect(test.writeJson).toHaveBeenCalledWith("quota", "settings", {
+      claudeConnected: true,
+      cursorConnected: false,
+      foldedProviders: [],
+    });
+    expect(test.writes[0]?.status).toBe(200);
+  });
+
+  it("rejects duplicated, unknown, oversized, or non-array fold sets", async () => {
+    const invalid: unknown[] = [
+      ["claude", "claude"],
+      ["claude", "bogus"],
+      ["claude", "codex", "xai", "cursor", "opencode", "kimi", "antigravity", "claude"],
+      "claude",
+      null,
+    ];
+    for (const folded of invalid) {
+      const test = harness("POST", "/plugins/quota/fold", { folded });
+      await handleFold(test.req, test.res, test.ctx, test.serializeSettings);
+      expect(test.writes, JSON.stringify(folded)).toEqual([{ status: 400, payload: { error: "invalid_fold_request" } }]);
+      expect(test.writeJson, JSON.stringify(folded)).not.toHaveBeenCalled();
+    }
+  });
+
+  // retainedSettings는 화이트리스트다. 새 키가 거기 없으면 다른 경로의 저장이 그것을
+  // 조용히 지운다 — 카드를 한 번 끌어다 놓거나 Claude를 연결하는 순간 접힘이 사라진다.
+  it("keeps a stored fold set when the order or a connection flag changes", async () => {
+    const foldedProviders = ["claude", "kimi"];
+    const order = ["kimi", "claude", "codex", "xai", "cursor", "opencode", "antigravity"];
+
+    const dragged = harness("POST", "/plugins/quota/order", { order });
+    dragged.readJson.mockResolvedValue({ claudeConnected: true, foldedProviders });
+    await handleOrder(dragged.req, dragged.res, dragged.ctx, dragged.serializeSettings);
+    expect(dragged.writeJson).toHaveBeenCalledWith("quota", "settings", {
+      claudeConnected: true,
+      foldedProviders,
+      providerOrder: order,
+    });
+
+    const connected = harness("POST", "/plugins/quota/connect", { provider: "cursor", connected: true });
+    connected.readJson.mockResolvedValue({ claudeConnected: true, foldedProviders });
+    await handleConnect(connected.req, connected.res, connected.ctx, connected.service, connected.serializeSettings);
+    expect(connected.writeJson).toHaveBeenCalledWith("quota", "settings", {
+      claudeConnected: true,
+      cursorConnected: true,
+      foldedProviders,
+    });
+  });
+
+  it("guards the fold route with the same method, auth, and media-type gates as the others", async () => {
+    const wrongMethod = harness("GET", "/plugins/quota/fold", { folded: [] });
+    await handleFold(wrongMethod.req, wrongMethod.res, wrongMethod.ctx, wrongMethod.serializeSettings);
+    expect(wrongMethod.writes).toEqual([{ status: 405, payload: { error: "method_not_allowed" } }]);
+
+    const wrongType = harness("POST", "/plugins/quota/fold", { folded: [] }, "text/plain");
+    await handleFold(wrongType.req, wrongType.res, wrongType.ctx, wrongType.serializeSettings);
+    expect(wrongType.writes).toEqual([{ status: 415, payload: { error: "unsupported_media_type" } }]);
+
+    const unauthorized = harness("POST", "/plugins/quota/fold", { folded: [] });
+    (unauthorized.ctx.host.security as unknown as { isTerminalAuthorized: () => boolean }).isTerminalAuthorized = () => false;
+    await handleFold(unauthorized.req, unauthorized.res, unauthorized.ctx, unauthorized.serializeSettings);
+    expect(unauthorized.writes).toEqual([{ status: 401, payload: { error: "unauthorized" } }]);
+    expect(unauthorized.writeJson).not.toHaveBeenCalled();
   });
 
   it("requires the exact JSON media type while accepting parameters", async () => {

--- a/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
+++ b/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
@@ -287,6 +287,26 @@ describe("folded card summary", () => {
   });
 });
 
+describe("fold revision", () => {
+  // 실측한 결함: 서버는 요청을 받은 시점의 접힘을 읽어 답하고, 그 답이 오는 사이에
+  // 사용자가 접은 카드의 저장은 이미 끝나 있을 수 있다. "지금 저장이 날아가는 중인가"로
+  // 판정하면 그 순간 카운터가 0이라 옛 집합이 통과했다 — 화면은 펼쳐졌는데 서버는
+  // 접힘이었고, 다음 토글이 그 옛 집합 위에서 계산되어 앞의 접힘을 지웠다.
+  it("stops a response that left before a toggle from adopting its stale fold set", () => {
+    const revision = { current: 0 };
+    const inFlight = revision.current;      // summary leaves
+    beginRequestGeneration(revision);        // user folds a card while it is in flight
+    expect(isLatestRequestGeneration(revision, inFlight)).toBe(false);
+  });
+
+  it("adopts a response that left after the last toggle", () => {
+    const revision = { current: 0 };
+    beginRequestGeneration(revision);        // user folds a card
+    const afterToggle = revision.current;    // the recovery/poll request leaves afterwards
+    expect(isLatestRequestGeneration(revision, afterToggle)).toBe(true);
+  });
+});
+
 describe("folded providers", () => {
   // 옛 설정 파일이 살아남는다. 순서와 달리 빠진 id를 채우지 않는 것이 계약이다 —
   // 목록에 없다는 것이 곧 "펼침"이고, 채우면 모든 카드가 접힌 채로 열린다.

--- a/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
+++ b/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
@@ -8,6 +8,8 @@ import {
   beginRequestGeneration,
   elapsedMarkPercent,
   EXPIRED_KEY,
+  FOLDED_STATUS_KEY,
+  foldedWindow,
   formatCountdown,
   formatPace,
   formatResetInstant,
@@ -18,8 +20,10 @@ import {
   projectedSpan,
   PROVIDER_ORDER_DEFAULT,
   riskNote,
+  sanitizeFoldedProviders,
   sanitizeProviderOrder,
   SIGNED_OUT_KEY,
+  toggledFoldedProviders,
   visibleCredits,
 } from "../client/rail-panel.js";
 import { providerGlyph } from "../client/cli-glyphs.js";
@@ -235,5 +239,74 @@ describe("provider order", () => {
       .toEqual(["claude", "codex", "xai", "opencode", "cursor", "kimi", "antigravity"]);
     expect(movedProviderOrder(PROVIDER_ORDER_DEFAULT, "claude", -1)).toBeNull();
     expect(movedProviderOrder(PROVIDER_ORDER_DEFAULT, "antigravity", 1)).toBeNull();
+  });
+});
+
+describe("folded card summary", () => {
+  function pool(usedPercent: number, extra: Partial<QuotaWindow> = {}): QuotaWindow {
+    return { id: "weekly", usedPercent, ...extra };
+  }
+
+  // 접힌 행이 대변할 창은 "가장 많이 쓴 창"이 아니라 "가장 급한 창"이다. 회차의 5분의 1
+  // 지점에서 44%를 쓴 창은 게이트웨이가 critical로 판정하고, 퍼센트만 보는 비교는 그
+  // 사실을 보지 못해 조용한 60% 창을 대표로 세운다.
+  it("lets the gateway's verdict outrank the raw percentage", () => {
+    const calm = pool(60, { risk: { pressure: "ok" } });
+    const urgent = pool(44, { risk: { pressure: "critical" } });
+    expect(foldedWindow([calm, urgent])).toBe(urgent);
+    expect(foldedWindow([urgent, calm])).toBe(urgent);
+  });
+
+  it("breaks a severity tie on how much of the pool is spent", () => {
+    const lighter = pool(30, { risk: { pressure: "elevated" } });
+    const heavier = pool(72, { risk: { pressure: "elevated" } });
+    expect(foldedWindow([lighter, heavier])).toBe(heavier);
+  });
+
+  // 집계 창은 형제 창들의 합이라 개별 풀이 말라도 평온하게 읽힌다. 그 창을 대표로
+  // 세우면 접힌 행은 "여유 있음"을 말하는데 실제로 모델이 당기는 풀은 비어 있다.
+  it("never speaks for an aggregate window while a real pool is present", () => {
+    const total = pool(40, { isAggregate: true });
+    const drained = pool(98, { scope: "api" });
+    expect(foldedWindow([total, drained])).toBe(drained);
+    // 집계뿐이면 그것이 이 공급자가 가진 전부다.
+    expect(foldedWindow([total])).toBe(total);
+  });
+
+  it("has nothing to say without a window", () => {
+    expect(foldedWindow(undefined)).toBeNull();
+    expect(foldedWindow([])).toBeNull();
+  });
+
+  // 수치가 없는 카드가 이름만 남으면 아직 못 읽은 카드와 구분되지 않는다. 사용자가
+  // 손을 써야 하는 상태에는 전부 접힌 행에 남을 한 마디가 있어야 한다.
+  it("names a reason for every status that carries no reading", () => {
+    for (const status of ["not_connected", "signed_out", "expired", "no_subscription", "error", "stale"] as const) {
+      expect(FOLDED_STATUS_KEY[status], status).toBeDefined();
+    }
+  });
+});
+
+describe("folded providers", () => {
+  // 옛 설정 파일이 살아남는다. 순서와 달리 빠진 id를 채우지 않는 것이 계약이다 —
+  // 목록에 없다는 것이 곧 "펼침"이고, 채우면 모든 카드가 접힌 채로 열린다.
+  it("drops unknown ids, dedupes, and leaves absent providers expanded", () => {
+    expect(sanitizeFoldedProviders(["kimi", "bogus", "claude", "kimi"])).toEqual(["claude", "kimi"]);
+    expect(sanitizeFoldedProviders(undefined)).toEqual([]);
+    expect(sanitizeFoldedProviders("claude")).toEqual([]);
+    expect(sanitizeFoldedProviders([])).toEqual([]);
+  });
+
+  // 같은 집합이 늘 같은 페이로드여야 저장이 순서 때문에 다시 쓰이지 않는다.
+  it("normalises to the default order however the set was built", () => {
+    expect(sanitizeFoldedProviders(["antigravity", "claude", "xai"]))
+      .toEqual(["claude", "xai", "antigravity"]);
+  });
+
+  it("toggles one provider without disturbing the rest", () => {
+    expect(toggledFoldedProviders([], "codex")).toEqual(["codex"]);
+    expect(toggledFoldedProviders(["codex"], "codex")).toEqual([]);
+    expect(toggledFoldedProviders(["antigravity", "claude"], "xai"))
+      .toEqual(["claude", "xai", "antigravity"]);
   });
 });

--- a/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
+++ b/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { QuotaWindow } from "@dotobokuri/core-ai-gateway";
 
 import {
+  adoptsFoldedProviders,
   beginRequestGeneration,
   elapsedMarkPercent,
   EXPIRED_KEY,
@@ -287,23 +288,36 @@ describe("folded card summary", () => {
   });
 });
 
-describe("fold revision", () => {
-  // 실측한 결함: 서버는 요청을 받은 시점의 접힘을 읽어 답하고, 그 답이 오는 사이에
-  // 사용자가 접은 카드의 저장은 이미 끝나 있을 수 있다. "지금 저장이 날아가는 중인가"로
-  // 판정하면 그 순간 카운터가 0이라 옛 집합이 통과했다 — 화면은 펼쳐졌는데 서버는
-  // 접힘이었고, 다음 토글이 그 옛 집합 위에서 계산되어 앞의 접힘을 지웠다.
-  it("stops a response that left before a toggle from adopting its stale fold set", () => {
-    const revision = { current: 0 };
-    const inFlight = revision.current;      // summary leaves
-    beginRequestGeneration(revision);        // user folds a card while it is in flight
-    expect(isLatestRequestGeneration(revision, inFlight)).toBe(false);
+describe("fold adoption", () => {
+  // 두 결함 모두 실측으로 재현했다. 화면과 서버가 갈리고, 다음 토글이 그 옛 집합 위에서
+  // 계산되어 이미 저장된 접힘을 지웠다. 조건 하나만으로는 각각 하나씩 남는다.
+
+  // (1) 요청이 떠난 뒤 사용자가 접은 경우 — 이 답은 그 조작 이전의 것이다.
+  it("refuses a response that left before a toggle", () => {
+    const captured = { persisted: 3, revision: 3 };
+    expect(adoptsFoldedProviders(captured, 4)).toBe(false);
   });
 
-  it("adopts a response that left after the last toggle", () => {
+  // (2) 저장이 아직 서버에 닿지 않은 채로 떠난 경우 — 리비전은 이미 올라 있어
+  // 통과하지만, 서버가 읽은 것은 그 이전 집합이다.
+  it("refuses a response that left while a fold was still unpersisted", () => {
+    const captured = { persisted: 3, revision: 4 };
+    expect(adoptsFoldedProviders(captured, 4)).toBe(false);
+  });
+
+  it("adopts a response that left with the server already holding what we hold", () => {
+    const captured = { persisted: 4, revision: 4 };
+    expect(adoptsFoldedProviders(captured, 4)).toBe(true);
+  });
+
+  // 저장 실패 뒤의 재동기화가 자기 검사에 걸리면 화면은 영영 갈린 채로 남는다.
+  it("adopts the recovery response after a failed save gives up its local intent", () => {
     const revision = { current: 0 };
-    beginRequestGeneration(revision);        // user folds a card
-    const afterToggle = revision.current;    // the recovery/poll request leaves afterwards
-    expect(isLatestRequestGeneration(revision, afterToggle)).toBe(true);
+    beginRequestGeneration(revision);
+    const persisted = { current: revision.current };
+    const captured = { persisted: persisted.current, revision: revision.current };
+    expect(adoptsFoldedProviders(captured, revision.current)).toBe(true);
+    expect(isLatestRequestGeneration(revision, captured.revision)).toBe(true);
   });
 });
 


### PR DESCRIPTION
> #920를 대체합니다. 리베이스 중 head를 base와 같은 커밋으로 잘못 강제 푸시해 GitHub가 #920을 자동으로 닫았고, 브랜치를 되돌린 뒤에도 재오픈이 거부되었습니다(`state cannot be changed. There are no new commits`). **코드·리뷰 결과는 그대로이며 #920의 3개 리뷰 패스 기록이 그곳에 남아 있습니다.** `canary`는 영향을 받지 않았습니다.

## Summary

- 사용 한도 패널의 공급자 카드를 하나씩 접을 수 있게 합니다. 접기 컨트롤은 헤더를 감싸는 대신 그립·연결 해제와 나란한 형제 버튼입니다 — 버튼은 버튼을 품을 수 없어 헤더 전체를 disclosure 버튼으로 만들면 이미 그 안에 사는 두 컨트롤이 접근성 트리에서 사라집니다.
- 접힌 줄은 계속 보고합니다: 가장 급한 회차의 사용률, 펼친 미터와 **같은 심각도 채널**(`--meter-accent`/`--meter-weight`)의 막대, 리셋 카운트다운. 위험한 채로 접힌 카드는 테두리도 그 색을 입습니다. quota는 이 패널 밖에 신호가 하나도 없어(`core/client` 참조 0건) 침묵하는 접힌 줄은 곧 사각지대가 됩니다.
- 접힘 집합은 `quota/settings`에 `providerOrder`와 나란히 영속되고, `retainedSettings` 화이트리스트에 함께 올라가 재배열·연결이 접힘을 지우지 않습니다.

### 실측 (격리 Console · instrument 테마 · 레일 392px)

| | 전 | 후(조용한 4장 접음) |
|---|---|---|
| 패널 콘텐츠 | 1,142px (2.35화면) | **745px** (1.54화면) |
| 접힌 행 높이 | — | 40px (두 카드형 동일) |

보고할 것이 없는 카드가 전체 높이의 **48.7%**(556px)를 차지하던 문제를 겨냥합니다. 좁은 레일은 미디어 쿼리가 아니라 패널 `@container`로 답합니다 — 레일은 240px까지 좁아지지만 창은 그대로입니다.

### #920 리뷰에서 반영한 것

두 건 모두 **실제 빌드에서 재현한 뒤** 수정했습니다. 접힘 채택은 이제 두 조건의 논리곱이며, 하나만 남기면 재현된 결함이 각각 하나씩 되살아난다는 사실을 테스트가 이름으로 못박습니다.

1. 요청이 떠난 뒤 사용자가 접은 경우 — 응답이 그 조작 이전의 집합을 실어 옴
2. 저장이 아직 서버에 닿지 않은 채로 요청이 떠난 경우 — 리비전은 이미 올라 있으나 서버가 읽은 것은 이전 집합

둘 다 화면과 서버가 갈리고 **다음 토글이 이미 저장된 접힘을 지우는** 결과였습니다.

## Test Plan

- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — exit 0
- [x] `pnpm test` — quota 플러그인 52건 포함 전량 통과. 단 `runtime/fleet-console/tests/published-manifest.test.ts` 1건 실패는 **canary 선존 결함**입니다: canary가 `scripts/pack-fleet-console-manifest.mjs`의 `EXTERNAL_DEP_NAMES`에 `@vscode/ripgrep`을 추가하면서 같은 테스트의 손수 만든 픽스처를 갱신하지 않았습니다. 이 PR은 두 파일 어디도 건드리지 않으며, 범위 밖이라 별도로 다뤄야 합니다.
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK
- [x] 헤디드 실측: 접기/펼치기, 새로고침 후 서버 복원, 같은 틱 다중 접기, 240px 레일 무오버플로, instrument/whites 두 테마의 심각도 사다리, 두 경합 시나리오와 저장 실패 복구