### PR TITLE
feat(fleet-console): quiet the selected-control grammar across themes

### DIFF
--- a/.changelog.d/quiet-controls.md
+++ b/.changelog.d/quiet-controls.md
@@ -1,0 +1,8 @@
+---
+branch: quiet-controls
+---
+
+### fleet-console
+#### Changed
+- Selected controls across all four themes now speak quietly: segmented switches raise the active option on a sliding neutral thumb with ink contrast, independent chips such as effort levels keep a soft tint, and boolean toggles mark "on" with a raised face plus a brass glyph, replacing the loud brass outline pill everywhere.
+  ko: 네 테마 전반의 선택된 컨트롤이 조용하게 말합니다. 세그먼트 스위치는 활성 항목을 미끄러지는 중립 융기면과 잉크 대비로 세우고, 강도 단계 같은 독립 칩은 옅은 워시만 유지하며, 불리언 토글은 융기면 위 브라스 글리프로 켬을 표시해 요란한 브라스 아웃라인 필을 전면 대체합니다.

--- a/.changelog.d/quiet-controls.md
+++ b/.changelog.d/quiet-controls.md
@@ -4,5 +4,5 @@ branch: quiet-controls
 
 ### fleet-console
 #### Changed
-- Selected controls across all four themes now speak quietly: segmented switches raise the active option on a sliding neutral thumb with ink contrast, independent chips such as effort levels keep a soft tint, and boolean toggles mark "on" with a raised face plus a brass glyph, replacing the loud brass outline pill everywhere.
-  ko: 네 테마 전반의 선택된 컨트롤이 조용하게 말합니다. 세그먼트 스위치는 활성 항목을 미끄러지는 중립 융기면과 잉크 대비로 세우고, 강도 단계 같은 독립 칩은 옅은 워시만 유지하며, 불리언 토글은 융기면 위 브라스 글리프로 켬을 표시해 요란한 브라스 아웃라인 필을 전면 대체합니다.
+- Selected controls across all four themes now speak quietly: segmented switches drop their boxes and mark the active option with a sliding low-contrast wash, ink contrast, and a tiny brass underline, independent chips such as effort levels keep a soft tint, and boolean toggles mark "on" with the wash plus a brass glyph, replacing the loud brass outline pill everywhere; forced-colors mode renders selection with system selection colors.
+  ko: 네 테마 전반의 선택된 컨트롤이 조용하게 말합니다. 세그먼트 스위치는 상자를 걷고 활성 항목을 미끄러지는 극저대비 워시와 잉크 대비, 작은 브라스 밑줄로 표시하며, 강도 단계 같은 독립 칩은 옅은 워시만 유지하고, 불리언 토글은 워시 위 브라스 글리프로 켬을 표시해 요란한 브라스 아웃라인 필을 전면 대체합니다. 고대비 모드에서는 시스템 선택색으로 선택을 표시합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExter
 import { Link, useNavigate } from "react-router-dom";
 
 import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
