### PR TITLE
fix(fleet-console): keep the Codex outline on the section being read

### DIFF
--- a/.changelog.d/codex-toc-tail-highlight.md
+++ b/.changelog.d/codex-toc-tail-highlight.md
@@ -1,0 +1,8 @@
+---
+branch: codex-toc-tail-highlight
+---
+
+### fleet-console
+#### Fixed
+- Keep the Codex outline on the section you are actually reading, including the last one when you scroll a document to its end.
+  ko: Codex 목차가 지금 읽는 절을 따라오게 하고, 문서를 끝까지 내리면 마지막 절을 가리키도록 고쳤습니다.

--- a/runtime/fleet-console/core/client/src/codex-host.ts
+++ b/runtime/fleet-console/core/client/src/codex-host.ts
@@ -308,7 +308,7 @@ export function mountReaderInto(
   });
   syncInlineOutline(tNode);
   attachSessionScrollSaver(readSlot);
-  // 노드만 옮기면 스크롤 스파이의 IntersectionObserver는 옛 루트를 계속 물고 있다 —
+  // 노드만 옮기면 스크롤 스파이의 리스너는 옛 스크롤 루트를 계속 붙잡고 있다 —
   // relocate한 쪽에서 다시 세워야 확대 화면의 목차가 읽는 위치를 따라온다.
   if (relocated) readerController.refreshScrollSpy();
 

--- a/runtime/fleet-console/core/client/src/codex/components/toc-sheet.ts
+++ b/runtime/fleet-console/core/client/src/codex/components/toc-sheet.ts
@@ -22,6 +22,15 @@ type TocCleanup = () => void;
 
 const ACTIVE_CLASS = "active";
 
