### PR TITLE
fix(fleet-console): fit terminals to their panel bodies

### DIFF
--- a/.changelog.d/terminal-edge-to-edge.md
+++ b/.changelog.d/terminal-edge-to-edge.md
@@ -1,0 +1,8 @@
+---
+branch: terminal-edge-to-edge
+---
+
+### fleet-console
+#### Changed
+- Let Agent Operations and the global Shell use the full terminal body without an inset gutter.
+  ko: Agent Operation과 전역 Shell이 안쪽 여백 없이 터미널 본문 전체를 사용합니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7324,8 +7324,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
   min-height: 0;
   overflow: hidden;
   border-radius: 0 0 calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px);
-  /* terminal-shell의 8px 패딩이 xterm 뷰포트를 사방에서 감싸므로 이 면은 실제로 보이는 띠다 —
-     캡션·작업면과 다른 값을 주면 창 안에 액자 테가 생긴다. field 채널 하나를 그대로 쓴다:
+  /* xterm은 정수 cols×rows만 그리므로 패널 픽셀을 나누고 남은 거터가 생길 수 있다.
+     캡션·작업면과 다른 값을 주면 그 거터가 액자 테로 읽히므로 field 채널 하나를 그대로 쓴다:
      다크+게이트 열림에서는 비어(transparent) 패널 루트의 유리 한 장이 필드와 거터를 함께 칠하고,
      라이트·게이트 닫힘에서는 xterm이 받는 불투명 실색과 같은 값을 칠해 격자 경계 띠를 없앤다.
      여기서 자기 틴트를 들면 루트 유리와 겹쳐 창 안이 두 값이 된다(이중 알파). */
@@ -7355,7 +7355,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 .canvas-operation-terminal .terminal-shell {
-  padding: var(--space-2);
+  padding: 0;
   border: 0;
   border-radius: var(--radius-md);
   background: transparent;
@@ -9457,8 +9457,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding: var(--space-3);
+  padding: 0;
   /* 이 기본 규칙의 소비처는 레일 Shell 하나다(캔버스 Operation은 아래에서 transparent로 덮는다).
+     슬롯 머리·테두리가 이미 Shell 크롬을 소유하므로 xterm 둘레에 두 번째 내부 여백을 만들지 않는다.
      카드 면은 그 안의 xterm과 같은 --surface-panel이어야 한다 — 유리(--surface-glass)는 뒤에
      오는 것에 따라 유효색이 흔들리는데 xterm 배경은 불투명 한 값이라 맞출 수가 없고, Maritime
      5.3%p·Carbon 6.6%p의 계단으로 남는다. 카드의 정체는 테두리가 지고 면은 터미널에 넘긴다. */

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2239,7 +2239,10 @@ describe("Instrument core design contract", () => {
     // 레일 Shell 카드도 같은 면이다 — xterm이 terminal 유리 채널을 따라 반투명해지므로
     // 카드 면도 panel-face로 물러나 유리 한 장으로 읽힌다(게이트가 닫히면 둘 다 불투명 복원).
     const terminalShellBlock = components.match(/^\.terminal-shell \{[^}]*\}/m)?.[0] ?? "";
+    expect(terminalShellBlock).toContain("padding: 0;");
     expect(terminalShellBlock).toContain("background: var(--glass-tint-terminal);");
+    const operationTerminalShellBlocks = components.match(/^\.canvas-operation-terminal \.terminal-shell \{[^}]*\}/gm) ?? [];
+    expect(operationTerminalShellBlocks.some((block) => block.includes("padding: 0;"))).toBe(true);
     // 휴면은 패널 면 위의 상태다 — 톤을 낮추는 베이스 레이어가 돌아오면 창 안에 다른 면이 생긴다.
     const dormantBlock = components.match(/^\.canvas-operation-dormant \{[^}]*\}/m)?.[0] ?? "";
     expect(dormantBlock).toContain("background: radial-gradient(");

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
@@ -8,7 +8,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  padding-top: var(--space-1);
+  /* 터미널 격자는 본문 가장자리까지 쓰되, 손가락 키는 바깥 슬롯에 닿지 않게 자기 거터를 진다.
+     focus outline은 버튼 밖으로 3px 나가므로 space-1이 네 변에서 잘림 없이 감싼다. */
+  padding: var(--space-1);
 }
 
 /* Equal columns, explicitly floored at 0: an auto-sized track lets one wide label (F10, PgDn)

--- a/runtime/fleet-plugins/terminal/tests/terminal-key-bar.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/terminal-key-bar.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from "node:fs";
+
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -158,6 +160,14 @@ afterEach(() => {
 });
 
 describe("TerminalKeyBar on a touch terminal", () => {
+  it("keeps its focus outline inside an edge-to-edge terminal shell", () => {
+    const css = readFileSync("client/shared/terminal-key-bar.css", "utf8");
+    const keyBarBlock = css.match(/^\.terminal-key-bar \{[^}]*\}/m)?.[0] ?? "";
+
+    expect(keyBarBlock).toContain("padding: var(--space-1);");
+    expect(keyBarBlock).not.toContain("padding-top:");
+  });
+
   it("carries the keys a soft keyboard has no room for", async () => {
     await renderSurface();
 


### PR DESCRIPTION
## Summary
- remove the 8px inset around Agent Operation terminals
- remove the 12px inset around the global Shell terminal
- preserve the edge-to-edge terminal layout in the Console design contract

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] browser measurement for Agent Operation, global Shell, and coarse-pointer touch key bar geometry