### PR TITLE
fix(fleet-console): center command band on console

### DIFF
--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -93,20 +93,17 @@ export function commandBandMenuClampedLeft(
 
 // 맵 컨트롤 클러스터(.command-band-map-controls)는 절대 배치라 그리드가 그 폭을 모른다.
 // 매직 오프셋 상수는 버튼이 늘 때마다 겹침으로 깨졌으므로(구 116px 사고) 실측 폭에서 계산한다.
-// 좌우 여백 트랙은 반드시 같은 하한을 쓴다 — 값이 어긋나면 하한이 물리는 순간 중앙이 밀린다.
-// mapControlsLead는 스테이지 원점에서 앵커까지의 거리다 — 펼침이면 앵커=사이드바 폭=스테이지
-// 원점이라 0, 접힘이면 스테이지 원점이 0이라 도킹 앵커 그대로다. 하한은 스테이지 원점 기준으로
-// 재야 접힌 상태에서도 겹치지 않는다.
+// 좌우 여백 트랙은 반드시 같은 하한을 쓴다. 한쪽만 맵 컨트롤 끝을 예약하면 브레드크럼이
+// viewport 중앙에서 밀린다. 앵커와 폭은 Command Band와 같은 viewport 좌표계다.
 const COMMAND_BAND_MAP_CONTROLS_INSET_PX = 8;
 const COMMAND_BAND_CENTER_BREATHING_PX = 12;
 const COMMAND_BAND_CENTER_GUTTER_FLOOR_PX = 44;
 const COMMAND_BAND_CENTER_MIN_PX = 168;
 
 // 접힘 앵커 — 사이드바가 접히면 맵 컨트롤의 정박 경계(사이드바 우측 경계선)가 사라지므로,
-// 좌측 컨트롤군의 실측 콘텐츠 끝을 새 앵커로 쓴다(브레드크럼이 이미 쓰는 "정렬 앵커는 실제
-// 스테이지 경계" 원칙의 클러스터 판). CSS가 앵커에 INSET(--space-2)을 더해 펼침 상태와 같은
-// 단일 간격으로 클러스터를 잇는다. 미측정(0 이하)이면 사이드바 폭 앵커로 폴백해 첫 페인트가
-// 기존 문법과 동일하게 남는다.
+// 좌측 컨트롤군의 실측 콘텐츠 끝을 새 앵커로 쓴다. CSS가 앵커에 INSET(--space-2)을 더해
+// 펼침 상태와 같은 단일 간격으로 클러스터를 잇는다. 미측정(0 이하)이면 사이드바 폭 앵커로
+// 폴백해 첫 페인트가 기존 문법과 동일하게 남는다.
 export function commandBandMapControlsAnchor(
   collapsed: boolean,
   sideBarWidth: number,
@@ -116,15 +113,11 @@ export function commandBandMapControlsAnchor(
   return leftContentEnd;
 }
 
-// Activity Rail의 고정 스트립 폭. 패널 폭은 포함하지 않는다 — PR #302가 밴드를 레일
-// 크기 조절에서 떼어냈고, 여기서 예약하는 것은 접히지 않은 레일이 늘 차지하는 스트립뿐이다.
-export const COMMAND_BAND_RAIL_STRIP_PX = 44;
-
-export function commandBandCenterGutter(mapControlsLead: number, mapControlsWidth: number): number {
+export function commandBandCenterGutter(mapControlsAnchor: number, mapControlsWidth: number): number {
   if (mapControlsWidth <= 0) return COMMAND_BAND_CENTER_GUTTER_FLOOR_PX;
   return Math.max(
     COMMAND_BAND_CENTER_GUTTER_FLOOR_PX,
-    mapControlsLead + COMMAND_BAND_MAP_CONTROLS_INSET_PX + mapControlsWidth + COMMAND_BAND_CENTER_BREATHING_PX,
+    mapControlsAnchor + COMMAND_BAND_MAP_CONTROLS_INSET_PX + mapControlsWidth + COMMAND_BAND_CENTER_BREATHING_PX,
   );
 }
 

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -8,7 +8,7 @@ import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../ap
 import { animateViewportTo, clearFormationView, fitAllOperations, selectFormationLayout, setStationKeeping, toggleFormationView, useCanvasState, useFormationLayout, useFormationView, useStationKeeping, type FormationLayout } from "../canvas/canvas-store.js";
 import { enterTriage, focusedTriageOperationId, setTriageActive, setTriageSpotlightEnabled, useTriageActive, useTriageDeckZoomLive, useTriageSpotlightEnabled, visitTriageTheater } from "../canvas/triage-store.js";
 import { cycleTriageDeckZoomPreset } from "../canvas/triage-watch-deck.js";
-import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandLaunchModelLabels, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
+import { commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandLaunchModelLabels, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
 import { ViewModeToggle } from "./view-mode-toggle.js";
@@ -175,17 +175,14 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const [environmentLoading, setEnvironmentLoading] = useState(false);
   const [copiedValue, setCopiedValue] = useState<string | null>(null);
   const [copyFailedValue, setCopyFailedValue] = useState<string | null>(null);
-  // 정렬 앵커는 실제 스테이지 경계다 — 접힌 사이드바는 폭 0, 접힌 레일 크롬은 스트립 0.
-  const stageLeftWidth = sideBar.collapsed ? 0 : sideBar.width;
-  const stageRightWidth = railChromeExpanded ? COMMAND_BAND_RAIL_STRIP_PX : 0;
-  // 맵 컨트롤 앵커도 같은 원칙을 따른다: 펼침 = 사이드바 경계선, 접힘 = 좌측 컨트롤군 끝(도킹).
-  // 옛 사이드바 폭에 남겨두면 경계 없는 밴드 한가운데에 떠 보이고, 넓힌 뒤 접으면 그만큼 더 밀린다.
+  // 맵 컨트롤 앵커는 펼침 = 사이드바 경계선, 접힘 = 좌측 컨트롤군 끝(도킹)이다.
+  // 브레드크럼은 Console 전체 정중앙에 고정하므로 여백 하한도 같은 viewport 좌표계로 잰다.
   const mapControlsAnchor = commandBandMapControlsAnchor(sideBar.collapsed, sideBar.width, leftContentEnd);
-  const centerGutter = commandBandCenterGutter(mapControlsAnchor - stageLeftWidth, mapControlsWidth);
-  const centerBreadcrumbVisible = viewMode.effective !== "mobile" && commandBandCenterFits(bandWidth - stageLeftWidth - stageRightWidth, centerGutter);
-  // 접힌 뒤에는 여백 트랙이 지킬 대상이 없다. 하한을 그대로 두면 고정 트랙 합이 밴드 폭을 넘어
-  // 우측 컨트롤이 화면 밖으로 밀린다 — 사이드바를 넓게 늘린 뒤 접으면 하한이 캡 폭만큼 커져
-  // 1280px 창에서도 터진다. 판정용 centerGutter는 그대로 두어 되돌아오는 폭이 흔들리지 않게 한다.
+  const centerGutter = commandBandCenterGutter(mapControlsAnchor, mapControlsWidth);
+  const centerBreadcrumbVisible = viewMode.effective !== "mobile" && commandBandCenterFits(bandWidth, centerGutter);
+  // 브레드크럼을 접은 뒤에는 지킬 중앙 트랙이 없다. 하한을 그대로 두면 고정 트랙 합이 밴드 폭을
+  // 넘어 우측 컨트롤이 화면 밖으로 밀린다. 판정용 centerGutter는 그대로 두어 되돌아오는 폭이
+  // 흔들리지 않게 하고, CSS에 주입하는 값만 0으로 내린다.
   const injectedCenterGutter = centerBreadcrumbVisible ? centerGutter : 0;
   // 열림/닫힘 전환 시 이벤트 핸들러에서 동기 호출한다 — open effect(폐기 후 fetch)는 paint 뒤에 돌므로
   // 여기서 지우지 않으면 재오픈 첫 프레임에 이전 절대경로가 그대로 렌더된다.
@@ -517,8 +514,6 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
         style={{
           "--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px`,
           "--command-band-map-anchor": `${mapControlsAnchor}px`,
-          "--command-band-stage-left": viewMode.effective === "mobile" ? "min-content" : `${stageLeftWidth}px`,
-          "--command-band-stage-right": `${stageRightWidth}px`,
           "--command-band-center-gutter": `${injectedCenterGutter}px`,
         } as CSSProperties}
         aria-hidden={commandBandHidden || undefined}

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -208,18 +208,15 @@ body:has([aria-modal="true"]:not([hidden])) .floating-widget-layer * {
   min-height: 0;
 }
 
-/* 중앙 브레드크럼은 실제 중앙 스테이지(.operations-center-stage)의 정중앙에 놓는다 —
-   좌측 앵커는 실제 사이드바 폭(접히면 0), 우측 앵커는 Activity Rail의 고정 스트립 폭이다.
-   레일 "패널" 폭은 예약하지 않는다: PR #302가 밴드를 레일 크기 조절에서 떼어냈고, 그 결정은 유효하다.
-   좌우 여백 트랙은 동일 하한 + 동일 1fr이라 하한이 물려도 중심이 유지된다. 하한은 좌측 캡과
-   맵 컨트롤 실측 폭에서 계산해 밴드에 주입한다(--command-band-center-gutter). */
+/* 중앙 브레드크럼은 Quick Launch와 같은 Console 전체 수평축에 놓는다.
+   좌우 여백 트랙은 동일 하한 + 동일 1fr이라 좌측 사이드바와 우측 레일의 비대칭에 끌려가지 않는다.
+   하한은 좌측 맵 컨트롤의 viewport 끝에서 계산해 주입한다(--command-band-center-gutter).
+   중앙이 그 하한 사이에 들어가지 못하는 폭에서는 브레드크럼을 접는다. */
 .command-band {
   --command-band-center-gutter: 44px;
-  --command-band-stage-left: var(--command-band-left-width, 280px);
-  --command-band-stage-right: 0px;
   position: relative;
   display: grid;
-  grid-template-columns: var(--command-band-stage-left) minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr) var(--command-band-stage-right);
+  grid-template-columns: minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr);
   flex: none;
   height: var(--chrome-band-height);
   min-height: var(--chrome-band-height);
@@ -357,7 +354,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band.is-utility {
-  grid-template-columns: auto minmax(0, 1fr) minmax(0, max-content) auto 0px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, max-content) minmax(0, 1fr);
 }
 
 .command-band-left,
@@ -369,7 +366,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-left {
-  grid-column: 1 / 3;
+  grid-column: 1;
   width: var(--command-band-left-width, 280px);
   gap: var(--space-1);
   padding-inline: var(--space-2);
@@ -583,14 +580,14 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-center {
-  grid-column: 3;
+  grid-column: 2;
   justify-content: center;
   gap: var(--space-3);
   padding-inline: var(--space-3);
 }
 
 .command-band-right {
-  grid-column: 4 / 6;
+  grid-column: 3;
   justify-content: flex-end;
   gap: var(--space-1);
   padding-inline: var(--space-2);

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -144,9 +144,11 @@ describe("Command Band center visibility measurements", () => {
     expect(commandBandCenterGutter(0, 1)).toBe(44);
   });
 
-  it("derives the gutter from the measured map control width", () => {
+  it("derives the gutter from the map controls' viewport edge", () => {
     expect(commandBandCenterGutter(0, 163)).toBe(8 + 163 + 12);
-    // 접힘 시 lead는 도킹 앵커(좌측 컨트롤군 끝 기준) 그대로다 — 스테이지 원점이 0이므로.
+    // 펼친 사이드바 경계도 viewport 좌표 그대로 포함한다 — 브레드크럼 중심은 Console 중앙이다.
+    expect(commandBandCenterGutter(280, 163)).toBe(280 + 8 + 163 + 12);
+    // 접힘 시에는 좌측 컨트롤군 끝으로 도킹한 앵커가 같은 좌표계에서 하한을 정한다.
     expect(commandBandCenterGutter(185, 163)).toBe(185 + 8 + 163 + 12);
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2132,7 +2132,8 @@ describe("Instrument core design contract", () => {
     expect(layout).toContain("left: calc(var(--command-band-map-anchor, var(--command-band-left-width, 280px)) + var(--space-2));");
     expect(commandBand).toContain('"--command-band-map-anchor": `${mapControlsAnchor}px`,');
     expect(commandBand).toContain("const mapControlsAnchor = commandBandMapControlsAnchor(sideBar.collapsed, sideBar.width, leftContentEnd);");
-    expect(commandBand).toContain("const centerGutter = commandBandCenterGutter(mapControlsAnchor - stageLeftWidth, mapControlsWidth);");
+    expect(commandBand).toContain("const centerGutter = commandBandCenterGutter(mapControlsAnchor, mapControlsWidth);");
+    expect(commandBand).toContain("commandBandCenterFits(bandWidth, centerGutter)");
     // 글라이드는 접힘/펼침 앵커 전환 전용 — 드래그 리사이즈는 :has 게이트로 즉시 추종을 유지한다.
     expect(layout).toContain("transition: left 200ms ease;");
     expect(layout).toContain('body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls { transition: none; }');
@@ -2141,27 +2142,24 @@ describe("Instrument core design contract", () => {
     // 구 문법(모드 전용 도구를 밴드에 상시 노출)의 잔재는 남기지 않는다.
     expect(layout).not.toContain(".command-band-formation-group {");
     expect(layout).not.toContain(".command-band-triage-toggle {");
-    // 데스크톱은 사이드바 폭을 그대로 미러하고, 모바일 셸에는 미러할 사이드바가 없으므로
-    // 좌측 트랙이 내용 크기로 접힌다. 두 갈래를 한 줄로 고정해 한쪽만 바뀌는 표류를 막는다.
+    // 좌측 캡 폭은 사이드바와 계속 맞추지만, 브레드크럼 트랙은 Console 전체 폭을 좌우 대칭으로
+    // 나눈다. 사이드바와 레일 폭이 달라도 Quick Launch와 같은 viewport 중앙축에서 움직이지 않는다.
     expect(commandBand).toContain('"--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px`');
-    expect(layout).toContain("grid-template-columns: var(--command-band-stage-left) minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr) var(--command-band-stage-right);");
+    expect(layout).toContain("grid-template-columns: minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr);");
     const commandBandCenterBlock = layout.match(/\.command-band-center \{[^}]*\}/)?.[0] ?? "";
     const commandBandLeftBlocks = [...layout.matchAll(/\.command-band-left \{[^}]*\}/g)].map((match) => match[0]);
     const commandBandRightBlocks = [...layout.matchAll(/\.command-band-right \{[^}]*\}/g)].map((match) => match[0]);
-    // 바깥 트랙은 실제 스테이지 경계(접힌 사이드바 0, 접힌 레일 스트립 0)를 담고, 좌측 캡과 우측
-    // 클러스터는 여백 트랙까지 걸쳐 밴드 양끝에 붙는다. 좌우 여백 트랙은 동일 하한을 공유한다 —
-    // 어느 한쪽이라도 어긋나면 브레드크럼이 스테이지 중심에서 밀린다.
-    expect(layout).toContain(".command-band.is-utility {\n  grid-template-columns: auto minmax(0, 1fr) minmax(0, max-content) auto 0px;\n}");
+    expect(layout).toContain(".command-band.is-utility {\n  grid-template-columns: minmax(0, 1fr) minmax(0, max-content) minmax(0, 1fr);\n}");
     expect(layout).toContain("  --command-band-center-gutter: 44px;");
-    expect(layout).toContain("  --command-band-stage-left: var(--command-band-left-width, 280px);");
-    expect(layout).toContain("  --command-band-stage-right: 0px;");
-    expect(commandBandLeftBlocks.some((block) => block.includes("grid-column: 1 / 3;"))).toBe(true);
-    expect(commandBandCenterBlock).toContain("grid-column: 3;");
-    expect(commandBandRightBlocks.some((block) => block.includes("grid-column: 4 / 6;"))).toBe(true);
-    expect(commandBand).toContain('"--command-band-stage-left": viewMode.effective === "mobile" ? "min-content" : `${stageLeftWidth}px`,');
-    expect(commandBand).toContain('"--command-band-stage-right": `${stageRightWidth}px`,');
-    // 접힌 뒤에도 여백 하한을 주입하면 고정 트랙 합이 밴드 폭을 넘어 우측 컨트롤이 화면 밖으로
-    // 밀린다(넓힌 사이드바를 접었을 때 특히). 주입값과 판정값을 분리해 고정한다.
+    expect(layout).not.toContain("--command-band-stage-left");
+    expect(layout).not.toContain("--command-band-stage-right");
+    expect(commandBandLeftBlocks.some((block) => block.includes("grid-column: 1;"))).toBe(true);
+    expect(commandBandCenterBlock).toContain("grid-column: 2;");
+    expect(commandBandRightBlocks.some((block) => block.includes("grid-column: 3;"))).toBe(true);
+    expect(commandBand).not.toContain("stageLeftWidth");
+    expect(commandBand).not.toContain("stageRightWidth");
+    // 브레드크럼을 접은 뒤에도 여백 하한을 주입하면 고정 트랙 합이 밴드 폭을 넘어 우측 컨트롤이
+    // 화면 밖으로 밀린다. 주입값과 판정값을 분리해 고정한다.
     expect(commandBand).toContain("const injectedCenterGutter = centerBreadcrumbVisible ? centerGutter : 0;");
     expect(commandBand).toContain('"--command-band-center-gutter": `${injectedCenterGutter}px`,');
     expect(commandBand).toContain("{centerBreadcrumbVisible ? <div className=\"command-band-center\">");


### PR DESCRIPTION
## Summary
- align the Command Band Theater and Operation switcher to the full Console viewport center
- keep map controls clear with symmetric viewport-based gutters
- update the Command Band guard and design contracts for the global center axis

## Test Plan
- [x] `corepack pnpm --dir runtime/fleet-console exec vitest run tests/command-band-v2-guards.test.ts tests/instrument-design-contract.test.ts`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] headed browser measurements at 2000px and 1440px with expanded and collapsed side chrome
- [x] verify the Command Band and Quick Launch centers both have 0px viewport-axis delta