### PR TITLE
fix(fleet-console): resolve the Claude binary once instead of per turn

### DIFF
--- a/.changelog.d/claude-binary-path-cache.md
+++ b/.changelog.d/claude-binary-path-cache.md
@@ -1,0 +1,8 @@
+---
+branch: claude-binary-path-cache
+---
+
+### fleet-console
+#### Fixed
+- Keep the Console answering requests while a chat view starts, instead of freezing every session behind a repeated Claude binary lookup.
+  ko: 채팅 뷰가 열리는 동안 Claude 실행 파일 탐색이 반복되며 모든 세션이 멈추던 문제를 고쳐, Console이 계속 요청에 응답합니다.

--- a/packages/core-agent/src/claude/vendor-sdk.ts
+++ b/packages/core-agent/src/claude/vendor-sdk.ts
@@ -6,6 +6,9 @@
  * vendor 타입이 형제 모듈의 `.d.ts`로 새면 소비자 해석 그래프가 다시 vendor를 요구하게 되고,
  * 그것이 이 패키지가 막으려는 바로 그 상태다.
  */
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+
 import {
   createSdkMcpServer as vendorCreateSdkMcpServer,
   getSessionInfo as vendorGetSessionInfo,
@@ -33,6 +36,138 @@ export interface VendorQueryInput {
 /** 세션용 vendor `query()` 인자. 프롬프트는 이 모듈이 만든 입력 스트림이 대신한다. */
 export interface VendorSessionInput {
   readonly options: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * 자식 CLI 바이너리를 담은 vendor 플랫폼 패키지의 이름 앞부분.
+ *
+ * 내보내지 않는다. `export`하면 이 리터럴이 `vendor-sdk.d.ts`에 상수 타입으로 실려, 형제 선언에
+ * vendor 이름이 남지 않아야 한다는 이 패키지의 격리가 그 자리에서 깨진다.
+ */
+const VENDOR_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+
+/** musl 동적 로더의 절대 경로. vendor의 실패 메시지가 지목하는 바로 그 파일이다. */
+const MUSL_LOADERS: Readonly<Record<string, string>> = {
+  x64: "/lib/ld-musl-x86_64.so.1",
+  arm64: "/lib/ld-musl-aarch64.so.1",
+};
+
+/**
+ * musl 바이너리를 먼저 볼지. vendor의 `process.report.getReport()` 판정을 대신한다.
+ *
+ * vendor는 리포트의 `header.glibcVersionRuntime`이 비어 있는 것을 musl의 증거로 쓴다. 그 한
+ * 필드를 얻으려고 힙·네이티브 스택·libuv 핸들·네트워크 인터페이스를 훑는 진단 리포트를 통째로
+ * 만드는데, 정작 우리가 물어야 하는 것은 훨씬 좁다: **musl 바이너리가 이 호스트에서 뜨는가.**
+ *
+ * 그 답은 musl 동적 로더 하나의 존재로 결정된다 — vendor 자신의 실패 메시지도 같은 것을 지목한다
+ * ("the musl dynamic loader (/lib/ld-musl-*) is missing"). musl 링크 바이너리는 로더가 있으면
+ * 돌고 없으면 어떤 판정을 내려도 돌지 않는다. 그래서 이 검사는 현실적인 모든 호스트에서 vendor와
+ * 같은 답을 내고(Alpine은 로더가 있어 musl, glibc 배포판은 없어 glibc), 둘이 어긋나는 드문
+ * 경우(glibc 호스트에 musl 패키지가 함께 깔린 경우)에도 **실제로 뜨는** 바이너리를 고른다.
+ *
+ * 로더 이름은 arch의 기계 이름을 쓴다. 표에 없는 arch는 vendor가 musl 빌드를 내지 않으므로
+ * 순서를 정할 필요 자체가 없다.
+ */
+function prefersMuslBinary(
+  platform: string,
+  arch: string,
+  exists: (candidate: string) => boolean,
+): boolean {
+  if (platform !== "linux") return false;
+  const loader = MUSL_LOADERS[arch];
+  return loader !== undefined && exists(loader);
+}
+
+/** 경로 해석이 기대는 바깥 사실들. 테스트는 이 시드로 다른 플랫폼의 판정을 재현한다. */
+export interface ClaudeExecutableProbe {
+  readonly platform: string;
+  readonly arch: string;
+  /** musl 빌드를 먼저 볼지. vendor의 `preferMusl`과 같은 자리다. */
+  readonly preferMusl: boolean;
+  /** vendor 자신의 위치를 기준으로 도는 `require.resolve`. */
+  readonly resolve: (specifier: string) => string;
+  readonly exists: (candidate: string) => boolean;
+}
+
+/**
+ * vendor가 고를 바이너리를 그대로 고른다.
+ *
+ * 후보 이름과 순서는 vendor의 해석기를 옮긴 것이다(0.3.212 확인). 이 리포는 배포 타깃 때문에
+ * `supportedArchitectures`로 8개 플랫폼 패키지를 전부 설치하므로, 리눅스에서는 glibc·musl
+ * 후보가 **둘 다 디스크에 있다**. 그래서 "설치된 것 하나를 고른다"로는 답이 정해지지 않고
+ * 순서가 곧 판정이 된다 — `preferMusl`이 그 순서를 쥔다.
+ */
+export function resolveClaudeExecutable(probe: ClaudeExecutableProbe): string | null {
+  const suffix = probe.platform === "win32" ? ".exe" : "";
+  const linux = `${VENDOR_PACKAGE}-linux-${probe.arch}`;
+  const packages = probe.platform === "android"
+    ? [`${linux}-android`]
+    : probe.platform === "linux"
+      ? (probe.preferMusl ? [`${linux}-musl`, linux] : [linux, `${linux}-musl`])
+      : [`${VENDOR_PACKAGE}-${probe.platform}-${probe.arch}`];
+
+  for (const name of packages) {
+    try {
+      const candidate = probe.resolve(`${name}/claude${suffix}`);
+      if (probe.exists(candidate)) return candidate;
+    } catch {
+      // 설치되지 않은 플랫폼 패키지는 resolve에서 걸린다. 다음 후보로 넘어갈 뿐 실패가 아니다.
+    }
+  }
+  return null;
+}
+
+/**
+ * 프로세스 수명 동안 유지되는 해석 결과.
+ *
+ * `undefined`는 "아직 안 풀었다", `null`은 "vendor에게 맡긴다"다. 두 상태를 한 값으로 합치면
+ * 맡기기로 한 판정을 매 턴 다시 계산하게 되고, 그것이 이 파일이 없애려는 바로 그 반복이다.
+ */
+let resolvedExecutable: string | null | undefined;
+
+function claudeExecutablePath(): string | null {
+  if (resolvedExecutable !== undefined) return resolvedExecutable;
+  resolvedExecutable = probeClaudeExecutable();
+  return resolvedExecutable;
+}
+
+function probeClaudeExecutable(): string | null {
+  try {
+    const requireFromHere = createRequire(import.meta.url);
+    // 플랫폼 패키지는 vendor의 optionalDependencies다. pnpm의 격리 레이아웃에서 그 패키지들은
+    // vendor 자신의 위치에서만 풀리므로, require 기준점을 이 패키지가 아니라 vendor 진입점으로 잡는다.
+    const requireFromVendor = createRequire(requireFromHere.resolve(VENDOR_PACKAGE));
+    const exists = (candidate: string): boolean => existsSync(candidate);
+    return resolveClaudeExecutable({
+      platform: process.platform,
+      arch: process.arch,
+      preferMusl: prefersMuslBinary(process.platform, process.arch, exists),
+      resolve: (specifier) => requireFromVendor.resolve(specifier),
+      exists,
+    });
+  } catch {
+    // 해석 실패는 기능이 아니라 최적화만 잃는다 — vendor가 오늘처럼 스스로 푼다.
+    return null;
+  }
+}
+
+/**
+ * vendor `query()` 옵션에 자식 바이너리 경로를 실어 준다.
+ *
+ * 이 한 줄이 이 모듈이 막으려는 정지의 전부다. vendor는 `pathToClaudeCodeExecutable`이 비어
+ * 있을 때만 스스로 경로를 푸는데(0.3.212: `if(!pathToClaudeCodeExecutable){…}`), 그 해석의
+ * 기본값이 리눅스에서 musl/glibc를 가르려고 `process.report.getReport()`를 부른다. 그 호출은
+ * 힙·네이티브 스택·libuv 핸들·네트워크 인터페이스를 훑는 진단 리포트를 **동기로** 만들고 vendor는
+ * 결과를 캐시하지 않으므로, 턴마다 자식을 새로 여는 채팅 경로에서는 그 정지가 매번 되풀이된다.
+ * 같은 프로세스가 HTTP도 서빙하므로 멈추는 것은 채팅만이 아니라 Console 전체다.
+ *
+ * 값을 실으면 vendor는 그 분기에 아예 들어가지 않는다. 못 풀었으면 오늘과 같은 옵션 그대로 간다.
+ */
+function withResolvedExecutable(
+  options: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const executable = claudeExecutablePath();
+  return executable === null ? { ...options } : { ...options, pathToClaudeCodeExecutable: executable };
 }
 
 /** vendor 응답에서 이 패키지의 어휘만 꺼낸다. 모양이 어긋나면 값이 아니라 `null`이다. */
@@ -83,7 +218,7 @@ function readVendorContextUsage(response: unknown): ClaudeGatewayContextUsage | 
 export function runVendorQuery(input: VendorQueryInput): ClaudeGatewayRun {
   const run = vendorQuery({
     prompt: input.prompt,
-    options: input.options,
+    options: withResolvedExecutable(input.options),
   } as never) as AsyncGenerator<unknown, void> & {
     return?: (value?: unknown) => Promise<unknown>;
     getContextUsage?: () => Promise<unknown>;
@@ -192,7 +327,7 @@ export function runVendorSession(input: VendorSessionInput): ClaudeGatewaySessio
   const queue = new VendorInputQueue();
   const run = vendorQuery({
     prompt: queue,
-    options: input.options,
+    options: withResolvedExecutable(input.options),
   } as never) as AsyncGenerator<unknown, void> & {
     close?: () => void;
     return?: (value?: unknown) => Promise<unknown>;

--- a/packages/core-agent/tests/claude-vendor-sdk.test.ts
+++ b/packages/core-agent/tests/claude-vendor-sdk.test.ts
@@ -1,5 +1,23 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+/**
+ * `existsSync`를 세는 이유는 캐시가 이 수정의 본체이기 때문이다. vendor는 경로 해석을 캐시하지
+ * 않아 턴마다 같은 판정을 다시 했고, 그 반복이 이벤트 루프를 세웠다. 호출 수가 늘지 않는 것이
+ * "한 번만 푼다"의 유일한 관측 가능한 증거다.
+ */
+const fsProbe = vi.hoisted(() => ({ existsCalls: [] as string[] }));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    default: actual,
+    existsSync: (target: string) => {
+      fsProbe.existsCalls.push(String(target));
+      return actual.existsSync(target);
+    },
+  };
+});
+
 const query = vi.fn();
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: (input: unknown) => query(input),
@@ -8,7 +26,27 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   tool: vi.fn(),
 }));
 
