### PR TITLE
fix(fleet-console): stop War Room from dimming the panel it stages

### DIFF
--- a/.changelog.d/war-room-stage-vignette.md
+++ b/.changelog.d/war-room-stage-vignette.md
@@ -1,0 +1,8 @@
+---
+branch: war-room-stage-vignette
+---
+
+### fleet-console
+#### Fixed
+- Stop War Room from casting a dark vignette over the panel it raises onto the stage, so a staged panel reads at full contrast to its corners.
+  ko: War Room이 무대에 올린 패널 위로 어두운 비네트를 덮던 문제를 고쳐, 무대에 오른 패널이 모서리까지 제 밝기로 읽힙니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3280,19 +3280,18 @@
   cursor: crosshair;
 }
 
+/* War Room은 바닥 색만 말하고 그 위에 상시 비네트를 얹지 않는다. 종전의 `::after`
+   (z-index 70, canvas-abyss 46% 방사 비네트)는 덱(z-index 80)·모드 프레임(76) 아래가 아니라
+   패널 세계(.operations-canvas-world, z-index auto) **위**에 놓여 있었다 — 그래서 덱 카드는
+   멀쩡한데 무대에 오른 패널만 네 모서리가 검게 죽었다(실측 1280×577, 무대 918×463:
+   Instrument 모서리 rgb(5,13,21)↔없을 때 (6,16,26), Maritime (6,21,33)↔(9,30,48),
+   Carbon (12,14,19)↔(16,20,26) — 파랑 채널 최대 −15/255. Whites는 abyss가 97.8%라 무변).
+   덱 상태에서 비네트가 실제로 닿는 곳은 캔버스 가장자리 26px 여백뿐이고 거기 바닥은 이미
+   심해라 기여가 ≤1/255였다 — 얻는 것 없이 무대 패널만 어둡게 하던 층이라 통째로 걷었다.
+   모드 진입의 스크림은 커튼(.canvas-mode-curtain)이 계속 소유한다. */
 .operations-canvas.is-triage {
   background: var(--canvas-field-triage);
   cursor: default;
-}
-
-/* 모드 스크림·비네트는 canvas-abyss를 따라 테마 극성에 맞춘다 — 다크=심해, 라이트=백무. */
-.operations-canvas.is-triage::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 70;
-  pointer-events: none;
-  background: radial-gradient(78% 66% at 50% 48%, transparent 55%, color-mix(in oklch, var(--canvas-abyss) 46%, transparent) 100%);
 }
 
 .operations-canvas.is-triage .operations-canvas-sea {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -664,6 +664,12 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".operations-canvas.is-triage {\n  background: var(--canvas-field-triage);");
     expect(components).toContain(".operations-canvas.is-formation-view {\n  background: var(--canvas-field-formation);");
 
+    // 모드 바닥은 색이지 그 위에 덮는 층이 아니다. 캔버스 전면 의사요소는 패널 세계
+    // (.operations-canvas-world, z-index auto) 위에 놓여 무대에 오른 패널을 통째로 어둡게 하므로
+    // 어떤 모드에서도 두지 않는다 — 진입 스크림은 커튼(.canvas-mode-curtain)이 소유한다.
+    expect(components).not.toMatch(/^\.operations-canvas\.is-triage::(after|before) \{/m);
+    expect(components).not.toMatch(/^\.operations-canvas\.is-formation-view::(after|before) \{/m);
+
     // 줌 곱셈은 격자 요소에서 일어나야 한다: :root 커스텀 속성 안에 중첩한 var()는 선언 지점인
     // :root에서 해석돼 컴포넌트가 넘긴 줌을 영원히 보지 못한다.
     // `.operations-canvas-grid`는 위치 선언을 sea와 공유하는 블록에도 등장한다 — 연출 블록만 고른다.


### PR DESCRIPTION
## Summary
- War Room의 `.operations-canvas.is-triage::after`(z-index 70, `--canvas-abyss` 46% 방사 비네트)는 덱(z-index 80)·모드 프레임(76) **아래**가 아니라 패널 세계(`.operations-canvas-world`, z-index auto) **위**에 놓여 있었습니다. 그래서 덱 카드는 멀쩡한데, 무대에 오른 패널만 네 모서리가 검게 죽었습니다 — War Room이 보여주려고 올린 바로 그 패널만.
- 이 층은 다른 어디서도 값을 하지 못했습니다. 덱 상태에서 비네트가 실제로 닿는 곳은 캔버스 가장자리 26px 여백뿐이고, 그 바닥은 이미 심해라 기여가 ≤1/255였습니다. 그래서 z 순서를 바꾸는 대신 층을 통째로 걷었고, 모드 진입 스크림은 커튼(`.canvas-mode-curtain`)이 계속 소유합니다.
- 디자인 계약에 모드 캔버스의 전면 의사요소 금지를 못 박았습니다 — 그 자리가 곧 패널 세계 위를 덮는 자리이기 때문입니다.

## Measurement
헤드리스 실측(1280×577 뷰포트, 무대 918×463). 패널 **모서리** 픽셀, 비네트 있음 → 없음:

| 테마 | 있음 | 없음 | Δ(파랑) |
|---|---|---|---|
| Instrument | rgb(5,13,21) | rgb(6,16,26) | −5 |
| Maritime | rgb(6,21,33) | rgb(9,30,48) | −15 |
| Carbon | rgb(12,14,19) | rgb(16,20,26) | −7 |
| Whites | rgb(250,249,246) | 동일 | 0 (abyss 97.8%) |

패널 **중앙**은 네 테마 모두 무변 — 패널 자신의 유리 재질은 건드리지 않았고 덮개만 걷혔습니다. 수정 후 실측값이 프로브(비네트만 끈 상태)와 세 다크 테마에서 정확히 일치합니다.

## Test Plan
- [x] `vitest run` — 194 files / 2422 passed, 1 file / 24 skipped
- [x] `vitest run tests/instrument-design-contract.test.ts` — 89 passed (신규 부정 단언 포함)
- [x] 신규 부정 정규식이 **옛 CSS 문자열에는 매치**하고 현재 파일에는 매치하지 않음을 확인 (계약이 실제로 red를 낼 수 있음)
- [x] `typecheck` — 통과
- [x] `check:core-boundary` / `check:claude-agent-sdk-boundary` / `check:core-unified-agent-absent` / `check:localized-attributes` — 모두 통과
- [x] `compile-changelog-fragments.mjs --check` — 2 fragments validated
- [x] 격리 콘솔 헤드리스 실측: 무대 상태 4개 테마 전/후 픽셀 비교, 덱 상태 여백 무변(≤1/255) 확인, page error·rejection 0건