### PR TITLE
fix(fleet-console): title a chat job from its originating tool call

### DIFF
--- a/.changelog.d/chat-job-title-cjk.md
+++ b/.changelog.d/chat-job-title-cjk.md
@@ -1,0 +1,8 @@
+---
+branch: chat-job-title-cjk
+---
+
+### fleet-console
+#### Fixed
+- Title a chat background job from the tool call that started it, so non-ASCII titles no longer arrive garbled on Windows.
+  ko: 채팅 백그라운드 작업 제목을 그 작업을 시작한 도구 호출에서 읽어, Windows에서 한글 제목이 깨져 보이던 문제를 고쳤습니다.

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-events.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-events.ts
@@ -332,6 +332,16 @@ export interface ChatEventMapOptions {
    * 되는지 판단하려면 이 축이 필요하다. 세션이 소유하고 매퍼는 읽기만 한다.
    */
   readonly toolNames?: ReadonlyMap<string, string>;
+  /**
+   * tool_use id → 그 도구 입력이 실어 온 `description` 원문. 세션이 소유하고 매퍼는 읽기만 한다.
+   *
+   * 잡 제목에는 같은 문장의 사본이 둘 있고, 권위는 이쪽이다. 알림이 싣는 값은 자식이 자기
+   * 태스크 레코드에서 다시 꺼낸 사본이고 그 레코드는 디스크를 왕복하는데, Windows 한국어
+   * 환경에서 그 사본만 ANSI 코드페이지(CP949)를 지나 CJK가 깨진 채 도착하는 것이 보고됐다
+   * (2026-08-27). 모델이 실제로 쓴 그 문장은 같은 스트림의 tool_use 입력으로 이미 한 번
+   * 흘렀으므로, 사본을 받아 적는 대신 원본을 되찾는다.
+   */
+  readonly toolTitles?: ReadonlyMap<string, string>;
 }
 
 /**
@@ -638,13 +648,19 @@ function jobStartedEvent(message: Readonly<Record<string, unknown>>, options: Ch
   // 제목은 도구 입력의 description — 모델이 쓴 자유 텍스트다. 절대 경로나 자격증명 모양이
   // 들어올 수 있고, 이 값은 저널에 실려 스트립·카드·상세 세 곳에 그대로 그려진다. 다른 잡
   // 텍스트와 같은 문(경로 정규화·축약·마스킹)을 지나지 않으면 이 표면이 유출 경로가 된다.
-  const description = readString(message.description);
+  //
+  // 원본을 먼저 보는 이유는 사본만 깨져 도착하는 경로가 있기 때문이다(`toolTitles`). 원본이
+  // 없으면 — 도구 호출 없이 선 잡이거나 원장 상한이 그 호출을 이미 밀어냈으면 — 알림이 아는
+  // 유일한 값으로 되돌아간다. 아는 것이 사본뿐일 때 제목을 비우는 쪽이 더 나쁘다.
+  const toolUseId = readString(message.tool_use_id);
+  const description = (toolUseId === undefined ? undefined : options.toolTitles?.get(toolUseId))
+    ?? readString(message.description);
   return [{
     kind: "job",
     id,
     jobKind: readJobKind(message.task_type),
     title: description === undefined ? id : safeJobText(description, options, MAX_JOB_TITLE_CHARS),
-    ...(readString(message.tool_use_id) !== undefined ? { toolUseId: readString(message.tool_use_id) as string } : {}),
+    ...(toolUseId !== undefined ? { toolUseId } : {}),
     ...(who !== undefined ? { who: safeJobText(who, options, MAX_JOB_TITLE_CHARS) } : {}),
     at: Date.now(),
   }];

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -418,6 +418,18 @@ class AgentChatSession {
    * 무한히 자라지 않게 상한을 두고 오래된 것부터 버린다 — 결과는 호출 직후에 오므로 잃을 게 없다.
    */
   private readonly toolNames = new Map<string, string>();
