### PR TITLE
feat(fleet-console): add truecolor glass terminals

### DIFF
--- a/.changelog.d/terminal-truecolor.md
+++ b/.changelog.d/terminal-truecolor.md
@@ -1,0 +1,8 @@
+---
+branch: terminal-truecolor
+---
+
+### fleet-console
+#### Changed
+- Advertise 24-bit color support to programs running in Shell and Agent terminals while retaining compatible terminal metadata, and let dark Liquid Glass terminal panels reveal the canvas through a smoked translucent surface.
+  ko: 호환 가능한 터미널 메타데이터를 유지하면서 Shell 및 Agent 터미널에서 실행되는 프로그램에 24비트 색상 지원을 알리고, 다크 리퀴드 글래스 터미널 패널이 스모크 반투명 표면을 통해 캔버스를 비추도록 개선합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -804,16 +804,12 @@ export function OperationsCanvas({
   // 캔버스 transform이 제거되는 모드에서 화면에 서는 패널은 net scale 1로 보정한다. 단, focus
   // layer 뒤의 peer는 기존 world geometry와 줌을 그대로 보존한다 — 숨은 xterm까지 fontSize/fit/PTY
   // resize를 fan-out하지 않기 위한 핵심 계약이다.
-  const visiblePanelCount = triageActive
-    ? pluginOperations.filter((operation) => !triageMinimizedSet.has(operation.id)).length
-    : theaterOperations.filter((operation) => !minimizedSet.has(operation.id)).length;
-  const adaptivePanelMaterial = visiblePanelCount >= 4;
   const topPanelZIndex = maxOperationZIndex(canvas.operations) + 1;
   const companionSlotCount = visibleCompanionPanels.length + 1;
 
   return (
     <main
-      className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""} ${glanceVisible ? "is-glance" : ""} ${panelMaximized ? "is-panel-maximized" : ""} ${panelCompanion ? "is-companion-layout" : ""} ${formationView ? "is-formation-view" : ""} ${formationEntering ? "is-formation-entering" : ""} ${triageActive ? "is-triage" : ""} ${triageEntering ? "is-triage-entering" : ""} ${focusFadeTransitionReady ? "" : "is-focus-fade-settling"} ${adaptivePanelMaterial ? "is-panel-density-high" : ""}`}
+      className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""} ${glanceVisible ? "is-glance" : ""} ${panelMaximized ? "is-panel-maximized" : ""} ${panelCompanion ? "is-companion-layout" : ""} ${formationView ? "is-formation-view" : ""} ${formationEntering ? "is-formation-entering" : ""} ${triageActive ? "is-triage" : ""} ${triageEntering ? "is-triage-entering" : ""} ${focusFadeTransitionReady ? "" : "is-focus-fade-settling"}`}
       onPointerDown={(event) => {
         // 메뉴 내부 클릭(캔버스 소유 메뉴는 <main> 자손이라 버블로 도달한다)은 실행 항목의
         // click을 살리기 위해 닫기 신호를 본내지 않는다 — data-canvas-blocker는 전파를 멈추지 않는다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4801,8 +4801,6 @@
     linear-gradient(var(--glass-tint-panel), var(--glass-tint-panel)),
     radial-gradient(150% 420px at 50% var(--pane-light-origin), var(--glass-pane-light) 0%, transparent 62%),
     var(--glass-underlay);
-  -webkit-backdrop-filter: var(--glass-backdrop-panel);
-  backdrop-filter: var(--glass-backdrop-panel);
   box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--shadow-soft);
   /* 공통 geometry 모션 레이어 — formation/최대화/companion/복원의 재배치가 같은 물리로 움직인다.
      visibility는 0s 즉시(복원·focus layer 즉시 표시), 최소화 시에만 is-minimized가 지연을 소유한다.
@@ -4816,16 +4814,6 @@
     opacity var(--duration-base) var(--ease-glide),
     transform var(--duration-base) var(--ease-glide),
     visibility 0s linear 0s;
-}
-
-/* Cruise·Tactical·War Room에서 패널이 넷 이상 보이면 각 창의 32px backdrop blur를 불투명
-   panel 토큰으로 축약한다. 포커스·캡션·상태 채널은 그대로이고 재질만 바뀐다. 최대화/companion
-   중에도 hidden peer가 blur surface로 남지 않으며, 대상 창은 같은 불투명 면 위에서 geometry만 전환한다. */
-.operations-canvas.is-panel-density-high {
-  --glass-tint-panel: var(--surface-panel);
-  --glass-underlay: var(--surface-panel);
-  --glass-pane-light: transparent;
-  --glass-backdrop-panel: none;
 }
 
 /* 드래그·리사이즈 조작 중에는 포인터 추적이 즉답해야 한다 — rail.css is-dragging 선례. */
@@ -7359,6 +7347,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
   border: 0;
   border-radius: var(--radius-md);
   background: transparent;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
   box-shadow: none;
 }
 
@@ -9460,12 +9450,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 0;
   /* 이 기본 규칙의 소비처는 레일 Shell 하나다(캔버스 Operation은 아래에서 transparent로 덮는다).
      슬롯 머리·테두리가 이미 Shell 크롬을 소유하므로 xterm 둘레에 두 번째 내부 여백을 만들지 않는다.
-     카드 면은 그 안의 xterm과 같은 --surface-panel이어야 한다 — 유리(--surface-glass)는 뒤에
-     오는 것에 따라 유효색이 흔들리는데 xterm 배경은 불투명 한 값이라 맞출 수가 없고, Maritime
-     5.3%p·Carbon 6.6%p의 계단으로 남는다. 카드의 정체는 테두리가 지고 면은 터미널에 넘긴다. */
+     Shell은 패널과 달리 항상 뒤를 흐리는 단일 유리 면이다. 게이트가 열리면 terminal tint와 전용
+     blur를 함께 쓰고, 닫히면 불투명 terminal tint와 none으로 복원된다. xterm도 같은 terminal
+     채널을 읽으므로 카드와 필드 사이에 색 계단을 만들지 않는다. */
   background: var(--glass-tint-terminal);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
+  -webkit-backdrop-filter: var(--glass-backdrop-terminal);
+  backdrop-filter: var(--glass-backdrop-terminal);
   box-shadow: var(--shadow-soft);
 }
 
