### PR TITLE
fix(fleet-console): keep Alt+Arrow alive in the chat composer

### DIFF
--- a/.changelog.d/chat-composer-alt-arrow.md
+++ b/.changelog.d/chat-composer-alt-arrow.md
@@ -1,0 +1,8 @@
+---
+branch: chat-composer-alt-arrow
+---
+
+### fleet-console
+#### Fixed
+- Keep the Alt+Arrow panel shortcuts working while a chat composer holds focus, so moving between panels no longer dies exactly where the caret lives.
+  ko: 채팅 컴포저에 포커스가 있어도 Alt+방향키 패널 단축키가 살아 있어, 캐럿이 머무는 자리에서 패널 이동이 죽지 않습니다.

--- a/runtime/fleet-console/core/client/src/shortcuts.tsx
+++ b/runtime/fleet-console/core/client/src/shortcuts.tsx
@@ -240,21 +240,22 @@ export function focusCommandBandToggleWhenPanelContainsActiveElement(panel: HTML
 /**
  * 편집 중인 요소에 포커스가 있을 때 Operations 단축키를 삼킬지 정하는 정책.
  *
- * 기본은 삼키는 것이다 — 타자가 단축키에 먹히면 글을 쓸 수 없다. 예외는 Console 뷰 축(Alt+문자)
- * 하나다: 같은 키가 터미널 포커스에서는 이미 살아 있으므로(xterm은 편집 판정에서 빠진다),
- * 채팅 컴포저에 포커스가 있다는 이유로만 화면을 바꾸는 키가 죽으면 표면마다 문법이 갈린다.
- * macOS의 Option+문자 합성은 각 분기의 preventDefault가 막으므로 문자가 새지 않는다.
+ * 기본은 삼키는 것이다 — 타자가 단축키에 먹히면 글을 쓸 수 없다. 예외는 Alt를 쥔 조합 전체,
+ * 즉 Console 뷰 축(Alt+문자)과 패널 축(Alt+화살표)이다: 같은 키가 터미널 포커스에서는 이미
+ * 살아 있으므로(xterm은 편집 판정에서 빠진다), 컴포저에 포커스가 있다는 이유로만 화면을 바꾸는
+ * 키가 죽으면 표면마다 문법이 갈린다. macOS의 Option+문자 합성은 각 분기의 preventDefault가
+ * 막으므로 문자가 새지 않는다.
  *
- * 화살표는 그 예외에서 다시 빠진다. 편집 중 Alt+화살표는 단어 단위 이동이고, 그것은 화면 배치
- * 명령보다 먼저 이 자리의 것이다.
+ * 화살표에도 예외를 두지 않는다. 채팅 패널에서 캐럿이 사는 자리는 컴포저 하나뿐이라, 편집 중
+ * Alt+화살표를 캐럿 이동에 내주면 패널 사이를 오가는 키가 정확히 필요한 순간에만 죽는다.
+ * macOS의 단어 단위 이동은 같은 사정을 이미 터미널에서 Console에 내주고 있고, 선택(Alt+Shift+
+ * 화살표)은 shiftKey 분기가 preventDefault 없이 통과시키므로 편집자에게 그대로 남는다.
  */
 export function blocksOperationsShortcutWhileEditing(
   editing: boolean,
-  event: { readonly altKey: boolean; readonly code: string },
+  event: { readonly altKey: boolean },
 ): boolean {
-  if (!editing) return false;
-  if (!event.altKey) return true;
-  return event.code.startsWith("Arrow");
+  return editing && !event.altKey;
 }
 
 // ─── arrow keys — Operations focus, triage, and layout actions ─────────────────

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -611,6 +611,38 @@ describe("Operations boot minimization", () => {
     expect(getState().activeOperationId).toBe("first");
   });
 
+  // 채팅 패널에서 캐럿이 사는 자리는 컴포저 하나뿐이다. 편집 중이라는 이유로 Alt+화살표를 삼키면
+  // 패널 축이 정확히 필요한 순간에만 죽는다 — 같은 키가 터미널 포커스에서는 이미 살아 있다.
+  it("keeps panel arrows alive while a composer textarea holds focus", async () => {
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      restoreOperation("first");
+      restoreOperation("second");
+      setActiveOperation("first");
+      await Promise.resolve();
+    });
+    keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(true);
+    const composer = document.createElement("textarea");
+    document.body.appendChild(composer);
+    composer.focus();
+    expect(document.activeElement).toBe(composer);
+
+    await act(async () => {
+      window.dispatchEvent(altKeyDown("ArrowRight"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getState().activeOperationId).toBe("second");
+
+    // 수식자 없는 키는 그대로 타자다 — 편집 중에는 언제나 컴포저의 것이다.
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { code: "Digit1", key: "!", shiftKey: true, bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    expect(getState().activeOperationId).toBe("second");
+    composer.remove();
+  });
+
   it("blocks panel arrows, companion shortcuts, and armed Escape behind a modal", async () => {
     registryMocks.operationKinds = [shortcutCompanionKind()];
     await bootApp([operation("first")]);

--- a/runtime/fleet-console/tests/operations-editing-shortcut-guard.test.ts
+++ b/runtime/fleet-console/tests/operations-editing-shortcut-guard.test.ts
@@ -4,28 +4,19 @@ import { blocksOperationsShortcutWhileEditing } from "../core/client/src/shortcu
 
 describe("Operations shortcut guard while editing", () => {
   it("lets every shortcut through when nothing is being edited", () => {
-    expect(blocksOperationsShortcutWhileEditing(false, { altKey: false, code: "KeyF" })).toBe(false);
-    expect(blocksOperationsShortcutWhileEditing(false, { altKey: true, code: "ArrowLeft" })).toBe(false);
+    expect(blocksOperationsShortcutWhileEditing(false, { altKey: false })).toBe(false);
+    expect(blocksOperationsShortcutWhileEditing(false, { altKey: true })).toBe(false);
   });
 
   // 타자가 단축키에 먹히면 글을 쓸 수 없다 — 수식자 없는 키는 편집 중 언제나 입력이다.
   it("swallows unmodified keys while an editor has focus", () => {
-    expect(blocksOperationsShortcutWhileEditing(true, { altKey: false, code: "KeyF" })).toBe(true);
-    expect(blocksOperationsShortcutWhileEditing(true, { altKey: false, code: "Digit1" })).toBe(true);
+    expect(blocksOperationsShortcutWhileEditing(true, { altKey: false })).toBe(true);
   });
 
-  // Console 뷰 축은 편집 중에도 산다. 같은 키가 터미널 포커스에서는 이미 살아 있으므로,
-  // 채팅 컴포저에 포커스가 있다는 이유로만 죽으면 표면마다 문법이 갈린다.
-  it("keeps the Console view axis alive while the chat composer has focus", () => {
-    for (const code of ["KeyF", "KeyS", "KeyT", "Digit2"]) {
-      expect(blocksOperationsShortcutWhileEditing(true, { altKey: true, code }), code).toBe(false);
-    }
-  });
-
-  // 편집 중 Alt+화살표는 단어 단위 이동이고, 그것은 화면 배치 명령보다 먼저 이 자리의 것이다.
-  it("still yields Alt+Arrow to word-wise caret movement", () => {
-    for (const code of ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]) {
-      expect(blocksOperationsShortcutWhileEditing(true, { altKey: true, code }), code).toBe(true);
-    }
+  // Alt 축은 뷰(Alt+문자)든 패널(Alt+화살표)이든 편집 중에도 산다. 같은 키가 터미널 포커스에서는
+  // 이미 살아 있으므로, 컴포저에 포커스가 있다는 이유로만 죽으면 표면마다 문법이 갈린다.
+  // 키별 디스패치는 operations-arrow-shortcut·boot-minimization 통합 테스트가 진다.
+  it("keeps the Alt axis alive while the chat composer has focus", () => {
+    expect(blocksOperationsShortcutWhileEditing(true, { altKey: true })).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

채팅뷰 컴포저에 포커스가 있을 때 Alt+방향키 패널 단축키(이전/다음 패널·최대화·최소화)가 죽는 문제를 고칩니다. 편집 가드가 Alt 조합을 통과시키면서 화살표만 다시 제외하고 있었는데, 채팅 패널은 캐럿이 사는 자리가 컴포저 하나뿐이라 그 예외가 패널 축을 **정확히 필요한 순간에만** 죽였습니다. 같은 키는 터미널 포커스에서 이미 살아 있었으므로(xterm은 편집 판정에서 제외) 예외는 일관성이 아니라 표면별 문법 분열이었습니다.

## Type of Change

- [x] fix — bug fix

## Scope

- [x] `runtime/fleet-console/core/client` (Operations 단축키 가드)

## Test Plan

격리 콘솔(채팅 패널 2 + 셸 패널 1)에서 실측했습니다.

**수정 전 재현**
- [x] 컴포저 포커스 + Alt+← → 캐럿만 단어 단위 이동(20→12), 패널 전환 없음
- [x] 터미널 포커스 + Alt+← → 패널 순환 동작 (표면별 문법 분열 확인)

**수정 후**
- [x] 컴포저 포커스 + Alt+←/→ → 패널 순환, 초안·캐럿 보존(`hello world composer`, caret 20)
- [x] Alt+↑ → 최대화/해제 토글, 캐럿 20 유지 (이전엔 0으로 튐)
- [x] Alt+↓ → 최소화 후 다음 패널로 이동
- [x] Alt+⇧+←/→ → 단어 선택 그대로 유지("composer" → "world composer"), 패널 전환 없음
- [x] 회귀: 수식자 없는 타자(`f1t s`) 그대로 입력 · Alt+S 뷰 축 유지 · 문자 누출 0 · 페이지 에러 0

**자동 검증**
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 2422 passed / 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — pass
- [x] `pnpm --filter @dotobokuri/fleet-console build` — pass
- [x] 경계 게이트 4종(`check:core-boundary` / `check:localized-attributes` / `check:claude-agent-sdk-boundary` / `check:core-unified-agent-absent`) — pass
- [x] 새 통합 테스트가 옛 정책에서 실제로 red임을 확인(공허한 통과 아님)

## Changelog

- `blocksOperationsShortcutWhileEditing`에서 화살표 예외 제거 — 편집 중에도 Alt 조합 전체가 가드를 통과합니다.
- 가드가 `event.code`를 더는 읽지 않으므로 파라미터 타입을 `{ altKey }`로 좁히고, 단위 테스트를 실제 정책 모양에 맞춰 정리했습니다.
- 키별 회귀 앵커는 `operations-boot-minimization.integration.test.ts`에 추가 — textarea 포커스 상태에서 Alt+→가 패널을 순환하고, 수식자 없는 키는 삼켜지지 않음을 함께 고정합니다.

## Notes for Reviewers

**의도된 트레이드오프(되돌리지 말 것)**: macOS 컴포저에서 ⌥←/→ 단어 단위 캐럿 이동은 이제 Console이 가져갑니다. 터미널 표면이 이미 내주고 있던 것과 같은 비용이고, ⌥⇧←/→ 단어 **선택**은 `shiftKey` 분기가 `preventDefault` 없이 통과시켜 편집자에게 그대로 남습니다(실측 확인).

제거된 예외는 2026-08-18 canary `994f48bdc`에서 의도적으로 넣은 것이라, 그 판단의 전제가 채팅 패널에서 성립하지 않는다는 근거를 `shortcuts.tsx` 주석에 남겼습니다.