### PR TITLE
fix(fleet-console): carry built-in plugin routes and manifests into the published build

### DIFF
--- a/.changelog.d/codex-plugin-routes-bundle.md
+++ b/.changelog.d/codex-plugin-routes-bundle.md
@@ -1,0 +1,11 @@
+---
+branch: codex-plugin-routes-bundle
+---
+
+### fleet-console
+
+#### Fixed
+- Load Codex again in installed builds. The Codex panel reported that it could not read a Theater's Fleet Wiki data, because the plugin's server routes were left out of the packaged build when Codex moved out of the console core.
+  ko: 설치본에서 Codex가 다시 열립니다. Codex가 콘솔 코어에서 플러그인으로 옮겨 갈 때 서버 라우트가 패키지에 담기지 않아, 패널이 Theater의 Fleet Wiki 데이터를 불러오지 못한다고 알렸습니다.
+- Hide the terminal's provider title from browser payloads in installed builds, which had kept it visible because a plugin's redaction list did not survive packaging.
+  ko: 설치본에서 터미널의 공급자 제목이 브라우저 페이로드에 그대로 나가던 것을 가립니다. 플러그인이 선언한 가림 목록이 패키징 과정에서 사라진 탓이었습니다.

--- a/runtime/fleet-console/package.json
+++ b/runtime/fleet-console/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "boundary:guard": "node ../../scripts/guard-fleet-agent-boundary.mjs",
-    "build": "pnpm boundary:guard && pnpm generate:admiral-assets && pnpm generate:shim-keys && tsup && node ../../scripts/check-dist-node-protocol.mjs && node ../../scripts/check-dist-published-externals.mjs && pnpm generate:desktop-protocol-declaration && pnpm verify:desktop-protocol && vite build --config core/client/vite.config.ts",
+    "build": "pnpm boundary:guard && pnpm generate:admiral-assets && pnpm generate:shim-keys && tsup && node ../../scripts/generate-plugin-dist-manifests.mjs && node ../../scripts/check-dist-node-protocol.mjs && node ../../scripts/check-dist-published-externals.mjs && pnpm generate:desktop-protocol-declaration && pnpm verify:desktop-protocol && vite build --config core/client/vite.config.ts",
     "dev": "vite --config core/client/vite.config.ts",
     "generate:admiral-assets": "node ../../scripts/generate-fleet-admiral-assets.mjs",
     "generate:desktop-protocol-declaration": "tsup core/host/desktop-protocol.ts --dts --dts-resolve --dts-only --out-dir dist --format esm --no-config",