-const { runVendorQuery } = await import("../src/claude/vendor-sdk.js");
+const { resolveClaudeExecutable, runVendorQuery, runVendorSession } = await import(
+  "../src/claude/vendor-sdk.js"
+);
+
+const VENDOR = "@anthropic-ai/claude-agent-sdk";
+
+/** 설치된 플랫폼 패키지 집합을 흉내 내는 시드. 실제 디스크를 건드리지 않는다. */
+function seedProbe(
+  installed: readonly string[],
+  overrides: { readonly platform: string; readonly arch: string; readonly preferMusl: boolean },
+) {
+  const present = new Set(installed);
+  return {
+    ...overrides,
+    resolve: (specifier: string) => {
+      if (!present.has(specifier)) throw new Error(`MODULE_NOT_FOUND: ${specifier}`);
+      return `/store/${specifier}`;
+    },
+    exists: (candidate: string) => candidate.startsWith("/store/"),
+  };
+}
 
 afterEach(() => {
   query.mockReset();
@@ -60,3 +98,88 @@ function makeVendorRun(returnFn: () => Promise<unknown>): AsyncGenerator<unknown
     },
   } as unknown as AsyncGenerator<unknown, void>;
 }
+
+describe("resolveClaudeExecutable", () => {
+  const BOTH_LINUX = [`${VENDOR}-linux-x64/claude`, `${VENDOR}-linux-x64-musl/claude`];
+
+  it("takes the glibc build when the musl loader is absent", () => {
+    const probe = seedProbe(BOTH_LINUX, { platform: "linux", arch: "x64", preferMusl: false });
+    expect(resolveClaudeExecutable(probe)).toBe(`/store/${VENDOR}-linux-x64/claude`);
+  });
+
+  // 이 리포는 8개 플랫폼 패키지를 전부 설치하므로 두 후보가 늘 함께 있다. 그래서 순서가 곧
+  // 판정이고, preferMusl이 뒤집혔을 때 결과도 뒤집히는 것이 이 함수의 실질이다.
+  it("takes the musl build when the musl loader is present", () => {
+    const probe = seedProbe(BOTH_LINUX, { platform: "linux", arch: "x64", preferMusl: true });
+    expect(resolveClaudeExecutable(probe)).toBe(`/store/${VENDOR}-linux-x64-musl/claude`);
+  });
+
+  it("falls through to the other libc build when the preferred one is not installed", () => {
+    const probe = seedProbe([`${VENDOR}-linux-arm64-musl/claude`], {
+      platform: "linux",
+      arch: "arm64",
+      preferMusl: false,
+    });
+    expect(resolveClaudeExecutable(probe)).toBe(`/store/${VENDOR}-linux-arm64-musl/claude`);
+  });
+
+  it("appends the Windows extension and uses the android package name", () => {
+    const win = seedProbe([`${VENDOR}-win32-x64/claude.exe`], {
+      platform: "win32",
+      arch: "x64",
+      preferMusl: false,
+    });
+    expect(resolveClaudeExecutable(win)).toBe(`/store/${VENDOR}-win32-x64/claude.exe`);
+
+    const android = seedProbe([`${VENDOR}-linux-arm64-android/claude`], {
+      platform: "android",
+      arch: "arm64",
+      preferMusl: false,
+    });
+    expect(resolveClaudeExecutable(android)).toBe(`/store/${VENDOR}-linux-arm64-android/claude`);
+  });
+
+  // 못 고르면 vendor가 오늘처럼 스스로 푼다. 여기서 예외를 던지면 최적화 실패가 기능 실패가 된다.
+  it("returns null when nothing is installed", () => {
+    const probe = seedProbe([], { platform: "linux", arch: "x64", preferMusl: false });
+    expect(resolveClaudeExecutable(probe)).toBeNull();
+  });
+});
+
+describe("child binary handoff", () => {
+  it("hands the vendor a path so its own resolver never runs", () => {
+    query.mockReturnValue(makeVendorRun(async () => undefined));
+    const report = vi.spyOn(process.report, "getReport");
+    try {
+      runVendorQuery({ prompt: "hi", options: { model: "sonnet" } });
+      runVendorSession({ options: { model: "sonnet" } });
+
+      for (const call of query.mock.calls) {
+        const options = (call[0] as { options: Record<string, unknown> }).options;
+        // vendor는 이 키가 비었을 때만 자기 해석 분기에 들어가고, 그 분기가 getReport를 부른다.
+        expect(typeof options.pathToClaudeCodeExecutable).toBe("string");
+        // 호출자가 고른 옵션은 그대로 남아야 한다 — 경로는 더해질 뿐 덮지 않는다.
+        expect(options.model).toBe("sonnet");
+      }
+      expect(query).toHaveBeenCalledTimes(2);
+      expect(report).not.toHaveBeenCalled();
+    } finally {
+      report.mockRestore();
+    }
+  });
+
+  it("resolves the path once and reuses it across runs", async () => {
+    vi.resetModules();
+    const fresh = await import("../src/claude/vendor-sdk.js");
+    query.mockReturnValue(makeVendorRun(async () => undefined));
+    fsProbe.existsCalls.length = 0;
+
+    fresh.runVendorQuery({ prompt: "one", options: {} });
+    const afterFirst = fsProbe.existsCalls.length;
+    fresh.runVendorQuery({ prompt: "two", options: {} });
+    fresh.runVendorSession({ options: {} });
+
+    expect(afterFirst).toBeGreaterThan(0);
+    expect(fsProbe.existsCalls.length).toBe(afterFirst);
+  });
+});