@@ -12965,6 +12957,26 @@ body[data-codex-reading="true"] .operations-canvas .codex-reading-sheet {
 /* 포커스는 위치 신호다 — brass 채널. 상태(aurora/warn/coral)와 섞지 않는다. */
 .expanded-surface-slot.is-focused {
   border-color: color-mix(in oklch, var(--brass) 52%, var(--surface-rim-strong));
+}
+
+/* 확대 Shell도 전용 terminal 재질 한 장을 slot 루트에서 칠한다. Codex 등 다른 확대 표면은 위의
+   강한 팝업 재질을 유지하고, Shell은 terminal tint와 항상 켜지는 전용 blur를 쓴다.
+   terminal-shell을 비워 xterm까지 같은 pane을 공유하며, 게이트가 닫히면 불투명 terminal 토큰과
+   무블러로 자동 복원된다. */
+.expanded-surface-slot:has(.terminal-shell) {
+  background:
+    linear-gradient(var(--glass-tint-terminal), var(--glass-tint-terminal)),
+    radial-gradient(150% 420px at 50% -48px, var(--glass-pane-light) 0%, transparent 62%),
+    var(--glass-underlay);
+  -webkit-backdrop-filter: var(--glass-backdrop-terminal);
+  backdrop-filter: var(--glass-backdrop-terminal);
+}
+
+.expanded-surface-slot .terminal-shell {
+  background: transparent;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  box-shadow: none;
 }
 
 .expanded-surface-slot-head {

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -207,7 +207,7 @@
 
   /* ── 리퀴드 글래스 채널 ──────────────────────────────────────────────
      부유층(팝업·메뉴·오버레이 슬롯)의 최하층·틴트·블러와 상주 크롬의 블러·림은
-     이 여섯 채널만 소비한다. 기본값은 현행 판독 계약 그대로다 — 불투명 언더레이,
+     아래 역할 채널만 소비한다. 기본값은 현행 판독 계약 그대로다 — 불투명 언더레이,
      현행 틴트, 무블러. 유리는 파일 하단의 data-glass 게이트 블록에서만 켜지므로,
      게이트가 닫히면(@supports 미달·prefers-reduced-transparency·설정 해제) 모든
      소비처가 자동으로 오늘의 불투명 계약으로 되돌아간다. */
@@ -256,6 +256,7 @@
   --glass-backdrop-strong: none;
   --glass-backdrop-soft: none;
   --glass-backdrop-panel: none;
+  --glass-backdrop-terminal: none;
   --glass-backdrop-scrim: none;
   --glass-rim: transparent;
   /* 아래쪽 어두운 베벨. 밝은 바탕에서는 흰 하이라이트에 여유가 없어(라이트 유리 본체 L*94.7,
@@ -279,23 +280,23 @@
   --glass-on-tint-deep: oklch(16.5% 0.016 245 / 48%);
   --glass-on-tint-abyss: oklch(13% 0.014 245 / 50%);
   --glass-on-tint-chrome: oklch(19% 0.018 245 / 50%);
-  /* 다크 유리의 밀도 문법 — 뒤에 비칠 빛이 없는 유리에서 투과는 재질감을 만들지 못하고 명도를
-     빼기만 한다(실측: 필드가 패널 면보다 3.1~6.1 L 아래로 내려앉아 사이드바·레일보다 어두워졌고,
-     ANSI black이 필드와 같거나 오히려 밝아졌다). 그래서 틴트는 원 면보다 살짝 위(+2 L)에 서고
-     밀도를 0.83으로 모은다. 명도만 올리면 잿빛 워시가 되므로 채도를 함께 1.7배로 싣고, 재질은
-     명도가 아니라 pane-light의 기울기가 말한다. 알파·명도를 다시 만지면 ANSI black과의 부호
-     (필드보다 어두울 것)를 반드시 재실측할 것. */
-  --glass-on-tint-panel: oklch(18.5% 0.028 245 / 83%);
+  /* 다크 유리의 smoked-glass 문법 — Operation·War Room 카드는 blur 없이 60% 틴트와
+     22% pane-light만으로 캔버스·겹친 창 윤곽을 그대로 통과시킨다. 패널 수에 따라 재질을 바꾸지
+     않아 모든 모드가 같은 투과도를 유지한다. Shell은 같은 60% terminal tint 위에서만 20px blur를
+     사용해 글자 밀도가 높은 단일 작업면의 판독성을 지킨다. 알파·명도를 다시 만지면 ANSI black과의
+     부호(필드보다 어두울 것)와 dim 셀 floor를 반드시 재실측할 것. */
+  --glass-on-tint-panel: oklch(18.5% 0.028 245 / 60%);
   --glass-on-tint-field: transparent;
-  --glass-on-pane-light: oklch(25% 0.032 245);
+  --glass-on-pane-light: oklch(25% 0.032 245 / 22%);
   --canvas-on-ambience: oklch(16% 0.022 245);
-  --glass-on-tint-caption: oklch(17% 0.018 245 / 82%);
-  --glass-on-tint-terminal: oklch(18.5% 0.028 245 / 83%);
-  --glass-on-tint-terminal-floor: oklch(18.1% 0.027 245);
+  --glass-on-tint-caption: oklch(17% 0.018 245 / 64%);
+  --glass-on-tint-terminal: oklch(18.5% 0.028 245 / 60%);
+  --glass-on-tint-terminal-floor: oklch(17.5% 0.026 245);
   --glass-on-tint-band: oklch(13% 0.018 245 / 55%);
   --glass-on-backdrop-strong: blur(24px) saturate(1.7);
   --glass-on-backdrop-soft: blur(12px) saturate(1.5);
-  --glass-on-backdrop-panel: blur(32px) saturate(1.45);
+  --glass-on-backdrop-panel: none;
+  --glass-on-backdrop-terminal: blur(20px) saturate(1.45);
   --glass-on-backdrop-scrim: blur(3px);
   --glass-on-rim: oklch(96% 0.01 90 / 16%);
   /* 유리 광택(sheen) — 대각 하이라이트 한 겹. 무채색 리터럴만 쓰는 독트린 예외 채널이며,
@@ -523,13 +524,13 @@
   --glass-on-tint-deep: oklch(20% 0.045 248 / 46%);
   --glass-on-tint-abyss: oklch(15% 0.04 250 / 48%);
   --glass-on-tint-chrome: oklch(27% 0.04 248 / 45%);
-  --glass-on-tint-panel: oklch(25% 0.05 248 / 83%);
+  --glass-on-tint-panel: oklch(25% 0.05 248 / 60%);
   --glass-on-tint-field: transparent;
-  --glass-on-pane-light: oklch(32% 0.055 248);
+  --glass-on-pane-light: oklch(32% 0.055 248 / 22%);
   --canvas-on-ambience: oklch(18% 0.035 235);
-  --glass-on-tint-caption: oklch(21% 0.03 248 / 82%);
-  --glass-on-tint-terminal: oklch(25% 0.05 248 / 83%);
-  --glass-on-tint-terminal-floor: oklch(23.9% 0.047 247);
+  --glass-on-tint-caption: oklch(21% 0.03 248 / 64%);
+  --glass-on-tint-terminal: oklch(25% 0.05 248 / 60%);
+  --glass-on-tint-terminal-floor: oklch(22.3% 0.043 245);
   --glass-on-tint-band: oklch(19% 0.045 248 / 50%);
   --glass-on-rim: oklch(96% 0.012 88 / 18%);
 
@@ -636,13 +637,13 @@
   --glass-on-tint-deep: oklch(18% 0.007 255 / 46%);
   --glass-on-tint-abyss: oklch(14% 0.006 255 / 48%);
   --glass-on-tint-chrome: oklch(24% 0.006 252 / 45%);
-  --glass-on-tint-panel: oklch(21% 0.013 252 / 83%);
+  --glass-on-tint-panel: oklch(21% 0.013 252 / 60%);
   --glass-on-tint-field: transparent;
-  --glass-on-pane-light: oklch(28% 0.014 252);
+  --glass-on-pane-light: oklch(28% 0.014 252 / 22%);
   --canvas-on-ambience: oklch(18% 0.014 250);
-  --glass-on-tint-caption: oklch(19% 0.008 252 / 84%);
-  --glass-on-tint-terminal: oklch(21% 0.013 252 / 83%);
-  --glass-on-tint-terminal-floor: oklch(20.5% 0.013 252);
+  --glass-on-tint-caption: oklch(19% 0.008 252 / 64%);
+  --glass-on-tint-terminal: oklch(21% 0.013 252 / 60%);
+  --glass-on-tint-terminal-floor: oklch(19.8% 0.013 251);
   --glass-on-tint-band: oklch(17% 0.007 255 / 50%);
   --glass-on-rim: oklch(95% 0.003 250 / 16%);
 
@@ -869,6 +870,7 @@
     --glass-backdrop-strong: var(--glass-on-backdrop-strong);
     --glass-backdrop-soft: var(--glass-on-backdrop-soft);
     --glass-backdrop-panel: var(--glass-on-backdrop-panel);
+    --glass-backdrop-terminal: var(--glass-on-backdrop-terminal);
     --glass-backdrop-scrim: var(--glass-on-backdrop-scrim);
     --glass-rim: var(--glass-on-rim);
     /* 베벨·부양·워시·블룸 채널은 여기서 싣지 않는다 — 재료를 가진 테마가 라이트뿐이었고,
@@ -900,6 +902,7 @@
       --glass-backdrop-strong: none;
       --glass-backdrop-soft: none;
       --glass-backdrop-panel: none;
+      --glass-backdrop-terminal: none;
       --glass-backdrop-scrim: none;
       --glass-rim: transparent;
       --glass-sheen: linear-gradient(transparent, transparent);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -876,11 +876,12 @@ describe("Instrument core design contract", () => {
     expect(css).not.toMatch(/--op-accent|--chip-accent/);
     // 리퀴드 글래스 계약: backdrop-filter는 theme.css의 glass 채널(var(--glass-backdrop-*))만
     // 소비한다. raw blur를 표면에 직접 들면 세 게이트(@supports 미달·prefers-reduced-transparency·
-    // 설정 data-glass="off")가 그 표면을 놓쳐 불투명 폴백 계약이 깨진다.
+    // 설정 data-glass="off")가 그 표면을 놓쳐 불투명 폴백 계약이 깨진다. 중첩 Shell·Operation
+    // 자식의 명시적 none은 조상 blur가 이중 적용되지 않게 닫는 유일한 예외다.
     const backdropDeclarations = css.match(/(?:-webkit-)?backdrop-filter:[^;\n]*;/g) ?? [];
     expect(backdropDeclarations.length).toBeGreaterThan(0);
     for (const declaration of backdropDeclarations) {
-      expect(declaration).toMatch(/^(?:-webkit-)?backdrop-filter: var\(--glass-backdrop-(?:strong|soft|panel|scrim)\);$/);
+      expect(declaration).toMatch(/^(?:-webkit-)?backdrop-filter: (?:var\(--glass-backdrop-(?:strong|soft|panel|terminal|scrim)\)|none);$/);
     }
     // 게이트와 폴백 기본값은 theme.css에 존재해야 한다 — 채널 기본값이 곧 구 불투명 계약이다.
     const theme = source("styles/theme.css");
@@ -1014,11 +1015,18 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--glass-tint-field: var(--surface-panel);");
     expect(theme).toContain("--glass-pane-light: transparent;");
     expect(theme).toContain("--canvas-ambience: var(--canvas-sea-core);");
-    // 다크 3종의 유리 재료는 밀도 문법이다 — 틴트가 원 면보다 어두우면 필드가 캔버스로 가라앉고
-    // ANSI black이 필드보다 밝아진다(실측 maritime +1.2 L·carbon +1.1 L 역전).
-    expect(theme).toContain("--glass-on-tint-panel: oklch(18.5% 0.028 245 / 83%);");
-    expect(theme).toContain("--glass-on-tint-panel: oklch(25% 0.05 248 / 83%);");
-    expect(theme).toContain("--glass-on-tint-panel: oklch(21% 0.013 252 / 83%);");
+    // 다크 3종은 Ghostty 계열 smoked pane처럼 60% tint로 뒤의 캔버스·겹친 창 윤곽을 통과시킨다.
+    // pane-light는 22%만 얹고 Operation·War Room 카드는 blur하지 않는다. Shell은 같은 60%
+    // terminal tint 위에 20px blur만 더해 글자 밀도가 높은 작업면의 판독성을 보존한다.
+    expect(theme).toContain("--glass-on-tint-panel: oklch(18.5% 0.028 245 / 60%);");
+    expect(theme).toContain("--glass-on-tint-panel: oklch(25% 0.05 248 / 60%);");
+    expect(theme).toContain("--glass-on-tint-panel: oklch(21% 0.013 252 / 60%);");
+    expect(theme).toContain("--glass-on-tint-terminal: oklch(18.5% 0.028 245 / 60%);");
+    expect(theme).toContain("--glass-on-tint-terminal: oklch(25% 0.05 248 / 60%);");
+    expect(theme).toContain("--glass-on-tint-terminal: oklch(21% 0.013 252 / 60%);");
+    expect((theme.match(/--glass-on-pane-light: oklch\([^)]+\/ 22%\);/g) ?? []).length).toBe(3);
+    expect(theme).toContain("--glass-on-backdrop-panel: none;");
+    expect(theme).toContain("--glass-on-backdrop-terminal: blur(20px) saturate(1.45);");
     // 유리를 받는 테마는 다크 3종뿐이고, 그 셋은 전부 필드를 루트 유리에 넘긴다.
     // 라이트는 게이트 밖이라 재료 자체가 없다(별칭 한 줄도 남기지 않는다).
     expect((theme.match(/--glass-on-tint-field: transparent;/g) ?? []).length).toBe(3);
@@ -1035,14 +1043,14 @@ describe("Instrument core design contract", () => {
     // 닫힌 게이트의 기본값은 곧 현행 불투명 계약이다 — floor가 따로 놀면 게이트를 닫아도 색이 갈린다.
     expect(theme).toContain("--glass-tint-terminal-floor: var(--glass-tint-terminal);");
     expect(theme).toContain("--glass-tint-terminal-floor: var(--glass-on-tint-terminal-floor);");
-    // 다크 3종은 틴트(83%)를 캔버스 대기광 위에 합성한 불투명 근사를 재료로 둔다.
-    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(18.1% 0.027 245);");
-    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(23.9% 0.047 247);");
-    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(20.5% 0.013 252);");
+    // Operation 패널용 floor는 60% panel tint를 캔버스 대기광 위에 sRGB alpha 합성한 불투명 근사다.
+    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(17.5% 0.026 245);");
+    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(22.3% 0.043 245);");
+    expect(theme).toContain("--glass-on-tint-terminal-floor: oklch(19.8% 0.013 251);");
 
-    // 필드를 비우는 경로는 floor 계산값을 읽어 알파만 0으로 눕힌다.
-    expect(surface).toContain('getPropertyValue("--glass-tint-terminal-floor")');
-    expect(surface).toContain("readLiquidGlassPaneActive()) return glassFieldClearColor();");
+    // Operation은 floor, 독립 Shell은 terminal tint 계산값을 읽어 알파만 0으로 눕힌다.
+    expect(surface).toContain('surface === "shell" ? "--glass-tint-terminal" : "--glass-tint-terminal-floor"');
+    expect(surface).toContain("return glassFieldClearColor(");
     // 검정 리터럴을 그대로 돌려주면 dim 셀 회귀가 재발한다 — 반환은 폴백 두 곳뿐이다.
     expect((surface.match(/return "rgba\(0, 0, 0, 0\)";/g) ?? []).length).toBe(2);
   });
@@ -2211,14 +2219,15 @@ describe("Instrument core design contract", () => {
     expect(components).toMatch(/\.operations-side-bar::before \{[^}]*background: var\(--glass-tint-chrome\);/);
     // 패널은 하나의 면이다 — 루트가 panel 유리 틴트를, 캡션·본문 팬은 panel-face(게이트 열림 시
     // transparent)를 소비해 유리 한 장으로 읽힌다. 자식이 자기 틴트를 들면 이중 알파 얼룩이 된다.
+    // Operation과 War Room 카드는 개수와 무관하게 blur하지 않고 같은 투명 면을 공유한다.
     const operationBlock = components.match(/^\.canvas-operation \{[^}]*\}/m)?.[0] ?? "";
     expect(operationBlock).toContain("linear-gradient(var(--glass-tint-panel), var(--glass-tint-panel)),");
     expect(operationBlock).toContain("var(--glass-underlay);");
-    // 유리 뒤가 캔버스(앱에서 가장 어두운 면)라 blur가 굴절시킬 빛이 없다 — 재질은 명도가 아니라
-    // 창 위쪽 광원의 기울기가 말한다. 기하는 절대 좌표라 떠 있는 캡션을 가진 패널은 원점을
-    // 캡션 높이만큼 위로 밀어 창 전체가 한 줄기 빛을 나눠 받는다.
+    // 유리 뒤가 캔버스(앱에서 가장 어두운 면)라 재질은 blur가 아니라 창 위쪽 광원의 기울기가
+    // 말한다. 기하는 절대 좌표라 떠 있는 캡션을 가진 패널은 원점을 캡션 높이만큼 위로 밀어
+    // 창 전체가 한 줄기 빛을 나눠 받는다.
     expect(operationBlock).toContain("radial-gradient(150% 420px at 50% var(--pane-light-origin), var(--glass-pane-light) 0%, transparent 62%),");
-    expect(operationBlock).toContain("backdrop-filter: var(--glass-backdrop-panel);");
+    expect(operationBlock).not.toContain("backdrop-filter:");
     expect(operationBlock).not.toContain("--surface-window");
     const titlebarBlock = components.match(/^\.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
     expect(titlebarBlock).toContain("background: var(--glass-tint-caption);");
@@ -2234,13 +2243,27 @@ describe("Instrument core design contract", () => {
     // 터미널 필드·거터는 field 채널 하나로 만난다 — 다크+열림에서는 비어(transparent) 루트 유리
     // 한 장이 둘 다 칠하고, 라이트·닫힘에서는 xterm이 받는 불투명 실색을 그대로 칠한다.
     expect(panelBodyBlock).toContain("background: var(--glass-tint-field);");
-    // 레일 Shell 카드도 같은 면이다 — xterm이 terminal 유리 채널을 따라 반투명해지므로
-    // 카드 면도 panel-face로 물러나 유리 한 장으로 읽힌다(게이트가 닫히면 둘 다 불투명 복원).
+    // 레일 Shell 카드는 xterm과 같은 terminal tint를 칠하고 전용 blur를 항상 소비한다. Operation
+    // 안의 terminal-shell은 더 구체적인 규칙이 transparent/none으로 덮어 패널에 blur가 새지 않는다.
     const terminalShellBlock = components.match(/^\.terminal-shell \{[^}]*\}/m)?.[0] ?? "";
     expect(terminalShellBlock).toContain("padding: 0;");
     expect(terminalShellBlock).toContain("background: var(--glass-tint-terminal);");
+    expect(terminalShellBlock).toContain("backdrop-filter: var(--glass-backdrop-terminal);");
     const operationTerminalShellBlocks = components.match(/^\.canvas-operation-terminal \.terminal-shell \{[^}]*\}/gm) ?? [];
     expect(operationTerminalShellBlocks.some((block) => block.includes("padding: 0;"))).toBe(true);
+    const operationTerminalShellBlock = operationTerminalShellBlocks.find((block) => block.includes("background:")) ?? "";
+    expect(operationTerminalShellBlock).toContain("background: transparent;");
+    expect(operationTerminalShellBlock).toContain("backdrop-filter: none;");
+    // 확대 Shell도 slot 루트에서 terminal tint와 전용 blur를 한 번만 합성한다. Codex 등
+    // 다른 확대 표면은 공통 팝업 재질을 유지하고, 안쪽 terminal-shell은 투명·무블러다.
+    const expandedShellSlotBlock = components.match(/^\.expanded-surface-slot:has\(\.terminal-shell\) \{[^}]*\}/m)?.[0] ?? "";
+    expect(expandedShellSlotBlock).toContain("linear-gradient(var(--glass-tint-terminal), var(--glass-tint-terminal)),");
+    expect(expandedShellSlotBlock).toContain("var(--glass-underlay);");
+    expect(expandedShellSlotBlock).toContain("backdrop-filter: var(--glass-backdrop-terminal);");
+    const expandedTerminalBlock = components.match(/^\.expanded-surface-slot \.terminal-shell \{[^}]*\}/m)?.[0] ?? "";
+    expect(expandedTerminalBlock).toContain("background: transparent;");
+    expect(expandedTerminalBlock).toContain("backdrop-filter: none;");
+    expect(expandedTerminalBlock).toContain("box-shadow: none;");
     // 휴면은 패널 면 위의 상태다 — 톤을 낮추는 베이스 레이어가 돌아오면 창 안에 다른 면이 생긴다.
     const dormantBlock = components.match(/^\.canvas-operation-dormant \{[^}]*\}/m)?.[0] ?? "";
     expect(dormantBlock).toContain("background: radial-gradient(");
@@ -2493,7 +2516,8 @@ describe("Instrument core design contract", () => {
 
     // xterm은 CSS 변수를 못 받으므로 계산값을 읽어 넘긴다 — 이 경로가 사라지면 터미널 필드가
     // 토큰과 갈라져 캡션 이음새가 되살아난다.
-    expect(surface).toContain('getComputedStyle(document.documentElement).getPropertyValue("--glass-tint-terminal")');
+    expect(surface).toContain("const rootStyle = getComputedStyle(document.documentElement);");
+    expect(surface).toContain('rootStyle.getPropertyValue("--glass-tint-terminal")');
     expect(surface).toContain("...base, background: resolvePanelSurface(");
 
     // allowTransparency는 상수가 아니라 해석된 배경의 알파에서 파생된다 — 상수 true는 불투명
@@ -3326,16 +3350,12 @@ describe("Instrument core design contract", () => {
     expect(canvasZoom).toContain("? canvas.viewport.zoom");
     expect(canvasZoom).toContain("formationView || triageActive || operationMaximized || operationCompanion");
     expect(canvasZoom).not.toContain("const effectiveZoom = panelMaximized");
-    // Cruise·Tactical·War Room 모두 visible 패널이 넷 이상이면 유리를 불투명 panel material로
-    // 축약한다. threshold와 스타일 모두 class 계약으로 고정해 :has() 기반 subtree 재판정을 추가하지 않는다.
-    expect(canvasZoom).toContain("const adaptivePanelMaterial = visiblePanelCount >= 4;");
-    expect(canvasZoom).not.toContain("visiblePanelCount >= 4 && !formationView && !triageActive");
-    expect(canvasZoom).toContain('adaptivePanelMaterial ? "is-panel-density-high" : ""');
-    const adaptiveMaterial = components.match(/\.operations-canvas\.is-panel-density-high \{[^}]*\}/)?.[0] ?? "";
-    expect(adaptiveMaterial).toContain("--glass-tint-panel: var(--surface-panel);");
-    expect(adaptiveMaterial).toContain("--glass-underlay: var(--surface-panel);");
-    expect(adaptiveMaterial).toContain("--glass-pane-light: transparent;");
-    expect(adaptiveMaterial).toContain("--glass-backdrop-panel: none;");
+    // Operation 재질은 visible 패널 수에 반응하지 않는다. Cruise·Tactical·War Room 카드가 모두
+    // 같은 60% 투명 면과 무블러 계약을 공유하며, 다패널 War Room의 LOD는 Map 전환만 맡는다.
+    expect(canvasZoom).not.toContain("visiblePanelCount");
+    expect(canvasZoom).not.toContain("adaptivePanelMaterial");
+    expect(canvasZoom).not.toContain("is-panel-density-high");
+    expect(components).not.toContain(".operations-canvas.is-panel-density-high");
     expect(source("canvas/coordinates.ts")).toContain("y: 18 + OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/coordinates.ts")).toContain("canvasSize.height - 36 - OPERATION_WINDOW_CAPTION_HEIGHT");
     expect(source("canvas/coordinates.ts")).toContain("export function operationWindowFrameFor");

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -101,6 +101,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
         FLEET_CONSOLE_SESSION_ID: "session-a",
         INIT_CWD: "/work/project",
         PWD: "/work/project",
+        COLORTERM: "truecolor",
         TERM: "xterm-256color",
       }),
       messagePolicy: { bracketedPaste: true, multilineStrategy: "paste-mode" },
@@ -589,6 +590,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       FLEET_CONSOLE_SESSION_ID: "session-a",
       INIT_CWD: "/work/project",
       PWD: "/work/project",
+      COLORTERM: "truecolor",
       TERM: "xterm-256color",
     });
   });
@@ -607,7 +609,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       args: [],
       cwd: "/work",
     });
-    expect(spec.env).toMatchObject({ TERM: "xterm-256color" });
+    expect(spec.env).toMatchObject({ COLORTERM: "truecolor", TERM: "xterm-256color" });
     expect(spec.env.FLEET_CONSOLE_SESSION_ID).toBeUndefined();
     expect(spec.env.INIT_CWD).toBeUndefined();
   });
@@ -630,7 +632,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       args: [],
       cwd: "/work",
     });
-    expect(spec.env).toMatchObject({ TERM: "xterm-256color" });
+    expect(spec.env).toMatchObject({ COLORTERM: "truecolor", TERM: "xterm-256color" });
     expect(spec.env.FLEET_CONSOLE_SESSION_ID).toBeUndefined();
     expect(spec.env.INIT_CWD).toBeUndefined();
   });

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -36,6 +36,8 @@ export interface TerminalSurfaceProps {
   /** 티켓 요청 본문에 얹을 추가 필드(전역 Shell의 첫 기동 Theater 등). */
   readonly ticketFields?: Readonly<Record<string, string>>;
   readonly wsPath: string;
+  /** 독립 Shell은 terminal tint를, Operation 안의 Agent는 panel tint를 기준으로 투명 RGB floor를 만든다. */
+  readonly surface?: "panel" | "shell";
   readonly theme?: TerminalThemeId;
   readonly onExit?: () => void;
   // 이 터미널이 활성(선택)으로 전환될 때 마우스 클릭 없이 키보드 포커스를 잡아준다(Map 검색 이동 등).
@@ -183,7 +185,7 @@ function terminalPolarityFor(theme: TerminalThemeId): "light" | "dark" {
   return LIGHT_TERMINAL_THEMES.has(theme) ? "light" : "dark";
 }
 
-export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath, theme = "instrument", onExit, active, keyboardFocusRequestId, zoom = 1, onStatusDetail, locale }: TerminalSurfaceProps) {
+export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath, surface = "panel", theme = "instrument", onExit, active, keyboardFocusRequestId, zoom = 1, onStatusDetail, locale }: TerminalSurfaceProps) {
   // 티켓 필드는 발급 순간에만 읽힌다 — 값이 바뀌었다고 살아 있는 PTY를 다시 붙이면
   // 사용자가 치던 셸이 끊긴다. 그래서 effect 의존성이 아니라 ref로 나른다.
   const ticketFieldsRef = useRef(ticketFields);
@@ -316,7 +318,7 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
       await waitForTerminalFallbackFonts();
       if (disposed) return;
 
-      const terminalTheme = terminalThemeFor(activeTheme);
+      const terminalTheme = terminalThemeFor(activeTheme, surface);
       const terminal = new XtermTerminal({
         ...TERMINAL_OPTIONS,
         fontFamily: terminalFontSettings.family,
@@ -538,7 +540,7 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
       resizeObserver?.disconnect();
       cleanupMountedTerminal?.();
     };
-  }, [operationId, ticketPath, wsPath]);
+  }, [operationId, surface, ticketPath, wsPath]);
 
   // 활성 전환 시 이미 마운트된 xterm에 포커스를 다시 주고 기존 contract대로 bottom following을 재개한다.
   // keyboard request는 동일 Operation 재선택 시 active 불변을, input-ready epoch는 비동기 마운트 갭을 대응한다.