+  /**
+   * tool_use id → 그 도구 입력이 실어 온 `description`. 잡 제목의 원본이다.
+   *
+   * 알림(`task_started`)도 같은 문장을 싣고 오지만 그것은 자식이 자기 태스크 레코드에서 다시
+   * 꺼낸 사본이고, Windows 한국어 환경에서 그 사본만 CJK가 깨진 채 도착하는 것이 보고됐다
+   * (2026-08-27). 모델이 쓴 문장 자체는 이 스트림의 assistant 줄에 이미 흘렀으므로 여기서
+   * 붙잡아 둔다 — 도구 호출은 언제나 그것이 낳은 잡보다 먼저 온다.
+   *
+   * `toolNames`와 같은 상한·같은 퇴장 규칙을 쓴다. 잡은 자기를 낳은 호출 직후에 서므로 오래된
+   * 항목을 버려서 잃는 제목은 없다.
+   */
+  private readonly toolTitles = new Map<string, string>();
   /** 잡 id → 종류. 상세를 어디서 읽을지 정하고, 동시에 상세 라우트가 받는 좌표의 화이트리스트다. */
   private readonly jobKinds = new Map<string, AgentChatJobKind>();
   /**
@@ -940,6 +952,38 @@ class AgentChatSession {
   }
 
   /**
+   * 이번 assistant 줄이 낸 도구 호출들의 `description`을 붙잡아 둔다.
+   *
+   * 여기가 그 문장이 서버에 닿는 첫 자리이고, 그래서 잡 제목의 원본이다. 뒤따라 오는
+   * `task_started`도 같은 문장을 싣지만 그것은 자식의 태스크 레코드를 지나온 사본이며,
+   * 그 경로에서만 CJK가 깨지는 것이 보고됐다(`toolTitles` 참조).
+   *
+   * 도구 이름과 달리 이벤트를 거치지 않고 원본 메시지에서 직접 읽는다 — 스텝 이벤트는
+   * description을 나르지 않고, 나르게 만들면 브라우저로 가는 어휘에 쓰이지 않는 필드가 하나
+   * 늘어난다. 이 값은 서버 안에서만 산다.
+   */
+  private rememberToolTitles(message: ClaudeGatewayMessage): void {
+    if (message.type !== "assistant") return;
+    const content = (message as { readonly message?: { readonly content?: unknown } }).message?.content;
+    if (!Array.isArray(content)) return;
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const record = block as { readonly type?: unknown; readonly id?: unknown; readonly input?: unknown };
+      if (record.type !== "tool_use") continue;
+      if (typeof record.id !== "string" || record.id.length === 0) continue;
+      const input = record.input;
+      if (!input || typeof input !== "object" || Array.isArray(input)) continue;
+      const description = (input as { readonly description?: unknown }).description;
+      if (typeof description !== "string" || description.length === 0) continue;
+      this.toolTitles.set(record.id, description);
+      if (this.toolTitles.size > TOOL_NAME_CAP) {
+        const oldest = this.toolTitles.keys().next();
+        if (!oldest.done) this.toolTitles.delete(oldest.value);
+      }
+    }
+  }
+
+  /**
    * 결말 알림이 알려 준 출력 파일 경로를 적어 둔다.
    *
    * 이 경로를 우리가 재구성하지 않는 이유는 실측이다: 셸 출력은 격리 config dir이 아니라 CLI가
@@ -1421,8 +1465,13 @@ class AgentChatSession {
         }
         this.rememberJobOutput(message);
         this.rememberJobKinds(message);
+        this.rememberToolTitles(message);
         this.trackLiveContext(message);
-        for (const event of chatEventsFromSdkMessage(message, { cwd: this.seed.cwd, toolNames: this.toolNames })) {
+        for (const event of chatEventsFromSdkMessage(message, {
+          cwd: this.seed.cwd,
+          toolNames: this.toolNames,
+          toolTitles: this.toolTitles,
+        })) {
           this.ingest(event);
         }
       }

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-events.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-events.test.ts
@@ -516,6 +516,33 @@ describe("background job mapping", () => {
     })).toEqual([expect.objectContaining({ kind: "job", id: "w1", jobKind: "workflow", who: "two-step" })]);
   });
 
+  it("titles a job from the model's own tool input, not the notification's copy", () => {
+    // 같은 문장의 사본이 둘이고 권위는 원본에 있다. Windows 한국어 환경에서는 알림이 실어 온
+    // 사본만 ANSI 코드페이지를 지나 CJK가 깨진 채 도착하는 것이 보고됐다(2026-08-27) —
+    // 아래 description이 바로 "WORLD 공간 조회"가 그 경로를 지났을 때의 모습이다.
+    expect(chatEventsFromSdkMessage({
+      type: "system", subtype: "task_started",
+      task_id: "b2", tool_use_id: "call-2", description: "WORLD 怨듦컙 議고쉶", task_type: "local_bash",
+    }, { toolTitles: new Map([["call-2", "WORLD 공간 조회"]]) }))
+      .toEqual([expect.objectContaining({ kind: "job", id: "b2", title: "WORLD 공간 조회", toolUseId: "call-2" })]);
+  });
+
+  it("falls back to the notification when no tool call carries the original", () => {
+    // 원본이 없는 잡도 있다(도구 호출 없이 서거나, 상한이 그 호출을 이미 밀어냈거나). 그때
+    // 제목을 비우면 사본이 깨졌을 때보다 더 나쁘다 — 아는 유일한 값으로 되돌아간다.
+    expect(chatEventsFromSdkMessage({
+      type: "system", subtype: "task_started",
+      task_id: "b3", tool_use_id: "call-3", description: "tail the log", task_type: "local_bash",
+    }, { toolTitles: new Map([["call-other", "unrelated"]]) }))
+      .toEqual([expect.objectContaining({ kind: "job", id: "b3", title: "tail the log" })]);
+
+    expect(chatEventsFromSdkMessage({
+      type: "system", subtype: "task_started",
+      task_id: "b4", description: "no tool call at all", task_type: "local_bash",
+    }, { toolTitles: new Map([["call-2", "unrelated"]]) }))
+      .toEqual([expect.objectContaining({ kind: "job", id: "b4", title: "no tool call at all" })]);
+  });
+
   it("keeps an unknown task_type visible instead of dropping it", () => {
     expect(chatEventsFromSdkMessage({
       type: "system", subtype: "task_started", task_id: "x1", description: "?", task_type: "remote_thing",

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-session.test.ts
@@ -1278,6 +1278,46 @@ describe("AgentChatRegistry — background jobs on a live session", () => {
     await registry.disposeAll();
   });
 
+  it("titles a live job from the tool call that started it, not from the notification's copy", async () => {
+    // 실사용 제보(2026-08-27, Windows 한국어): 채팅뷰의 잡 카드 제목만 CJK가 깨져 섰다.
+    // 어시스턴트 본문은 멀쩡했으므로 자식에게 닿은 바이트는 온전했고, 깨진 것은 자식이 자기
+    // 태스크 레코드에서 다시 꺼낸 사본뿐이었다. 화면은 모델이 쓴 그 문장을 읽어야 한다.
+    const transcriptPath = writeTranscript("sid-job-title", []);
+    const { factory } = createFakeSdkFactory([
+      {
+        messages: [
+          {
+            type: "assistant",
+            message: {
+              content: [{
+                type: "tool_use",
+                id: "call-9",
+                name: "Bash",
+                input: { command: "echo hi", description: "WORLD 공간 조회", run_in_background: true },
+              }],
+            },
+          },
+          {
+            type: "system", subtype: "task_started",
+            task_id: "sh9", tool_use_id: "call-9", description: "WORLD 怨듦컙 議고쉶", task_type: "local_bash",
+          },
+          { type: "result", subtype: "success", is_error: false, duration_ms: 5 },
+        ],
+      },
+    ]);
+    const registry = new AgentChatRegistry(factory);
+    const session = await registry.ensure("op-job-title", () => seedFor(transcriptPath));
+    const events: AgentChatJournalEvent[] = [];
+    session.subscribe((entry) => events.push(entry));
+
+    session.send("run it in the background");
+    await drainTurn(registry, "op-job-title");
+
+    const job = events.find((entry) => entry.event.kind === "job");
+    expect(job?.event).toEqual(expect.objectContaining({ kind: "job", id: "sh9", title: "WORLD 공간 조회" }));
+    await registry.disposeAll();
+  });
+
   it("closes still-running jobs as stopped when the session goes away", async () => {
     // 자식과 함께 사라진 작업을 "도는 중"으로 남겨 두면 화면은 오지 않을 결말을 기다린다.
     const transcriptPath = writeTranscript("sid-job-retire", []);


### PR DESCRIPTION
## Summary

- 채팅뷰 백그라운드 작업 카드의 제목이 Windows 한국어 환경에서 CJK가 깨진 채 서던 문제를 고칩니다. 제목의 출처를 자식이 자기 태스크 레코드에서 다시 꺼낸 사본(`task_started.description`)에서, 모델이 실제로 쓴 원본(그 작업을 시작한 `tool_use`의 입력)으로 옮겼습니다.
- 알림이 `tool_use_id`를 함께 실어오므로 연결에 새 좌표가 필요 없습니다. 원본이 없는 잡 — 도구 호출 없이 섰거나 원장 상한이 그 호출을 이미 밀어낸 경우 — 은 기존대로 알림 값으로 폴백하므로, 어떤 경로에서도 지금보다 나빠지지 않습니다.
- 진단 근거: 깨진 문자열은 UTF-8 바이트를 CP949로 디코딩한 mojibake이며(`怨듦컙` → `공간` 역변환으로 확인), Fleet 서버·클라이언트·Agent SDK(`spawn` + `readline` + `StringDecoder`, shell 미사용)는 전 구간 UTF-8 안전합니다. 같은 스트림의 어시스턴트 본문이 멀쩡했다는 점이 자식에게 닿은 바이트는 온전했고 깨진 것은 사본뿐이라는 증거입니다. 오염원 자체는 Windows의 CLI 측이라 Fleet이 닿을 수 없어, 같은 알림에서 오는 `note`와 `summary`는 대응할 원본이 없어 그대로 두었습니다.

## Test Plan

- [x] `runtime/fleet-plugins/terminal` 자체 러너 — 93 files / 1006 tests 통과
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 194 files / 2422 tests 통과
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] 신규 회귀 테스트 3건이 계약을 실제로 잡는지 확인 — 수정을 되돌리면 `title: "WORLD 怨듦컙 議고쉶"`으로 정확히 실패
- [ ] Windows 실기 재현은 하지 못했습니다. "tool_use 입력은 온전하다"는 전제는 본문이 멀쩡하다는 간접 증거(같은 SSE 바이트에 실려 옴)에 기댄 것이지 실측이 아닙니다.