--- a/packages/core-agent/tsup.config.ts
+++ b/packages/core-agent/tsup.config.ts
@@ -9,5 +9,9 @@ export default defineConfig({
   dts: false,
   sourcemap: true,
   clean: true,
+  // `src/claude/vendor-sdk.ts`가 vendor 플랫폼 패키지를 찾으려고 `import.meta.url`을 기준점으로
+  // 쓴다. 이 shim이 없으면 esbuild가 CJS 출력에서 `import.meta`를 `{}`로 접어 기준점이 undefined가
+  // 되고, 경로 해석이 조용히 실패해 vendor의 비싼 자체 해석으로 되돌아간다.
+  shims: true,
   target: "es2022"
 });


### PR DESCRIPTION
## Summary

- 채팅 뷰를 열면 Console 전체가 멈추던 원인을 제거합니다. vendor Claude Agent SDK는 `pathToClaudeCodeExecutable`이 없으면 `query()`마다 자식 CLI 경로를 다시 풀고, 그 해석이 musl/glibc 판별용으로 `process.report.getReport()`를 캐시 없이 호출합니다. 그 리포트는 힙·네이티브 스택·libuv 핸들·네트워크 인터페이스를 훑어 **동기로** 만들어지므로 이벤트 루프가 멈추고, 같은 프로세스가 HTTP도 서빙하는 탓에 멈추는 것은 채팅뿐이 아닙니다.
- 자식 바이너리 경로를 프로세스당 한 번만 풀어 모든 vendor query에 실어 줍니다. 값이 실리면 vendor는 자기 해석 분기에 아예 들어가지 않습니다.
- musl 판정은 `getReport` 대신 musl 동적 로더 존재 확인으로 대체했습니다. 해석에 실패하면 vendor의 기존 해석으로 되돌아가므로, 최적화 실패가 기능 실패가 되지 않습니다.

