### PR TITLE
fix(fleet-console): keep long file lists filled on scroll

### DIFF
--- a/.changelog.d/file-explorer-scroll-clip-fix.md
+++ b/.changelog.d/file-explorer-scroll-clip-fix.md
@@ -1,0 +1,8 @@
+---
+branch: file-explorer-scroll-clip-fix
+---
+
+### fleet-console
+#### Fixed
+- Keep long File Explorer lists filled while scrolling in tall panels.
+  ko: 세로로 긴 패널에서 파일 탐색기의 긴 목록을 스크롤해도 목록이 빈 공간 없이 이어집니다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,6 +494,12 @@ importers:
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -751,6 +751,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
   const [watchDegraded, setWatchDegraded] = useState(false);
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const treeRef = useRef<HTMLDivElement>(null);
+  const treeResizeObserverRef = useRef<ResizeObserver | null>(null);
   const filterInputRef = useRef<HTMLInputElement>(null);
   const sortButtonRef = useRef<HTMLButtonElement>(null);
   const rowRefs = useRef(new Map<string, HTMLButtonElement>());
@@ -991,14 +992,21 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
     };
   }, [contextKey, filterText, searchScope, showHidden, theaterId]);
 
-  useEffect(() => {
-    const el = treeRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver(() => setContainerHeight(el.clientHeight));
-    ro.observe(el);
-    setContainerHeight(el.clientHeight);
-    return () => ro.disconnect();
+  const attachTreeRef = useCallback((node: HTMLDivElement | null) => {
+    treeResizeObserverRef.current?.disconnect();
+    treeResizeObserverRef.current = null;
+    treeRef.current = node;
+    if (!node) return;
+    setScrollTop(node.scrollTop);
+    setContainerHeight(node.clientHeight);
+    const observer = new ResizeObserver(() => {
+      if (treeRef.current === node) setContainerHeight(node.clientHeight);
+    });
+    observer.observe(node);
+    treeResizeObserverRef.current = observer;
   }, []);
+
+  useEffect(() => () => treeResizeObserverRef.current?.disconnect(), []);
 
   // SSE 자동 새로고침 — theaterId/files 변경 시 재구독, 언마운트 시 close
   useEffect(() => {
@@ -1699,7 +1707,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
         />
       ) : (
         <div
-          ref={treeRef}
+          ref={attachTreeRef}
           className="fexp-tree"
           role="tree"
           tabIndex={-1}

--- a/runtime/fleet-plugins/file-explorer/package.json
+++ b/runtime/fleet-plugins/file-explorer/package.json
@@ -17,6 +17,8 @@
   "devDependencies": {
     "@types/node": "^24.10.0",
     "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "react-dom": "^19.2.3",
     "typescript": "^6.0.2",
     "vitest": "^4.1.5"
   }

--- a/runtime/fleet-plugins/file-explorer/tests/tree-resize.test.tsx
+++ b/runtime/fleet-plugins/file-explorer/tests/tree-resize.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getT } from "../client/i18n/index.js";
+import { FileTree, type PluginFilesClient } from "../client/tree.js";
+import type { FolderEntry, FolderListResult } from "../server/types.js";
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = [];
+
+  readonly observe = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverMock.instances.push(this);
+  }
+}
+
+class EventSourceMock {
+  readonly addEventListener = vi.fn();
+  readonly close = vi.fn();
+  onopen: (() => void) | null = null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let treeHeight: number;
+
+const entries: FolderEntry[] = Array.from({ length: 260 }, (_, index) => {
+  const name = `file-${String(index + 1).padStart(3, "0")}.txt`;
+  return { name, relativePath: name, kind: "file" };
+});
+
+const result: FolderListResult = {
+  relativePath: "",
+  parentRelativePath: null,
+  entries,
+};
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  ResizeObserverMock.instances = [];
+  treeHeight = 1117;
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  vi.stubGlobal("EventSource", EventSourceMock);
+  vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false })));
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function (this: HTMLElement) {
+    return this.classList.contains("fexp-tree") ? treeHeight : 0;
+  });
+  container = document.createElement("div");
+  document.body.replaceChildren(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function renderedNames(): string[] {
+  return [...container.querySelectorAll<HTMLElement>(".fexp-tree-row")]
+    .map((row) => row.textContent?.trim() ?? "");
+}
+
+function renderTree(files: PluginFilesClient): void {
+  root.render(
+    <FileTree
+      contextKey="theater-a:root"
+      files={files}
+      theaterId="theater-a"
+      selectedPath={null}
+      onSelect={vi.fn()}
+      onContextMenu={vi.fn()}
+      t={getT("en")}
+    />,
+  );
+}
+
+describe("FileTree viewport measurement", () => {
+  it("measures the tree when an asynchronous listing mounts it, then fills a tall viewport while scrolling", async () => {
+    let resolveListing!: (value: FolderListResult) => void;
+    const listFolder = vi.fn(() => new Promise<FolderListResult>((resolve) => {
+      resolveListing = resolve;
+    }));
+
+    await act(async () => renderTree({ listFolder }));
+    expect(container.querySelector(".fexp-tree")).toBeNull();
+    expect(ResizeObserverMock.instances).toHaveLength(0);
+
+    await act(async () => resolveListing(result));
+
+    expect(ResizeObserverMock.instances).toHaveLength(1);
+    expect(ResizeObserverMock.instances[0]?.observe).toHaveBeenCalledWith(container.querySelector(".fexp-tree"));
+    expect(renderedNames()).toHaveLength(42);
+    expect(renderedNames().at(-1)).toBe("file-042.txt");
+
+    const tree = container.querySelector<HTMLDivElement>(".fexp-tree")!;
+    Object.defineProperty(tree, "scrollTop", { configurable: true, writable: true, value: 450 });
+    await act(async () => tree.dispatchEvent(new Event("scroll", { bubbles: true })));
+
+    expect(renderedNames()[0]).toBe("file-010.txt");
+    expect(renderedNames().at(-1)).toBe("file-057.txt");
+  });
+
+  it("reconnects measurement when filtering replaces and restores the tree node", async () => {
+    const listFolder = vi.fn(async () => result);
+    await act(async () => renderTree({ listFolder }));
+    expect(ResizeObserverMock.instances).toHaveLength(1);
+
+    const input = container.querySelector<HTMLInputElement>(".fexp-filter-input")!;
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      valueSetter?.call(input, "needle");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(container.querySelector(".fexp-tree")).toBeNull();
+    expect(ResizeObserverMock.instances[0]?.disconnect).toHaveBeenCalled();
+
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      valueSetter?.call(input, "");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(container.querySelector(".fexp-tree")).not.toBeNull();
+    expect(ResizeObserverMock.instances).toHaveLength(2);
+    expect(renderedNames()[0]).toBe("file-001.txt");
+    expect(renderedNames().at(-1)).toBe("file-042.txt");
+  });
+});


### PR DESCRIPTION
## Summary
- bind File Explorer viewport measurement to the actual tree scroll node lifecycle
- remeasure virtualized lists after asynchronous mounting, filter remounting, and resizing
- add component regression coverage for tall lists with more than 200 rows

## Test Plan
- [x] `pnpm --filter @fleet-plugins/file-explorer test`
- [x] `pnpm --filter @fleet-plugins/file-explorer typecheck`
- [x] `pnpm --filter @fleet-plugins/file-explorer build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] browser E2E with 260 files at 1280x1200 and scrollTop 450; verified zero blank pixels and filter remount recovery