@@ -631,7 +633,7 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
     const container = containerRef.current;
     if (!terminal || !container) return;
     const applyTerminalTheme = () => {
-      const terminalTheme = terminalThemeFor(activeTheme);
+      const terminalTheme = terminalThemeFor(activeTheme, surface);
       // 뷰포트 인라인 배경이 allowTransparency보다 먼저 자리를 잡아야 한다 — 이 옵션이 꺼지면
       // xterm이 `.xterm:not(.allow-transparency)` 클래스를 떼고, 그 규칙의 background-color:#000이
       // 인라인 값 없이 드러난다. 두 줄의 순서가 곧 그 검은 프레임을 막는 계약이다.
@@ -643,7 +645,7 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
     applyTerminalTheme();
     // liquidGlassPane 의존이 곧 리로드 없는 즉시 전환이다 — 설정 토글이 data-glass 속성을
     // 바꾸면 위 옵저버가 상태를 올리고, 이 효과가 terminal 채널 계산값을 다시 읽는다.
-  }, [activeTheme, mountedTerminalEpoch, liquidGlassPane]);
+  }, [activeTheme, mountedTerminalEpoch, liquidGlassPane, surface]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
@@ -762,8 +764,9 @@ function baseTerminalThemeFor(theme: TerminalThemeId): ITheme {
 /* 터미널 필드의 단일층 규약 — xterm 필드(cols×rows 격자)는 패널 본문을 꽉 채우지 못하므로,
    필드와 남는 거터가 서로 다른 층을 칠하면 경계 띠가 어긋난다(실측). 그래서:
    - 다크 + 게이트 열림: xterm 배경은 알파 0으로 비우고(RGB는 아래 glassFieldClearColor 참조),
-     필드·거터를 컨테이너(.canvas-operation-terminal/.terminal-shell)의 --glass-tint-terminal
-     한 겹이 칠한다. 다크는 minimumContrastRatio=1이라 투명 배경이 대비 보정에 관여하지 않는다.
+     Agent Operation은 .canvas-operation 루트의 panel tint를, 독립 Shell은 .terminal-shell/expanded
+     slot의 terminal tint와 blur를 필드·거터 한 겹으로 공유한다. 다크는 minimumContrastRatio=1이라
+     투명 배경이 대비 보정에 관여하지 않는다.
    - 게이트 닫힘: mCR이 배경 실색을 요구하므로 xterm은 채널 계산값(불투명 --surface-panel)을
      그대로 받는다 — 컨테이너도 같은 채널을 칠해 필드·거터가 같은 값으로 만난다.
      라이트(Whites)는 언제나 이쪽이다. 테마 극성 자체가 유리 게이트의 넷째 닫힘 조건이라
@@ -775,10 +778,17 @@ function baseTerminalThemeFor(theme: TerminalThemeId): ITheme {
    xterm은 CSS 변수를 못 받으므로 계산값을 읽고, 압축 CSS의 oklch 변형(`.022` 선행 0
    생략·% 알파)을 xterm 파서가 검정으로 낙하시키므로(실측) canvas로 rgba() 정규화해 넘긴다.
    위 ITheme의 background 리터럴은 토큰을 읽을 수 없는 환경(jsdom·SSR)의 폴백이다. */
-export function resolvePanelSurface(theme: TerminalThemeId, fallback: string): string {
+export function resolvePanelSurface(
+  theme: TerminalThemeId,
+  fallback: string,
+  surface: "panel" | "shell" = "panel",
+): string {
   if (typeof document === "undefined") return fallback;
-  if (!LIGHT_TERMINAL_THEMES.has(theme) && readLiquidGlassPaneActive()) return glassFieldClearColor();
-  const resolved = getComputedStyle(document.documentElement).getPropertyValue("--glass-tint-terminal").trim();
+  const rootStyle = getComputedStyle(document.documentElement);
+  if (!LIGHT_TERMINAL_THEMES.has(theme) && readLiquidGlassPaneActive()) {
+    return glassFieldClearColor(surface === "shell" ? "--glass-tint-terminal" : "--glass-tint-terminal-floor", rootStyle);
+  }
+  const resolved = rootStyle.getPropertyValue("--glass-tint-terminal").trim();
   if (!resolved) return fallback;
   return normalizeCssColorToRgba(resolved) ?? fallback;
 }
@@ -790,11 +800,15 @@ export function resolvePanelSurface(theme: TerminalThemeId, fallback: string): s
    화면 전체를 지우는 뷰포트 사각형만 알파를 보존하므로, 필드는 투명한데 dim 셀만 불투명해진다.
    `rgba(0,0,0,0)`을 넘기면 그 셀이 순수 검정으로 칠해진다 — Claude Code가 diff 거터를 dim으로
    찍는 것이 실측으로 확인됐고(PTY 원시 바이트), 유리 위에 검정 블록으로 드러났다.
-   그래서 RGB에는 유리 유효색의 불투명 근사(--glass-tint-terminal-floor)를 싣는다: 알파 0이라
-   필드 자체는 그대로 유리를 통과시키고, 알파가 1로 강제되는 dim 사각형만 필드와 같은 색이 된다.
-   유리는 뒤에 오는 것에 따라 유효색이 흔들리므로 이 값은 일치가 아니라 근사다. */
-function glassFieldClearColor(): string {
-  const floor = getComputedStyle(document.documentElement).getPropertyValue("--glass-tint-terminal-floor").trim();
+   그래서 Operation은 유리 유효색의 불투명 근사(--glass-tint-terminal-floor)를, 독립 Shell은
+   실제 terminal tint를 RGB에 싣는다: 알파 0이라 필드 자체는 뒤의 면과 blur를 통과시키고,
+   알파가 1로 강제되는 dim 사각형만 각 면과 가까운 색이 된다. 유리는 뒤에 오는 것에 따라
+   유효색이 흔들리므로 이 값은 일치가 아니라 근사다. */
+function glassFieldClearColor(
+  token: "--glass-tint-terminal-floor" | "--glass-tint-terminal",
+  rootStyle: CSSStyleDeclaration = getComputedStyle(document.documentElement),
+): string {
+  const floor = rootStyle.getPropertyValue(token).trim();
   // 빈 값을 프로브에 넘기면 fillStyle 할당이 무시되어 직전 색이 그대로 읽힌다 — 여기서 끊는다.
   if (!floor) return "rgba(0, 0, 0, 0)";
   const channels = /^rgba?\(([^)]+)\)$/i.exec(normalizeCssColorToRgba(floor) ?? "")?.[1]?.split(",");
@@ -859,9 +873,9 @@ export function readLiquidGlassPaneActive(): boolean {
   return backdrop !== "" && backdrop !== "none";
 }
 
-function terminalThemeFor(theme: TerminalThemeId): ITheme {
+function terminalThemeFor(theme: TerminalThemeId, surface: "panel" | "shell"): ITheme {
   const base = baseTerminalThemeFor(theme);
-  return { ...base, background: resolvePanelSurface(theme, base.background ?? "") };
+  return { ...base, background: resolvePanelSurface(theme, base.background ?? "", surface) };
 }
 
 export function syncTerminalViewportBackground(container: HTMLElement, theme: ITheme): void {

--- a/runtime/fleet-plugins/terminal/client/shell/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/shell/index.tsx
@@ -39,6 +39,7 @@ function ShellSurfaceBody({ ctx }: { readonly ctx: ExpandedSurfaceContext }) {
       operationId={SHELL_SURFACE_ID}
       ticketPath={SHELL_TICKET_PATH}
       wsPath={SHELL_WS_PATH}
+      surface="shell"
       theme={ctx.theme ?? "instrument"}
       active={ctx.focused}
       zoom={1}

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -33,7 +33,7 @@ import { resolveClaudeCodeSystemPrompt } from "../settings-routes.js";
 import { createSessionIdentityResolver } from "./session-identity.js";
 import { buildConsoleAttentionHookCommand, buildConsoleAutoNameHookCommand, buildConsoleBackgroundHookCommand, buildConsoleCaptureHookCommand, buildConsoleTurnHookCommand, toCaptureProvider, type ConsoleHookCommandEntry } from "./host-hooks.js";
 import type { TerminalLaunchContext, TerminalLaunchSpec } from "../shared/terminal-types.js";
-import { stripConsoleInternalEnv } from "../shared/launch-env.js";
+import { stripConsoleInternalEnv, TERMINAL_TERM, withTerminalCapabilities } from "../shared/launch-env.js";
 import { applyAgentCliPathEnvOverlay } from "./agent-cli-paths.js";
 
 /** AI gateway를 Console의 실제 listening origin에 연결하는 launch 바인딩. */
@@ -106,7 +106,6 @@ export function isGatewayLaunchEffortAllowed(
 export type TerminalLaunchResolver = (cwd?: string, context?: TerminalLaunchContext) => Promise<TerminalLaunchSpec>;
 
 const DEFAULT_TERMINAL_CWD_FALLBACK = os.homedir;
-const TERMINAL_TERM = "xterm-256color";
 const CONSOLE_ENTRY_PATH = fileURLToPath(import.meta.url);
 const HOOK_ENTRY_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".mjs", ".mts", ".ts", ".tsx"]);
 const require = createRequire(import.meta.url);
@@ -435,13 +434,12 @@ function parseTerminalCommand(command: string | undefined): { readonly bin: stri
 }
 
 function buildLaunchEnv(env: NodeJS.ProcessEnv, cwd: string, sessionId: string | undefined, colorScheme?: "light" | "dark"): NodeJS.ProcessEnv {
-  return {
+  return withTerminalCapabilities({
     ...stripConsoleInternalEnv(env),
     ...(sessionId ? { FLEET_CONSOLE_SESSION_ID: sessionId, INIT_CWD: cwd, PWD: cwd } : {}),
-    TERM: TERMINAL_TERM,
     // 배경을 질의하지 않는 agent CLI를 위한 고전적 테마 극성 힌트 — spawn 시점 값에 고정된다.
     ...(colorScheme ? { COLORFGBG: colorScheme === "light" ? "0;15" : "15;0" } : {}),
-  };
+  });
 }
 
 function resolveOptionalPackage(id: string): string | undefined {

--- a/runtime/fleet-plugins/terminal/server/shared/launch-env.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/launch-env.ts
@@ -1,3 +1,14 @@
+export const TERMINAL_TERM = "xterm-256color";
+
+export function withTerminalCapabilities(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    // xterm.js의 24-bit SGR 렌더링을 알리되, TERM은 널리 호환되는 terminfo 항목을 유지한다.
+    COLORTERM: "truecolor",
+    TERM: TERMINAL_TERM,
+  };
+}
+
 const CONSOLE_INTERNAL_ENV_KEYS = [
   "FLEET_CONSOLE_OWNER_ID",
   "FLEET_CONSOLE_OWNER_KIND",

--- a/runtime/fleet-plugins/terminal/server/shared/pty.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/pty.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { resolvePathBinary } from "@dotobokuri/core-process";
 
 import { resolveConsolePackageRequire } from "./console-require.js";
-import { stripConsoleInternalEnv } from "./launch-env.js";
+import { stripConsoleInternalEnv, TERMINAL_TERM, withTerminalCapabilities } from "./launch-env.js";
 import type { TerminalLaunchContext, TerminalLaunchSpec, TerminalPtyHandle } from "./terminal-types.js";
 
 export type TerminalLaunchResolver = (cwd?: string, context?: TerminalLaunchContext) => Promise<TerminalLaunchSpec>;
@@ -27,7 +27,6 @@ type NodePtyModule = {
 type NodeRequire = ReturnType<typeof createRequire>;
 
 const DEFAULT_TERMINAL_CWD_FALLBACK = os.homedir;
-const TERMINAL_TERM = "xterm-256color";
 const require = createRequire(import.meta.url);
 
 export function createShellTerminalLaunchResolver(deps: {
@@ -124,11 +123,10 @@ function resolveWindowsLaunchBinary(
 }
 
 function buildShellLaunchEnv(env: NodeJS.ProcessEnv, colorScheme?: "light" | "dark"): NodeJS.ProcessEnv {
-  return {
+  return withTerminalCapabilities({
     ...stripConsoleInternalEnv(env),
-    TERM: TERMINAL_TERM,
     // COLORFGBG는 배경을 질의하지 않는 CLI/TUI를 위한 고전적 극성 힌트다("fg;bg" ANSI 인덱스).
     // 값이 없으면 변수 자체를 싣지 않아 사용자 셸 환경의 기존 값을 훼손하지 않는다.
     ...(colorScheme ? { COLORFGBG: colorScheme === "light" ? "0;15" : "15;0" } : {}),
-  };
+  });
 }

--- a/runtime/fleet-plugins/terminal/tests/launch-prompt.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/launch-prompt.test.ts
@@ -39,6 +39,27 @@ function createFakeRuntime() {
   };
 }
 
+describe("createAgentTerminalLaunchResolver launch environment", () => {
+  it("advertises truecolor without replacing the compatible TERM entry", async () => {
+    const resolve = createAgentTerminalLaunchResolver({
+      cwd: "/work",
+      env: {
+        COLORTERM: "256color",
+        FLEET_TERMINAL_CMD: "/bin/sh",
+        PATH: "/bin",
+      } as NodeJS.ProcessEnv,
+      platform: "linux",
+    });
+
+    const spec = await resolve("/work/project", { sessionId: "session-a" });
+
+    expect(spec.env).toMatchObject({
+      COLORTERM: "truecolor",
+      TERM: "xterm-256color",
+    });
+  });
+});
+
 describe("createAgentTerminalLaunchResolver prompt threading", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/runtime/fleet-plugins/terminal/tests/pty.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/pty.test.ts
@@ -3,12 +3,29 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ensureNodePtySpawnHelpersExecutable } from "../server/shared/pty.js";
+import { createShellTerminalLaunchResolver, ensureNodePtySpawnHelpersExecutable } from "../server/shared/pty.js";
 
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("createShellTerminalLaunchResolver", () => {
+  it("advertises truecolor without replacing the compatible TERM entry", async () => {
+    const resolve = createShellTerminalLaunchResolver({
+      cwd: "/work",
+      env: { COLORTERM: "256color", SHELL: "/bin/sh" } as NodeJS.ProcessEnv,
+      platform: "linux",
+    });
+
+    const spec = await resolve();
+
+    expect(spec.env).toMatchObject({
+      COLORTERM: "truecolor",
+      TERM: "xterm-256color",
+    });
+  });
 });
 
 describe("ensureNodePtySpawnHelpersExecutable", () => {

--- a/runtime/fleet-plugins/terminal/tests/terminal-field-translucency.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-field-translucency.test.ts
@@ -59,6 +59,16 @@ describe("resolved terminal field drives allowTransparency", () => {
     expect(terminalFieldIsTranslucent(cleared)).toBe(true);
   });
 
+  /* 독립 Shell은 blur가 선명한 terminal tint를 실제 배경으로 삼으므로, 투명 필드의 RGB도 그 tint를
+     써야 dim 셀만 panel floor 색으로 내려앉지 않는다. */
+  it("clears the shell field to the terminal tint while its blur is active", () => {
+    openGlassGate();
+    setTerminalTint("rgb(17, 24, 33)");
+    setTerminalFloor("rgb(7, 19, 29)");
+    expect(resolvePanelSurface("instrument", "oklch(16.5% 0.016 245)", "shell"))
+      .toBe("rgba(17, 24, 33, 0)");
+  });
+
   /* floor를 못 읽는 환경(토큰 부재·프로브 없음)은 완전 투명으로 물러난다 — 알파가 살아 있어야
      필드가 유리를 통과시키고, 색을 지어내지 않는다. */
   it("falls back to a fully transparent field when the floor token is missing", () => {


### PR DESCRIPTION
## Summary
- advertise `COLORTERM=truecolor` to Shell and Agent PTYs while retaining `TERM=xterm-256color`
- keep Cruise, Tactical, and War Room Operation panels translucent without backdrop blur
- apply the dedicated Liquid Glass blur only to Shell surfaces and preserve opaque fallbacks

## Test Plan
- [x] `corepack pnpm --filter @fleet-plugins/terminal test`
- [x] `corepack pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `corepack pnpm --filter @fleet-plugins/terminal build`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] Browser E2E: Tactical four-panel, War Room four-card, Shell blur, Glass Off, and Whites fallback