## Type of Change

- [x] fix — bug fix

## Test Plan

- [x] 실제 vendor SDK 실측 (`process.platform`을 linux로 강제해 문제 분기 재현): 5턴 기준 `getReport` **5회 / 69.1ms → 0회 / 1.0ms**
- [x] vendor가 고르는 바이너리와 우리 선택이 **문자열 동일**, 그 바이너리 실행 확인 (`2.1.212 (Claude Code)`). `a`가 같은 문자열이므로 vendor의 인자 조립(`Obe(a)` 분기)도 동일합니다.
- [x] `pnpm build` / `pnpm typecheck` / `pnpm test` 리포 전역 통과 (6,500+ 케이스)
- [x] boundary 게이트 4종 + `compile-changelog-fragments --check` 통과
- [x] ESM·CJS 두 빌드 산출물에서 해석 기준점이 실제로 동작하는지 확인

## Notes for Reviewers

- 코드는 `packages/core-agent`에 있지만 사용자가 체감하는 표면은 Fleet Console이라 scope와 changelog runtime을 `fleet-console`로 잡았습니다. `packages/CLAUDE.md`가 core-agent를 유일하게 허가된 vendor-SDK import 지점으로 지정하고 `src/index.ts`가 "이 패키지 안에서도 `vendor-sdk.ts` 한 곳만 그 이름을 안다"를 불변식으로 두고 있어, 새 파일 대신 그 파일 안에서 해결했습니다.
- 이 리포는 `supportedArchitectures` 때문에 8개 플랫폼 바이너리를 **전부** 설치합니다. linux glibc·musl 후보가 둘 다 디스크에 있으므로 libc 판정이 실제로 결과를 가르며, 그래서 판정을 없애는 대신 싸게 다시 세웠습니다.
- `tsup`의 `shims: true`는 esbuild가 CJS 빌드에서 `import.meta`를 `{}`로 접어 해석 기준점이 `undefined`가 되고 수정이 **조용히 무력화**되던 것을 잡은 것입니다. 빌드 산출물을 확인한 뒤 추가했습니다.
- **한계**: 개발 머신이 macOS이고 Linux 런타임이 없어 WSL2 실측은 못 했습니다. Linux에서의 glibc/musl 순서 선택은 주입 시드 단위 테스트로만 검증했습니다.