### PR TITLE
fix(fleet-console): keep Session Analyst out of the unfocused-panel recede

### DIFF
--- a/.changelog.d/companion-focus-recede.md
+++ b/.changelog.d/companion-focus-recede.md
@@ -1,0 +1,8 @@
+---
+branch: companion-focus-recede
+---
+
+### fleet-console
+#### Fixed
+- Keep the Session Analyst panel at full strength while its session holds focus, so the panel you just opened no longer fades along with the neighboring panels.
+  ko: 세션에 포커스가 있는 동안 Session Analyst 패널이 또렷하게 남습니다. 방금 연 패널이 곁의 패널과 함께 물러나지 않습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6496,6 +6496,12 @@ body[data-side-bar-animating="true"] .canvas-operation {
    무대만 어두워진다: 대기 큐가 비어 있지 않으면 enterTriage가 활성 id를 카드에 남기고
    (triage-store.ts), 무대의 자동 포커스는 모달·투어가 떠 있던 프레임에서 한 번 걸러지면
    캐시 때문에 다시 시도되지 않는다(canvas.tsx). 게이트와 표식은 같은 것을 가리켜야 한다.
+   companion 프레임(Session Analyst)도 같은 이유로 빠진다 — 호스트가 프레임 껍데기를 재사용해
+   .canvas-operation을 쓸 뿐, 활성 Operation과 겨루는 이웃이 아니라 그 Operation에 딸린 두 번째
+   면이다. companion은 활성 id를 받는 경로가 아예 없어(CompanionFrame은 is-active를 붙이지 않는다)
+   구조적으로 영원한 비포커스였고, 그래서 부모 세션에 포커스가 서는 순간 언제나 물러나 있었다 —
+   후퇴가 곁을 가려 주는 대신 지금 보려고 연 패널을 가렸다. 여기서도 표식·게이트·제외는 한 벌이다:
+   표식을 받을 수 없는 것은 남을 물러서게 하지도, 스스로 물러서지도 않는다.
    세기는 사람마다 다르므로 설정이 소유한다(겉모습 > 비포커스 패널 흐리기). 여기 적힌 0.5는
    그 값이 아직 실리지 않은 첫 페인트의 폴백이자 기본값이다 — 규칙은 그대로 두고 세기만 바뀐다.
    이 값이 곁의 본문에서 읽기 편함을 얼마나 떼어 포커스에 줄지를 정한다: 실측(다크, 터미널
@@ -6503,7 +6509,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
    기본값 0.5는 본문 대비 기준(4.5:1) 아래이고 큰 글자 기준(3:1)은 넘는 자리다: 물러난 패널은
    지금 읽는 자리가 아니라 곁눈으로 훑는 자리이며, 포커스를 주는 순간 9.22:1로 돌아온다.
    상한(0.3)을 그보다 낮추지 않는 이유도 같다 — 곁을 훑는 일까지 끊기면 후퇴가 아니라 소거다. */
-.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile) > .canvas-operation-terminal {
+.operations-canvas:has(.canvas-operation.is-active:not(.is-deck-tile)) .canvas-operation:not(.is-active):not(.is-deck-tile):not(.canvas-companion-frame) > .canvas-operation-terminal {
   opacity: var(--unfocused-panel-opacity, 0.5);
   transition: opacity var(--duration-base) var(--ease-glide);
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -3217,8 +3217,12 @@ describe("Instrument core design contract", () => {
     expect(focusWash).toContain("background-clip: padding-box;");
     // 후퇴는 본문이 진다 — 캡션은 어느 패널인지를 말하는 자리라 흐려지면 목록을 훑는 일이 함께
     // 흐려진다. 상태 레일은 캡션 소속이라 자동으로 남는다. 무대에 포커스가 설 때만 일어나며
-    // (:has() 게이트), 덱 타일은 대상에서도 게이트에서도 빠진다.
-    const recede = components.match(/\.operations-canvas:has\(\.canvas-operation\.is-active:not\(\.is-deck-tile\)\) \.canvas-operation:not\(\.is-active\):not\(\.is-deck-tile\) > \.canvas-operation-terminal \{[^}]*\}/)?.[0] ?? "";
+    // (:has() 게이트), 덱 타일은 대상에서도 게이트에서도 빠진다. companion 프레임도 같이 빠진다 —
+    // 활성 표식을 받을 경로가 없어(호스트가 is-active를 붙이지 않는다) 구조적으로 영원한
+    // 비포커스이고, 그래서 부모 세션이 포커스인 동안 늘 물러나 있었다.
+    const recede = components.match(/\.operations-canvas:has\(\.canvas-operation\.is-active:not\(\.is-deck-tile\)\) \.canvas-operation:not\(\.is-active\):not\(\.is-deck-tile\):not\(\.canvas-companion-frame\) > \.canvas-operation-terminal \{[^}]*\}/)?.[0] ?? "";
+    // 옛 셀렉터(= companion 제외 없음)가 되살아나면 Session Analyst가 다시 흐려진다.
+    expect(components).not.toMatch(/^\.operations-canvas:has\([^{]*\) \.canvas-operation:not\(\.is-active\):not\(\.is-deck-tile\) > \.canvas-operation-terminal \{/m);
     // 세기는 설정이 소유한다 — 규칙은 변수를 소비하고, 폴백이 곧 기본값이라 값이 실리기 전
     // 첫 페인트에서도 패널이 제자리를 지킨다. 폴백 없는 참조로 바뀌면 설정 이전 프레임이 비어 버린다.
     expect(recede).toContain("opacity: var(--unfocused-panel-opacity, 0.5);");


### PR DESCRIPTION
## Summary
- 비포커스 패널 후퇴 규칙이 `.canvas-operation` 프레임 껍데기를 재사용하는 companion 프레임(Session Analyst)까지 흐리게 만들고 있었습니다. companion은 활성 표식(`is-active`)을 받는 경로가 아예 없어 구조적으로 영원한 비포커스였고, 그래서 부모 세션에 포커스가 서는 순간 — 즉 사용자가 방금 그 패널을 열어 보려는 순간 — 언제나 물러나 있었습니다.
- 덱 타일과 같은 문법으로 `:not(.canvas-companion-frame)`를 후퇴 셀렉터에 더했습니다. 표식·게이트·제외를 한 벌로 유지합니다: 표식을 받을 수 없는 것은 남을 물러서게 하지도, 스스로 물러서지도 않습니다.
- 이웃 Operation 패널의 후퇴(기본 opacity 0.5)와 설정 슬라이더 동작은 그대로입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 188 files / 2312 tests passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — exit 0
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK
- [x] 격리 Console 실측(agent-browser, 시드 Theater + agent Operation 2개 + Session Analyst companion)
  - 수정 전 빌드: companion 본문 `opacity 0.5`, 이웃 패널 1 (companion layout에서 숨김)
  - 수정 후 빌드: companion 본문 `opacity 1`
  - 역방향: companion을 닫으면 비활성 Operation은 다시 `opacity 0.5` — 기존 후퇴 계약 유지