+import { SegmentedThumb } from "@fleet-console/sdk/react/browser";
 
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { animateViewportTo, clearFormationView, fitAllOperations, selectFormationLayout, setStationKeeping, toggleFormationView, useCanvasState, useFormationLayout, useFormationView, useStationKeeping, type FormationLayout } from "../canvas/canvas-store.js";
@@ -552,6 +553,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       </div>
       {operationsViewVisible ? <div ref={mapControlsRef} className="command-band-map-controls">
         <div className="command-band-mode-switch" role="group" aria-label={t("chrome.commandBand.canvasMode")}>
+          <SegmentedThumb />
           {CANVAS_MODES.map((mode) => (
             <button
               key={mode.id}

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { FontPicker, type FontPickerInstalledFont, type FontPickerSelection } from "@fleet-console/font-picker/browser";
 import type { ConsoleLocale, Translate } from "@fleet-console/sdk/i18n";
 import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
-import { PluginErrorBoundary } from "@fleet-console/sdk/react/browser";
+import { PluginErrorBoundary, SegmentedThumb } from "@fleet-console/sdk/react/browser";
 import { ExperimentalBadge, SettingsScope as SettingsScopeChip, type SettingsScopeKind } from "@fleet-console/sdk/settings/browser";
 import type { SettingsSectionDescriptor, SettingsSectionGroup } from "@fleet-console/sdk/settings";
 import "@fleet-console/font-picker/styles.css";
@@ -781,6 +781,7 @@ export function LanguageCard({
           <p className="global-settings-help">{t("settings.language.help")}</p>
         </div>
         <div className="segmented language-picker" role="group" aria-label={t("settings.language.aria")}>
+          <SegmentedThumb />
           {languages.map((language) => {
             const isActive = state.language === language.id;
             return (
@@ -1749,6 +1750,7 @@ function ConsolePortSettings({
       </div>
       <div className="console-port-control">
         <div className="segmented" role="group" aria-label={t("settings.port.modeAria")}>
+          <SegmentedThumb />
           {portModes.map((mode) => {
             const isActive = state.consolePortMode === mode.id;
             return (

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import type { Translate } from "@fleet-console/sdk/i18n";
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 import type { OperationRuntimeState } from "@fleet-console/sdk/plugin";
+import { SegmentedThumb } from "@fleet-console/sdk/react/browser";
 
 import { getT, useT, type CoreMessageKey } from "../i18n/index.js";
 import { getIdleArrivalIds, subscribeIdleArrival } from "../operation-marks.js";
@@ -919,6 +920,7 @@ export function OperationsSideBar({
           목록도 없으므로 스트립도 서지 않는다. */}
       {theaters.length > 0 ? (
         <div className="operations-side-bar-axis" role="group" aria-label={t("sidebar.axis.aria")}>
+          <SegmentedThumb />
           <button
             type="button"
             className="operations-side-bar-axis-seg"

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2595,6 +2595,10 @@
   .fc-select__option[aria-selected="true"],
   .global-settings-nav-item.is-active,
   .global-settings-nav-item[aria-pressed="true"],
+  .appearance-preview-rail b,
+  .host-switcher-panel > button.is-current,
+  .remote-interface-preset.is-selected,
+  .theme-card.is-active,
   .settings-switch.is-on,
   .fc-settings-toggle__input:checked + .settings-switch {
     background: SelectedItem;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -317,13 +317,13 @@
   background: var(--control-hover-fill);
 }
 
-/* 현재 섹션은 선택이 아니라 위치다 — 면은 융기 중립(thumb)으로 물러나고,
+/* 현재 섹션은 선택이 아니라 위치다 — 면은 극저대비 워시로 물러나고,
    위치 채널의 brass는 2px 스파인 하나로만 남는다. */
 .global-settings-nav-item.is-active,
 .global-settings-nav-item[aria-pressed="true"] {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: inset 2px 0 0 var(--brass), var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
+  box-shadow: inset 2px 0 0 var(--brass);
 }
 
 .global-settings-nav-label {
@@ -555,9 +555,9 @@
 }
 
 .appearance-preview-rail b {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: inset 2px 0 0 var(--brass), var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
+  box-shadow: inset 2px 0 0 var(--brass);
   color: var(--text-primary);
   font-weight: var(--weight-medium);
 }
@@ -1165,9 +1165,8 @@
 }
 
 .host-switcher-panel > button.is-current {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
   color: var(--text-primary);
   cursor: default;
 }
@@ -1769,8 +1768,8 @@
 }
 
 .settings-switch:hover:not(:disabled):not(.is-on) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
-/* 불리언 ON = 자리 + 글리프 — 트랙이 융기 중립 면으로 떠오르고 켬을 말하는 accent는 brass 손잡이뿐이다. */
-.settings-switch.is-on { border-color: var(--control-thumb-line); background: var(--control-thumb); box-shadow: var(--control-thumb-lift); }
+/* 불리언 ON = 워시 + 글리프 — 트랙이 은은한 워시로 밝아지고 켬을 말하는 accent는 brass 손잡이뿐이다. */
+.settings-switch.is-on { background: var(--control-wash); }
 .settings-switch.is-on .settings-switch-knob { transform: translateX(20px); background: var(--brass-bright); }
 .settings-switch:active:not(:disabled) { transform: translateY(1px); }
 .settings-switch:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
@@ -1787,7 +1786,7 @@
 .remote-interface-preset { display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-1); min-width: 0; padding: var(--space-2) var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 32%, transparent); color: var(--text-secondary); text-align: left; }
 .remote-interface-preset code { color: var(--text-primary); font-family: var(--font-mono); font-size: var(--t-sm); overflow-wrap: anywhere; }
 .remote-interface-preset:hover:not(:disabled):not(.is-selected) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
-.remote-interface-preset.is-selected { border-color: var(--control-thumb-line); background: var(--control-thumb); box-shadow: var(--control-thumb-lift); }
+.remote-interface-preset.is-selected { border-color: transparent; background: var(--control-wash); box-shadow: inset 2px 0 0 var(--brass); }
 .remote-interface-preset:active:not(:disabled) { transform: translateY(1px); }
 .remote-interface-preset:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 .remote-field input, .remote-port-control input[type="number"] {
@@ -2090,9 +2089,9 @@
 
 .theme-card.is-active {
   color: var(--text-primary);
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift), var(--shadow-soft);
+  border-color: var(--surface-rim);
+  background: var(--control-wash);
+  box-shadow: inset 2px 0 0 var(--brass);
 }
 
 .theme-card:active:not(:disabled) {
@@ -2470,8 +2469,9 @@
   font-size: var(--t-sm);
 }
 
-/* 세그먼트 컨트롤 — 배타 선택은 자리(Quiet Controls)로 말한다: 트랙이 한 단 가라앉고
-   활성 세그먼트가 융기 중립 면(thumb)으로 떠오르며, 글자는 잉크 대비(tertiary→primary)가 진다. */
+/* 세그먼트 컨트롤 — 배타 선택은 은은한 자리(Quiet Controls C′)로 말한다: 상자·테두리·그림자
+   없이, 활성 세그먼트만 극저대비 워시 위에 잉크 대비(tertiary→primary)로 떠오르고
+   2px brass 다텀 한 점이 "선택"과 "밝은 글자"를 가른다. */
 .segmented {
   position: relative;
   display: inline-flex;
@@ -2480,29 +2480,37 @@
   /* grid 부모에서는 align-self가 인라인 축을 잡지 못해 트랙 폭만큼 늘어난다 — 두 축 모두에서
      내용 폭을 유지해야 짧은 라벨 두 개가 빈 상자 왼쪽에 몰리지 않는다. */
   justify-self: start;
-  padding: 3px;
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
-  background: var(--control-track);
+  gap: var(--space-1);
 }
 
-/* 미끄러지는 융기면 — JS 훅(use-segmented-thumb)이 활성 세그먼트의 좌표를 얹는다.
-   훅이 아직 자리를 잡지 못했으면(is-placed 없음) 활성 옵션의 자체 face가 그대로 선다. */
+/* 미끄러지는 워시 — JS 훅(SegmentedThumb)이 활성 세그먼트의 좌표를 얹고, 다텀은 ::after로
+   워시와 한 몸으로 움직인다. 훅이 아직 자리를 잡지 못했으면(is-placed 없음) 활성 옵션의
+   자체 face가 그대로 선다. */
 .segmented-thumb {
   position: absolute;
   top: 0;
   left: 0;
   z-index: 0;
   opacity: 0;
-  border: 1px solid var(--control-thumb-line);
   border-radius: var(--radius-xs);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  background: var(--control-wash);
   pointer-events: none;
   transition:
     transform var(--duration-fast) var(--ease-spring),
     width var(--duration-fast) var(--ease-spring),
     height var(--duration-fast) var(--ease-spring);
+}
+
+.segmented-thumb::after {
+  position: absolute;
+  bottom: 3px;
+  left: 50%;
+  width: 14px;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  transform: translateX(-50%);
+  content: "";
 }
 
 .segmented-thumb.is-placed { opacity: 1; }
@@ -2531,21 +2539,67 @@
     background var(--duration-fast) var(--ease-spring);
 }
 
+/* 세그먼트의 hover는 brass 예고가 아니라 같은 워시 계열의 약한 단이다 — 선택 워시(잉크 대비
+   + 다텀 동반)와 층만 다르게 서서, 조용한 표면 안에서 색이 갑자기 데워지지 않는다. */
 .segmented-option:hover:not(:disabled):not(.is-active) {
-  background: var(--control-hover-fill);
-  color: var(--text-primary);
+  background: var(--control-wash-hover);
+  color: var(--text-secondary);
 }
 
 .segmented-option.is-active {
-  background: var(--control-thumb);
+  position: relative;
+  background: var(--control-wash);
   color: var(--text-primary);
-  box-shadow: inset 0 0 0 1px var(--control-thumb-line), var(--control-thumb-lift);
 }
 
-/* 썸이 자리를 잡으면 활성 옵션의 자체 face는 물러난다 — 이중 도장은 슬라이드 중 두 자리를 만든다. */
+.segmented-option.is-active::after {
+  position: absolute;
+  bottom: 3px;
+  left: 50%;
+  width: 14px;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  transform: translateX(-50%);
+  content: "";
+}
+
+/* 썸이 자리를 잡으면 활성 옵션의 자체 face·다텀은 물러난다 — 이중 도장은 슬라이드 중 두 자리를 만든다. */
 .segmented:has(> .segmented-thumb.is-placed) .segmented-option.is-active {
   background: transparent;
-  box-shadow: none;
+}
+
+.segmented:has(> .segmented-thumb.is-placed) .segmented-option.is-active::after {
+  content: none;
+}
+
+/* 24px 높이의 좁은 세그먼트(사이드바 축)는 다텀도 한 치수 좁게 선다. */
+.operations-side-bar-axis > .segmented-thumb::after {
+  bottom: 2px;
+  width: 12px;
+}
+
+/* 고대비(forced-colors) — 워시·다텀·그림자가 모두 걷히는 환경에서는 선택을 시스템
+   선택색으로 직접 말한다. 썸 장식은 배경을 잃어 유령이 되므로 감추고, 자체 face 소거
+   규칙(:has)보다 나중에 같은 대상을 다시 세워 폴백 face가 항상 이긴다. */
+@media (forced-colors: active) {
+  .segmented-thumb { display: none; }
+
+  .segmented-option.is-active,
+  .segmented:has(> .segmented-thumb.is-placed) .segmented-option.is-active,
+  .operations-side-bar-axis-seg[aria-pressed="true"],
+  .operations-side-bar-axis:has(> .segmented-thumb.is-placed) .operations-side-bar-axis-seg[aria-pressed="true"],
+  .canvas-operation-icon-button.is-active,
+  .fleet-caption-action[aria-pressed="true"],
+  .codex-reader-tool[aria-pressed="true"],
+  .fc-select__option[aria-selected="true"],
+  .global-settings-nav-item.is-active,
+  .global-settings-nav-item[aria-pressed="true"],
+  .settings-switch.is-on,
+  .fc-settings-toggle__input:checked + .settings-switch {
+    background: SelectedItem;
+    color: SelectedItemText;
+  }
 }
 
 .segmented-option:active:not(:disabled) {
@@ -5398,18 +5452,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 /* 축 스트립은 스크롤 목록 바깥에 고정된 하나짜리 뷰 스위치다 — 커맨드 밴드의
    .command-band-mode-switch와 같은 세그먼트 문법을 사이드바 폭에 맞춰 좁힌 것이고,
-   새 어휘가 아니다. 눌림은 Quiet Controls의 융기 중립 면(thumb)이 말한다. */
+   새 어휘가 아니다. 눌림은 Quiet Controls C′의 워시+다텀이 말하고 상자는 없다. */
 .operations-side-bar-axis {
   position: relative;
   display: flex;
   flex: none;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-1);
   margin: var(--space-1) var(--space-1) 2px;
-  padding: 2px;
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
-  background: var(--control-track);
 }
 
 .operations-side-bar-axis-seg {
@@ -5441,19 +5491,33 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .operations-side-bar-axis-seg:hover {
-  border-color: var(--hairline-strong);
-  color: var(--text-primary);
+  background: var(--control-wash-hover);
+  color: var(--text-secondary);
 }
 
 .operations-side-bar-axis-seg[aria-pressed="true"] {
-  background: var(--control-thumb);
+  background: var(--control-wash);
   color: var(--text-primary);
-  box-shadow: inset 0 0 0 1px var(--control-thumb-line), var(--control-thumb-lift);
+}
+
+.operations-side-bar-axis-seg[aria-pressed="true"]::after {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  width: 12px;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  transform: translateX(-50%);
+  content: "";
 }
 
 .operations-side-bar-axis:has(> .segmented-thumb.is-placed) .operations-side-bar-axis-seg[aria-pressed="true"] {
   background: transparent;
-  box-shadow: none;
+}
+
+.operations-side-bar-axis:has(> .segmented-thumb.is-placed) .operations-side-bar-axis-seg[aria-pressed="true"]::after {
+  content: none;
 }
 
 .operations-side-bar-axis-seg:focus-visible {
@@ -6999,13 +7063,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: var(--control-hover-fill);
 }
 
-/* 불리언 ON = 자리 + 글리프 — 면은 융기 중립(thumb)이고 켬을 말하는 accent는 글리프 색뿐이다. */
+/* 불리언 ON = 워시 + 글리프 — 면은 극저대비 워시이고 켬을 말하는 accent는 글리프 색뿐이다. */
 .canvas-operation-icon-button.is-active,
 .fleet-caption-action[aria-pressed="true"] {
   color: var(--brass-bright);
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
 }
 
 .canvas-operation-icon-button svg,
@@ -12023,9 +12086,7 @@ body[data-codex-side="true"] .command-card {
    aurora로 칠한 iOS형 스위치를 써서, 같은 켬/끔이 코어와 플러그인 사이에서 다른 색과 다른
    크기로 갈렸다. 켜짐은 선택이므로 brass가 칠하고, aurora는 상태 채널로 돌아간다. */
 .fc-settings-toggle__input:checked + .settings-switch {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  background: var(--control-wash);
 }
 
 .fc-settings-toggle__input:checked + .settings-switch .settings-switch-knob {
@@ -12347,9 +12408,8 @@ body[data-codex-side="true"] .command-card {
 
 .codex-reader-tool[aria-pressed="true"] {
   color: var(--brass-bright);
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
 }
 
 .codex-reader-tool:disabled {
@@ -13286,7 +13346,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
   transition: background var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
 .fc-select__option[data-active="true"]:not([aria-disabled="true"]):not([aria-selected="true"]) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); color: var(--text-primary); }
-.fc-select__option[aria-selected="true"] { border-color: var(--control-thumb-line); background: var(--control-thumb); color: var(--text-primary); box-shadow: var(--control-thumb-lift); }
+.fc-select__option[aria-selected="true"] { border-color: transparent; background: var(--control-wash); color: var(--text-primary); }
 .fc-select__option[aria-selected="true"]::after { content: "✓"; font-size: var(--t-xs); color: var(--brass-bright); }
 .fc-select__option[aria-disabled="true"] { color: var(--text-tertiary); cursor: not-allowed; font-style: italic; opacity: var(--control-disabled-opacity); }
 .fc-select__option[aria-disabled="true"][data-active="true"] { background: transparent; border-color: transparent; color: var(--text-tertiary); }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -225,7 +225,7 @@
 }
 
 .settings-search:focus-within {
-  border-color: var(--control-selected-rim);
+  border-color: var(--control-open-rim);
 }
 
 .settings-search svg {
@@ -317,11 +317,13 @@
   background: var(--control-hover-fill);
 }
 
+/* 현재 섹션은 선택이 아니라 위치다 — 면은 융기 중립(thumb)으로 물러나고,
+   위치 채널의 brass는 2px 스파인 하나로만 남는다. */
 .global-settings-nav-item.is-active,
 .global-settings-nav-item[aria-pressed="true"] {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
-  box-shadow: inset 2px 0 0 var(--brass);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: inset 2px 0 0 var(--brass), var(--control-thumb-lift);
 }
 
 .global-settings-nav-label {
@@ -553,9 +555,9 @@
 }
 
 .appearance-preview-rail b {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
-  box-shadow: inset 2px 0 0 var(--brass);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: inset 2px 0 0 var(--brass), var(--control-thumb-lift);
   color: var(--text-primary);
   font-weight: var(--weight-medium);
 }
@@ -1082,8 +1084,8 @@
 }
 
 .host-switcher-chip[aria-expanded="true"] {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  border-color: var(--control-open-rim);
+  background: var(--control-tint-fill);
   color: var(--text-primary);
 }
 
@@ -1163,7 +1165,9 @@
 }
 
 .host-switcher-panel > button.is-current {
-  background: var(--control-selected-fill);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
   color: var(--text-primary);
   cursor: default;
 }
@@ -1765,7 +1769,8 @@
 }
 
 .settings-switch:hover:not(:disabled):not(.is-on) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
-.settings-switch.is-on { border-color: var(--control-selected-rim); background: var(--control-selected-fill); }
+/* 불리언 ON = 자리 + 글리프 — 트랙이 융기 중립 면으로 떠오르고 켬을 말하는 accent는 brass 손잡이뿐이다. */
+.settings-switch.is-on { border-color: var(--control-thumb-line); background: var(--control-thumb); box-shadow: var(--control-thumb-lift); }
 .settings-switch.is-on .settings-switch-knob { transform: translateX(20px); background: var(--brass-bright); }
 .settings-switch:active:not(:disabled) { transform: translateY(1px); }
 .settings-switch:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
@@ -1782,7 +1787,7 @@
 .remote-interface-preset { display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-1); min-width: 0; padding: var(--space-2) var(--space-3); border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 32%, transparent); color: var(--text-secondary); text-align: left; }
 .remote-interface-preset code { color: var(--text-primary); font-family: var(--font-mono); font-size: var(--t-sm); overflow-wrap: anywhere; }
 .remote-interface-preset:hover:not(:disabled):not(.is-selected) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
-.remote-interface-preset.is-selected { border-color: var(--control-selected-rim); background: var(--control-selected-fill); box-shadow: inset 3px 0 0 var(--brass); }
+.remote-interface-preset.is-selected { border-color: var(--control-thumb-line); background: var(--control-thumb); box-shadow: var(--control-thumb-lift); }
 .remote-interface-preset:active:not(:disabled) { transform: translateY(1px); }
 .remote-interface-preset:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 .remote-field input, .remote-port-control input[type="number"] {
@@ -1880,7 +1885,7 @@
   font-size: var(--t-sm);
 }
 
-.remote-create { border-color: var(--control-selected-rim); background: var(--control-selected-fill); color: var(--brass-bright); }
+.remote-create { border-color: var(--control-hover-rim); background: var(--control-tint-fill); color: var(--brass-bright); }
 .remote-create:hover:not(:disabled):not(.is-quiet):not(.is-danger) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); color: var(--text-primary); }
 .remote-rotate.is-armed { border-color: color-mix(in oklch, var(--warn) 55%, transparent); background: var(--warn-glow); color: var(--warn-ink); }
 .remote-rotate:hover:not(:disabled):not(.is-armed) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); color: var(--text-primary); }
@@ -2085,9 +2090,9 @@
 
 .theme-card.is-active {
   color: var(--text-primary);
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
-  box-shadow: 0 0 0 1px var(--control-selected-rim), var(--shadow-soft);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift), var(--shadow-soft);
 }
 
 .theme-card:active:not(:disabled) {
@@ -2465,8 +2470,10 @@
   font-size: var(--t-sm);
 }
 
-/* 터미널 렌더러 — 2지선다 세그먼트 컨트롤. 트랙 위 활성 세그먼트만 brass로 채운다. */
+/* 세그먼트 컨트롤 — 배타 선택은 자리(Quiet Controls)로 말한다: 트랙이 한 단 가라앉고
+   활성 세그먼트가 융기 중립 면(thumb)으로 떠오르며, 글자는 잉크 대비(tertiary→primary)가 진다. */
 .segmented {
+  position: relative;
   display: inline-flex;
   flex: none;
   align-self: flex-start;
@@ -2476,10 +2483,37 @@
   padding: 3px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--ink-abyss) 42%, transparent);
+  background: var(--control-track);
+}
+
+/* 미끄러지는 융기면 — JS 훅(use-segmented-thumb)이 활성 세그먼트의 좌표를 얹는다.
+   훅이 아직 자리를 잡지 못했으면(is-placed 없음) 활성 옵션의 자체 face가 그대로 선다. */
+.segmented-thumb {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  opacity: 0;
+  border: 1px solid var(--control-thumb-line);
+  border-radius: var(--radius-xs);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
+  pointer-events: none;
+  transition:
+    transform var(--duration-fast) var(--ease-spring),
+    width var(--duration-fast) var(--ease-spring),
+    height var(--duration-fast) var(--ease-spring);
+}
+
+.segmented-thumb.is-placed { opacity: 1; }
+
+@media (prefers-reduced-motion: reduce) {
+  .segmented-thumb { transition: none; }
 }
 
 .segmented-option {
+  position: relative;
+  z-index: 1;
   min-width: 72px;
   min-height: 30px;
   padding: 5px var(--space-4);
@@ -2503,9 +2537,15 @@
 }
 
 .segmented-option.is-active {
-  background: var(--control-selected-fill);
-  color: var(--brass-ink);
-  box-shadow: inset 0 0 0 1px var(--control-selected-rim), inset 0 -2px 0 var(--brass);
+  background: var(--control-thumb);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px var(--control-thumb-line), var(--control-thumb-lift);
+}
+
+/* 썸이 자리를 잡으면 활성 옵션의 자체 face는 물러난다 — 이중 도장은 슬라이드 중 두 자리를 만든다. */
+.segmented:has(> .segmented-thumb.is-placed) .segmented-option.is-active {
+  background: transparent;
+  box-shadow: none;
 }
 
 .segmented-option:active:not(:disabled) {
@@ -2649,8 +2689,8 @@
 }
 
 .model-auth-button.is-primary {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  border-color: var(--control-hover-rim);
+  background: var(--control-tint-fill);
   color: var(--brass-ink);
 }
 
@@ -2748,7 +2788,7 @@
 
 .backend-api-core-toggle[aria-expanded="true"],
 .backend-api-plugin-toggle[aria-expanded="true"] {
-  background: var(--control-selected-fill);
+  background: var(--control-tint-fill);
   color: var(--brass-bright);
 }
 
@@ -2934,10 +2974,10 @@
   color: var(--text-primary);
 }
 
+/* 열림은 지속 선택이 아니라 순간 상태 — 잉크 워시 하나로 말하고 밑줄 다텀은 두지 않는다. */
 .settings-disclosure-toggle[aria-expanded="true"] {
-  background: var(--control-selected-fill);
+  background: var(--control-tint-fill);
   color: var(--brass-bright);
-  box-shadow: inset 0 -2px 0 var(--brass);
 }
 
 .settings-disclosure-toggle:active:not(:disabled) {
@@ -5358,8 +5398,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 /* 축 스트립은 스크롤 목록 바깥에 고정된 하나짜리 뷰 스위치다 — 커맨드 밴드의
    .command-band-mode-switch와 같은 세그먼트 문법을 사이드바 폭에 맞춰 좁힌 것이고,
-   새 어휘가 아니다. 눌림 채움은 brass(위치 채널)를 oklab에서 섞는다. */
+   새 어휘가 아니다. 눌림은 Quiet Controls의 융기 중립 면(thumb)이 말한다. */
 .operations-side-bar-axis {
+  position: relative;
   display: flex;
   flex: none;
   align-items: center;
@@ -5368,9 +5409,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 2px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
+  background: var(--control-track);
 }
 
 .operations-side-bar-axis-seg {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex: 1;
   align-items: center;
@@ -5402,8 +5446,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .operations-side-bar-axis-seg[aria-pressed="true"] {
-  background: color-mix(in oklab, var(--brass) 12%, transparent);
-  color: var(--brass-ink);
+  background: var(--control-thumb);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px var(--control-thumb-line), var(--control-thumb-lift);
+}
+
+.operations-side-bar-axis:has(> .segmented-thumb.is-placed) .operations-side-bar-axis-seg[aria-pressed="true"] {
+  background: transparent;
+  box-shadow: none;
 }
 
 .operations-side-bar-axis-seg:focus-visible {
@@ -6949,12 +6999,13 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: var(--control-hover-fill);
 }
 
+/* 불리언 ON = 자리 + 글리프 — 면은 융기 중립(thumb)이고 켬을 말하는 accent는 글리프 색뿐이다. */
 .canvas-operation-icon-button.is-active,
 .fleet-caption-action[aria-pressed="true"] {
   color: var(--brass-bright);
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
-  box-shadow: inset 0 -2px 0 var(--brass);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
 }
 
 .canvas-operation-icon-button svg,
@@ -11972,8 +12023,9 @@ body[data-codex-side="true"] .command-card {
    aurora로 칠한 iOS형 스위치를 써서, 같은 켬/끔이 코어와 플러그인 사이에서 다른 색과 다른
    크기로 갈렸다. 켜짐은 선택이므로 brass가 칠하고, aurora는 상태 채널로 돌아간다. */
 .fc-settings-toggle__input:checked + .settings-switch {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
 }
 
 .fc-settings-toggle__input:checked + .settings-switch .settings-switch-knob {
@@ -12294,9 +12346,10 @@ body[data-codex-side="true"] .command-card {
 }
 
 .codex-reader-tool[aria-pressed="true"] {
-  color: var(--text-primary);
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  color: var(--brass-bright);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
 }
 
 .codex-reader-tool:disabled {
@@ -12405,9 +12458,9 @@ body[data-codex-side="true"] .command-card {
   flex: none;
   height: 22px;
   padding: 0 var(--space-2);
-  border: 1px solid var(--control-selected-rim);
+  border: 1px solid var(--surface-rim);
   border-radius: var(--radius-pill);
-  background: var(--control-selected-fill);
+  background: var(--control-tint-fill);
   color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
@@ -13209,7 +13262,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
 }
 .fc-select__trigger:hover:not(:disabled):not([aria-expanded="true"]) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); }
 .fc-select__trigger:focus-visible { border-color: var(--control-hover-rim); outline: 2px solid var(--control-focus-ring); outline-offset: 2px; }
-.fc-select__trigger[aria-expanded="true"] { border-color: var(--control-selected-rim); background: var(--control-selected-fill); }
+.fc-select__trigger[aria-expanded="true"] { border-color: var(--control-open-rim); background: var(--control-tint-fill); }
 .fc-select__trigger:active:not(:disabled) { transform: translateY(1px); }
 .fc-select__trigger:disabled { opacity: var(--control-disabled-opacity); cursor: not-allowed; }
 .fc-select__caret { color: var(--text-tertiary); font-size: var(--t-xs); transition: transform var(--duration-fast) var(--ease-glide); }
@@ -13233,7 +13286,7 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
   transition: background var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
 .fc-select__option[data-active="true"]:not([aria-disabled="true"]):not([aria-selected="true"]) { border-color: var(--control-hover-rim); background: var(--control-hover-fill); color: var(--text-primary); }
-.fc-select__option[aria-selected="true"] { border-color: var(--control-selected-rim); background: var(--control-selected-fill); color: var(--brass-bright); }
+.fc-select__option[aria-selected="true"] { border-color: var(--control-thumb-line); background: var(--control-thumb); color: var(--text-primary); box-shadow: var(--control-thumb-lift); }
 .fc-select__option[aria-selected="true"]::after { content: "✓"; font-size: var(--t-xs); color: var(--brass-bright); }
 .fc-select__option[aria-disabled="true"] { color: var(--text-tertiary); cursor: not-allowed; font-style: italic; opacity: var(--control-disabled-opacity); }
 .fc-select__option[aria-disabled="true"][data-active="true"] { background: transparent; border-color: transparent; color: var(--text-tertiary); }

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -630,12 +630,13 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   color: var(--text-primary);
 }
 
-/* 눌린 아이콘 버튼은 밴드의 다른 토글과 같은 문법으로 말한다 — .command-band-mode-seg·
-   .command-band-mode-tool이 쓰는 brass 채움이며, War Room 스포트라이트처럼 불리언 토글도
-   이미 이 문법을 입고 있다. 이 규칙이 없던 동안 aria-pressed는 접근성 트리에만 존재하고
-   화면에는 아무 흔적도 남기지 않았다. */
+/* 눌린 아이콘 버튼은 밴드의 다른 토글과 같은 문법으로 말한다 — 불리언 ON = 자리 + 글리프.
+   면은 융기 중립(thumb)이고 켬을 말하는 accent는 글리프의 brass뿐이다. 이 규칙이 없던 동안
+   aria-pressed는 접근성 트리에만 존재하고 화면에는 아무 흔적도 남기지 않았다. */
 .command-band-button[aria-pressed="true"] {
-  background: var(--control-selected-fill);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
   color: var(--brass-ink);
 }
 
@@ -660,6 +661,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 /* Cruise / Tactical / War Room — 캔버스 모드는 이 세그먼트 스위치 하나만 소유한다.
    모드 전용 도구는 오른쪽 트레이에 붙으므로, 다른 모드의 도구는 애초에 존재하지 않는다. */
 .command-band-mode-switch {
+  position: relative;
   display: flex;
   flex: none;
   align-items: center;
@@ -667,10 +669,12 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   padding: 2px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
-  background: color-mix(in oklab, var(--surface-glass) 62%, transparent);
+  background: var(--control-track);
 }
 
 .command-band-mode-seg {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex: none;
   align-items: center;
@@ -686,7 +690,8 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 }
 
 /* hover는 경계와 낮은 wash로 다음 행동만 예고하고, focus는 전역 외곽 링을 보존한다.
-   활성 모드는 wash 아래 짧은 datum을 더해 인접 도구의 pressed 면과 형상으로 갈린다. */
+   활성 모드는 Quiet Controls의 융기 중립 면(thumb)이다 — 인접 도구의 pressed 면과는
+   글리프 accent 유무(모드는 잉크 대비, 불리언 도구는 brass 글리프)로 갈린다. */
 .command-band-mode-seg:hover:not(:disabled):not([aria-pressed="true"]),
 .command-band-mode-seg:focus-visible:not([aria-pressed="true"]) {
   border-color: var(--control-hover-rim);
@@ -695,21 +700,16 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 }
 
 .command-band-mode-seg[aria-pressed="true"] {
-  position: relative;
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
-  color: var(--brass-ink);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  color: var(--text-primary);
+  box-shadow: var(--control-thumb-lift);
 }
 
-.command-band-mode-seg[aria-pressed="true"]::after {
-  position: absolute;
-  right: var(--space-2);
-  bottom: -3px;
-  left: var(--space-2);
-  height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brass);
-  content: "";
+.command-band-mode-switch:has(> .segmented-thumb.is-placed) .command-band-mode-seg[aria-pressed="true"] {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
 }
 
 .command-band-mode-seg:active:not(:disabled) { transform: translateY(1px); }
@@ -768,8 +768,9 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 }
 
 .command-band-mode-tool[aria-pressed="true"] {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
   color: var(--brass-ink);
 }
 
@@ -864,8 +865,8 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 }
 
 .command-band-segment-trigger.is-open {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  border-color: var(--control-open-rim);
+  background: var(--control-tint-fill);
   color: var(--text-primary);
 }
 
@@ -949,7 +950,8 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 
 .command-band-menu-item.is-active {
   color: var(--text-primary);
-  background: var(--control-selected-fill);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
 }
 
 .command-band-menu-item.is-active::before {

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -630,13 +630,12 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   color: var(--text-primary);
 }
 
-/* 눌린 아이콘 버튼은 밴드의 다른 토글과 같은 문법으로 말한다 — 불리언 ON = 자리 + 글리프.
-   면은 융기 중립(thumb)이고 켬을 말하는 accent는 글리프의 brass뿐이다. 이 규칙이 없던 동안
+/* 눌린 아이콘 버튼은 밴드의 다른 토글과 같은 문법으로 말한다 — 불리언 ON = 워시 + 글리프.
+   면은 극저대비 워시이고 켬을 말하는 accent는 글리프의 brass뿐이다. 이 규칙이 없던 동안
    aria-pressed는 접근성 트리에만 존재하고 화면에는 아무 흔적도 남기지 않았다. */
 .command-band-button[aria-pressed="true"] {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
   color: var(--brass-ink);
 }
 
@@ -659,17 +658,20 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls { transition: none; }
 
 /* Cruise / Tactical / War Room — 캔버스 모드는 이 세그먼트 스위치 하나만 소유한다.
-   모드 전용 도구는 오른쪽 트레이에 붙으므로, 다른 모드의 도구는 애초에 존재하지 않는다. */
+   모드 전용 도구는 오른쪽 트레이에 붙으므로, 다른 모드의 도구는 애초에 존재하지 않는다.
+   C′ 문법: 상자를 걷고 워시+다텀이 선택을 말한다 — 그룹 경계는 간격이 진다. */
 .command-band-mode-switch {
   position: relative;
   display: flex;
   flex: none;
   align-items: center;
-  gap: 2px;
-  padding: 2px;
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
-  background: var(--control-track);
+  gap: var(--space-1);
+}
+
+/* 24px 높이의 좁은 세그먼트는 다텀도 한 치수 좁게 선다. */
+.command-band-mode-switch > .segmented-thumb::after {
+  bottom: 2px;
+  width: 12px;
 }
 
 .command-band-mode-seg {
@@ -689,31 +691,54 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   font-weight: var(--weight-bold);
 }
 
-/* hover는 경계와 낮은 wash로 다음 행동만 예고하고, focus는 전역 외곽 링을 보존한다.
-   활성 모드는 Quiet Controls의 융기 중립 면(thumb)이다 — 인접 도구의 pressed 면과는
-   글리프 accent 유무(모드는 잉크 대비, 불리언 도구는 brass 글리프)로 갈린다. */
+/* hover는 같은 워시 계열의 약한 단으로 예고하고, focus는 전역 외곽 링을 보존한다.
+   활성 모드는 워시+잉크 대비+다텀이다 — 인접 불리언 도구의 pressed 면과는
+   글리프 accent 유무(모드는 잉크 대비+다텀, 불리언 도구는 brass 글리프)로 갈린다. */
 .command-band-mode-seg:hover:not(:disabled):not([aria-pressed="true"]),
 .command-band-mode-seg:focus-visible:not([aria-pressed="true"]) {
-  border-color: var(--control-hover-rim);
-  background: var(--control-hover-fill);
-  color: var(--text-primary);
+  background: var(--control-wash-hover);
+  color: var(--text-secondary);
 }
 
 .command-band-mode-seg[aria-pressed="true"] {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
+  background: var(--control-wash);
   color: var(--text-primary);
-  box-shadow: var(--control-thumb-lift);
+}
+
+.command-band-mode-seg[aria-pressed="true"]::after {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  width: 12px;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  transform: translateX(-50%);
+  content: "";
 }
 
 .command-band-mode-switch:has(> .segmented-thumb.is-placed) .command-band-mode-seg[aria-pressed="true"] {
-  border-color: transparent;
   background: transparent;
-  box-shadow: none;
+}
+
+.command-band-mode-switch:has(> .segmented-thumb.is-placed) .command-band-mode-seg[aria-pressed="true"]::after {
+  content: none;
 }
 
 .command-band-mode-seg:active:not(:disabled) { transform: translateY(1px); }
 .command-band-mode-seg:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
+
+/* 고대비(forced-colors) — 워시가 걷히는 환경에서는 밴드의 선택·눌림을 시스템 선택색으로 말한다. */
+@media (forced-colors: active) {
+  .command-band-mode-seg[aria-pressed="true"],
+  .command-band-mode-switch:has(> .segmented-thumb.is-placed) .command-band-mode-seg[aria-pressed="true"],
+  .command-band-button[aria-pressed="true"],
+  .command-band-mode-tool[aria-pressed="true"],
+  .command-band-menu-item.is-active {
+    background: SelectedItem;
+    color: SelectedItemText;
+  }
+}
 
 .command-band-mode-tray {
   display: flex;
@@ -768,9 +793,8 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 }
 
 .command-band-mode-tool[aria-pressed="true"] {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
   color: var(--brass-ink);
 }
 
@@ -950,8 +974,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 
 .command-band-menu-item.is-active {
   color: var(--text-primary);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  background: var(--control-wash);
 }
 
 .command-band-menu-item.is-active::before {

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -396,23 +396,22 @@
   --duration-base: 220ms;
   --duration-slow: 360ms;
 
-  /* 상호작용 컨트롤의 상태 recipe(Quiet Controls) — rest는 각 소비처의 중립 면이 맡고,
-     hover는 예고(brass 워시), focus는 입력 수단의 별도 외곽 링이다. "지속" 상태는 accent가
-     아니라 세 문장으로 갈린다: 배타 선택 = 자리(--control-thumb 융기 중립 면 + 잉크 대비),
-     독립 ON = 잉크(--control-tint-* 저채도 워시), 불리언 ON = 자리 + brass 글리프.
-     열림(aria-expanded·is-open)과 필드 focus-within은 지속이 아니라 순간이므로
-     --control-open-rim이 진다. 선택이 brass 소비를 멈추므로 "brass = 위치·포커스·호버"
-     채널 계약은 이 recipe로 좁아진다(넓어지지 않는다). track/thumb 리터럴은 각 테마
-     블록이 자기 잉크 스케일에서 재조율한다 — thumb은 잉크 사다리의 한 칸이 아니라
-     패널 면에서 한 단 융기한 값이라 별도 채널이다. */
+  /* 상호작용 컨트롤의 상태 recipe(Quiet Controls C′) — rest는 각 소비처의 중립 면이 맡고,
+     focus는 입력 수단의 별도 외곽 링이다. "지속" 상태는 accent가 아니라 세 문장으로 갈린다:
+     배타 선택 = 극저대비 중립 워시(--control-wash) + 잉크 대비 + 2px brass 다텀 한 점,
+     독립 ON = 잉크(--control-tint-* 저채도 워시), 불리언 ON = 워시 + brass 글리프.
+     상자·테두리·그림자는 선택을 말하지 않는다 — 융기(thumb) 문법은 실기 기각으로 퇴역했다.
+     세그먼트의 hover는 같은 워시 계열의 약한 단(--control-wash-hover)이고, 그 밖의 컨트롤
+     hover는 기존 brass 예고를 유지한다. 열림(aria-expanded·is-open)과 필드 focus-within은
+     지속이 아니라 순간이므로 --control-open-rim이 진다. 선택이 brass를 다텀 한 점으로만
+     소비하므로 "brass = 위치·포커스·호버" 채널 계약은 좁아진다. 워시 리터럴은 각 테마
+     블록이 자기 잉크 위에서 재조율한다 — 다크는 화이트 워시, 라이트는 잉크 워시로 극이 뒤집힌다. */
   --control-hover-fill: color-mix(in oklab, var(--brass) 8%, transparent);
   --control-hover-rim: color-mix(in oklab, var(--brass) 42%, var(--surface-rim));
-  --control-track: oklch(10% 0.014 245 / 80%);
-  --control-thumb: oklch(26.5% 0.022 245);
-  --control-thumb-line: transparent;
-  --control-thumb-lift: 0 1px 2px oklch(0% 0 0 / 45%), inset 0 1px 0 oklch(96% 0.01 90 / 8%);
-  --control-tint-fill: color-mix(in oklab, var(--brass) 11%, transparent);
-  --control-tint-ink: color-mix(in oklab, var(--brass-ink) 62%, var(--text-primary));
+  --control-wash: oklch(96% 0.01 90 / 7%);
+  --control-wash-hover: oklch(96% 0.01 90 / 4%);
+  --control-tint-fill: color-mix(in oklab, var(--brass) 9%, transparent);
+  --control-tint-ink: color-mix(in oklab, var(--brass-ink) 55%, var(--text-primary));
   --control-open-rim: color-mix(in oklab, var(--brass) 56%, var(--surface-rim));
   --control-focus-ring: var(--brass);
   --control-disabled-opacity: 0.5;
@@ -537,10 +536,9 @@
   --hairline: oklch(36% 0.035 248);
   --hairline-strong: oklch(48% 0.03 248);
 
-  /* Quiet Controls 융기면 — 감청 잉크의 mid(28%)와 veil(36%) 사이에서 채도를 유지한 채 떠오른다. */
-  --control-track: oklch(13% 0.035 248 / 72%);
-  --control-thumb: oklch(31.5% 0.042 248);
-  --control-thumb-lift: 0 1px 2px oklch(0% 0 0 / 48%), inset 0 1px 0 oklch(96% 0.012 88 / 10%);
+  /* Quiet Controls 워시 — pearl(hue 88) 화이트를 얹어 감청 위에서도 워시가 차갑게 식지 않는다. */
+  --control-wash: oklch(96% 0.012 88 / 8%);
+  --control-wash-hover: oklch(96% 0.012 88 / 4.5%);
 
   --id-crimson: oklch(74% 0.09 25);
   --id-amber: oklch(78% 0.088 70);
@@ -651,10 +649,9 @@
   --hairline: oklch(33% 0.006 252);
   --hairline-strong: oklch(45% 0.005 252);
 
-  /* Quiet Controls 융기면 — 무채 흑연 한 단. 선택마저 무채가 되고 구리색은 focus·글리프에만 남는다. */
-  --control-track: oklch(11% 0.006 255 / 80%);
-  --control-thumb: oklch(28% 0.008 252);
-  --control-thumb-lift: 0 1px 2px oklch(0% 0 0 / 48%), inset 0 1px 0 oklch(95% 0.003 250 / 8%);
+  /* Quiet Controls 워시 — 무채 화이트 한 겹. 선택마저 무채가 되고 구리색은 다텀·focus·글리프에만 남는다. */
+  --control-wash: oklch(95% 0.003 250 / 7%);
+  --control-wash-hover: oklch(95% 0.003 250 / 4%);
 
   --id-crimson: oklch(72% 0.052 25);
   --id-amber: oklch(76% 0.05 70);
@@ -819,12 +816,10 @@
   --hairline: oklch(86% 0.01 100);
   --hairline-strong: oklch(76% 0.014 100);
 
-  /* Quiet Controls 융기면 — 종이 위 흰 카드. 라이트는 그림자가 부양을 말하므로 thumb-line
-     헤어라인이 단면을 마감하고, lift는 다크의 inset 광원 대신 접촉+대기 두 겹 그늘이다. */
-  --control-track: oklch(91% 0.008 100);
-  --control-thumb: oklch(99.4% 0.003 100);
-  --control-thumb-line: oklch(38% 0.02 95 / 12%);
-  --control-thumb-lift: 0 1px 1px oklch(30% 0.015 95 / 14%), 0 2px 5px -1px oklch(30% 0.015 95 / 26%);
+  /* Quiet Controls 워시 — 종이 위 잉크 극. 다크의 화이트 워시를 그대로 반전하면 백지 위
+     백워시라 지각 불가이므로, 라이트만 어두운 잉크를 낮은 알파로 얹는다. */
+  --control-wash: oklch(30% 0.015 95 / 6.5%);
+  --control-wash-hover: oklch(30% 0.015 95 / 3.5%);
 
   --shadow-soft: 0 1px 0 0 oklch(99.5% 0.004 100 / 70%) inset, 0 18px 38px -22px oklch(30% 0.015 95 / 26%);
   --shadow-floating: 0 1px 0 0 oklch(99.5% 0.004 100 / 80%) inset, 0 32px 60px -28px oklch(28% 0.015 95 / 30%);

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -396,13 +396,24 @@
   --duration-base: 220ms;
   --duration-slow: 360ms;
 
-  /* 상호작용 컨트롤의 상태 recipe — 색 역할을 새로 만들지 않고 위치 채널(brass)을
-     한 강도 사다리로 묶는다. rest는 각 소비처의 중립 면이 맡고, hover는 예고,
-     selected는 지속 위치, focus는 입력 수단의 별도 외곽 링이다. */
+  /* 상호작용 컨트롤의 상태 recipe(Quiet Controls) — rest는 각 소비처의 중립 면이 맡고,
+     hover는 예고(brass 워시), focus는 입력 수단의 별도 외곽 링이다. "지속" 상태는 accent가
+     아니라 세 문장으로 갈린다: 배타 선택 = 자리(--control-thumb 융기 중립 면 + 잉크 대비),
+     독립 ON = 잉크(--control-tint-* 저채도 워시), 불리언 ON = 자리 + brass 글리프.
+     열림(aria-expanded·is-open)과 필드 focus-within은 지속이 아니라 순간이므로
+     --control-open-rim이 진다. 선택이 brass 소비를 멈추므로 "brass = 위치·포커스·호버"
+     채널 계약은 이 recipe로 좁아진다(넓어지지 않는다). track/thumb 리터럴은 각 테마
+     블록이 자기 잉크 스케일에서 재조율한다 — thumb은 잉크 사다리의 한 칸이 아니라
+     패널 면에서 한 단 융기한 값이라 별도 채널이다. */
   --control-hover-fill: color-mix(in oklab, var(--brass) 8%, transparent);
   --control-hover-rim: color-mix(in oklab, var(--brass) 42%, var(--surface-rim));
-  --control-selected-fill: color-mix(in oklab, var(--brass) 12%, transparent);
-  --control-selected-rim: color-mix(in oklab, var(--brass) 56%, var(--surface-rim));
+  --control-track: oklch(10% 0.014 245 / 80%);
+  --control-thumb: oklch(26.5% 0.022 245);
+  --control-thumb-line: transparent;
+  --control-thumb-lift: 0 1px 2px oklch(0% 0 0 / 45%), inset 0 1px 0 oklch(96% 0.01 90 / 8%);
+  --control-tint-fill: color-mix(in oklab, var(--brass) 11%, transparent);
+  --control-tint-ink: color-mix(in oklab, var(--brass-ink) 62%, var(--text-primary));
+  --control-open-rim: color-mix(in oklab, var(--brass) 56%, var(--surface-rim));
   --control-focus-ring: var(--brass);
   --control-disabled-opacity: 0.5;
 
@@ -526,6 +537,11 @@
   --hairline: oklch(36% 0.035 248);
   --hairline-strong: oklch(48% 0.03 248);
 
+  /* Quiet Controls 융기면 — 감청 잉크의 mid(28%)와 veil(36%) 사이에서 채도를 유지한 채 떠오른다. */
+  --control-track: oklch(13% 0.035 248 / 72%);
+  --control-thumb: oklch(31.5% 0.042 248);
+  --control-thumb-lift: 0 1px 2px oklch(0% 0 0 / 48%), inset 0 1px 0 oklch(96% 0.012 88 / 10%);
+
   --id-crimson: oklch(74% 0.09 25);
   --id-amber: oklch(78% 0.088 70);
   --id-moss: oklch(76% 0.085 140);
@@ -634,6 +650,11 @@
 
   --hairline: oklch(33% 0.006 252);
   --hairline-strong: oklch(45% 0.005 252);
+
+  /* Quiet Controls 융기면 — 무채 흑연 한 단. 선택마저 무채가 되고 구리색은 focus·글리프에만 남는다. */
+  --control-track: oklch(11% 0.006 255 / 80%);
+  --control-thumb: oklch(28% 0.008 252);
+  --control-thumb-lift: 0 1px 2px oklch(0% 0 0 / 48%), inset 0 1px 0 oklch(95% 0.003 250 / 8%);
 
   --id-crimson: oklch(72% 0.052 25);
   --id-amber: oklch(76% 0.05 70);
@@ -797,6 +818,13 @@
 
   --hairline: oklch(86% 0.01 100);
   --hairline-strong: oklch(76% 0.014 100);
+
+  /* Quiet Controls 융기면 — 종이 위 흰 카드. 라이트는 그림자가 부양을 말하므로 thumb-line
+     헤어라인이 단면을 마감하고, lift는 다크의 inset 광원 대신 접촉+대기 두 겹 그늘이다. */
+  --control-track: oklch(91% 0.008 100);
+  --control-thumb: oklch(99.4% 0.003 100);
+  --control-thumb-line: oklch(38% 0.02 95 / 12%);
+  --control-thumb-lift: 0 1px 1px oklch(30% 0.015 95 / 14%), 0 2px 5px -1px oklch(30% 0.015 95 / 26%);
 
   --shadow-soft: 0 1px 0 0 oklch(99.5% 0.004 100 / 70%) inset, 0 18px 38px -22px oklch(30% 0.015 95 / 26%);
   --shadow-floating: 0 1px 0 0 oklch(99.5% 0.004 100 / 80%) inset, 0 32px 60px -28px oklch(28% 0.015 95 / 30%);

--- a/runtime/fleet-console/font-picker/styles.css
+++ b/runtime/fleet-console/font-picker/styles.css
@@ -87,12 +87,18 @@
   border-color: var(--control-hover-rim);
   background: var(--control-hover-fill);
 }
-/* The chosen font stays marked as the raised neutral seat (Quiet Controls thumb)
+/* The chosen font stays marked as the quiet neutral wash (Quiet Controls C')
    even when keyboard focus moves elsewhere, so a click highlights it immediately. */
 .fc-font-browser__row[aria-selected="true"] {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
+}
+
+@media (forced-colors: active) {
+  .fc-font-browser__row[aria-selected="true"] {
+    background: SelectedItem;
+    color: SelectedItemText;
+  }
 }
 .fc-font-browser__row.is-unavailable,
 .fc-font-browser[data-disabled="true"] { opacity: var(--control-disabled-opacity); }

--- a/runtime/fleet-console/font-picker/styles.css
+++ b/runtime/fleet-console/font-picker/styles.css
@@ -87,11 +87,12 @@
   border-color: var(--control-hover-rim);
   background: var(--control-hover-fill);
 }
-/* The chosen font stays marked with a soft brass fill (brass = current selection)
+/* The chosen font stays marked as the raised neutral seat (Quiet Controls thumb)
    even when keyboard focus moves elsewhere, so a click highlights it immediately. */
 .fc-font-browser__row[aria-selected="true"] {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
 }
 .fc-font-browser__row.is-unavailable,
 .fc-font-browser[data-disabled="true"] { opacity: var(--control-disabled-opacity); }

--- a/runtime/fleet-console/sdk/react/browser.tsx
+++ b/runtime/fleet-console/sdk/react/browser.tsx
@@ -446,14 +446,14 @@ export function Select({
 }
 
 /**
- * Quiet Controls의 미끄러지는 융기면(thumb).
+ * Quiet Controls C′의 미끄러지는 워시(+다텀).
  *
  * 세그먼트 컨테이너(position: relative)의 첫 자식으로 넣으면, 활성 옵션
  * (`aria-pressed="true"` 또는 `.is-active`)의 offset 좌표 위에 `.segmented-thumb`
  * 장식을 얹고 선택 이동을 미끄러짐으로 잇는다. 시각과 전환은 전부 CSS 토큰
- * (--control-thumb*)과 CSS transition이 지므로 prefers-reduced-motion 단락도
- * CSS에서 함께 닫힌다. 자리를 잡기 전(is-placed 없음)에는 활성 옵션의 자체
- * face가 그대로 서므로 JS가 늦는 프레임에도 선택 상태는 항상 보인다.
+ * (--control-wash·brass 다텀)과 CSS transition이 지므로 prefers-reduced-motion
+ * 단락도 CSS에서 함께 닫힌다. 자리를 잡기 전(is-placed 없음)에는 활성 옵션의
+ * 자체 face가 그대로 서므로 JS가 늦는 프레임에도 선택 상태는 항상 보인다.
  */
 export function SegmentedThumb({
   activeSelector = '[aria-pressed="true"], .is-active',

--- a/runtime/fleet-console/sdk/react/browser.tsx
+++ b/runtime/fleet-console/sdk/react/browser.tsx
@@ -444,3 +444,80 @@ export function Select({
     </div>
   );
 }
+
+/**
+ * Quiet Controls의 미끄러지는 융기면(thumb).
+ *
+ * 세그먼트 컨테이너(position: relative)의 첫 자식으로 넣으면, 활성 옵션
+ * (`aria-pressed="true"` 또는 `.is-active`)의 offset 좌표 위에 `.segmented-thumb`
+ * 장식을 얹고 선택 이동을 미끄러짐으로 잇는다. 시각과 전환은 전부 CSS 토큰
+ * (--control-thumb*)과 CSS transition이 지므로 prefers-reduced-motion 단락도
+ * CSS에서 함께 닫힌다. 자리를 잡기 전(is-placed 없음)에는 활성 옵션의 자체
+ * face가 그대로 서므로 JS가 늦는 프레임에도 선택 상태는 항상 보인다.
+ */
+export function SegmentedThumb({
+  activeSelector = '[aria-pressed="true"], .is-active',
+}: {
+  readonly activeSelector?: string;
+} = {}): React.ReactElement {
+  const thumbRef = React.useRef<HTMLSpanElement | null>(null);
+
+  React.useLayoutEffect(() => {
+    const thumb = thumbRef.current;
+    const host = thumb?.parentElement;
+    if (!thumb || !host) return;
+
+    const place = () => {
+      const active = host.querySelector<HTMLElement>(activeSelector);
+      // display:none 조상 아래에서는 offsetWidth가 0이다 — 그 좌표로 자리를 잡으면
+      // 탭 복귀 프레임에 0폭 썸이 미끄러진다. 자리를 걷고 face 폴백에 맡긴다.
+      // classList.add/remove는 값이 그대로여도 class 어트리뷰트를 다시 써서 MutationObserver
+      // 레코드를 만든다 — 무조건 쓰면 아래 관찰과 무한 반향이 된다. 변할 때만 쓴다.
+      if (!active || active.offsetWidth === 0) {
+        if (thumb.classList.contains("is-placed")) thumb.classList.remove("is-placed");
+        return;
+      }
+      // 첫 자리 잡기(또는 숨김 복귀)는 이동이 아니라 등장이다 — 좌상단 원점에서
+      // 미끄러져 들어오는 유령 슬라이드가 보이지 않도록 전환 없이 앉힌다.
+      const firstPlacement = !thumb.classList.contains("is-placed");
+      if (firstPlacement) thumb.style.transition = "none";
+      thumb.style.width = `${active.offsetWidth}px`;
+      thumb.style.height = `${active.offsetHeight}px`;
+      thumb.style.transform = `translate(${active.offsetLeft}px, ${active.offsetTop}px)`;
+      if (firstPlacement) {
+        thumb.classList.add("is-placed");
+        void thumb.offsetWidth;
+        thumb.style.transition = "";
+      }
+    };
+
+    place();
+    // 크기 변화(RO)와 활성 표식 변화(MO)를 함께 듣는다 — aria-pressed 토글은
+    // 컨테이너의 어떤 크기도 바꾸지 않으므로 ResizeObserver만으로는 놓친다.
+    // jsdom에는 ResizeObserver가 없다 — 관찰만 건너뛰고 place()는 항상 달린다
+    // (조기 반환으로 훅 전체를 잠그면 테스트 환경이 배치 로직까지 잃는다).
+    const resizeObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(place);
+    if (resizeObserver) {
+      resizeObserver.observe(host);
+      for (const child of host.children) {
+        if (child !== thumb) resizeObserver.observe(child);
+      }
+    }
+    const mutationObserver = new MutationObserver((records) => {
+      // thumb 자신의 표식 변화는 place()의 메아리다 — 되울리면 무한 루프로 렌더러가 잠긴다.
+      if (records.every((record) => record.target === thumb)) return;
+      place();
+    });
+    mutationObserver.observe(host, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["aria-pressed", "class"],
+    });
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [activeSelector]);
+
+  return <span ref={thumbRef} className="segmented-thumb" aria-hidden="true" />;
+}

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -501,16 +501,33 @@ describe("Instrument core design contract", () => {
   it("keeps the interaction control recipe theme-owned", () => {
     const theme = source("styles/theme.css");
     const root = theme.match(/^:root \{[\s\S]*?^\}/m)?.[0] ?? "";
+    // Quiet Controls: 지속 상태는 accent가 아니라 세 문장으로 갈린다 — 배타 선택 = 자리(thumb),
+    // 독립 ON = 잉크(tint), 불리언 ON = 자리 + brass 글리프. 열림·focus-within은 open-rim이 진다.
     for (const token of [
       "--control-hover-fill",
       "--control-hover-rim",
-      "--control-selected-fill",
-      "--control-selected-rim",
+      "--control-track",
+      "--control-thumb",
+      "--control-thumb-line",
+      "--control-thumb-lift",
+      "--control-tint-fill",
+      "--control-tint-ink",
+      "--control-open-rim",
       "--control-focus-ring",
       "--control-disabled-opacity",
     ]) expect(root).toContain(`${token}:`);
     expect(root).toContain("--control-hover-fill: color-mix(in oklab, var(--brass) 8%, transparent);");
-    expect(root).toContain("--control-selected-rim: color-mix(in oklab, var(--brass) 56%, var(--surface-rim));");
+    expect(root).toContain("--control-tint-fill: color-mix(in oklab, var(--brass) 11%, transparent);");
+    expect(root).toContain("--control-open-rim: color-mix(in oklab, var(--brass) 56%, var(--surface-rim));");
+    // 융기면은 잉크 사다리의 한 칸이 아니라 테마별 리터럴이다 — 네 테마가 각자 재조율한다.
+    // carbon 셀렉터는 공유 legacy 블록에도 서므로, 개별 블록 중 하나가 재조율을 실으면 된다.
+    for (const name of ["maritime", "carbon", "whites"]) {
+      const blocks = theme.match(new RegExp(`^:root\\[data-theme="${name}"\\] \\{[\\s\\S]*?\\n\\}`, "gm")) ?? [];
+      expect(blocks.some((block) => block.includes("--control-thumb:") && block.includes("--control-track:"))).toBe(true);
+    }
+    // 옛 selected recipe(테두리+채움+brass 글자 동시 발화)는 퇴역했다 — 부활 금지.
+    expect(theme).not.toContain("--control-selected-fill");
+    expect(theme).not.toContain("--control-selected-rim");
     expect(theme).toMatch(/:focus-visible \{[^}]*outline: 2px solid var\(--control-focus-ring\);/);
   });
 
@@ -551,8 +568,9 @@ describe("Instrument core design contract", () => {
     for (const token of [
       "var(--control-hover-fill)",
       "var(--control-hover-rim)",
-      "var(--control-selected-fill)",
-      "var(--control-selected-rim)",
+      "var(--control-thumb)",
+      "var(--control-thumb-line)",
+      "var(--control-thumb-lift)",
       "var(--control-focus-ring)",
       "var(--control-disabled-opacity)",
     ]) {
@@ -560,6 +578,9 @@ describe("Instrument core design contract", () => {
       expect(terminalSettings).toContain(token);
       expect(fontPicker).toContain(token);
     }
+    // 독립 ON 칩(EFFORT 사다리)은 잉크 문법을 소비한다 — 자리(thumb)를 세우면 줄이 키보드가 된다.
+    expect(terminalSettings).toContain("var(--control-tint-fill)");
+    expect(terminalSettings).toContain("var(--control-tint-ink)");
     expect(fontPicker).toContain('.fc-font-browser__row:hover:not(:disabled):not(.is-active):not([aria-selected="true"])');
     expect(fontPicker).toContain('@media (forced-colors: active)');
     expect(components).toContain('.fc-settings-toggle:has(.fc-settings-toggle__input:focus-visible)');
@@ -579,12 +600,14 @@ describe("Instrument core design contract", () => {
     const svgSize = components.match(/\.canvas-operation-icon-button svg,\n\.fleet-caption-action svg \{[^}]*\}/)?.[0] ?? "";
     expect(svgSize).toContain("width: 14px;");
 
-    // 선택·hover는 theme.css의 oklab control recipe 하나를 소비한다. hover와 focus를 한
+    // 선택·hover는 theme.css의 control recipe 하나를 소비한다. hover와 focus를 한
     // 선택자로 합치면 마우스를 스칠 때도 외곽 focus ring이 떠 입력 수단의 신호가 사라진다.
+    // 불리언 ON = 자리 + 글리프: 면은 융기 중립(thumb)이고 켬은 글리프의 brass가 말한다.
     const pressed = components.match(/\.canvas-operation-icon-button\.is-active,\n\.fleet-caption-action\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(pressed).toContain("border-color: var(--control-selected-rim);");
-    expect(pressed).toContain("background: var(--control-selected-fill);");
-    expect(pressed).toContain("box-shadow: inset 0 -2px 0 var(--brass);");
+    expect(pressed).toContain("border-color: var(--control-thumb-line);");
+    expect(pressed).toContain("background: var(--control-thumb);");
+    expect(pressed).toContain("box-shadow: var(--control-thumb-lift);");
+    expect(pressed).toContain("color: var(--brass-bright);");
     const hover = components.match(/\.canvas-operation-icon-button:hover:not\(\.is-active\),\n\.fleet-caption-action:hover:not\(:disabled\):not\(\[aria-pressed="true"\]\) \{[^}]*\}/)?.[0] ?? "";
     expect(hover).toContain("border-color: var(--control-hover-rim);");
     expect(hover).toContain("background: var(--control-hover-fill);");
@@ -1497,11 +1520,12 @@ describe("Instrument core design contract", () => {
     expect(shell).not.toContain("overflow: hidden;");
 
     // 켜진 단계는 사다리 위의 위치이지 Operation 상태가 아니다 — 신호색을 빌리면 같은 카드의
-    // 활동 축과 충돌하므로, 코어 segmented와 같은 brass 워시+brass ink+inset 링만 쓴다.
+    // 활동 축과 충돌한다. 독립 ON은 잉크 문법이다: 저채도 tint 워시+잉크 대비만 쓰고,
+    // 테두리 링·자리(thumb)는 두지 않는다(다중 on 칩 줄에 자리를 세우면 키보드가 된다).
     const on = css.match(/\.ai-gateway-effort-level\.is-on \{[^}]*\}/)?.[0] ?? "";
-    expect(on).toContain("background: var(--control-selected-fill);");
-    expect(on).toContain("color: var(--brass-ink);");
-    expect(on).toContain("box-shadow: inset 0 0 0 1px var(--control-selected-rim);");
+    expect(on).toContain("background: var(--control-tint-fill);");
+    expect(on).toContain("color: var(--control-tint-ink);");
+    expect(on).not.toContain("box-shadow");
     for (const [, , body] of css.matchAll(/([^{}]*\.ai-gateway-effort[^{}]*)\{([^}]*)\}/g)) {
       expect(body).not.toMatch(/var\(--(aurora|warn|coral|positive)[a-z-]*\)/);
     }
@@ -2269,19 +2293,22 @@ describe("Instrument core design contract", () => {
     expect(whatsNewOverlayBlock).toContain("z-index: 35;");
     // 모달 뒤로 물러나는 것은 떠 있는 밴드뿐이다 — 도킹된 밴드에 걸면 44px 빈 띠만 남는다.
     expect(layout).toContain('body:has([aria-modal="true"]:not([hidden])) .command-band.is-fullscreen:not(.is-docked),');
-    // aria-pressed가 화면에 흔적을 남기지 않던 회귀를 막는다 — 밴드 토글의 눌림은 brass 채움이다.
+    // aria-pressed가 화면에 흔적을 남기지 않던 회귀를 막는다 — 불리언 토글의 눌림은
+    // 자리(thumb) + brass 글리프다.
     const pressedBandButtonBlock = layout.match(/\.command-band-button\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(pressedBandButtonBlock).toContain("background: var(--control-selected-fill);");
+    expect(pressedBandButtonBlock).toContain("background: var(--control-thumb);");
     expect(pressedBandButtonBlock).toContain("color: var(--brass-ink);");
-    // 캔버스 모드는 선택 datum을 가져 인접 도구의 pressed 면과 형상으로 갈린다.
+    // 캔버스 모드는 배타 선택 = 자리다 — 융기 중립 면 + 잉크 대비이며, 인접 불리언 도구와는
+    // 글리프 accent 유무로 갈린다. 옛 밑줄 datum은 퇴역했다.
     const modePressedBlock = layout.match(/\.command-band-mode-seg\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(modePressedBlock).toContain("border-color: var(--control-selected-rim);");
-    expect(modePressedBlock).toContain("background: var(--control-selected-fill);");
-    expect(layout).toMatch(/\.command-band-mode-seg\[aria-pressed="true"\]::after \{[^}]*background: var\(--brass\);/);
+    expect(modePressedBlock).toContain("border-color: var(--control-thumb-line);");
+    expect(modePressedBlock).toContain("background: var(--control-thumb);");
+    expect(modePressedBlock).toContain("color: var(--text-primary);");
+    expect(layout).not.toMatch(/\.command-band-mode-seg\[aria-pressed="true"\]::after \{/);
     expect(layout).toContain('.command-band-mode-seg:hover:not(:disabled):not([aria-pressed="true"])');
-    // 열린 스위처는 hover보다 지속적인 selected 면을 갖고 caret이 방향을 바꾼다.
+    // 열린 스위처는 hover보다 지속적인 open 면(잉크 워시)을 갖고 caret이 방향을 바꾼다.
     const openTriggerBlock = layout.match(/\.command-band-segment-trigger\.is-open \{[^}]*\}/)?.[0] ?? "";
-    expect(openTriggerBlock).toContain("border-color: var(--control-selected-rim);");
+    expect(openTriggerBlock).toContain("border-color: var(--control-open-rim);");
     expect(layout).toContain(".command-band-segment-trigger.is-open .command-band-trigger-caret { transform: rotate(180deg); }");
   });
 
@@ -2397,7 +2424,8 @@ describe("Instrument core design contract", () => {
       const declarations = stripComments(block).match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|glass)[a-z-]*:$/);
+        // control-track/thumb은 형상이 아니라 팔레트다 — 융기면 명도·채도를 테마 잉크 위에서 재조율한다.
+        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|glass|control)[a-z-]*:$/);
       }
     }
     // Light 테마만 팔레트 + 광학(color-scheme/shadow/scrollbar/신호 ink·halo/계기 무게/본문 regular 굵기 보정)을
@@ -2418,7 +2446,7 @@ describe("Instrument core design contract", () => {
       const declarations = stripComments(block).match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|provider|shadow|scrollbar|gauge|glass|live-sweep)[a-z-]*|--weight-regular|color-scheme):$/);
+        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|provider|shadow|scrollbar|gauge|glass|live-sweep|control)[a-z-]*|--weight-regular|color-scheme):$/);
       }
     }
     // 신호 ink 티어는 base에서 별칭으로 존재해 다크 3종이 var 간접으로 base 신호색을 상속한다.
@@ -3417,8 +3445,8 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain("font-weight: var(--weight-medium); font-size: var(--t-md); line-height: 1.2; font-family: var(--font-body);");
     expect(selectBlock).toContain("padding: 0 13px;");
     expect(selectBlock).toContain("box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);");
-    expect(selectBlock).toContain("border-color: var(--control-selected-rim);");
-    expect(selectBlock).toContain("background: var(--control-selected-fill);");
+    expect(selectBlock).toContain("border-color: var(--control-thumb-line);");
+    expect(selectBlock).toContain("background: var(--control-thumb);");
     expect(selectBlock).toContain('content: "✓";');
     expect(selectBlock).toContain("font-style: italic;");
     expect(selectBlock).toContain(".fc-select--compact .fc-select__trigger {");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -501,15 +501,14 @@ describe("Instrument core design contract", () => {
   it("keeps the interaction control recipe theme-owned", () => {
     const theme = source("styles/theme.css");
     const root = theme.match(/^:root \{[\s\S]*?^\}/m)?.[0] ?? "";
-    // Quiet Controls: 지속 상태는 accent가 아니라 세 문장으로 갈린다 — 배타 선택 = 자리(thumb),
-    // 독립 ON = 잉크(tint), 불리언 ON = 자리 + brass 글리프. 열림·focus-within은 open-rim이 진다.
+    // Quiet Controls C′: 지속 상태는 accent가 아니라 세 문장으로 갈린다 — 배타 선택 =
+    // 극저대비 워시(wash) + 잉크 대비 + 2px brass 다텀, 독립 ON = 잉크(tint),
+    // 불리언 ON = 워시 + brass 글리프. 열림·focus-within은 open-rim이 진다.
     for (const token of [
       "--control-hover-fill",
       "--control-hover-rim",
-      "--control-track",
-      "--control-thumb",
-      "--control-thumb-line",
-      "--control-thumb-lift",
+      "--control-wash",
+      "--control-wash-hover",
       "--control-tint-fill",
       "--control-tint-ink",
       "--control-open-rim",
@@ -517,18 +516,25 @@ describe("Instrument core design contract", () => {
       "--control-disabled-opacity",
     ]) expect(root).toContain(`${token}:`);
     expect(root).toContain("--control-hover-fill: color-mix(in oklab, var(--brass) 8%, transparent);");
-    expect(root).toContain("--control-tint-fill: color-mix(in oklab, var(--brass) 11%, transparent);");
+    expect(root).toContain("--control-tint-fill: color-mix(in oklab, var(--brass) 9%, transparent);");
     expect(root).toContain("--control-open-rim: color-mix(in oklab, var(--brass) 56%, var(--surface-rim));");
-    // 융기면은 잉크 사다리의 한 칸이 아니라 테마별 리터럴이다 — 네 테마가 각자 재조율한다.
+    // 워시는 잉크 사다리의 한 칸이 아니라 테마별 리터럴이다 — 네 테마가 각자 재조율한다
+    // (다크는 화이트 워시, 라이트는 잉크 워시로 극이 뒤집힌다).
     // carbon 셀렉터는 공유 legacy 블록에도 서므로, 개별 블록 중 하나가 재조율을 실으면 된다.
     for (const name of ["maritime", "carbon", "whites"]) {
       const blocks = theme.match(new RegExp(`^:root\\[data-theme="${name}"\\] \\{[\\s\\S]*?\\n\\}`, "gm")) ?? [];
-      expect(blocks.some((block) => block.includes("--control-thumb:") && block.includes("--control-track:"))).toBe(true);
+      expect(blocks.some((block) => block.includes("--control-wash:") && block.includes("--control-wash-hover:"))).toBe(true);
     }
-    // 옛 selected recipe(테두리+채움+brass 글자 동시 발화)는 퇴역했다 — 부활 금지.
+    // 옛 selected recipe(테두리+채움+brass 글자 동시 발화)와 융기(thumb) recipe는 퇴역했다 — 부활 금지.
     expect(theme).not.toContain("--control-selected-fill");
     expect(theme).not.toContain("--control-selected-rim");
+    expect(theme).not.toContain("--control-thumb");
     expect(theme).toMatch(/:focus-visible \{[^}]*outline: 2px solid var\(--control-focus-ring\);/);
+    // 고대비 환경에서는 워시가 걷히므로 선택을 시스템 선택색으로 직접 말한다(리뷰 확인 사항).
+    const components = source("styles/components.css");
+    const layout = source("styles/layout.css");
+    expect(components).toContain("background: SelectedItem;");
+    expect(layout).toContain("background: SelectedItem;");
   });
 
   it("keeps selected controls stronger than hover and preserves forced-color form state", () => {
@@ -568,9 +574,7 @@ describe("Instrument core design contract", () => {
     for (const token of [
       "var(--control-hover-fill)",
       "var(--control-hover-rim)",
-      "var(--control-thumb)",
-      "var(--control-thumb-line)",
-      "var(--control-thumb-lift)",
+      "var(--control-wash)",
       "var(--control-focus-ring)",
       "var(--control-disabled-opacity)",
     ]) {
@@ -602,11 +606,11 @@ describe("Instrument core design contract", () => {
 
     // 선택·hover는 theme.css의 control recipe 하나를 소비한다. hover와 focus를 한
     // 선택자로 합치면 마우스를 스칠 때도 외곽 focus ring이 떠 입력 수단의 신호가 사라진다.
-    // 불리언 ON = 자리 + 글리프: 면은 융기 중립(thumb)이고 켬은 글리프의 brass가 말한다.
+    // 불리언 ON = 워시 + 글리프: 면은 극저대비 워시이고 켬은 글리프의 brass가 말한다.
     const pressed = components.match(/\.canvas-operation-icon-button\.is-active,\n\.fleet-caption-action\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(pressed).toContain("border-color: var(--control-thumb-line);");
-    expect(pressed).toContain("background: var(--control-thumb);");
-    expect(pressed).toContain("box-shadow: var(--control-thumb-lift);");
+    expect(pressed).toContain("border-color: transparent;");
+    expect(pressed).toContain("background: var(--control-wash);");
+    expect(pressed).not.toContain("box-shadow");
     expect(pressed).toContain("color: var(--brass-bright);");
     const hover = components.match(/\.canvas-operation-icon-button:hover:not\(\.is-active\),\n\.fleet-caption-action:hover:not\(:disabled\):not\(\[aria-pressed="true"\]\) \{[^}]*\}/)?.[0] ?? "";
     expect(hover).toContain("border-color: var(--control-hover-rim);");
@@ -2294,17 +2298,16 @@ describe("Instrument core design contract", () => {
     // 모달 뒤로 물러나는 것은 떠 있는 밴드뿐이다 — 도킹된 밴드에 걸면 44px 빈 띠만 남는다.
     expect(layout).toContain('body:has([aria-modal="true"]:not([hidden])) .command-band.is-fullscreen:not(.is-docked),');
     // aria-pressed가 화면에 흔적을 남기지 않던 회귀를 막는다 — 불리언 토글의 눌림은
-    // 자리(thumb) + brass 글리프다.
+    // 워시 + brass 글리프다.
     const pressedBandButtonBlock = layout.match(/\.command-band-button\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(pressedBandButtonBlock).toContain("background: var(--control-thumb);");
+    expect(pressedBandButtonBlock).toContain("background: var(--control-wash);");
     expect(pressedBandButtonBlock).toContain("color: var(--brass-ink);");
-    // 캔버스 모드는 배타 선택 = 자리다 — 융기 중립 면 + 잉크 대비이며, 인접 불리언 도구와는
-    // 글리프 accent 유무로 갈린다. 옛 밑줄 datum은 퇴역했다.
+    // 캔버스 모드는 배타 선택 = 은은한 자리다 — 워시 + 잉크 대비에 2px brass 다텀이 붙어
+    // 인접 불리언 도구(글리프 accent)와 형상으로 갈린다.
     const modePressedBlock = layout.match(/\.command-band-mode-seg\[aria-pressed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(modePressedBlock).toContain("border-color: var(--control-thumb-line);");
-    expect(modePressedBlock).toContain("background: var(--control-thumb);");
+    expect(modePressedBlock).toContain("background: var(--control-wash);");
     expect(modePressedBlock).toContain("color: var(--text-primary);");
-    expect(layout).not.toMatch(/\.command-band-mode-seg\[aria-pressed="true"\]::after \{/);
+    expect(layout).toMatch(/\.command-band-mode-seg\[aria-pressed="true"\]::after \{[^}]*background: var\(--brass\);/);
     expect(layout).toContain('.command-band-mode-seg:hover:not(:disabled):not([aria-pressed="true"])');
     // 열린 스위처는 hover보다 지속적인 open 면(잉크 워시)을 갖고 caret이 방향을 바꾼다.
     const openTriggerBlock = layout.match(/\.command-band-segment-trigger\.is-open \{[^}]*\}/)?.[0] ?? "";
@@ -2424,7 +2427,7 @@ describe("Instrument core design contract", () => {
       const declarations = stripComments(block).match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        // control-track/thumb은 형상이 아니라 팔레트다 — 융기면 명도·채도를 테마 잉크 위에서 재조율한다.
+        // control-wash는 형상이 아니라 팔레트다 — 워시의 명도·알파를 테마 잉크 위에서 재조율한다.
         expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|glass|control)[a-z-]*:$/);
       }
     }
@@ -3445,8 +3448,7 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain("font-weight: var(--weight-medium); font-size: var(--t-md); line-height: 1.2; font-family: var(--font-body);");
     expect(selectBlock).toContain("padding: 0 13px;");
     expect(selectBlock).toContain("box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);");
-    expect(selectBlock).toContain("border-color: var(--control-thumb-line);");
-    expect(selectBlock).toContain("background: var(--control-thumb);");
+    expect(selectBlock).toContain("background: var(--control-wash);");
     expect(selectBlock).toContain('content: "✓";');
     expect(selectBlock).toContain("font-style: italic;");
     expect(selectBlock).toContain(".fc-select--compact .fc-select__trigger {");

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -403,11 +403,7 @@
 .fexp-view-mode {
   flex-shrink: 0;
   display: flex;
-  gap: 2px;
-  padding: 2px;
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xs);
-  background: var(--control-track);
+  gap: var(--space-1);
 }
 
 .fexp-view-mode button {
@@ -432,20 +428,36 @@
 
 .fexp-view-mode button:hover:not(:disabled):not([aria-pressed="true"]),
 .fexp-view-mode button:focus-visible:not([aria-pressed="true"]) {
-  border-color: var(--control-hover-rim);
-  background: var(--control-hover-fill);
+  background: var(--control-wash-hover);
+  color: var(--text-secondary);
+}
+
+/* 배타 선택 = 은은한 자리(Quiet Controls C′) — 워시 + 잉크 대비 + 2px 다텀이 말한다. */
+.fexp-view-mode button[aria-pressed="true"] {
+  background: var(--control-wash);
   color: var(--text-primary);
 }
 
-/* 배타 선택 = 자리(Quiet Controls) — 활성 뷰는 융기 중립 면과 잉크 대비가 말한다. */
-.fexp-view-mode button[aria-pressed="true"] {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  color: var(--text-primary);
-  box-shadow: var(--control-thumb-lift);
+.fexp-view-mode button[aria-pressed="true"]::after {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  width: 12px;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  transform: translateX(-50%);
+  content: "";
 }
 
 .fexp-view-mode button:active:not(:disabled) { transform: translateY(1px); }
+
+@media (forced-colors: active) {
+  .fexp-view-mode button[aria-pressed="true"] {
+    background: SelectedItem;
+    color: SelectedItemText;
+  }
+}
 .fexp-view-mode button:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 .fexp-viewer-meta {

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -407,6 +407,7 @@
   padding: 2px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
+  background: var(--control-track);
 }
 
 .fexp-view-mode button {
@@ -436,21 +437,12 @@
   color: var(--text-primary);
 }
 
+/* 배타 선택 = 자리(Quiet Controls) — 활성 뷰는 융기 중립 면과 잉크 대비가 말한다. */
 .fexp-view-mode button[aria-pressed="true"] {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
-  color: var(--brass-ink);
-}
-
-.fexp-view-mode button[aria-pressed="true"]::after {
-  position: absolute;
-  right: var(--space-2);
-  bottom: -3px;
-  left: var(--space-2);
-  height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brass);
-  content: "";
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  color: var(--text-primary);
+  box-shadow: var(--control-thumb-lift);
 }
 
 .fexp-view-mode button:active:not(:disabled) { transform: translateY(1px); }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -153,11 +153,7 @@
 .repository-view-toggle {
   margin-left: auto;
   display: inline-flex;
-  background: var(--control-track);
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xs);
-  padding: 2px;
-  gap: 2px;
+  gap: var(--space-1);
 }
 
 .repository-toggle-btn {
@@ -180,20 +176,37 @@
 
 .repository-toggle-btn:hover:not(.is-active),
 .repository-toggle-btn:focus-visible:not(.is-active) {
-  border-color: var(--control-hover-rim);
-  background: var(--control-hover-fill);
-  color: var(--text-primary);
+  background: var(--control-wash-hover);
+  color: var(--text-secondary);
 }
 
-/* 배타 선택 = 자리(Quiet Controls) — 활성 뷰는 융기 중립 면과 잉크 대비가 말한다. */
+/* 배타 선택 = 은은한 자리(Quiet Controls C′) — 워시 + 잉크 대비 + 2px 다텀이 말한다. */
 .repository-toggle-btn.is-active {
-  border-color: var(--control-thumb-line);
+  position: relative;
   color: var(--text-primary);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  background: var(--control-wash);
+}
+
+.repository-toggle-btn.is-active::after {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  width: 12px;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  transform: translateX(-50%);
+  content: "";
 }
 
 .repository-toggle-btn:active:not(:disabled) { transform: translateY(1px); }
+
+@media (forced-colors: active) {
+  .repository-toggle-btn.is-active {
+    background: SelectedItem;
+    color: SelectedItemText;
+  }
+}
 .repository-toggle-btn:disabled { cursor: not-allowed; opacity: var(--control-disabled-opacity); }
 
 /* ── 섹션 스크롤 컨테이너 ── */

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -153,7 +153,7 @@
 .repository-view-toggle {
   margin-left: auto;
   display: inline-flex;
-  background: color-mix(in oklch, var(--ink-abyss) 35%, transparent);
+  background: var(--control-track);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
   padding: 2px;
@@ -185,11 +185,12 @@
   color: var(--text-primary);
 }
 
+/* 배타 선택 = 자리(Quiet Controls) — 활성 뷰는 융기 중립 면과 잉크 대비가 말한다. */
 .repository-toggle-btn.is-active {
-  border-color: var(--control-selected-rim);
-  color: var(--brass-ink);
-  background: var(--control-selected-fill);
-  box-shadow: inset 0 -2px 0 var(--brass);
+  border-color: var(--control-thumb-line);
+  color: var(--text-primary);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
 }
 
 .repository-toggle-btn:active:not(:disabled) { transform: translateY(1px); }

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -197,8 +197,9 @@ describe("Repository design grammar", () => {
     for (const selector of [".repository-filter-input", ".history-filter-input"]) {
       expect(blockOf(selector), selector).toContain("var(--ink-abyss) 35%");
     }
-    // 뷰 토글은 세그먼트 트랙이다 — Quiet Controls의 공용 track 채널을 소비해 네 테마가 함께 재조율된다.
-    expect(blockOf(".repository-view-toggle")).toContain("var(--control-track)");
+    // 뷰 토글은 상자 없는 세그먼트다(Quiet Controls C′) — 선택은 워시+다텀이 말하고 그룹 경계는 간격이 진다.
+    expect(blockOf(".repository-view-toggle")).not.toContain("background");
+    expect(blockOf(".repository-toggle-btn.is-active")).toContain("var(--control-wash)");
   });
 
   it("keeps the sync button spin animation reducible and omits the status strip", () => {

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -194,9 +194,11 @@ describe("Repository design grammar", () => {
     expect(detailPanes.length).toBeGreaterThanOrEqual(2);
     for (const body of detailPanes) expect(body).toContain("var(--surface-glass) 70%");
 
-    for (const selector of [".repository-filter-input", ".history-filter-input", ".repository-view-toggle"]) {
+    for (const selector of [".repository-filter-input", ".history-filter-input"]) {
       expect(blockOf(selector), selector).toContain("var(--ink-abyss) 35%");
     }
+    // 뷰 토글은 세그먼트 트랙이다 — Quiet Controls의 공용 track 채널을 소비해 네 테마가 함께 재조율된다.
+    expect(blockOf(".repository-view-toggle")).toContain("var(--control-track)");
   });
 
   it("keeps the sync button spin animation reducible and omits the status strip", () => {

--- a/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
+++ b/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
@@ -521,11 +521,10 @@
   outline-offset: 2px;
 }
 
-/* 불리언 ON = 자리 + 글리프 — 면은 융기 중립(thumb)이고 켬은 라벨의 brass 잉크가 말한다. */
+/* 불리언 ON = 워시 + 글리프 — 면은 극저대비 워시이고 켬은 라벨의 brass 잉크가 말한다. */
 .ai-gateway-host-only.is-on {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
   color: var(--brass-ink);
 }
 
@@ -720,9 +719,8 @@
 }
 
 .ai-gateway-axis-toggle.is-on {
-  border-color: var(--control-thumb-line);
-  background: var(--control-thumb);
-  box-shadow: var(--control-thumb-lift);
+  border-color: transparent;
+  background: var(--control-wash);
   color: var(--brass-ink);
 }
 
@@ -920,3 +918,13 @@
   color: var(--warn-ink);
 }
 
+
+/* 고대비(forced-colors) — 워시·잉크 워시가 걷히는 환경에서는 켜짐을 시스템 선택색으로 말한다. */
+@media (forced-colors: active) {
+  .ai-gateway-host-only.is-on,
+  .ai-gateway-axis-toggle.is-on,
+  .ai-gateway-effort-level.is-on {
+    background: SelectedItem;
+    color: SelectedItemText;
+  }
+}

--- a/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
+++ b/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
@@ -157,7 +157,7 @@
 }
 
 .agent-cli-path-button.is-primary {
-  border-color: var(--control-selected-rim);
+  border-color: var(--control-open-rim);
 }
 
 .agent-cli-path-button:active:not(:disabled) {
@@ -521,9 +521,11 @@
   outline-offset: 2px;
 }
 
+/* 불리언 ON = 자리 + 글리프 — 면은 융기 중립(thumb)이고 켬은 라벨의 brass 잉크가 말한다. */
 .ai-gateway-host-only.is-on {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
   color: var(--brass-ink);
 }
 
@@ -650,10 +652,11 @@
   outline-offset: 2px;
 }
 
+/* 독립 ON = 잉크 — 사다리의 켜진 단은 저채도 워시와 잉크 대비만으로 말한다.
+   다중 on 칩에 자리(thumb)를 세우면 줄 전체가 키보드처럼 읽힌다. */
 .ai-gateway-effort-level.is-on {
-  background: var(--control-selected-fill);
-  color: var(--brass-ink);
-  box-shadow: inset 0 0 0 1px var(--control-selected-rim);
+  background: var(--control-tint-fill);
+  color: var(--control-tint-ink);
 }
 
 .ai-gateway-effort-level:active:not(:disabled) {
@@ -717,8 +720,9 @@
 }
 
 .ai-gateway-axis-toggle.is-on {
-  border-color: var(--control-selected-rim);
-  background: var(--control-selected-fill);
+  border-color: var(--control-thumb-line);
+  background: var(--control-thumb);
+  box-shadow: var(--control-thumb-lift);
   color: var(--brass-ink);
 }
 
@@ -740,9 +744,9 @@
 .ai-gateway-add-button {
   margin-left: auto;
   padding: var(--space-2) var(--space-4);
-  border: 1px solid var(--control-selected-rim);
+  border: 1px solid var(--control-hover-rim);
   border-radius: var(--radius-xs);
-  background: var(--control-selected-fill);
+  background: var(--control-tint-fill);
   color: var(--brass-ink);
   font-family: var(--font-mono);
   font-size: var(--t-xs);

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -4,7 +4,7 @@ import { fetchSystemFonts } from "@fleet-console/font-picker/system-fonts";
 import { defineNotificationKind } from "@fleet-console/sdk/notifications/browser";
 import { defineOperationKind } from "@fleet-console/sdk/plugin/browser";
 import { definePlugin, React } from "@fleet-console/sdk/plugin/browser";
-import { Select } from "@fleet-console/sdk/react/browser";
+import { SegmentedThumb, Select } from "@fleet-console/sdk/react/browser";
 import { launchProviderGlyph } from "@fleet-console/sdk/components/launch-provider-glyphs";
 import {
   CaptionActionButton,
@@ -1080,6 +1080,7 @@ function AiGatewayCompactTimingCard() {
           <p className="global-settings-help">{t("terminal.settings.compactTimingHelp")}</p>
         </div>
         <div className="segmented" role="group" aria-labelledby="compact-timing-label">
+          <SegmentedThumb />
           <button type="button" className={`segmented-option${policy === "auto" ? " is-active" : ""}`} disabled={saving} onClick={() => savePolicy("auto")}>
             {t("terminal.settings.compactTimingAuto")}
           </button>
@@ -1576,6 +1577,7 @@ function AiGatewayXaiEndpointRow({ saving }: { readonly saving: boolean }) {
     <div className="ai-gateway-composer">
       <span className="ai-gateway-field-label" id="xai-endpoint-label">{t("terminal.settings.xaiEndpoint")}</span>
       <div className="segmented" role="group" aria-labelledby="xai-endpoint-label">
+        <SegmentedThumb />
         <button
           type="button"
           className={`segmented-option${endpoint === "cli-proxy" ? " is-active" : ""}`}
@@ -2238,6 +2240,7 @@ function TerminalDrawingCard({ terminalRenderer, terminalInactiveFlush }: {
           <p className="global-settings-help">{t("terminal.settings.terminalRendererHelp")}</p>
         </div>
         <div className="segmented" role="group" aria-label={t("terminal.settings.terminalRendererAria")}>
+          <SegmentedThumb />
           {RENDERER_IDS.map((rendererId) => {
             const isActive = rendererId === terminalRenderer;
             return (
@@ -2260,6 +2263,7 @@ function TerminalDrawingCard({ terminalRenderer, terminalInactiveFlush }: {
           <p className="global-settings-help">{t("terminal.settings.inactiveFlushHelp")}</p>
         </div>
         <div className="segmented" role="group" aria-label={t("terminal.settings.inactiveFlushAria")}>
+          <SegmentedThumb />
           {INACTIVE_FLUSH_IDS.map((inactiveFlushId) => {
             const isActive = inactiveFlushId === terminalInactiveFlush;
             return (


### PR DESCRIPTION
## Summary
- 선택된 컨트롤의 brass 아웃라인 pill 문법(테두리+채움+brass 글자+밑줄, 최대 4채널 동시 발화)을 Quiet Controls 문법으로 전면 대체합니다: 배타 선택 = 미끄러지는 중립 융기면(thumb) + 잉크 대비, 독립 ON 칩(EFFORT 등) = 저채도 brass 워시, 불리언 토글 = 융기면 + brass 글리프. 승인된 제안 아티팩트(4테마 × 4문법 벤치)의 A안 그대로입니다.
- `--control-selected-fill/rim` 토큰을 퇴역시키고 `--control-track/thumb/thumb-line/thumb-lift/tint-fill/tint-ink/open-rim`을 신설, 4테마(instrument/maritime/carbon/whites)가 각자 잉크 스케일에서 융기면을 재조율합니다. 선택이 brass 소비를 멈추므로 "brass = 위치·포커스·호버" 채널 독트린은 강화됩니다.
- SDK `react/browser`에 `SegmentedThumb`(슬라이드 엔진, reduced-motion 단락, JS 이전 face 폴백)를 추가해 Settings 세그먼트·커맨드 밴드 모드 스위치·사이드바 축 스트립·터미널 플러그인 세그먼트 8곳에 연결하고, 표면별 선택 장식(밑줄 datum·이중 링·좌측 바)을 퇴역시켰습니다(내비 위치 스파인은 유지). 계약 테스트(instrument-design-contract·repository design-grammar)를 공동 갱신했습니다.

## Test Plan
- [x] `instrument-design-contract.test.ts` 92/92 통과 (신규 토큰 어휘·퇴역 토큰 부활 금지 핀 포함)
- [x] fleet-console vitest 전체 195파일/0실패, typecheck·build green
- [x] terminal(1012)·repository(441)·file-explorer(241) 플러그인 테스트 green
- [x] console-e2e 격리 콘솔 실측: 4테마 스크린샷, 썸 슬라이드(3px→157px, 140ms), EFFORT 칩 tint(oklab brass 11%), 불리언 thumb+glyph, 페이지 에러 0