### PR TITLE
fix(fleet-console): remove ambient War Room scan

### DIFF
--- a/.changelog.d/war-room-map-line-motion.md
+++ b/.changelog.d/war-room-map-line-motion.md
@@ -1,0 +1,8 @@
+---
+branch: war-room-map-line-motion
+---
+
+### fleet-console
+#### Changed
+- Keep the War Room Map still after its entry sequence instead of repeating a vertical scan line.
+  ko: War Room Map의 진입 연출은 유지하면서 이후 세로 스캔 선이 반복되지 않도록 정돈합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -818,7 +818,6 @@ export function OperationsCanvas({
       ref={canvasRef}
     >
       <CanvasGrid viewport={canvas.viewport} />
-      {triageActive ? <div className="canvas-triage-scan" aria-hidden="true" /> : null}
       <div
         style={{
           // 최대화 시 transform 제거(none)로 net scale 1. 일반 상태에서는 pan 좌표를 정수 픽셀로 스냅해

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3419,18 +3419,6 @@
 .is-formation-entering .canvas-mode-bracket--sw { animation: formation-bracket-sw var(--duration-slow) cubic-bezier(0.2, 0.9, 0.25, 1) both; }
 .is-formation-entering .canvas-mode-bracket--se { animation: formation-bracket-se var(--duration-slow) cubic-bezier(0.2, 0.9, 0.25, 1) both; }
 
-.canvas-triage-scan {
-  position: absolute;
-  left: 12%;
-  right: 12%;
-  top: 12%;
-  z-index: 0;
-  height: 1px;
-  pointer-events: none;
-  background: linear-gradient(to right, transparent, color-mix(in oklch, var(--brass) 34%, transparent) 22%, color-mix(in oklch, var(--brass) 34%, transparent) 78%, transparent);
-  animation: triage-scan-line 9s linear infinite;
-}
-
 .canvas-triage-sweep {
   position: absolute;
   inset: 0;
@@ -4229,12 +4217,6 @@
 @keyframes formation-bracket-sw { from { transform: translate(-18px, 18px); } to { transform: translate(0, 0); } }
 @keyframes formation-bracket-se { from { transform: translate(18px, 18px); } to { transform: translate(0, 0); } }
 
-@keyframes triage-scan-line {
-  from { transform: translateY(0); opacity: 0.25; }
-  50% { opacity: 0.85; }
-  to { transform: translateY(68vh); opacity: 0.25; }
-}
-
 @keyframes triage-sweep-pass {
   from { transform: translateY(-100%); }
   to { transform: translateY(100%); }
@@ -4281,7 +4263,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .canvas-triage-sweep,
-  .canvas-triage-scan,
   .canvas-triage-map-dot.is-awaiting::after,
   .canvas-triage-deck.is-map-mode .canvas-triage-map-dot,
   .canvas-triage-deck.is-map-mode .canvas-triage-map-dot.is-landed,

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -641,6 +641,16 @@ describe("Instrument core design contract", () => {
     for (const path of OWNED_SOURCES) expect(source(path)).not.toMatch(FORBIDDEN_DECORATION);
   });
 
+  it("keeps the War Room entry sweep without an ambient scan line", () => {
+    const canvas = source("canvas/canvas.tsx");
+    const components = source("styles/components.css");
+
+    expect(canvas).not.toContain("canvas-triage-scan");
+    expect(components).not.toContain("triage-scan-line");
+    expect(canvas).toContain('{triageEntering ? <div className="canvas-triage-sweep" aria-hidden="true" /> : null}');
+    expect(components).toContain("animation: triage-sweep-pass 900ms");
+  });
+
   it("denies the canvas a scroll port so a focused overhanging descendant cannot shift the board", () => {
     const components = source("styles/components.css");
     const canvasBlock = components.match(/\n\.operations-canvas \{[\s\S]*?\n\}/)?.[0] ?? "";


### PR DESCRIPTION
## Summary
- remove the vertical scan line that repeated while the War Room Map remained open
- preserve the one-time War Room entry sweep and curtain sequence
- add a design contract that keeps ambient and entry motion separated

## Test Plan
- [x] `corepack pnpm --dir runtime/fleet-console exec vitest run tests/instrument-design-contract.test.ts`
- [x] `corepack pnpm --dir runtime/fleet-console typecheck`
- [x] `corepack pnpm --dir runtime/fleet-console build`
- [x] verify in an isolated Console that entry sweep/curtain appear, disappear after entry, and no scan line remains
- [x] `node scripts/compile-changelog-fragments.mjs --check`