### PR TITLE
perf(fleet-console): reduce dense panel rendering work

### DIFF
--- a/.changelog.d/console-adaptive-panel-performance.md
+++ b/.changelog.d/console-adaptive-panel-performance.md
@@ -1,0 +1,8 @@
+---
+branch: console-adaptive-panel-performance
+---
+
+### fleet-console
+#### Changed
+- Keep multi-panel terminal input responsive by avoiding hidden peer refits during focus-layer changes and reducing compositor work at high panel density across Cruise, Tactical, and War Room.
+  ko: 포커스 레이어 전환 중 숨은 패널의 터미널 재맞춤을 피하고 Cruise, Tactical, War Room 전반에서 패널 밀도가 높을 때 합성 부담을 줄여 다중 패널 터미널 입력의 반응성을 유지합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -115,6 +115,7 @@ export function OperationsCanvas({
   const minimized = useMinimized();
   const idleArrivalIds = useSyncExternalStore(subscribeIdleArrival, getIdleArrivalIds, getIdleArrivalIds);
   const activePluginOperationId = state.activeOperationId;
+  const [focusFadeTransitionReady, setFocusFadeTransitionReady] = useState(activePluginOperationId !== null);
   const [contextMenu, setContextMenu] = useState<ContextMenuRequest | null>(null);
   const registry = usePluginRegistry();
   const globalSettings = useGlobalSettingsStore();
@@ -257,6 +258,19 @@ export function OperationsCanvas({
     // 빈 바다 클릭은 패널을 고르지 않은 것이다 — 터미널 키보드와 캡션 포커스(is-active)를 함께 걷는다.
     onClick: clearActiveOperation,
   });
+
+  // 무포커스 → 첫 포커스에서는 곁의 모든 본문이 한꺼번에 220ms opacity 합성을 시작하지 않게
+  // 한 페인트 동안만 전환을 닫는다. A → B 이동은 이미 후퇴한 패널과 새 도착지 두 곳만 바뀌므로
+  // 기존 모션을 유지한다. 포커스가 다시 비면 다음 첫 진입을 위해 재무장한다.
+  useEffect(() => {
+    if (activePluginOperationId === null) {
+      setFocusFadeTransitionReady(false);
+      return;
+    }
+    if (focusFadeTransitionReady) return;
+    const frame = window.requestAnimationFrame(() => setFocusFadeTransitionReady(true));
+    return () => window.cancelAnimationFrame(frame);
+  }, [activePluginOperationId, focusFadeTransitionReady]);
 
   // 우클릭 가드는 다음 우클릭에서만 돈다. 마지막 Theater를 잊는 동안 이미 열린 상자는
   // 목록이 비워져도 그대로 남으므로, 그 전환에서 걷는다.
@@ -787,14 +801,19 @@ export function OperationsCanvas({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formationView, formationLayout]);
-  // 최대화 시에는 net scale 1(기본 줌)로 렌더한다 — 현재 배율과 무관하게 터미널이 선명하게 그려진다.
-  const effectiveZoom = panelMaximized || panelCompanion || formationView || triageActive ? 1 : canvas.viewport.zoom;
+  // 캔버스 transform이 제거되는 모드에서 화면에 서는 패널은 net scale 1로 보정한다. 단, focus
+  // layer 뒤의 peer는 기존 world geometry와 줌을 그대로 보존한다 — 숨은 xterm까지 fontSize/fit/PTY
+  // resize를 fan-out하지 않기 위한 핵심 계약이다.
+  const visiblePanelCount = triageActive
+    ? pluginOperations.filter((operation) => !triageMinimizedSet.has(operation.id)).length
+    : theaterOperations.filter((operation) => !minimizedSet.has(operation.id)).length;
+  const adaptivePanelMaterial = visiblePanelCount >= 4;
   const topPanelZIndex = maxOperationZIndex(canvas.operations) + 1;
   const companionSlotCount = visibleCompanionPanels.length + 1;
 
   return (
     <main
-      className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""} ${glanceVisible ? "is-glance" : ""} ${panelMaximized ? "is-panel-maximized" : ""} ${panelCompanion ? "is-companion-layout" : ""} ${formationView ? "is-formation-view" : ""} ${formationEntering ? "is-formation-entering" : ""} ${triageActive ? "is-triage" : ""} ${triageEntering ? "is-triage-entering" : ""}`}
+      className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""} ${glanceVisible ? "is-glance" : ""} ${panelMaximized ? "is-panel-maximized" : ""} ${panelCompanion ? "is-companion-layout" : ""} ${formationView ? "is-formation-view" : ""} ${formationEntering ? "is-formation-entering" : ""} ${triageActive ? "is-triage" : ""} ${triageEntering ? "is-triage-entering" : ""} ${focusFadeTransitionReady ? "" : "is-focus-fade-settling"} ${adaptivePanelMaterial ? "is-panel-density-high" : ""}`}
       onPointerDown={(event) => {
         // 메뉴 내부 클릭(캔버스 소유 메뉴는 <main> 자손이라 버블로 도달한다)은 실행 항목의
         // click을 살리기 위해 닫기 신호를 본내지 않는다 — data-canvas-blocker는 전파를 멈추지 않는다.
@@ -870,6 +889,11 @@ export function OperationsCanvas({
             ? !operationTriageStage && !deckSlot
             : (panelMaximized !== null || panelCompanion !== null) && !operationMaximized && !operationCompanion;
           const formationSlot = formationSlotByOperationId.get(operation.id);
+          const operationZoom = focusLayerHidden
+            ? canvas.viewport.zoom
+            : formationView || triageActive || operationMaximized || operationCompanion
+              ? 1
+              : canvas.viewport.zoom;
           const glanceHud = resolveGlanceHudModel(triageActive
             ? {
                 mode: "triage",
@@ -903,7 +927,7 @@ export function OperationsCanvas({
           // 보더 위 캡션(top: -32px)이 캔버스 상단 클립에 잘리는 뷰포트-상대 위치.
           // Tactical/War Room/최대화는 슬롯을 32px 내려 캡션을 밖에 둔다. 본문·PTY geometry는 그대로다.
           const topEdge = !operationTriageStage && !operationMaximized && !operationCompanion && !formationSlot && !deckSlot
-            && canvas.viewport.y + frameGeometry.y * effectiveZoom < TITLEBAR_OUTSET_PX * effectiveZoom;
+            && canvas.viewport.y + frameGeometry.y * operationZoom < TITLEBAR_OUTSET_PX * operationZoom;
           return renderPluginOperation(operation, {
             active: activePluginOperationId === operation.id,
             unseen: idleArrivalIds.has(operation.id),
@@ -920,7 +944,7 @@ export function OperationsCanvas({
             runtimeState: pluginRuntimeState(state.operationRuntime, state.operationRuntimeHydration, operation.id),
             theme: state.activeTheme,
             language,
-            viewportZoom: effectiveZoom,
+            viewportZoom: operationZoom,
             // 선별 중 무대 밖 패널은 덱 칸으로 간다 — 자리가 있으면 그 자리에 실물로 서므로
             // 숨기지 않고, 자리가 아직 없을 때만(입장 연출·지도 전환 직전) 접어 둔다.
             minimized: triageActive ? !operationTriageStage && !deckSlot : minimizedSet.has(operation.id),

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4766,6 +4766,16 @@
     visibility 0s linear 0s;
 }
 
+/* Cruise·Tactical·War Room에서 패널이 넷 이상 보이면 각 창의 32px backdrop blur를 불투명
+   panel 토큰으로 축약한다. 포커스·캡션·상태 채널은 그대로이고 재질만 바뀐다. 최대화/companion
+   중에도 hidden peer가 blur surface로 남지 않으며, 대상 창은 같은 불투명 면 위에서 geometry만 전환한다. */
+.operations-canvas.is-panel-density-high {
+  --glass-tint-panel: var(--surface-panel);
+  --glass-underlay: var(--surface-panel);
+  --glass-pane-light: transparent;
+  --glass-backdrop-panel: none;
+}
+
 /* 드래그·리사이즈 조작 중에는 포인터 추적이 즉답해야 한다 — rail.css is-dragging 선례. */
 .canvas-operation.is-dragging {
   transition: none;
@@ -6424,6 +6434,18 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-terminal {
   opacity: var(--unfocused-panel-opacity, 0.5);
   transition: opacity var(--duration-base) var(--ease-glide);
+}
+
+/* 무포커스 → 첫 포커스는 모든 peer가 동시에 후퇴하는 유일한 fan-out이다. 한 페인트 동안만
+   모션을 끊고 목표 opacity에 바로 놓는다. 이후 A → B 이동은 두 본문만 전환한다. */
+.operations-canvas.is-focus-fade-settling .canvas-operation-terminal {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-operation-terminal {
+    transition: none;
+  }
 }
 
 /* 캡션 아랫변 = 상태 채널. 포커스는 채움이 말하므로 선은 상태 하나만 소유한다. */

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -3157,6 +3157,12 @@ describe("Instrument core design contract", () => {
     // 세기는 설정이 소유한다 — 규칙은 변수를 소비하고, 폴백이 곧 기본값이라 값이 실리기 전
     // 첫 페인트에서도 패널이 제자리를 지킨다. 폴백 없는 참조로 바뀌면 설정 이전 프레임이 비어 버린다.
     expect(recede).toContain("opacity: var(--unfocused-panel-opacity, 0.5);");
+    expect(recede).toContain("transition: opacity var(--duration-base) var(--ease-glide);");
+    const firstFocusSettle = components.match(/\.operations-canvas\.is-focus-fade-settling \.canvas-operation-terminal \{[^}]*\}/)?.[0] ?? "";
+    expect(firstFocusSettle).toContain("transition: none;");
+    const reducedMotionTerminal = components.match(/@media \(prefers-reduced-motion: reduce\) \{\n  \.canvas-operation-terminal \{[^}]*\}/)?.[0] ?? "";
+    expect(reducedMotionTerminal).toContain("transition: none;");
+    expect(source("canvas/canvas.tsx")).toContain('focusFadeTransitionReady ? "" : "is-focus-fade-settling"');
     expect(source("store.ts")).toContain("--unfocused-panel-opacity");
     expect(source("pages/global-settings.tsx")).toContain('className="fleet-slider settings-slider"');
     expect(components).not.toMatch(/\.canvas-operation:not\(\.is-active\)[^{]*> \.canvas-operation-titlebar \{/);
@@ -3244,7 +3250,22 @@ describe("Instrument core design contract", () => {
     expect(source("canvas/canvas-store.ts")).toContain("function resolveStationKeepingPosition");
     expect(source("canvas/canvas.tsx")).toContain("const TITLEBAR_OUTSET_PX = OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/canvas.tsx")).toContain("y: TITLEBAR_OUTSET_PX");
-    expect(source("canvas/canvas.tsx")).toContain("TITLEBAR_OUTSET_PX * effectiveZoom");
+    const canvasZoom = source("canvas/canvas.tsx");
+    expect(canvasZoom).toContain("TITLEBAR_OUTSET_PX * operationZoom");
+    expect(canvasZoom).toContain("const operationZoom = focusLayerHidden");
+    expect(canvasZoom).toContain("? canvas.viewport.zoom");
+    expect(canvasZoom).toContain("formationView || triageActive || operationMaximized || operationCompanion");
+    expect(canvasZoom).not.toContain("const effectiveZoom = panelMaximized");
+    // Cruise·Tactical·War Room 모두 visible 패널이 넷 이상이면 유리를 불투명 panel material로
+    // 축약한다. threshold와 스타일 모두 class 계약으로 고정해 :has() 기반 subtree 재판정을 추가하지 않는다.
+    expect(canvasZoom).toContain("const adaptivePanelMaterial = visiblePanelCount >= 4;");
+    expect(canvasZoom).not.toContain("visiblePanelCount >= 4 && !formationView && !triageActive");
+    expect(canvasZoom).toContain('adaptivePanelMaterial ? "is-panel-density-high" : ""');
+    const adaptiveMaterial = components.match(/\.operations-canvas\.is-panel-density-high \{[^}]*\}/)?.[0] ?? "";
+    expect(adaptiveMaterial).toContain("--glass-tint-panel: var(--surface-panel);");
+    expect(adaptiveMaterial).toContain("--glass-underlay: var(--surface-panel);");
+    expect(adaptiveMaterial).toContain("--glass-pane-light: transparent;");
+    expect(adaptiveMaterial).toContain("--glass-backdrop-panel: none;");
     expect(source("canvas/coordinates.ts")).toContain("y: 18 + OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/coordinates.ts")).toContain("canvasSize.height - 36 - OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/coordinates.ts")).toContain("export function operationWindowFrameFor");

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -195,6 +195,10 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   const scrollFollowRef = useRef<TerminalScrollFollowController | null>(null);
   // 줌 보정 effect에서 fit()을 재호출하기 위해 마운트 effect의 지역 FitAddon을 ref로 끌어올린다.
   const fitAddonRef = useRef<FitAddon | null>(null);
+  // ResizeObserver와 zoom/font 보정이 같은 settle 큐를 쓴다. geometry 전환 중 zoom effect가 별도
+  // fit을 먼저 실행하면 전환 끝의 observer fit까지 두 번 PTY resize/full refresh가 나가므로,
+  // refresh 필요 여부만 OR해 마지막 geometry 알림 뒤 한 번에 처리한다.
+  const scheduleFitAndResizeRef = useRef<((refresh?: boolean) => void) | null>(null);
   // 실제 보정에 반영된 줌(=settle된 zoom). zoom prop은 보간 중 매 프레임 바뀌므로 디바운스로 이 값에 수렴시킨다.
   // 초기값을 zoom으로 두어 이미 확대된 패널이 마운트될 때 첫 렌더부터 올바른 스타일을 갖게 한다.
   const [appliedZoom, setAppliedZoom] = useState(zoom);
@@ -298,6 +302,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
     let disposed = false;
     let resizeObserver: ResizeObserver | null = null;
     let resizeDebounce: ReturnType<typeof setTimeout> | null = null;
+    let refreshAfterFit = false;
     let cleanupMountedTerminal: (() => void) | null = null;
 
     const mountTerminal = async () => {
@@ -440,19 +445,25 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
       // 이미 전체 refresh를 예약했고(RenderService가 bufferService.onResize와 handleResize 양쪽에서),
       // 바뀌지 않았으면 다시 그릴 내용이 없다. 어느 쪽이든 이 호출은 같은 rAF로 합쳐지는 낭비이고,
       // WebGL 경로에서는 커서 blink 애니메이션까지 되감는다. 스크롤 복원은 아래 wrapper가 소유한다.
-      const fitAndResize = () => {
+      const fitAndResize = (refresh = false) => {
         scrollFollow.preserveAfterGeometryChange(() => {
           fitAddon.fit();
           connection.resize(terminal.cols, terminal.rows);
+          if (refresh) terminal.refresh(0, terminal.rows - 1);
         });
       };
-      const scheduleFitAndResize = () => {
+      const scheduleFitAndResize = (refresh = false) => {
+        refreshAfterFit ||= refresh;
         if (resizeDebounce) clearTimeout(resizeDebounce);
         resizeDebounce = setTimeout(() => {
           resizeDebounce = null;
-          if (!disposed) fitAndResize();
+          if (disposed) return;
+          const shouldRefresh = refreshAfterFit;
+          refreshAfterFit = false;
+          fitAndResize(shouldRefresh);
         }, RESIZE_DEBOUNCE_MS);
       };
+      scheduleFitAndResizeRef.current = scheduleFitAndResize;
 
       const runInitialFit = async () => {
         await document.fonts?.ready;
@@ -471,7 +482,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         if (activeRef.current !== false && !keyPanelOpenRef.current) terminal.focus();
       };
 
-      resizeObserver = new ResizeObserver(scheduleFitAndResize);
+      resizeObserver = new ResizeObserver(() => scheduleFitAndResize());
       resizeObserver.observe(container);
       void runInitialFit();
 
@@ -496,6 +507,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         statusDetailReporterRef.current = null;
         scrollFollowRef.current = null;
         fitAddonRef.current = null;
+        scheduleFitAndResizeRef.current = null;
         // xterm WebglAddon(0.19.0)은 terminal.dispose() 시 AddonManager가 addon을 자동 정리하는
         // 경로에 내부 버그가 있어 TypeError(reading "_isDisposed")를 던질 수 있다. 이 예외가
         // useEffect cleanup 밖으로 전파되면 error boundary가 없는 React 트리가 통째로 언마운트되어
@@ -630,7 +642,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
     const terminal = terminalRef.current;
     if (!terminal) return;
     terminal.options.fontFamily = terminalFontSettings.family;
-    fitResizeAndRefreshTerminal(terminal, fitAddonRef.current, connectionRef.current, scrollFollowRef.current);
+    scheduleFitAndResizeRef.current?.(true);
   }, [terminalFontSettings.family, mountedTerminalEpoch]);
 
   // 줌 settle 감지: zoom prop은 rAF 보간 중 매 프레임 바뀌므로, 마지막 변경 후 ZOOM_SETTLE_MS가 지나야
@@ -656,8 +668,9 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
     // 다른 터미널 화면이 깨진다(특히 마운트·복원 시 effect가 1회 실행되며 발생). 게다가 fontSize가 실제로
     // 바뀌면 xterm이 옵션 변경 핸들러(_handleOptionsChanged→_refreshCharAtlas→acquireTextureAtlas)에서 새
     // cell크기 키로 atlas를 자동 재획득하므로 수동 무효화는 불필요하다. atlas는 건드리지 않고 이 터미널만
-    // fit + refresh로 재배치/재도색한다.
-    fitResizeAndRefreshTerminal(terminal, fitAddonRef.current, connectionRef.current, scrollFollowRef.current);
+    // fit + refresh로 재배치/재도색한다. geometry observer와 같은 settle 큐를 써 마지막 크기에서
+    // 한 번만 PTY resize/full refresh를 실행한다.
+    scheduleFitAndResizeRef.current?.(true);
   }, [appliedZoom, touchFontScale, terminalFontSettings.size, mountedTerminalEpoch]);
 
   // 연결이 'live'면 상태 바를 숨겨 터미널 canvas가 카드를 가득 채우게 하고,
@@ -1063,24 +1076,6 @@ function concatTerminalOutput(chunks: readonly Uint8Array[], totalBytes: number)
     offset += chunk.byteLength;
   }
   return output;
-}
-
-function fitResizeAndRefreshTerminal(
-  terminal: XtermTerminal,
-  fitAddon: FitAddon | null,
-  connection: TerminalConnection | null,
-  scrollFollow: TerminalScrollFollowController | null,
-): void {
-  const fitResizeAndRefresh = () => {
-    fitAddon?.fit();
-    connection?.resize(terminal.cols, terminal.rows);
-    terminal.refresh(0, terminal.rows - 1);
-  };
-  if (scrollFollow) {
-    scrollFollow.preserveAfterGeometryChange(fitResizeAndRefresh);
-    return;
-  }
-  fitResizeAndRefresh();
 }
 
 /** A coarse pointer means fingers, and a finger-sized terminal starts at its smallest step. */

--- a/runtime/fleet-plugins/terminal/tests/terminal-surface-focus.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/terminal-surface-focus.test.tsx
@@ -5,7 +5,10 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const terminalMocks = vi.hoisted(() => ({
+  fit: vi.fn(),
   focus: vi.fn(),
+  refresh: vi.fn(),
+  resize: vi.fn(),
   resumeFollowing: vi.fn(),
   setActive: vi.fn(),
   start: vi.fn(),
@@ -28,13 +31,13 @@ vi.mock("@xterm/xterm", () => ({
     loadAddon() {}
     onData() { return { dispose() {} }; }
     open() {}
-    refresh() {}
+    refresh = terminalMocks.refresh;
     scrollToBottom() {}
     scrollToLine() {}
     write(_data: Uint8Array, callback?: () => void) { callback?.(); }
   },
 }));
-vi.mock("@xterm/addon-fit", () => ({ FitAddon: class FitAddon { fit() {} } }));
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class FitAddon { readonly fit = terminalMocks.fit; } }));
 vi.mock("@xterm/addon-unicode11", () => ({ Unicode11Addon: class Unicode11Addon {} }));
 vi.mock("@xterm/addon-webgl", () => ({
   WebglAddon: class WebglAddon {
@@ -53,7 +56,7 @@ vi.mock("../client/shared/ime-shift-enter.js", () => ({
 }));
 vi.mock("../client/shared/terminal-fallback-fonts.js", () => ({ waitForTerminalFallbackFonts: terminalMocks.waitForSymbols }));
 vi.mock("../client/shared/terminal-connection.js", () => ({
-  createTerminalConnection: () => ({ dispose() {}, resize() {}, start: terminalMocks.start }),
+  createTerminalConnection: () => ({ dispose() {}, resize: terminalMocks.resize, start: terminalMocks.start }),
 }));
 vi.mock("../client/shared/terminal-copy-on-select.js", () => ({
   createTerminalCopyOnSelect: () => ({ dispose() {} }),
@@ -80,12 +83,16 @@ import { TerminalSurface } from "../client/shared/terminal-surface.js";
 let container: HTMLDivElement | null = null;
 let fontsDescriptor: PropertyDescriptor | undefined;
 let resizeObserverDescriptor: PropertyDescriptor | undefined;
+let resizeObserverCallback: (() => void) | null = null;
 let root: Root | null = null;
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 beforeEach(() => {
+  terminalMocks.fit.mockClear();
   terminalMocks.focus.mockClear();
+  terminalMocks.refresh.mockClear();
+  terminalMocks.resize.mockClear();
   terminalMocks.resumeFollowing.mockClear();
   terminalMocks.setActive.mockClear();
   terminalMocks.start.mockClear();
@@ -100,7 +107,12 @@ beforeEach(() => {
   Object.defineProperty(globalThis, "ResizeObserver", {
     configurable: true,
     value: class ResizeObserver {
-      disconnect() {}
+      constructor(callback: () => void) {
+        resizeObserverCallback = callback;
+      }
+      disconnect() {
+        resizeObserverCallback = null;
+      }
       observe() {}
     },
   });
@@ -123,6 +135,7 @@ afterEach(() => {
   }
   container?.remove();
   container = null;
+  resizeObserverCallback = null;
   root = null;
 });
 
@@ -173,9 +186,37 @@ describe("TerminalSurface keyboard focus requests", () => {
 
     expect(terminalMocks.focus).not.toHaveBeenCalled();
   });
+
+  it("coalesces zoom correction with the final resize settle", async () => {
+    vi.useFakeTimers();
+    try {
+      await renderSurface(true, 1, 0.75);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      terminalMocks.fit.mockClear();
+      terminalMocks.resize.mockClear();
+      terminalMocks.refresh.mockClear();
+
+      await renderSurface(true, 1, 1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(120);
+      });
+      await act(async () => {
+        resizeObserverCallback?.();
+        await vi.advanceTimersByTimeAsync(80);
+      });
+
+      expect(terminalMocks.fit).toHaveBeenCalledTimes(1);
+      expect(terminalMocks.resize).toHaveBeenCalledTimes(1);
+      expect(terminalMocks.refresh).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
-async function renderSurface(active: boolean, keyboardFocusRequestId: number): Promise<void> {
+async function renderSurface(active: boolean, keyboardFocusRequestId: number, zoom = 1): Promise<void> {
   await act(async () => {
     root!.render(createElement(TerminalSurface, {
       operationId: "operation-a",
@@ -183,6 +224,7 @@ async function renderSurface(active: boolean, keyboardFocusRequestId: number): P
       wsPath: "/terminal",
       active,
       keyboardFocusRequestId,
+      zoom,
     }));
     await Promise.resolve();
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- Keep hidden terminal peers at their existing canvas zoom during maximize and companion transitions, avoiding background xterm and PTY resize fan-out.
- Coalesce terminal zoom, font, and geometry settling into one final fit, resize, and refresh.
- Reduce compositor work at four or more visible panels across Cruise, Tactical, and War Room, and suppress the all-peer first-focus fade.

## Test Plan
- [x] Run the Fleet Console test suite (2422 passed, 24 skipped).
- [x] Typecheck Fleet Console and the Terminal plugin.
- [x] Build Fleet Console and the Terminal plugin.
- [x] Validate changelog fragments and `git diff --check`.
- [x] Verify nine live Shell terminals in an isolated Console through zoomed maximize and restore while retaining Operation, xterm, and WebSocket identities.
- [x] Confirm the high-density material disables panel backdrop filtering and the browser reports no errors or unhandled rejections.