--- a/runtime/fleet-console/tests/built-in-plugin-routes-bundle.test.ts
+++ b/runtime/fleet-console/tests/built-in-plugin-routes-bundle.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const consoleRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pluginsRoot = path.resolve(consoleRoot, "../fleet-plugins");
+
+/**
+ * 빌트인 플러그인의 서버 라우트가 게시 산출물까지 따라오는지 지키는 자리.
+ *
+ * plugin-host는 소스 체크아웃에서는 `<plugin>/routes.ts`를 직접 찾아 esbuild로 번들한다.
+ * 게시 설치본에는 그 소스가 없으므로 `dist/fleet-plugins/<id>/routes.mjs`만 본다 — 그 파일은
+ * tsup 엔트리에 적힌 플러그인에 대해서만 만들어진다. 두 목록이 어긋나면 소스에서는 모든
+ * 것이 동작하고 게시본에서만 그 플러그인의 라우트가 통째로 사라진다.
+ *
+ * 실제로 Codex가 코어에서 플러그인으로 옮겨 갈 때 이 엔트리가 빠졌고, 테스트·빌드·E2E가
+ * 전부 소스에서 돌아 초록인 채로 1.77.0이 나갔다. 사용자는 위키가 열리지 않는 것으로 그것을
+ * 처음 알았다. 목록 대조는 사람이 기억할 일이 아니라 여기서 할 일이다.
+ */
+function readTsupPluginRouteEntries(): ReadonlySet<string> {
+  const source = fs.readFileSync(path.join(consoleRoot, "tsup.config.ts"), "utf8");
+  const ids = new Set<string>();
+  for (const match of source.matchAll(/"fleet-plugins\/([a-z0-9][a-z0-9-]*)\/routes"/gu)) {
+    ids.add(match[1]!);
+  }
+  return ids;
+}
+
+function readPluginsWithServerRoutes(): readonly string[] {
+  return fs
+    .readdirSync(pluginsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && fs.existsSync(path.join(pluginsRoot, entry.name, "routes.ts")))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+describe("built-in plugin route bundles", () => {
+  it("builds a published route bundle for every plugin that serves routes", () => {
+    const declared = readTsupPluginRouteEntries();
+    const withRoutes = readPluginsWithServerRoutes();
+
+    expect(withRoutes.length).toBeGreaterThan(0);
+    const missing = withRoutes.filter((id) => !declared.has(id));
+    expect(missing, `tsup.config.ts is missing a "fleet-plugins/<id>/routes" entry for: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("declares no route bundle for a plugin that has no routes.ts", () => {
+    const declared = [...readTsupPluginRouteEntries()].sort();
+    const withRoutes = new Set(readPluginsWithServerRoutes());
+
+    // 반대 방향도 지킨다 — 사라진 플러그인의 엔트리가 남으면 빌드가 그 자리에서 깨진다.
+    const stale = declared.filter((id) => !withRoutes.has(id));
+    expect(stale, `tsup.config.ts declares a route bundle for a plugin without routes.ts: ${stale.join(", ")}`).toEqual([]);
+  });
+});

--- a/runtime/fleet-console/tsup.config.ts
+++ b/runtime/fleet-console/tsup.config.ts
@@ -7,13 +7,18 @@ import { defineConfig } from "tsup";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(__dirname, "../..");
 
-// Vite 산출물과 다른 플러그인은 보존하되, 이름이 바뀐 diff 라우트만 빌드 전에 제거한다.
-fs.rmSync(path.join(__dirname, "dist", "fleet-plugins", "diff"), { recursive: true, force: true });
+// 빌트인 플러그인 산출물은 매 빌드마다 통째로 다시 만든다.
+//
+// 낡은 산출물이 남으면 "그 파일이 있는가"라는 검사가 거짓말을 한다 — 엔트리를 빼도 지난
+// 빌드의 routes.mjs가 그대로 남아 검사를 통과시키고, 게이트가 결함을 승인한 기록이 된다.
+// 이름이 바뀐(diff→codex 등) 플러그인의 유령 디렉터리가 남는 문제도 같은 뿌리다.
+// dist/client(vite 산출물)과 dist/cli.*는 건드리지 않는다.
+fs.rmSync(path.join(__dirname, "dist", "fleet-plugins"), { recursive: true, force: true });
 
 // dist/client(vite 산출물)을 보존해야 하므로 clean을 끈다 — dist/cli.*만 이 빌드의 소유다.
 export default defineConfig([
   {
-    entry: { fleet: "cli/fleet-entry.ts", cli: "core/host/cli.ts", "access-protocol": "core/host/access-link.ts", "desktop-protocol": "core/host/desktop-protocol.ts", "fleet-plugins/terminal/routes": "../fleet-plugins/terminal/routes.ts", "fleet-plugins/repository/routes": "../fleet-plugins/repository/routes.ts", "fleet-plugins/file-explorer/routes": "../fleet-plugins/file-explorer/routes.ts", "fleet-plugins/skills/routes": "../fleet-plugins/skills/routes.ts", "fleet-plugins/ledger/routes": "../fleet-plugins/ledger/routes.ts", "fleet-plugins/quota/routes": "../fleet-plugins/quota/routes.ts", "fleet-plugins/scuttlebutt/routes": "../fleet-plugins/scuttlebutt/routes.ts" },
+    entry: { fleet: "cli/fleet-entry.ts", cli: "core/host/cli.ts", "access-protocol": "core/host/access-link.ts", "desktop-protocol": "core/host/desktop-protocol.ts", "fleet-plugins/terminal/routes": "../fleet-plugins/terminal/routes.ts", "fleet-plugins/repository/routes": "../fleet-plugins/repository/routes.ts", "fleet-plugins/file-explorer/routes": "../fleet-plugins/file-explorer/routes.ts", "fleet-plugins/skills/routes": "../fleet-plugins/skills/routes.ts", "fleet-plugins/ledger/routes": "../fleet-plugins/ledger/routes.ts", "fleet-plugins/quota/routes": "../fleet-plugins/quota/routes.ts", "fleet-plugins/scuttlebutt/routes": "../fleet-plugins/scuttlebutt/routes.ts", "fleet-plugins/codex/routes": "../fleet-plugins/codex/routes.ts" },
     format: ["esm"],
     banner: { js: "#!/usr/bin/env node" },
     // 선언(.d.ts)은 패키지가 타입으로 노출하는 cli·access-protocol 엔트리에만 생성한다.

--- a/scripts/generate-plugin-dist-manifests.mjs
+++ b/scripts/generate-plugin-dist-manifests.mjs
@@ -1,0 +1,89 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * 빌트인 플러그인의 매니페스트를 게시 산출물로 옮기는 자리.
+ *
+ * plugin-host는 소스 체크아웃에서 `runtime/fleet-plugins/<id>/plugin.json`을 읽지만, 게시
+ * 설치본에는 그 파일이 없어 디렉터리 이름만으로 `{ id, routes }`짜리 매니페스트를 **지어낸다**.
+ * 지어낸 매니페스트에는 `consoleRoutePrefix`와 `sensitiveFields`가 없다.
+ *
+ * 그 두 필드는 장식이 아니다. `consoleRoutePrefix`가 없으면 `/console/<prefix>` 등록이 스코프
+ * 검사에 걸려 plugin_route_outside_scope로 **콘솔 부팅 자체가 실패**하고, `sensitiveFields`가
+ * 없으면 그 플러그인이 추가로 가리라고 선언한 필드가 브라우저 DTO로 나간다(고정 목록 밖의
+ * 것만 해당한다).
+ *
+ * 그래서 산출물에 진짜 매니페스트를 함께 내보낸다. `routes`만 빌드된 이름으로 바꾼다 —
+ * 소스는 `routes.ts`를 가리키지만 게시본에 있는 것은 tsup이 낸 `routes.mjs`다. `client`는
+ * 빼는데, 클라이언트는 vite 번들에 흡수되어 이 디렉터리에 존재하지 않기 때문이다.
+ */
+const DIST_ROUTES_FILE = "routes.mjs";
+
+/** 산출물 매니페스트로 옮길 값. 소스 매니페스트에서 의미를 지닌 필드만 추린다. */
+export function createPluginDistManifest(sourceManifest) {
+  const manifest = { id: sourceManifest.id, routes: DIST_ROUTES_FILE };
+  if (typeof sourceManifest.apiVersion === "number") manifest.apiVersion = sourceManifest.apiVersion;
+  if (typeof sourceManifest.name === "string") manifest.name = sourceManifest.name;
+  if (typeof sourceManifest.consoleRoutePrefix === "string") manifest.consoleRoutePrefix = sourceManifest.consoleRoutePrefix;
+  if (Array.isArray(sourceManifest.sensitiveFields)) {
+    manifest.sensitiveFields = sourceManifest.sensitiveFields.filter((field) => typeof field === "string");
+  }
+  return manifest;
+}
+
+/**
+ * 라우트를 서빙하는 빌트인 플러그인 목록. `routes.ts`의 존재가 곧 "서버 라우트가 있다"는
+ * 사실이므로, tsup 엔트리 목록이 아니라 소스에서 읽는다 — 엔트리를 빠뜨린 것이야말로
+ * 이 검사가 잡아야 할 결함이다.
+ */
+export function readBuiltInPluginsWithRoutes(pluginsRoot) {
+  return readdirSync(pluginsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(path.join(pluginsRoot, entry.name, "routes.ts")))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function main() {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(scriptDir, "..");
+  const pluginsRoot = path.join(repoRoot, "runtime", "fleet-plugins");
+  const distRoot = path.join(repoRoot, "runtime", "fleet-console", "dist", "fleet-plugins");
+
+  const missingBundles = [];
+  let written = 0;
+
+  for (const id of readBuiltInPluginsWithRoutes(pluginsRoot)) {
+    const distPluginDir = path.join(distRoot, id);
+    if (!existsSync(path.join(distPluginDir, DIST_ROUTES_FILE))) {
+      missingBundles.push(id);
+      continue;
+    }
+    const sourceManifestPath = path.join(pluginsRoot, id, "plugin.json");
+    if (!existsSync(sourceManifestPath)) {
+      throw new Error(`[generate:plugin-dist-manifests] ${id}: routes.ts는 있는데 plugin.json이 없습니다.`);
+    }
+    const sourceManifest = JSON.parse(readFileSync(sourceManifestPath, "utf8"));
+    writeFileSync(
+      path.join(distPluginDir, "plugin.json"),
+      `${JSON.stringify(createPluginDistManifest(sourceManifest), null, 2)}\n`,
+      "utf8",
+    );
+    written += 1;
+  }
+
+  if (missingBundles.length > 0) {
+    // 소스에서는 plugin-host가 routes.ts를 직접 번들하므로 테스트도 E2E도 초록으로 지나간다.
+    // 게시본에서만 그 플러그인의 라우트가 통째로 사라지므로, 판정은 산출물에서 내린다.
+    throw new Error(
+      `[generate:plugin-dist-manifests] 다음 플러그인의 라우트 번들이 없습니다: ${missingBundles.join(", ")}\n` +
+        `runtime/fleet-console/tsup.config.ts의 entry에 "fleet-plugins/<id>/routes"를 추가하세요.`,
+    );
+  }
+
+  console.log(`[generate:plugin-dist-manifests] ${written}개 플러그인 매니페스트 기록`);
+}
+
+if (process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/generate-plugin-dist-manifests.test.mjs
+++ b/scripts/generate-plugin-dist-manifests.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createPluginDistManifest } from './generate-plugin-dist-manifests.mjs';
+
+test('carries the fields the published host cannot infer from a directory name', () => {
+  const manifest = createPluginDistManifest({
+    id: 'codex',
+    name: 'Codex',
+    apiVersion: 1,
+    routes: 'routes.ts',
+    client: 'client/index.tsx',
+    consoleRoutePrefix: 'codex',
+  });
+
+  // consoleRoutePrefix가 없으면 `/console/codex` 등록이 스코프 검사에 걸려 콘솔이 부팅하지 못한다.
+  assert.equal(manifest.consoleRoutePrefix, 'codex');
+  assert.deepEqual(manifest, { id: 'codex', routes: 'routes.mjs', apiVersion: 1, name: 'Codex', consoleRoutePrefix: 'codex' });
+});
+
+test('keeps the extra fields a plugin asks the host to redact', () => {
+  const manifest = createPluginDistManifest({ id: 'terminal', routes: 'routes.ts', sensitiveFields: ['cwd', 'providerTitle', 7] });
+
+  // 지어낸 매니페스트에는 이 목록이 없어, 고정 목록 밖의 필드가 브라우저 DTO로 나갔다.
+  assert.deepEqual(manifest.sensitiveFields, ['cwd', 'providerTitle']);
+});
+
+test('points routes at the built bundle, never the TypeScript source', () => {
+  // 소스 매니페스트의 routes는 `routes.ts`다. 그대로 옮기면 게시본이 해석에 실패해
+  // 플러그인을 통째로 건너뛴다 — 라우트가 없는 것과 같은 증상이 된다.
+  assert.equal(createPluginDistManifest({ id: 'ledger', routes: 'routes.ts' }).routes, 'routes.mjs');
+  assert.equal(createPluginDistManifest({ id: 'ledger' }).routes, 'routes.mjs');
+});
+
+test('omits the client entry, which the web build absorbs', () => {
+  assert.equal(createPluginDistManifest({ id: 'quota', client: 'client/index.tsx' }).client, undefined);
+});


### PR DESCRIPTION
## Summary

1.77.0 설치본에서 Codex 패널이 "이 Theater의 Fleet Wiki 데이터를 불러오지 못했습니다"를 표시합니다. 원인은 위키도 Theater도 아니고 **패키징**입니다.

#940이 Codex를 콘솔 코어에서 `runtime/fleet-plugins/codex/`로 옮기면서 `tsup.config.ts`의 라우트 엔트리 목록에 codex를 추가하지 않았습니다. 소스 체크아웃에서는 `plugin-host`가 `<plugin>/routes.ts`를 직접 찾아 번들하므로 테스트·빌드·브라우저 E2E가 전부 초록이었고, 게시본에서만 Codex 서버 라우트가 통째로 사라졌습니다.

엔트리만 추가하면 상황이 더 나빠집니다. `plugin-host`는 번들 옆에 `plugin.json`이 없으면 디렉터리 이름으로 `{ id, routes }` 매니페스트를 **지어내며**, 그 과정에서 `consoleRoutePrefix`와 `sensitiveFields`를 버립니다. Codex는 `consoleRoutePrefix`를 선언한 첫 빌트인이라 `/console/codex` 등록이 스코프 검사에 걸려 **설치본이 부팅 자체에 실패**합니다(`plugin_route_outside_scope`). 같은 조작이 terminal의 가림 목록도 버려, 고정 목록 밖의 `providerTitle`이 브라우저 페이로드로 나가고 있었습니다.

- codex 라우트 엔트리를 추가하고, 각 빌트인의 **진짜 매니페스트**를 dist로 내보냅니다(`routes`만 빌드된 이름으로 교체, `client`는 web 번들이 흡수하므로 제외).
- 라우트를 서빙하는 플러그인에 번들이 없으면 **빌드를 실패**시키고, `dist/fleet-plugins`를 매 빌드 새로 만들어 낡은 산출물이 그 검사를 통과시키지 못하게 합니다.
- 엔트리 목록과 매니페스트 변환 양쪽에 계약 테스트를 겁니다.

## 왜 게이트를 함께 넣었나

한 줄만 고치면 다음 플러그인에서 그대로 재발합니다. 이 결함의 본질은 "두 목록이 어긋났는데 아무도 대조하지 않았다"이고, 판정은 소스가 아니라 **산출물**에서 나와야 합니다. 저장소 doctrine이 이미 그렇게 말합니다 — *"validate the affected path against the built distribution because source tests and builds can stay green."*

## Test Plan

**게시 설치본 재현 실측** — 옆에 소스 트리가 없는 위치에 `dist`만 두어 `plugin-host`가 `dist/fleet-plugins/`만 보게 한 상태:

| 확인 | 수정 전 | 수정 후 |
|---|---|---|
| 콘솔 부팅 | `plugin_route_outside_scope`로 실패 | 성공 |
| `POST /api/v1/plugins/codex/workspace` | 404 (라우트 없음) | **400 `invalid_theater`** |
| `POST /api/v1/plugins/nosuch/x` (대조군) | 404 | 404 |
| `GET /console/codex` | — | **200** |
| `dist/fleet-plugins/codex/` | 없음 | `routes.mjs` + `plugin.json` |
| 총 라우트 수 | — | 146 (계약과 일치) |

**변이 검증** — 네 게이트가 실제로 결함을 잡는지:

- [x] tsup 엔트리에서 codex 제거 → 계약 테스트 실패 (`missing: ["codex"]`)
- [x] 같은 상태로 빌드 → 빌드 실패 (`라우트 번들이 없습니다: codex`)
- [x] `consoleRoutePrefix` 전달 제거 → scripts 테스트 실패
- [x] `sensitiveFields` 전달 제거 → scripts 테스트 실패

첫 시도에서 변이 2가 **잡히지 않았습니다** — 이전 빌드의 낡은 `routes.mjs`가 존재 검사를 통과시켰습니다. `dist/fleet-plugins`를 매 빌드 새로 만들도록 바꾼 뒤 재확인했습니다.

**정적 검증**

- [x] `fleet-console typecheck` — 0
- [x] `fleet-console test` — 2312 passed / 24 skipped
- [x] `@fleet-plugins/codex test` — 176 passed
- [x] `@fleet-plugins/terminal test` — 1106 passed
- [x] `node --test scripts/*.test.mjs` — 63 passed
- [x] `fleet-console build` — ok
- [x] `compile-changelog-fragments --check` — 2 entries ok