+/**
+ * 읽는 줄 — 헤딩 상단이 스크롤포트 높이의 이 비율까지 올라오면 그 절이 "지금 읽는 절"이 된다.
+ * 옛 IntersectionObserver 밴드(-20%/-65%)의 아랫변과 같은 자리라 활성 전환 시점은 그대로다.
+ */
+const READING_LINE_RATIO = 0.35;
+
+/** 분수 픽셀·확대 배율 때문에 scrollTop은 최대치에 1px 못 미치는 값에서 멈출 수 있다. */
+const BOTTOM_EPSILON = 2;
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 export function renderTocSheet(items: TocItem[]): string {
@@ -37,12 +46,20 @@ export function renderTocSheet(items: TocItem[]): string {
     .join("");
 }
 
+/**
+ * 목차가 읽는 자리를 따라오게 한다.
+ *
+ * 활성 절은 스크롤 위치의 전(全)함수로 푼다 — 교차 관측만으로는 읽는 자리를 말할 수 없기
+ * 때문이다. 좁은 관측 밴드는 (1) 한 번의 휠 스텝에 통째로 건너뛰고, (2) 문서 끝의 절들은
+ * 남은 스크롤이 모자라 그 밴드까지 영영 올라오지 못한다. 두 경우 모두 관측이 오지 않으므로
+ * 사용자가 계속 스크롤해도 목차는 마지막으로 풀린 절에 얼어붙는다.
+ */
 export function installTocScrollSpy(
   article: HTMLElement,
   items: TocItem[],
   tocPanel: HTMLElement,
 ): TocCleanup {
-  if (items.length === 0 || typeof IntersectionObserver === "undefined") return () => {};
+  if (items.length === 0) return () => {};
 
   const links = [...tocPanel.querySelectorAll<HTMLAnchorElement>("[data-toc-id]")];
   const headingIds = new Set(items.map((item) => item.id));
@@ -53,8 +70,11 @@ export function installTocScrollSpy(
   if (links.length === 0 || headings.length === 0) return () => {};
 
   const scrollRoot = article.closest<HTMLElement>(".codex-reading-sheet-read, .codex-doc-scroll");
-  const visibleHeadings = new Set<string>();
+  // 리스너는 설치 시점의 스크롤 루트를 붙잡는다 — 리더 노드가 split↔확대로 옮겨지면
+  // 옮긴 쪽이 스파이를 다시 세워야 한다(reading-controller.refreshScrollSpy).
+  const scrollTarget: EventTarget = scrollRoot ?? window;
   let lastEmittedId: string | null = null;
+  let appliedId: string | null | undefined;
 
   // 접힌 아웃라인 스파인이 "지금 읽는 섹션"을 되비출 수 있도록 활성 전환을 이벤트로 알린다.
   const emitActive = (activeId: string | null) => {
@@ -64,56 +84,83 @@ export function installTocScrollSpy(
     tocPanel.dispatchEvent(new CustomEvent("codex-toc-active", { bubbles: true, detail: { id: activeId, text } }));
   };
 
-  const observer = new IntersectionObserver(
-    (entries) => {
-      for (const entry of entries) {
-        const id = entry.target instanceof HTMLElement ? entry.target.id : "";
-        if (!id) continue;
-        if (entry.isIntersecting) visibleHeadings.add(id);
-        else visibleHeadings.delete(id);
-      }
-      const activeId =
-        firstVisible(headings, visibleHeadings) ??
-        lastAboveFold(headings, scrollRoot) ??
-        headings[0]?.id ??
-        null;
-      setActiveLink(links, activeId);
-      emitActive(activeId);
-    },
-    {
-      root: scrollRoot,
-      rootMargin: "-20% 0px -65% 0px",
-      threshold: [0, 0.2, 0.6, 1],
-    },
-  );
+  // 스크롤 이벤트는 브라우저가 이미 프레임당 한 번으로 묶어 보내고(옆의 진도 표시기도 같은
+  // 방식으로 읽는다), 실제 쓰기는 절이 바뀔 때만 일어난다 — 그래서 프레임마다 DOM을 건드리거나
+  // 스파인의 setState를 흔들지 않는다.
+  const resolve = () => {
+    const activeId = resolveActiveId(headings, scrollRoot);
+    // 기하를 읽을 수 없는 한순간(아직 자리를 잡지 않은 스크롤포트) 때문에 이미 말한 절을
+    // 첫 절로 되돌리지는 않는다.
+    if (activeId === null && appliedId !== undefined) return;
+    if (activeId === appliedId) return;
+    appliedId = activeId;
+    setActiveLink(links, activeId);
+    emitActive(activeId);
+  };
 
-  for (const h of headings) observer.observe(h);
-  setActiveLink(links, headings[0]?.id ?? null);
-  emitActive(headings[0]?.id ?? null);
+  scrollTarget.addEventListener("scroll", resolve, { passive: true });
+
+  // 스크롤 없이도 기하는 변한다 — 창 크기, 컨테이너 질의(940px에서 관련 항목이 옆 열로 빠짐),
+  // 늦게 자리를 잡는 본문. 그때도 목차는 지금 읽는 자리를 말해야 한다.
+  let resizeObserver: ResizeObserver | null = null;
+  if (typeof ResizeObserver !== "undefined") {
+    resizeObserver = new ResizeObserver(() => resolve());
+    if (scrollRoot) resizeObserver.observe(scrollRoot);
+    resizeObserver.observe(article);
+  }
+
+  resolve();
 
   return () => {
-    observer.disconnect();
+    scrollTarget.removeEventListener("scroll", resolve);
+    resizeObserver?.disconnect();
+    resizeObserver = null;
     emitActive(null);
   };
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function firstVisible(headings: HTMLElement[], visible: Set<string>): string | null {
-  for (const h of headings) {
-    if (visible.has(h.id)) return h.id;
-  }
-  return null;
+interface PortMetrics {
+  readonly top: number;
+  readonly clientHeight: number;
+  readonly scrollTop: number;
+  readonly scrollHeight: number;
 }
 
-function lastAboveFold(headings: HTMLElement[], scrollRoot: HTMLElement | null): string | null {
-  const foldTop = scrollRoot ? scrollRoot.getBoundingClientRect().top : 0;
-  let lastId: string | null = null;
-  for (const h of headings) {
-    if (h.getBoundingClientRect().top - foldTop <= 80) lastId = h.id;
-    else break;
+function readPortMetrics(scrollRoot: HTMLElement | null): PortMetrics {
+  if (scrollRoot) {
+    return {
+      top: scrollRoot.getBoundingClientRect().top,
+      clientHeight: scrollRoot.clientHeight,
+      scrollTop: scrollRoot.scrollTop,
+      scrollHeight: scrollRoot.scrollHeight,
+    };
   }
-  return lastId;
+  const doc = document.scrollingElement ?? document.documentElement;
+  return { top: 0, clientHeight: doc.clientHeight, scrollTop: doc.scrollTop, scrollHeight: doc.scrollHeight };
+}
+
+function resolveActiveId(headings: HTMLElement[], scrollRoot: HTMLElement | null): string | null {
+  const port = readPortMetrics(scrollRoot);
+  // 높이가 0인 스크롤포트는 아직 읽는 자리를 말해 주지 못한다.
+  if (port.clientHeight <= 0) return null;
+  const maxScroll = port.scrollHeight - port.clientHeight;
+
+  // 문서 끝. 마지막 절들은 뒤에 남은 스크롤이 없어 읽는 줄까지 결코 올라오지 못한다 —
+  // 바닥에 닿았다면 화면을 채운 마지막 절이 지금 읽는 절이다.
+  if (maxScroll > BOTTOM_EPSILON && port.scrollTop >= maxScroll - BOTTOM_EPSILON) {
+    return headings[headings.length - 1]?.id ?? null;
+  }
+
+  const readingLine = port.top + port.clientHeight * READING_LINE_RATIO;
+  let activeId: string | null = null;
+  // 문서 순서는 곧 위에서 아래 순서다 — 읽는 줄을 처음 넘어서는 헤딩에서 멈출 수 있다.
+  for (const h of headings) {
+    if (h.getBoundingClientRect().top > readingLine) break;
+    activeId = h.id;
+  }
+  return activeId ?? headings[0]?.id ?? null;
 }
 
 function setActiveLink(links: HTMLAnchorElement[], activeId: string | null): void {

--- a/runtime/fleet-console/core/client/src/codex/reading-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/reading-controller.ts
@@ -65,8 +65,9 @@ export interface ReadingController {
   navigateSub(subId: string | undefined): Promise<void>;
   /**
    * 스크롤 스파이를 현재 스크롤 루트 위에 다시 세운다. 리더 노드가 split↔확대로 relocate되면
-   * IntersectionObserver는 설치 시점의 루트(옛 스크롤 컨테이너)를 계속 물고 있어 교차를 영영
-   * 보고하지 않는다 — 노드를 옮긴 쪽이 이 함수를 불러야 목차가 다시 읽는 위치를 따라온다.
+   * 스파이의 스크롤·크기 리스너는 설치 시점의 루트(옛 스크롤 컨테이너)를 계속 붙잡고 있어 새
+   * 컨테이너의 스크롤을 영영 듣지 못한다 — 노드를 옮긴 쪽이 이 함수를 불러야 목차가 다시 읽는
+   * 위치를 따라온다.
    */
   refreshScrollSpy(): void;
   /** 헤드바·링크 복사·원문 보기가 쓰는 현재 문서 사실. */

--- a/runtime/fleet-console/tests/codex-toc-scroll-spy.test.ts
+++ b/runtime/fleet-console/tests/codex-toc-scroll-spy.test.ts
@@ -1,0 +1,280 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installTocScrollSpy, renderTocSheet } from "../core/client/src/codex/components/toc-sheet.js";
+
+// 스크롤포트는 화면 맨 위에서 시작하고 600px 높이다 — 읽는 줄은 0.35 * 600 = 210px.
+const PORT_TOP = 0;
+const PORT_HEIGHT = 600;
+
+interface HeadingSpec {
+  readonly id: string;
+  readonly text: string;
+  /** 문서 좌표(문서 맨 위에서 이 헤딩 상단까지). */
+  readonly docY: number;
+  readonly level?: 2 | 3;
+}
+
+interface Reader {
+  readonly toc: HTMLElement;
+  readonly events: { id: string | null; text: string }[];
+  scrollTo(scrollTop: number): void;
+  /** 스크롤 이벤트 없이 위치만 바꾼다(크기 변화만으로 다시 푸는지 보기 위해). */
+  setScrollTop(scrollTop: number): void;
+  /** 스크롤포트 높이를 0으로 만든다(아직 자리를 잡지 않은 순간). */
+  collapsePort(): void;
+  activeIds(): string[];
+  currentIds(): string[];
+  cleanup(): void;
+}
+
+const teardown: (() => void)[] = [];
+
+afterEach(() => {
+  while (teardown.length > 0) teardown.pop()?.();
+  document.body.innerHTML = "";
+});
+
+function rect(top: number, height: number): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    right: 800,
+    bottom: top + height,
+    width: 800,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function mountReader(options: {
+  readonly rootClass: "codex-reading-sheet-read" | "codex-doc-scroll";
+  readonly headings: readonly HeadingSpec[];
+  /** 스크롤 가능한 전체 콘텐츠 높이. PORT_HEIGHT 이하면 스크롤되지 않는 문서다. */
+  readonly contentHeight: number;
+}): Reader {
+  const root = document.createElement("div");
+  root.className = options.rootClass;
+  const article = document.createElement("article");
+  root.append(article);
+  document.body.append(root);
+
+  // jsdom은 레이아웃이 없어 scrollTop/clientHeight/scrollHeight가 모두 0이다 — 스크롤포트의
+  // 기하를 직접 정의하고, 헤딩 사각형은 문서 좌표에서 현재 scrollTop을 뺀 값으로 계산한다.
+  let scrollTop = 0;
+  Object.defineProperty(root, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (next: number) => {
+      scrollTop = next;
+    },
+  });
+  let portHeight = PORT_HEIGHT;
+  Object.defineProperty(root, "clientHeight", { configurable: true, get: () => portHeight });
+  Object.defineProperty(root, "scrollHeight", { configurable: true, get: () => options.contentHeight });
+  root.getBoundingClientRect = () => rect(PORT_TOP, portHeight);
+
+  const items = options.headings.map((heading) => ({
+    id: heading.id,
+    text: heading.text,
+    level: heading.level ?? (2 as const),
+  }));
+
+  for (const heading of options.headings) {
+    const node = document.createElement(heading.level === 3 ? "h3" : "h2");
+    node.id = heading.id;
+    node.textContent = heading.text;
+    node.getBoundingClientRect = () => rect(PORT_TOP + heading.docY - scrollTop, 30);
+    article.append(node);
+  }
+
+  const toc = document.createElement("nav");
+  toc.innerHTML = renderTocSheet(items);
+  document.body.append(toc);
+
+  const events: { id: string | null; text: string }[] = [];
+  const onActive = (event: Event) => {
+    const detail = (event as CustomEvent<{ id: string | null; text: string }>).detail;
+    events.push({ id: detail.id, text: detail.text });
+  };
+  document.addEventListener("codex-toc-active", onActive);
+
+  const cleanupSpy = installTocScrollSpy(article, items, toc);
+  const cleanup = () => {
+    cleanupSpy();
+    document.removeEventListener("codex-toc-active", onActive);
+  };
+  teardown.push(cleanup);
+
+  return {
+    toc,
+    events,
+    scrollTo(next: number) {
+      root.scrollTop = next;
+      root.dispatchEvent(new Event("scroll"));
+    },
+    setScrollTop(next: number) {
+      root.scrollTop = next;
+    },
+    collapsePort() {
+      portHeight = 0;
+    },
+    activeIds: () => [...toc.querySelectorAll<HTMLElement>(".ti.active")].map((el) => el.dataset.tocId ?? ""),
+    currentIds: () =>
+      [...toc.querySelectorAll<HTMLElement>('[aria-current="location"]')].map((el) => el.dataset.tocId ?? ""),
+    cleanup,
+  };
+}
+
+// 문서 맨 아래 두 절은 뒤에 남은 스크롤이 40px뿐이라, 최대 스크롤에서도 읽는 줄(210px)까지
+// 올라오지 못한다 — 사용자가 보고한 확대 화면의 문서 끝 상태 그대로다.
+const TAIL_DOC = {
+  headings: [
+    { id: "overview", text: "개요", docY: 0 },
+    { id: "api", text: "일반화된 operations API", docY: 700 },
+    { id: "direction", text: "이전 방향", docY: 1180, level: 3 as const },
+    { id: "waves", text: "구현 웨이브", docY: 1560 },
+    { id: "related", text: "관련 자료", docY: 1720 },
+  ],
+  contentHeight: 1900,
+} as const;
+
+describe("codex TOC scroll spy", () => {
+  it("marks the last section once the reader reaches the bottom of the document", () => {
+    const reader = mountReader({ rootClass: "codex-reading-sheet-read", ...TAIL_DOC });
+
+    // 문서 끝(최대 스크롤 = 1900 - 600 = 1300). 마지막 두 절은 화면 아래쪽에 보이지만
+    // 읽는 줄 위로는 결코 올라오지 못한다.
+    reader.scrollTo(1300);
+
+    expect(reader.activeIds()).toEqual(["related"]);
+    expect(reader.currentIds()).toEqual(["related"]);
+  });
+
+  it("keeps the split reader on the same rule at the bottom", () => {
+    const reader = mountReader({ rootClass: "codex-doc-scroll", ...TAIL_DOC });
+
+    reader.scrollTo(1300);
+
+    expect(reader.activeIds()).toEqual(["related"]);
+  });
+
+  it("follows the reading line while scrolling through the middle of the document", () => {
+    const reader = mountReader({ rootClass: "codex-reading-sheet-read", ...TAIL_DOC });
+
+    // api 헤딩이 읽는 줄을 막 넘어선 자리(700 - 500 = 200px < 210px).
+    reader.scrollTo(500);
+    expect(reader.activeIds()).toEqual(["api"]);
+
+    // 계속 올라가 헤딩이 화면 위쪽 80px 안으로 들어가기 전 구간 — 옛 규칙은 여기서 앞 절로
+    // 되돌아갔다. 지금은 지나온 절을 유지한다.
+    reader.scrollTo(600);
+    expect(reader.activeIds()).toEqual(["api"]);
+
+    reader.scrollTo(1000);
+    expect(reader.activeIds()).toEqual(["direction"]);
+  });
+
+  it("holds the first section at the top of the document", () => {
+    const reader = mountReader({ rootClass: "codex-reading-sheet-read", ...TAIL_DOC });
+
+    expect(reader.activeIds()).toEqual(["overview"]);
+
+    reader.scrollTo(120);
+    expect(reader.activeIds()).toEqual(["overview"]);
+  });
+
+  it("does not force the last section when the document does not scroll", () => {
+    const reader = mountReader({
+      rootClass: "codex-reading-sheet-read",
+      headings: [
+        { id: "overview", text: "개요", docY: 0 },
+        { id: "detail", text: "세부", docY: 400 },
+      ],
+      contentHeight: PORT_HEIGHT,
+    });
+
+    expect(reader.activeIds()).toEqual(["overview"]);
+  });
+
+  it("resolves the restored position from a scroll event, not from the install-time observation", () => {
+    // relocate 후 스파이는 스크롤 복원보다 먼저 세워진다 — 설치 시점의 관측만으로는
+    // 복원된 자리를 알 수 없고, 복원이 만들어 내는 스크롤이 그 자리를 말한다.
+    const reader = mountReader({ rootClass: "codex-reading-sheet-read", ...TAIL_DOC });
+    expect(reader.activeIds()).toEqual(["overview"]);
+
+    reader.scrollTo(1300);
+
+    expect(reader.activeIds()).toEqual(["related"]);
+  });
+
+  it("announces a section change once, and clears the section on cleanup", () => {
+    const reader = mountReader({ rootClass: "codex-reading-sheet-read", ...TAIL_DOC });
+
+    expect(reader.events).toEqual([{ id: "overview", text: "개요" }]);
+
+    reader.scrollTo(1300);
+    reader.scrollTo(1299);
+    reader.scrollTo(1300);
+
+    expect(reader.events).toEqual([
+      { id: "overview", text: "개요" },
+      { id: "related", text: "관련 자료" },
+    ]);
+
+    reader.cleanup();
+
+    expect(reader.events.at(-1)).toEqual({ id: null, text: "" });
+  });
+
+  it("re-resolves when the scrollport resizes without a scroll event", () => {
+    // 확대 화면은 940px에서 관련 항목을 옆 열로 빼는 등 스크롤 없이도 기하가 바뀐다.
+    const fire: (() => void)[] = [];
+    class StubResizeObserver {
+      constructor(callback: () => void) {
+        fire.push(callback);
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    const original = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver;
+    try {
+      const reader = mountReader({ rootClass: "codex-reading-sheet-read", ...TAIL_DOC });
+      reader.setScrollTop(1300);
+      expect(reader.activeIds()).toEqual(["overview"]);
+
+      for (const callback of fire) callback();
+
+      expect(reader.activeIds()).toEqual(["related"]);
+    } finally {
+      globalThis.ResizeObserver = original;
+    }
+  });
+
+  it("keeps the section it already reported when the scrollport has no height", () => {
+    // 확대↔split 전환 한순간처럼 아직 자리를 잡지 않은 스크롤포트는 읽는 자리를 말해 주지
+    // 못한다 — 그 순간 때문에 이미 말한 절을 첫 절로 되돌리지 않는다.
+    const reader = mountReader({ rootClass: "codex-reading-sheet-read", ...TAIL_DOC });
+    reader.scrollTo(1300);
+    expect(reader.activeIds()).toEqual(["related"]);
+
+    reader.collapsePort();
+    reader.scrollTo(1300);
+
+    expect(reader.activeIds()).toEqual(["related"]);
+    expect(reader.events.at(-1)).toEqual({ id: "related", text: "관련 자료" });
+  });
+
+  it("stops following the reader after cleanup", () => {
+    const reader = mountReader({ rootClass: "codex-reading-sheet-read", ...TAIL_DOC });
+    reader.cleanup();
+
+    reader.scrollTo(1300);
+
+    expect(reader.activeIds()).toEqual(["overview"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Codex(wiki) 리더에서 본문을 끝까지 내리면 좌측 목차 하이라이트가 읽는 자리와 어긋나던 문제를 고칩니다. 문서 끝 절들은 남은 스크롤이 없어 옛 관측 밴드(스크롤포트 높이의 15%)까지 올라올 수 없었고, 어떤 헤딩도 밴드를 넘지 않는 동안에는 관측 자체가 오지 않아 목차가 얼어붙었습니다.
- 활성 절을 스크롤 위치의 전(全)함수로 풉니다: 읽는 줄(스크롤포트 높이의 0.35, 옛 밴드 아랫변과 같은 자리)을 지나온 마지막 헤딩 → 바닥에 닿았으면 마지막 헤딩 → 그 외 첫 헤딩. 트리거는 passive scroll 리스너와 스크롤포트·본문 ResizeObserver이며 IntersectionObserver는 걷어냅니다.
- 활성 절이 실제로 바뀔 때만 `.active`/`aria-current`를 쓰고 `codex-toc-active`를 쏘므로, 접힌 아웃라인 스파인의 갱신 빈도는 그대로입니다. relocate 시 `refreshScrollSpy`가 리스너를 새 스크롤 루트에 다시 붙이는 계약도 유지됩니다.

## Test Plan
- [x] `corepack pnpm --filter @dotobokuri/fleet-console exec vitest run tests/codex-toc-scroll-spy.test.ts` — 10 passed (문서 끝·읽는 줄·최상단·스크롤 없는 문서·복원 위치·리사이즈·높이 0·정리·확대/split 양쪽)
- [x] `corepack pnpm --filter @dotobokuri/fleet-console test` — 2432 passed / 24 skipped
- [x] `corepack pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] 실측(격리 Console, 확대 리더, 1512x945, 스크롤포트 762px, maxScroll 8792, 100px 단위)
  - 수정 전: 8200~8700 구간이 "이전 방향"에 고정, 8100에서 "마이그레이션 표"로 갔다가 되돌아오는 뒤집힘, 최대 스크롤에서 "구현 웨이브"
  - 수정 후: 7800~8000 "이전 방향", 8100~8700 "마이그레이션 표", 최대 스크롤에서 "관련 자료"(활성 링크 1개, `aria-current="location"`)
  - split 리더(`.codex-doc-scroll`)도 같은 규칙으로 따라오고 바닥에서 마지막 절에 안착, 페이지 오류 0건
- [x] 변이 검증: 바닥 클램프 제거 시 6개 테스트 red, scroll 리스너 제거 시 6개 테스트 red