### PR TITLE
feat(fleet-console): stop applying liquid glass on the light theme

### DIFF
--- a/.changelog.d/light-theme-no-glass.md
+++ b/.changelog.d/light-theme-no-glass.md
@@ -1,0 +1,9 @@
+---
+branch: light-theme-no-glass
+---
+
+### fleet-console
+#### Changed
+
+- The light theme no longer uses liquid glass. On paper there is no light behind the glass to bend, so floating menus, panels and console chrome return to their solid material, and the Liquid glass switch in Settings reads off and cannot be changed while the light theme is active. Your choice is kept for the dark themes and comes back when you return to one.
+  ko: 라이트 테마는 더 이상 리퀴드 글래스를 쓰지 않습니다. 종이 위에는 유리가 굴절시킬 빛이 없어, 떠 있는 메뉴와 패널·콘솔 크롬이 불투명한 본래 재질로 돌아가고, 라이트 테마를 쓰는 동안 설정의 리퀴드 글래스 손잡이는 꺼짐으로 표시되며 바꿀 수 없습니다. 선택한 값은 다크 테마를 위해 그대로 남아 다시 돌아오면 살아납니다.

--- a/runtime/fleet-console/core/client/src/components/liquid-glass-welcome.tsx
+++ b/runtime/fleet-console/core/client/src/components/liquid-glass-welcome.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { getGlobalSettingsStoreState, isSavingGlobalSettingsField, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { useT } from "../i18n/index.js";
+import { themePolarity } from "../store.js";
 import type { ConsoleState } from "../types.js";
 import { appendSeenFeatureTour } from "./feature-tour.js";
 
@@ -16,6 +17,8 @@ import { appendSeenFeatureTour } from "./feature-tour.js";
  * 이 모달의 제품 계약이다(기능 안내 자체는 설정 체크박스 도움말이 상시 대신한다).
  * 이미 설정에서 리퀴드 글래스를 꺼 둔 사용자에게는 소개가 무의미하므로 띄우지 않는다
  * (그 경우에도 seen을 남기지 않는다 — 켠 뒤 처음 What's New를 닫는 순간 소개를 받는다).
+ * 라이트 테마도 같은 이유로 건너뛴다 — 그 테마에는 유리가 실리지 않으므로 소개가 곧 거짓이
+ * 되고, 마찬가지로 seen을 남기지 않아 다크로 옮긴 뒤 제때 소개를 받는다.
  */
 export const GLASS_WELCOME_SEEN_KEY = "liquid-glass.welcome";
 
@@ -28,7 +31,9 @@ export function LiquidGlassWelcome({ state }: { readonly state: ConsoleState }) 
   const confirmRef = useRef<HTMLButtonElement | null>(null);
 
   const seen = settings.state?.seenFeatureTours ?? null;
-  const liquidGlassOn = settings.state?.liquidGlass ?? true;
+  // 화면에 실제로 유리가 실렸는가 — 저장된 선호와 테마 극성이 함께 정한다. 극성은 DOM에 방금
+  // 실린 activeTheme에서 읽는다(설정 왕복을 기다리는 settings.state.theme는 한 박자 늦다).
+  const liquidGlassOn = (settings.state?.liquidGlass ?? true) && themePolarity(state.activeTheme) === "dark";
 
   useEffect(() => {
     const wasOpen = prevWhatsNewOpen.current;

--- a/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
@@ -45,6 +45,7 @@ export const pagesEn = {
   "settings.theme.cliNote": "* Agent CLIs paint their own colors. After changing the console theme, pick a matching theme in each CLI too - for example, run /theme in Claude Code or Codex.",
   "settings.theme.liquidGlass": "Liquid glass",
   "settings.theme.liquidGlassHelp": "Floating menus and chrome take on a translucent, blurred material. Turn it off for the classic solid look.",
+  "settings.theme.liquidGlassLightHelp": "The light theme does not use liquid glass - on paper there is no light behind the glass to bend. Your setting is kept for the dark themes.",
   "settings.theme.panelFade": "Unfocused panel fade",
   "settings.theme.panelFadeHelp": "How far the panels you are not working in step back on the Map. Drag right to make the focused panel stand out more; at 0% nothing fades.",
   "settings.theme.instrument": "Instrument",
@@ -333,8 +334,8 @@ export const pagesEn = {
 
   // whatsnew tabs (catalog labels owned by pages; chrome owns modal chrome)
   "glassWelcome.title": "A new liquid glass finish",
-  "glassWelcome.body": "Floating menus, popups, and the console chrome now carry a translucent, blurred glass material on every theme.",
-  "glassWelcome.revert": "Prefer the classic solid look? Open Settings \u2192 Theme and uncheck \u201cLiquid glass\u201d anytime.",
+  "glassWelcome.body": "Floating menus, popups, and the console chrome now carry a translucent, blurred glass material on the dark themes.",
+  "glassWelcome.revert": "Prefer the classic solid look? Open Settings \u2192 Theme and uncheck \u201cLiquid glass\u201d anytime. The light theme always stays solid.",
   "glassWelcome.confirm": "Got it",
   "glassWelcome.dismiss": "Dismiss the liquid glass introduction",
   "glassWelcome.aria": "Liquid glass introduction",
@@ -594,6 +595,7 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "settings.theme.cliNote": "* Agent CLI는 자체 색상으로 출력합니다. 콘솔 테마를 바꾼 뒤에는 각 CLI에서도 어울리는 테마를 다시 선택해 주세요 — 예: Claude Code·Codex에서 /theme 실행.",
   "settings.theme.liquidGlass": "리퀴드 글래스",
   "settings.theme.liquidGlassHelp": "떠 있는 메뉴와 크롬에 반투명 블러 질감을 입힙니다. 끄면 기존의 불투명한 모습으로 돌아갑니다.",
+  "settings.theme.liquidGlassLightHelp": "라이트 테마는 리퀴드 글래스를 쓰지 않습니다 — 종이 위에는 유리가 굴절시킬 빛이 없습니다. 설정값은 다크 테마를 위해 그대로 둡니다.",
   "settings.theme.panelFade": "비포커스 패널 흐리기",
   "settings.theme.panelFadeHelp": "Map에서 지금 쓰고 있지 않은 패널이 얼마나 물러날지 정합니다. 오른쪽으로 끌수록 포커스한 패널이 더 도드라지고, 0%면 아무것도 흐려지지 않습니다.",
   "settings.theme.instrument": "Instrument",
@@ -879,8 +881,8 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "shortcuts.codex.fitLightbox": "다이어그램 라이트박스를 뷰포트에 맞추기",
 
   "glassWelcome.title": "새로운 리퀴드 글래스 마감",
-  "glassWelcome.body": "떠 있는 메뉴·팝업과 콘솔 크롬에 모든 테마에서 반투명 블러 유리 질감이 적용됩니다.",
-  "glassWelcome.revert": "기존의 불투명한 모습이 좋다면 언제든 설정 \u2192 테마에서 \u201c리퀴드 글래스\u201d 체크를 해제하세요.",
+  "glassWelcome.body": "떠 있는 메뉴·팝업과 콘솔 크롬에 다크 테마에서 반투명 블러 유리 질감이 적용됩니다.",
+  "glassWelcome.revert": "기존의 불투명한 모습이 좋다면 언제든 설정 \u2192 테마에서 \u201c리퀴드 글래스\u201d 체크를 해제하세요. 라이트 테마는 늘 불투명합니다.",
   "glassWelcome.confirm": "확인",
   "glassWelcome.dismiss": "리퀴드 글래스 소개 닫기",
   "glassWelcome.aria": "리퀴드 글래스 소개",

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -20,7 +20,7 @@ import { isDesktopShell } from "../desktop-shell.js";
 import { forgetRemoteHost, probeRemoteHost, refreshRemoteHosts, renameRemoteHost, useRemoteHosts, type RemoteHost, type RemoteHostReach } from "../remote-hosts.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { usePluginRegistry } from "../plugin-registry.js";
-import { setActiveTheme, setActiveUiFont, setLiquidGlass, setUnfocusedPanelFade } from "../store.js";
+import { setActiveTheme, setActiveUiFont, setLiquidGlass, setUnfocusedPanelFade, themePolarity } from "../store.js";
 import { DEFAULT_UI_FONT, UI_FONT_BUILT_INS, UI_FONT_DESCRIPTION_KEYS, UI_FONT_SIZE_RANGE, uiFontFamily } from "../ui-font.js";
 import { buildRemoteEndpointPresentation, generateRemoteAutoPort, REMOTE_AUTO_PORT_MAX, REMOTE_AUTO_PORT_MIN, isCommittableRemotePortDraft, isValidRemoteAdvertisedHost, isValidRemoteListenAddress, isWarnableLocalPort, remoteAccessStateEquals, remoteEndpointImpact, type GlobalSettingsState, type RemoteAccessLink, type RemoteAccessPort, type RemoteAccessState, type RemoteAccessStatus, type RemoteEndpointRequirement, type RemoteForwardRule, type ThemeId, type UiFontId, type UiFontSettings } from "../types.js";
 
@@ -439,7 +439,14 @@ export function ThemeCard({
       if (!saved) setActiveTheme(previousTheme);
     });
   };
-  const liquidGlass = state?.liquidGlass ?? true;
+  /* 라이트 테마는 유리를 받지 않는다(theme.css 게이트가 극성으로 제외한다). 그래서 이 줄은
+     저장된 선호가 아니라 **지금 화면에 실제로 실린 재질**을 말해야 한다 — 크롬이 불투명한데
+     손잡이만 켜져 있으면 화면과 컨트롤이 서로 다른 말을 한다. 켜진 채로 흐려진 손잡이는
+     이 저장소에서 이미 "꺼진 것으로 읽힌다"고 못박은 실패 양식이기도 하다(agent-cli 강도 사다리).
+     저장값 자체는 건드리지 않는다 — 쓰기는 toggleLiquidGlass 하나뿐이고, 다크로 돌아오면
+     사용자가 고른 값이 그대로 다시 선다. */
+  const lightTheme = themePolarity(activeTheme) === "light";
+  const liquidGlass = (state?.liquidGlass ?? true) && !lightTheme;
   const savedPanelFade = state?.unfocusedPanelFade ?? UNFOCUSED_PANEL_FADE_DEFAULT;
   // 끄는 동안의 값은 화면이 들고, 서버 값은 손을 뗄 때 따라온다. 저장 왕복마다 손잡이가
   // 서버 값으로 되튀면 연속 조작이 끊긴다.
@@ -514,11 +521,15 @@ export function ThemeCard({
                 {t("settings.theme.liquidGlass")}
                 <SettingsScope kind="live" />
               </p>
-              <p className="global-settings-help">{t("settings.theme.liquidGlassHelp")}</p>
+              {/* 도움말은 줄마다 한 문단이다 — 두 번째 문단을 쌓지 않고 문장을 갈아 끼운다.
+                  기본 문안은 "끄면 원래대로"라고 말하므로, 끌 수 없는 자리에 그대로 두면 거짓이 된다. */}
+              <p className="global-settings-help">
+                {t(lightTheme ? "settings.theme.liquidGlassLightHelp" : "settings.theme.liquidGlassHelp")}
+              </p>
             </div>
             <SettingsSwitch
               checked={liquidGlass}
-              disabled={saving || state === null}
+              disabled={saving || state === null || lightTheme}
               label={t("settings.theme.liquidGlass")}
               onChange={toggleLiquidGlass}
             />

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -257,7 +257,12 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
 
    게이트 뒤에 둔다 — 유리를 끄면 공간 예약 레이아웃이 정확히 돌아온다.
    현재 문서 스크롤을 갖는 데스크톱 라우트는 설정 하나뿐이다. Operations 캔버스는 스크롤이
-   아니라 고정 프레임이라 이 규칙의 대상이 아니다. */
+   아니라 고정 프레임이라 이 규칙의 대상이 아니다.
+
+   제외 목록은 theme.css의 채널 게이트와 **글자까지 같아야 한다**. 이 규칙은 채널이 아니라
+   data-glass 속성을 직접 읽으므로, 라이트(Whites)를 theme.css에서만 빼면 여기는 계속 열려
+   있다 — 불투명해진 밴드 뒤로 본문이 흘러 굴절 대신 가려지기만 한다(축소-투명도에서 이미
+   같은 이유로 되돌리는 실패 양식이다). :not(A, B) 목록 형태를 지키는 이유도 같다. */
 @supports (selector(:has(*)) and ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)))) {
   /* 셸은 밴드와 라우트 사이에 흐름 바(연결·저하 배너, 업데이트 결과 바, 제어 반납 바)를
      조건부로 끼운다. 그 바가 하나라도 서면 음수 마진은 밴드가 아니라 그 바를 라우트로 덮어
@@ -271,14 +276,14 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
      사이에 있어 영영 매칭되지 않는다.
      --band-underflow는 그 자리에서만 켜지고 자손이 상속한다 — 조건이 깨지면 0px 기본값으로
      떨어져 페이지 패딩과 sticky 오프셋이 함께 원래 레이아웃으로 돌아간다. */
-  :root:not([data-glass="off"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .console-route-content {
+  :root:not([data-glass="off"], [data-theme="whites"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .console-route-content {
     --band-underflow: var(--chrome-band-height);
     margin-top: calc(-1 * var(--band-underflow));
   }
 
   /* 밴드는 라우트 본문(위치 없음, z:auto)만 이기면 된다. 값을 키우면 What's new(35) 같은
      낮은 오버레이 위로 밴드가 올라서므로(기존 is-docked 주석의 실측 회귀) 사다리의 맨 아래에 둔다. */
-  :root:not([data-glass="off"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .command-band {
+  :root:not([data-glass="off"], [data-theme="whites"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .command-band {
     --z-band-underflow: 2;
     isolation: isolate;
     z-index: var(--z-band-underflow);
@@ -287,12 +292,12 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
   /* 유리 게이트의 셋째 조건. 투명도 축소를 선호하면 밴드는 불투명 실색으로 돌아가므로,
      본문을 그 뒤로 보내면 굴절 대신 가려지기만 한다 — 공간 예약 레이아웃으로 되돌린다. */
   @media (prefers-reduced-transparency: reduce) {
-    :root:not([data-glass="off"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .console-route-content {
+    :root:not([data-glass="off"], [data-theme="whites"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .console-route-content {
       --band-underflow: 0px;
       margin-top: 0;
     }
 
-    :root:not([data-glass="off"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .command-band {
+    :root:not([data-glass="off"], [data-theme="whites"]) .console-shell:has(.command-band):has(.global-settings-page):not(:has(.console-shell-bars > *)) .command-band {
       isolation: auto;
       z-index: auto;
     }

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -750,56 +750,10 @@
 
   --surface-glass: oklch(98% 0.004 100 / 70%);
   --surface-chrome: oklch(96% 0.004 100);
-  /* 라이트 유리는 종이보다 살짝 어두운 스모크드 밀크다 — 백지 위 백유리는 지각 불가라서
-     틴트를 L92~94 대역으로 내리고 채도 증폭을 올려야 부유층이 종이와 분리되어 읽힌다
-     (실측 피드백). 텍스트 잉크(L22~37)는 L93 합성 위에서 AA를 유지하고, 패널만은
-     "종이가 최명면" 극성 계약 때문에 밝은 틴트를 지킨다.
-     명도 대역과 알파는 출시값 그대로 두고 chroma만 0.005 -> 0.015 대역으로 올린다.
-     명도 이동은 라이트에서 상대 1.5~2.2%라 지각 문턱 아래이지만(실측), 같은 자리의 chroma는
-     3 -> 12(RGB 스프레드)로 문턱을 넘는다. 명도를 손대면 잉크 대비가 함께 움직이므로
-     더하는 축은 색 하나뿐이다. hue는 대기광(84)과 한 가족이 되도록 100 -> 90으로 당긴다. */
-  --glass-on-tint-strong: oklch(93% 0.016 90 / 58%);
-  --glass-on-tint-soft: oklch(93.5% 0.015 90 / 52%);
-  --glass-on-tint-pillar: oklch(94% 0.015 90 / 55%);
-  --glass-on-tint-raised: oklch(92.5% 0.016 90 / 52%);
-  --glass-on-tint-deep: oklch(92.5% 0.016 90 / 52%);
-  --glass-on-tint-abyss: oklch(94% 0.014 90 / 52%);
-  --glass-on-tint-chrome: oklch(92% 0.015 90 / 52%);
-  --glass-on-tint-panel: oklch(98.2% 0.004 100 / 60%);
-  --glass-on-tint-caption: oklch(96% 0.014 90 / 88%);
-  /* 라이트 필드는 불투명 종이 — mCR(가독 보정)이 배경 실색을 요구하고, 종이 위 젖빛 유리는
-     어차피 지각 불가 수준이다. 필드·거터가 같은 불투명 값으로 만나 격자 경계 띠가 없다. */
-  --glass-on-tint-terminal: oklch(98.2% 0.004 100);
-  --glass-on-tint-terminal-floor: var(--glass-on-tint-terminal);
-  --glass-on-tint-field: var(--glass-on-tint-terminal);
-  /* 라이트는 유리 뒤가 이미 밝다 — 굴절할 빛이 부족한 문제가 없으므로 광원도 대기광도 얹지 않는다.
-     백지 위에 광원을 더하면 종이가 평평해지고 최명면 극성만 흐려진다. */
-  --glass-on-pane-light: transparent;
-  /* 대기광·워시·블룸이 Move A다. 라이트 캔버스의 chroma는 0.003~0.006으로 다크 3종의
-     0.005~0.030 대비 1/3~1/5 예산이었고, saturate가 0에 걸려 항등함수였다(실측).
-     명도는 그대로 두고 chroma만 다크와 같은 예산으로 올린다 — 눈에는 여전히 흰 책상이다.
-     베이스 계조에서 hue를 벌리면 보간이 초록을 통과해 종이가 상해 보이므로(실측),
-     한랭/온난 두 극은 이미 sea에 있던 aurora·brass 라디알의 혼합률로 만든다. */
-  --canvas-on-ambience: oklch(95.4% 0.016 84);
-  --canvas-on-wash-near: oklch(95.3% 0.011 88);
-  --canvas-on-wash-mid: oklch(96.5% 0.008 94);
-  --canvas-on-wash-far: oklch(97.4% 0.006 98);
-  --canvas-on-bloom-aurora: 12%;
-  --canvas-on-bloom-brass: 8%;
-  --glass-on-tint-band: oklch(92% 0.016 90 / 52%);
-  /* 입력이 0이 아니게 된 뒤의 증폭이다. 입력과 증폭을 함께 올리면 곱해져서,
-     saturate(2.2)에서는 사이드바가 RGB 스프레드 27의 베이지로 넘어갔다(실측). */
-  --glass-on-backdrop-strong: blur(30px) saturate(1.75);
-  --glass-on-backdrop-soft: blur(16px) saturate(1.6);
-  --glass-on-backdrop-panel: blur(32px) saturate(1.5);
-  --glass-on-rim: oklch(100% 0 0 / 92%);
-  /* 라이트 유리의 두께는 그늘 쪽이 말한다 — 흰 하이라이트는 본체 L*94.7 위로 4.2포인트를
-     얻는 데 그치지만, 어두운 쪽으로는 74포인트가 비어 있다(모서리 단면 실측). */
-  --glass-on-bevel: oklch(34% 0.03 92 / 30%);
-  /* 접촉 + 대기 두 겹. 밝은 바탕에서 부유를 만드는 것은 명도차가 아니라 그림자다.
-     색을 중성 회색에서 brass 쪽으로 기울여 먼지가 아니라 따뜻한 재질을 통과한 빛으로 읽힌다. */
-  --glass-on-lift: 0 2px 5px -1px oklch(34% 0.035 88 / 22%), 0 20px 46px -18px oklch(32% 0.04 88 / 30%);
-  --glass-on-sheen: linear-gradient(118deg, oklch(100% 0 0 / 72%) 0%, transparent 30%, transparent 74%, oklch(100% 0 0 / 34%) 100%);
+  /* 라이트(Whites)는 리퀴드 글래스를 받지 않는다 — 파일 하단 게이트가 이 테마를 제외하므로
+     유리 재료(--glass-on-, --canvas-on- 계열)를 여기 두지 않는다. 채널은 전부 base의 닫힌-게이트
+     기본값(불투명 언더레이·현행 틴트·무블러)으로 남고, 그 폴백이 곧 종이 위의 판독 계약이다.
+     백지 위 백유리는 애초에 지각 불가에 가깝고, 밝은 바탕에서 blur가 굴절시킬 명도차도 없다. */
   /* 라이트에서 패널은 종이다 — 크롬(96%)보다 밝은 최명면이어야 시선이 작업면에 남는다.
      캔버스는 base 색이 아니라 그 위에 칠하는 sea 그라디언트가 실제 픽셀을 정하며 패널 둘레에서
      L 94.9~96.6으로 실측된다. 그래서 프레임 톤(ink-deep 95.5%)으로 통일하면 패널이 책상과
@@ -832,10 +786,20 @@
    설정 해제는 서버 주입(static-console)·부트 힌트(theme-boot)·store가 :root에
    data-glass="off"를 세운다. 블러를 그릴 수 없는 엔진은 @supports가 걸러내고,
    투명도 축소 선호는 아래 media 블록이 같은 특이도로 나중에 서서 기본값(불투명
-   언더레이)으로 되돌린다 — 세 게이트 중 하나만 닫혀도 유리는 꺼지고, 소비처는
-   아무것도 몰라도 된다(채널 기본값이 곧 현행 계약이므로). */
+   언더레이)으로 되돌린다 — 네 게이트 중 하나만 닫혀도 유리는 꺼지고, 소비처는
+   아무것도 몰라도 된다(채널 기본값이 곧 현행 계약이므로).
+
+   넷째 게이트는 테마 극성이다. 라이트(Whites)는 유리를 아예 받지 않는다 — 종이 위
+   백유리는 지각 불가에 가깝고, 뒤가 이미 밝아 blur가 굴절시킬 명도차가 없다. 이 제외는
+   설정값과 무관하다: 저장된 선호는 다크로 돌아갈 때를 위해 그대로 보존되고(그래서
+   라이트에서도 data-glass 속성은 사용자의 선호 그대로다), 화면을 닫는 일은 여기서만 한다.
+
+   제외는 반드시 **선택자 목록** :not(A, B) 한 겹으로 쓴다. :not(A):not(B)로 사슬을 걸면
+   특이도가 (0,2,0)에서 (0,3,0)으로 올라가고, 아래 축소-투명도 되돌림 블록이 같은 특이도로
+   나중에 서서 이기던 계약이 깨진다(@media는 특이도를 더하지 않는다). 두 선택자는 언제나
+   글자까지 같아야 하며, 그 대칭은 계약 테스트가 못박는다. */
 @supports ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  :root:not([data-glass="off"]) {
+  :root:not([data-glass="off"], [data-theme="whites"]) {
     --glass-underlay: var(--glass-on-underlay);
     --glass-tint-strong: var(--glass-on-tint-strong);
     --glass-tint-soft: var(--glass-on-tint-soft);
@@ -858,20 +822,15 @@
     --glass-backdrop-panel: var(--glass-on-backdrop-panel);
     --glass-backdrop-scrim: var(--glass-on-backdrop-scrim);
     --glass-rim: var(--glass-on-rim);
-    /* 베벨·부양·워시·블룸은 라이트에만 재료가 있다. fallback이 곧 현행 계약이라
-       다크 3종은 이 다섯 줄이 있어도 한 픽셀도 바뀌지 않는다. */
-    --glass-bevel: var(--glass-on-bevel, transparent);
-    --glass-lift: var(--glass-on-lift, var(--shadow-floating));
-    --canvas-wash-near: var(--canvas-on-wash-near, var(--canvas-sea-near));
-    --canvas-wash-mid: var(--canvas-on-wash-mid, var(--canvas-sea-mid));
-    --canvas-wash-far: var(--canvas-on-wash-far, var(--canvas-sea-far));
-    --canvas-bloom-aurora: var(--canvas-on-bloom-aurora, 7%);
-    --canvas-bloom-brass: var(--canvas-on-bloom-brass, 5%);
+    /* 베벨·부양·워시·블룸 채널은 여기서 싣지 않는다 — 재료를 가진 테마가 라이트뿐이었고,
+       라이트가 게이트에서 빠지면서 재료가 사라졌다. 채널 자체는 base에 그대로 살아 있으니
+       (--glass-bevel: transparent 외 6종), 나중에 어느 테마가 재료를 갖게 되면 그때
+       테마 블록에 리터럴을 두고 이 자리에 한 줄을 되살리면 된다. */
     --glass-sheen: var(--glass-on-sheen);
   }
 
   @media (prefers-reduced-transparency: reduce) {
-    :root:not([data-glass="off"]) {
+    :root:not([data-glass="off"], [data-theme="whites"]) {
       --glass-underlay: var(--ink-deep);
       --glass-tint-strong: var(--surface-glass-strong);
       --glass-tint-soft: var(--surface-glass);
@@ -894,13 +853,6 @@
       --glass-backdrop-panel: none;
       --glass-backdrop-scrim: none;
       --glass-rim: transparent;
-      --glass-bevel: transparent;
-      --glass-lift: var(--shadow-floating);
-      --canvas-wash-near: var(--canvas-sea-near);
-      --canvas-wash-mid: var(--canvas-sea-mid);
-      --canvas-wash-far: var(--canvas-sea-far);
-      --canvas-bloom-aurora: 7%;
-      --canvas-bloom-brass: 5%;
       --glass-sheen: linear-gradient(transparent, transparent);
     }
   }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -856,13 +856,84 @@ describe("Instrument core design contract", () => {
     // 게이트와 폴백 기본값은 theme.css에 존재해야 한다 — 채널 기본값이 곧 구 불투명 계약이다.
     const theme = source("styles/theme.css");
     expect(theme).toContain("--glass-underlay: var(--ink-deep);");
-    expect(theme).toContain(':root:not([data-glass="off"])');
     expect(theme).toContain("@media (prefers-reduced-transparency: reduce)");
     expect(theme).toMatch(/@supports \(\(backdrop-filter: blur\(1px\)\) or \(-webkit-backdrop-filter: blur\(1px\)\)\)/);
     expect(css).toContain("background: var(--surface-glass)");
     expect(css).toContain(":focus-visible");
     // brass 채움 버튼은 전용 on-brass 텍스트 티어를 소비한다 — abyss 재결합은 라이트 AA 회귀다.
     expect(css).toMatch(/\.fc-btn--primary \{[^}]*color: var\(--text-on-brass\);/);
+  });
+
+  /* 라이트(Whites)는 리퀴드 글래스를 받지 않는다. 이 계약은 세 조각이 **함께** 서야만 성립한다.
+
+     (1) 게이트 여섯 곳이 글자까지 같아야 한다. theme.css 둘은 채널을, layout.css 넷은 밴드
+         언더플로를 연다. layout.css는 채널이 아니라 data-glass 속성을 직접 읽으므로,
+         theme.css만 고치면 라이트에서 불투명해진 밴드 뒤로 본문이 계속 흘러 가려지기만 한다.
+     (2) 제외는 :not(A, B) 목록 한 겹이어야 한다. :not(A):not(B) 사슬은 특이도를 (0,2,0)에서
+         (0,3,0)으로 올려, 같은 특이도로 나중에 서서 이기던 축소-투명도 되돌림 블록을 무력화한다
+         (@media는 특이도를 더하지 않는다). 주 선택자만 고치면 다크 3종의 접근성 계약이 깨진다.
+     (3) 라이트 블록에 유리 재료가 없어야 한다. 재료를 남긴 채 게이트만 닫으면 죽은 리터럴이고,
+         게이트를 안 닫은 채 재료만 지우면 라이트가 base(다크) 재료를 상속해 밤빛 유리를 칠한다. */
+  it("closes the liquid glass gate on the light theme across every gate that reads data-glass", () => {
+    const theme = source("styles/theme.css");
+    const layout = source("styles/layout.css");
+    const GATE = ':root:not([data-glass="off"], [data-theme="whites"])';
+
+    // 사슬 형태는 특이도를 올려 축소-투명도 되돌림을 죽인다 — 어느 파일에도 있어선 안 된다.
+    for (const css of [theme, layout]) {
+      expect(css).not.toMatch(/:not\(\[data-glass="off"\]\):not\(/);
+      expect(css).not.toMatch(/:not\(\[data-theme="whites"\]\):not\(\[data-glass/);
+      // data-glass를 읽는 선택자는 전부 같은 제외 목록을 달고 있어야 한다.
+      const gates = css.match(/:root:not\(\[data-glass="off"\][^)]*\)/g) ?? [];
+      expect(gates.length).toBeGreaterThan(0);
+      for (const gate of gates) expect(gate).toBe(GATE);
+    }
+    // 채널 게이트 둘(주 + 축소-투명도 되돌림)과 밴드 언더플로 넷.
+    expect((theme.match(/:root:not\(\[data-glass="off"\], \[data-theme="whites"\]\)/g) ?? []).length).toBe(2);
+    expect((layout.match(/:root:not\(\[data-glass="off"\], \[data-theme="whites"\]\)/g) ?? []).length).toBe(4);
+
+    // 라이트 블록에는 유리 재료 선언이 한 줄도 없다. 주석은 그 부재를 설명해야 하므로
+    // 토큰 이름을 그대로 적는다 — 계약은 산문이 아니라 선언에만 걸린다.
+    const whites = theme.match(/:root\[data-theme="whites"\] \{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(whites).not.toBe("");
+    const whitesDeclarations = whites.replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(whitesDeclarations).not.toMatch(/--(?:glass|canvas)-on-/);
+    // 반대 방향도 못박는다 — 다크 3종은 계속 재료를 가져야 게이트가 실을 것이 있다.
+    expect(theme).toMatch(/--glass-on-backdrop-strong: blur\(/);
+  });
+
+  /* 설정의 리퀴드 글래스 줄은 라이트에서 "끌 수 없고, 지금 실린 재질을 보여 주고, 저장값은
+     건드리지 않는다"를 동시에 지켜야 한다. 셋 중 하나만 빠져도 실패가 다르다.
+     - 끄기만 하고 checked를 저장값에 묶어 두면: 크롬은 불투명한데 손잡이는 켜짐이라 화면과
+       컨트롤이 다른 말을 한다. 게다가 .settings-switch:disabled는 늘 opacity를 내리므로
+       "켜진 채 흐려진" 손잡이가 되는데, 이 저장소는 그 모양을 이미 "꺼진 것으로 읽힌다"고
+       못박았다(agent-cli 강도 사다리).
+     - 반대로 테마 전환에서 setLiquidGlass(false)나 저장 왕복을 부르면: 사용자가 다크에서
+       고른 값이 조용히 지워진다. 쓰기 경로는 toggleLiquidGlass 하나뿐이어야 한다.
+     페이지 컴포넌트는 번들러 가상 모듈(virtual:fleet-plugins)을 끌어와 단위 렌더가 불가능하므로
+     (quick-launch.ts의 같은 주석), 이 파일의 다른 설정 계약과 같은 소스 수준으로 못박는다. */
+  it("locks the liquid glass row to the material actually on screen under the light theme", () => {
+    const settings = source("pages/global-settings.tsx");
+
+    // 극성 판정은 store의 단일 소유자를 쓴다 — 여기서 === "whites"를 다시 쓰면 두 번째 진실이 된다.
+    expect(settings).toMatch(/import \{[^}]*\bthemePolarity\b[^}]*\} from "\.\.\/store\.js";/);
+    expect(settings).toMatch(/const lightTheme = themePolarity\(activeTheme\) === "light";/);
+
+    // 손잡이는 저장값이 아니라 화면에 실린 재질을 말한다.
+    expect(settings).toMatch(/const liquidGlass = \(state\?\.liquidGlass \?\? true\) && !lightTheme;/);
+    // 그리고 끌 수 없다.
+    expect(settings).toMatch(/disabled=\{saving \|\| state === null \|\| lightTheme\}/);
+
+    // 도움말은 갈아 끼운다 — 기본 문안("끄면 원래대로")은 끌 수 없는 자리에서 거짓이 된다.
+    expect(settings).toContain('t(lightTheme ? "settings.theme.liquidGlassLightHelp" : "settings.theme.liquidGlassHelp")');
+
+    // 저장값을 건드리는 경로는 사용자가 손잡이를 누르는 하나뿐이다. 테마 전환이 유리 설정을
+    // 쓰기 시작하면 다크에서 고른 값이 사라진다.
+    expect((settings.match(/setLiquidGlass\(/g) ?? []).length).toBe(2); // toggle 낙관 적용 + 실패 복원
+    expect((settings.match(/setGlobalSettingsField\("liquidGlass"/g) ?? []).length).toBe(1);
+    const selectTheme = settings.match(/const selectTheme = \([\s\S]*?\n  \};/)?.[0] ?? "";
+    expect(selectTheme).not.toBe("");
+    expect(selectTheme).not.toMatch(/[Ll]iquidGlass/);
   });
 
   /* 겉모습 축소판은 자기가 고르게 하는 화면을 대신 보여 준다. 계약은 둘이다. 축소판은 컨트롤
@@ -919,9 +990,10 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--glass-on-tint-panel: oklch(18.5% 0.028 245 / 83%);");
     expect(theme).toContain("--glass-on-tint-panel: oklch(25% 0.05 248 / 83%);");
     expect(theme).toContain("--glass-on-tint-panel: oklch(21% 0.013 252 / 83%);");
-    // 다크에서만 필드를 루트 유리에 넘긴다 — 라이트는 mCR이 불투명 실색을 요구한다.
-    expect(theme).toContain("--glass-on-tint-field: var(--glass-on-tint-terminal);");
+    // 유리를 받는 테마는 다크 3종뿐이고, 그 셋은 전부 필드를 루트 유리에 넘긴다.
+    // 라이트는 게이트 밖이라 재료 자체가 없다(별칭 한 줄도 남기지 않는다).
     expect((theme.match(/--glass-on-tint-field: transparent;/g) ?? []).length).toBe(3);
+    expect(theme).not.toMatch(/--glass-on-tint-field: var\(/);
   });
 
   /* 비운 터미널 필드의 RGB는 검정이 아니라 유리 톤이어야 한다. xterm은 dim(SGR 2)을 배경 워드의
@@ -938,8 +1010,6 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(18.1% 0.027 245);");
     expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(23.9% 0.047 247);");
     expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(20.5% 0.013 252);");
-    // 라이트는 유리에서도 불투명 종이라 floor가 곧 그 값이다.
-    expect(theme).toContain("--glass-on-tint-terminal-floor: var(--glass-on-tint-terminal);");
 
     // 필드를 비우는 경로는 floor 계산값을 읽어 알파만 0으로 눕힌다.
     expect(surface).toContain('getPropertyValue("--glass-tint-terminal-floor")');
@@ -948,17 +1018,17 @@ describe("Instrument core design contract", () => {
     expect((surface.match(/return "rgba\(0, 0, 0, 0\)";/g) ?? []).length).toBe(2);
   });
 
-  // 라이트 유리는 명도가 아니라 색·그늘·부양으로 읽힌다. 밝은 바탕에서 명도 이동은 상대
-  // 1.5~2.2%로 지각 문턱 아래이고(실측), 흰 하이라이트는 본체 L*94.7 위로 4.2포인트밖에
-  // 얻지 못한다. 그래서 라이트에만 베벨(아래 그늘)·부양(접촉 그림자)·대기 채도가 실린다.
-  it("carries the light glass on chroma, bevel and lift instead of luminance", () => {
+  /* 베벨·부양·워시·블룸 넷은 라이트 유리 전용 재료였다. 라이트가 게이트에서 빠지면서 어느
+     테마도 이 재료를 갖지 않으므로, 게이트는 더 이상 이 채널을 싣지 않고 채널은 base의 중립
+     기본값 하나로 산다. 재료 없는 채널에 fallback 다리를 남겨 두면 "여기 라이트 재료가 있다"고
+     거짓말하는 죽은 줄이 되고, 반대로 채널까지 지우면 소비처가 통째로 무너진다. */
+  it("keeps the bevel, lift, wash and bloom channels neutral now that no theme feeds them", () => {
     const theme = source("styles/theme.css");
     const components = source("styles/components.css");
     const layout = source("styles/layout.css");
     const rail = source("styles/rail.css");
 
-    // 새 채널 넷의 닫힌-게이트 기본값이 곧 구 계약이다 — 하나라도 어긋나면 유리를 꺼도
-    // 화면이 돌아오지 않는다.
+    // 채널의 중립 기본값이 곧 이제 모든 테마가 보는 값이다.
     expect(theme).toContain("--glass-bevel: transparent;");
     expect(theme).toContain("--glass-lift: var(--shadow-floating);");
     expect(theme).toContain("--canvas-wash-near: var(--canvas-sea-near);");
@@ -967,29 +1037,21 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--canvas-bloom-aurora: 7%;");
     expect(theme).toContain("--canvas-bloom-brass: 5%;");
 
-    // 게이트는 라이트에만 있는 재료를 fallback으로 받는다 — 다크 3종이 값을 갖지 않아야
-    // 이 다섯 줄이 다크를 한 픽셀도 건드리지 않는다.
-    expect(theme).toContain("--glass-bevel: var(--glass-on-bevel, transparent);");
-    expect(theme).toContain("--glass-lift: var(--glass-on-lift, var(--shadow-floating));");
+    // 재료도, 그 재료를 싣던 게이트 다리도 남아 있지 않다.
     for (const material of [
       "--glass-on-bevel",
       "--glass-on-lift",
       "--canvas-on-wash-near",
+      "--canvas-on-wash-mid",
+      "--canvas-on-wash-far",
       "--canvas-on-bloom-aurora",
       "--canvas-on-bloom-brass",
     ]) {
-      expect((theme.match(new RegExp(`${material}:`, "g")) ?? []).length).toBe(1);
+      expect(theme).not.toContain(material);
     }
 
-    // 라이트 틴트는 무채색이 아니다. chroma 0.005 대역에서는 saturate가 항등함수라
-    // 유리가 "약간 회색이 된 카드"로만 읽혔다(ON/OFF RGB 스프레드 3 대 3, 실측).
-    const whites = theme.match(/:root\[data-theme="whites"\] \{[\s\S]*?\n\}/)?.[0] ?? "";
-    expect(whites).not.toBe("");
-    const lightTints = [...whites.matchAll(/--glass-on-tint-(?:strong|soft|pillar|raised|deep|abyss|chrome|band): oklch\([\d.]+% ([\d.]+) /g)];
-    expect(lightTints.length).toBe(8);
-    for (const [, chroma] of lightTints) expect(Number(chroma)).toBeGreaterThanOrEqual(0.012);
-
-    // 소비처: 크롬·패널·떠 있는 면은 위 rim과 아래 bevel을 한 쌍으로 쓴다.
+    // 소비처의 rim/bevel 짝은 그대로 둔다 — 지금은 bevel이 늘 transparent라 아무것도 그리지
+    // 않지만, 짝이 깨진 채로 두면 나중에 어느 테마가 베벨 재료를 갖는 순간 한쪽만 살아난다.
     for (const css of [components, layout, rail]) {
       const rims = (css.match(/inset 0 1px 0 var\(--glass-rim\)/g) ?? []).length;
       const bevels = (css.match(/inset 0 -1px 0 var\(--glass-bevel\)/g) ?? []).length;

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -495,7 +495,12 @@ describe("console static and terminal ticket boundary", () => {
     for (const pathname of ["console/", "console/operations"]) {
       const response = await fetch(`${fixture.endpoint}${pathname}`);
       expect(response.status).toBe(200);
-      expect(await response.text()).toContain('data-theme="whites" data-theme-source="server"');
+      const html = await response.text();
+      expect(html).toContain('data-theme="whites" data-theme-source="server"');
+      /* data-glass는 "사용자가 유리를 원하는가"만 말한다 — 라이트에서 유리를 끄는 일은 CSS
+         게이트가 하고, 주입은 극성을 모른다. 여기서 data-glass="off"를 함께 실으면 저장된
+         선호가 화면 상태로 덮여, 다크로 돌아갔을 때 사용자가 고른 값이 사라진다. */
+      expect(html).not.toContain("data-glass");
     }
   });
 

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -744,9 +744,14 @@ function baseTerminalThemeFor(theme: TerminalThemeId): ITheme {
    - 다크 + 게이트 열림: xterm 배경은 알파 0으로 비우고(RGB는 아래 glassFieldClearColor 참조),
      필드·거터를 컨테이너(.canvas-operation-terminal/.terminal-shell)의 --glass-tint-terminal
      한 겹이 칠한다. 다크는 minimumContrastRatio=1이라 투명 배경이 대비 보정에 관여하지 않는다.
-   - 라이트(Whites)와 게이트 닫힘: mCR이 배경 실색을 요구하므로 xterm은 채널 계산값
-     (라이트 유리=불투명 종이, 게이트 닫힘=불투명 --surface-panel)을 그대로 받는다 —
-     컨테이너도 같은 채널을 칠해 필드·거터가 같은 값으로 만난다.
+   - 게이트 닫힘: mCR이 배경 실색을 요구하므로 xterm은 채널 계산값(불투명 --surface-panel)을
+     그대로 받는다 — 컨테이너도 같은 채널을 칠해 필드·거터가 같은 값으로 만난다.
+     라이트(Whites)는 언제나 이쪽이다. 테마 극성 자체가 유리 게이트의 넷째 닫힘 조건이라
+     (theme.css), 라이트에서 --glass-backdrop-*는 설정과 무관하게 none이고
+     readLiquidGlassPaneActive()는 false다. 아래 LIGHT_TERMINAL_THEMES 조건은 그래서
+     제품 경로에서는 이미 참인 조건을 한 번 더 세우는 둘째 자물쇠다 — 남겨 둔다. 이 한 곳이
+     틀리면 밝은 바탕에서 allowTransparency가 켜져 획 잉크가 18.2% 사라지는데(dpr=2 실측),
+     그 비용에 비하면 조건 하나는 공짜다.
    xterm은 CSS 변수를 못 받으므로 계산값을 읽고, 압축 CSS의 oklch 변형(`.022` 선행 0
    생략·% 알파)을 xterm 파서가 검정으로 낙하시키므로(실측) canvas로 rgba() 정규화해 넘긴다.
    위 ITheme의 background 리터럴은 토큰을 읽을 수 없는 환경(jsdom·SSR)의 폴백이다. */
@@ -824,8 +829,10 @@ export function terminalFieldIsTranslucent(background: string): boolean {
   return channels.length > 3 && Number.parseFloat(channels[3] ?? "1") < 1;
 }
 
-/* 게이트가 열려 있을 때만 backdrop 채널이 none이 아니다 — 세 게이트(설정·@supports·
-   reduced-transparency)를 개별로 다시 판정하지 않고 채널 계산값 하나를 진실로 삼는다. */
+/* 게이트가 열려 있을 때만 backdrop 채널이 none이 아니다 — 네 게이트(설정·@supports·
+   reduced-transparency·테마 극성)를 개별로 다시 판정하지 않고 채널 계산값 하나를 진실로 삼는다.
+   특히 극성은 여기서 다시 묻지 않는다: 라이트를 닫는 일은 CSS 게이트가 하고, 이 함수는
+   그 결과만 읽는다. JS에 극성 분기를 심으면 진실이 두 벌이 된다. */
 export function readLiquidGlassPaneActive(): boolean {
   if (typeof document === "undefined") return false;
   const backdrop = getComputedStyle(document.documentElement).getPropertyValue("--glass-backdrop-strong").trim();


### PR DESCRIPTION
## Summary

- 라이트(Whites) 테마를 리퀴드 글래스 게이트에서 완전히 제외했습니다. 종이 위 백유리는 지각 불가에 가깝고, 밝은 캔버스는 blur가 굴절시킬 명도차가 없습니다.
- `data-glass`를 읽는 게이트 **여섯 곳 전부**에 제외를 넣었습니다 — `theme.css`의 채널 게이트 2곳과 `layout.css`의 밴드 언더플로 4곳. `layout.css`는 채널이 아니라 속성을 직접 읽으므로, `theme.css`만 고치면 라이트에서 불투명해진 밴드 뒤로 설정 본문이 계속 흘러 가려지기만 합니다(축소-투명도가 이미 같은 이유로 되돌리는 실패 양식).
- 제외는 `:not(A, B)` **목록 형태**로 씁니다. `:not(A):not(B)` 사슬은 특이도를 (0,2,0) → (0,3,0)으로 올려, 뒤에 서서 이기던 `prefers-reduced-transparency` 되돌림 블록을 다크 3종에서 무력화합니다(`@media`는 특이도를 더하지 않음).
- Whites의 유리 재료와, 그 재료만 싣던 게이트 다리 7줄을 제거했습니다. 7줄은 모두 base 기본값과 동일한 fallback으로 풀리던 자리라 다크 3종은 픽셀 변화가 없습니다.
- Settings: 라이트 활성 중 리퀴드 글래스 손잡이는 **꺼짐 + 비활성**으로 서고 도움말 문장을 갈아 끼웁니다. 이 경로는 저장값을 쓰지 않으므로 다크로 돌아오면 사용자가 고른 값이 그대로 살아납니다.
- 유리 소개 모달은 라이트에서 `seen`을 남기지 않고 건너뜁니다(이미 "유리 꺼둔 사용자"에게 하던 것과 같은 문법).

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run` — 2424 passed / 24 skipped
- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run` — 1006 passed
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` — clean
- [x] `pnpm --filter @dotobokuri/fleet-console build` — clean
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK
- [x] 헤디드 실측(격리 콘솔 + agent-browser): 라이트에서 선호가 **켜진 채로도** `--glass-backdrop-strong: none`, `--glass-underlay: oklch(95.5% .005 100)`(불투명), rim/sheen transparent, `--canvas-ambience`가 sea-core로 복귀. 다크 3종은 `blur(24px) saturate(1.7)` 유지 — 회귀 없음.
- [x] 헤디드 실측: 라이트 설정에서 손잡이 `disabled=true` / `aria-checked=false` / `is-on` 없음, 도움말은 라이트 문안. Carbon 복귀 시 `disabled=false` / `aria-checked=true` / 기본 도움말.
- [x] 헤디드 실측: 밴드 언더플로가 라이트에서 해제(`margin-top: 0px`, `z-index: auto`), 다크 복귀 시 `-44px` 재개입.
- [x] 헤디드 실측: 디스크의 `settings.json`에 `liquidGlass` 키가 **생성되지 않음** — 라이트 경로가 저장값을 건드리지 않음을 증명.
- [x] 첫 페인트 경로: 서버가 whites를 주입한 로드에서 밴드/사이드바 `backdrop-filter: none`, 페이지 에러 0.

## Notes

계약 테스트를 강화했습니다: 여섯 게이트 선택자의 **글자 단위 동일성**, 사슬 `:not()` 형태 금지, Whites 블록의 유리 재료 부재, 그리고 설정 줄의 세 계약(끌 수 없음 / 화면에 실린 재질 표시 / 저장값 미변경)을 못박습니다. 기존 pin은 부분 문자열이라 `layout.css`를 보지 못했고 선택자 변경 후에도 계속 green이었습니다.