### PR TITLE
feat(fleet-console): hand alternate-screen scrolling to TUIs

### DIFF
--- a/.changelog.d/terminal-alternate-screen.md
+++ b/.changelog.d/terminal-alternate-screen.md
@@ -1,0 +1,8 @@
+---
+branch: terminal-alternate-screen
+---
+
+### fleet-console
+#### Changed
+- Let full-screen terminal applications own scrolling while they use the alternate screen, reclaim scrollbar and sub-cell grid space, and restore normal terminal history when they exit.
+  ko: 전체 화면 터미널 애플리케이션이 대체 화면을 사용하는 동안 자체 스크롤을 사용하고 스크롤바와 셀 미만의 격자 여백을 회수하며 종료하면 일반 터미널 기록으로 복귀합니다.

--- a/runtime/fleet-console/tests/session-manager.test.ts
+++ b/runtime/fleet-console/tests/session-manager.test.ts
@@ -4,7 +4,7 @@ import { createTerminalSessionManager } from "../../fleet-plugins/terminal/serve
 import type { TerminalPtyDataDisposable, TerminalPtyHandle, TerminalSocket, TerminalSocketData } from "../../fleet-plugins/terminal/server/shared/terminal-types.js";
 
 interface MockPty extends TerminalPtyHandle {
-  readonly writes: string[];
+  readonly writes: Array<string | Buffer>;
   readonly resizes: Array<{ readonly cols: number; readonly rows: number }>;
   readonly killed: () => boolean;
   readonly killCount: () => number;
@@ -364,11 +364,13 @@ describe("terminal session manager", () => {
     await manager.attach(secondA, { sessionId: "session-a", cwd: "/a" });
 
     expect(secondA.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
+      JSON.stringify({ type: "replay_state", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
       "alpha",
-      JSON.stringify({ type: "replay_end" }),
+      JSON.stringify({ type: "replay_end", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
     ]);
     expect(firstB.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
-      JSON.stringify({ type: "replay_end" }),
+      JSON.stringify({ type: "replay_state", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
+      JSON.stringify({ type: "replay_end", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
       "beta",
     ]);
   });
@@ -392,7 +394,8 @@ describe("terminal session manager", () => {
     ptys.get("session-a")?.emitData(queryOutput);
     expect(ptys.get("session-a")?.writes).toEqual([]);
     expect(socket.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
-      JSON.stringify({ type: "replay_end" }),
+      JSON.stringify({ type: "replay_state", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
+      JSON.stringify({ type: "replay_end", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
       queryOutput,
     ]);
 
@@ -400,7 +403,8 @@ describe("terminal session manager", () => {
     ptys.get("session-a")?.emitData(queryOutput);
     expect(ptys.get("session-a")?.writes).toEqual(responses);
     expect(socket.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
-      JSON.stringify({ type: "replay_end" }),
+      JSON.stringify({ type: "replay_state", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
+      JSON.stringify({ type: "replay_end", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
       queryOutput,
     ]);
   });
@@ -525,8 +529,9 @@ describe("terminal session manager", () => {
     // 재연결하면 같은 세션에 다시 붙어 scrollback을 그대로 재생한다.
     await manager.attach(second, { sessionId: "session-a", cwd: "/a" });
     expect(second.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
+      JSON.stringify({ type: "replay_state", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
       "before-detach",
-      JSON.stringify({ type: "replay_end" }),
+      JSON.stringify({ type: "replay_end", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" }),
     ]);
     expect(ptys.get("session-a")?.killed()).toBe(false);
   });

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-alternate-screen.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-alternate-screen.ts
@@ -1,0 +1,133 @@
+import type { FitAddon } from "@xterm/addon-fit";
+import type { IDisposable, Terminal } from "@xterm/xterm";
+
+export interface TerminalAlternateScreenReplayState {
+  readonly alternateScreenActive: boolean;
+  readonly mouseProtocol?: "none" | "x10" | "vt200" | "drag" | "any";
+  readonly mouseEncoding?: "default" | "sgr" | "sgr-pixels";
+}
+
+export interface TerminalAlternateScreenController extends IDisposable {
+  readonly prepareReplay: (state: TerminalAlternateScreenReplayState) => void;
+  readonly finishReplay: (state: TerminalAlternateScreenReplayState) => void;
+}
+
+interface TerminalAlternateScreenOptions {
+  readonly terminal: Terminal;
+  readonly fitAddon: Pick<FitAddon, "fit">;
+  readonly resizePty: (cols: number, rows: number) => void;
+  readonly isReplaying: () => boolean;
+  readonly onAlternateScreenChange?: (active: boolean) => void;
+}
+
+const ALTERNATE_SCREEN_MODES = new Set([47, 1047, 1049]);
+
+export function createTerminalAlternateScreenController(options: TerminalAlternateScreenOptions): TerminalAlternateScreenController {
+  const { terminal } = options;
+  let disposed = false;
+  let alternateScreenActive = terminal.buffer.active.type === "alternate";
+  let appliedAlternateScreenActive: boolean | null = null;
+
+  const apply = (next: boolean) => {
+    if (disposed || appliedAlternateScreenActive === next) return;
+    appliedAlternateScreenActive = next;
+    terminal.options.scrollbar = {
+      ...terminal.options.scrollbar,
+      showScrollbar: !next,
+    };
+    options.fitAddon.fit();
+    options.resizePty(terminal.cols, terminal.rows);
+    options.onAlternateScreenChange?.(next);
+  };
+
+  const observeBuffer = (next: boolean) => {
+    alternateScreenActive = next;
+    if (!options.isReplaying()) apply(next);
+  };
+
+  const bufferSubscription = terminal.buffer.onBufferChange((buffer) => {
+    observeBuffer(buffer.type === "alternate");
+  });
+
+  // xterm's public buffer event is the live authority. These pass-through handlers add one missing
+  // capability: when bounded replay no longer contains the original DECSET, the server sideband can
+  // restore the buffer before the retained cursor-positioned paint commands are parsed.
+  const setModeHandler = terminal.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+    if (params.some(isAlternateScreenMode)) alternateScreenActive = true;
+    return false;
+  });
+  const resetModeHandler = terminal.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+    if (params.some(isAlternateScreenMode)) alternateScreenActive = false;
+    return false;
+  });
+  const resetHandler = terminal.parser.registerEscHandler({ final: "c" }, () => {
+    alternateScreenActive = false;
+    return false;
+  });
+
+  const restoreModes = (state: TerminalAlternateScreenReplayState, force: boolean, callback?: () => void) => {
+    const sequence = terminalModeRestoreSequence(state, alternateScreenActive, force);
+    if (!sequence) {
+      callback?.();
+      return;
+    }
+    terminal.write(sequence, () => {
+      alternateScreenActive = state.alternateScreenActive;
+      callback?.();
+    });
+  };
+
+  return {
+    prepareReplay: (state) => restoreModes(state, true),
+    finishReplay: (state) => restoreModes(state, false, () => apply(alternateScreenActive)),
+    dispose: () => {
+      disposed = true;
+      bufferSubscription.dispose();
+      setModeHandler.dispose();
+      resetModeHandler.dispose();
+      resetHandler.dispose();
+      options.onAlternateScreenChange?.(false);
+    },
+  };
+}
+
+function terminalModeRestoreSequence(state: TerminalAlternateScreenReplayState, currentAlternateScreenActive: boolean, force: boolean): string {
+  const sequences: string[] = [];
+  if (force || state.alternateScreenActive !== currentAlternateScreenActive) {
+    sequences.push(state.alternateScreenActive ? "\x1b[?1049h" : "\x1b[?1047l");
+  }
+  if (state.mouseProtocol !== undefined || state.mouseEncoding !== undefined) {
+    sequences.push("\x1b[?1006l\x1b[?1016l\x1b[?1003l\x1b[?1002l\x1b[?1000l\x1b[?9l");
+    const protocolMode = mouseProtocolMode(state.mouseProtocol);
+    if (protocolMode !== undefined) sequences.push(`\x1b[?${protocolMode}h`);
+    const encodingMode = mouseEncodingMode(state.mouseEncoding);
+    if (encodingMode !== undefined) sequences.push(`\x1b[?${encodingMode}h`);
+  }
+  return sequences.join("");
+}
+
+function mouseProtocolMode(protocol: TerminalAlternateScreenReplayState["mouseProtocol"]): number | undefined {
+  switch (protocol) {
+    case "x10": return 9;
+    case "vt200": return 1000;
+    case "drag": return 1002;
+    case "any": return 1003;
+    case "none":
+    case undefined:
+      return undefined;
+  }
+}
+
+function mouseEncodingMode(encoding: TerminalAlternateScreenReplayState["mouseEncoding"]): number | undefined {
+  switch (encoding) {
+    case "sgr": return 1006;
+    case "sgr-pixels": return 1016;
+    case "default":
+    case undefined:
+      return undefined;
+  }
+}
+
+function isAlternateScreenMode(value: number | number[]): boolean {
+  return typeof value === "number" && ALTERNATE_SCREEN_MODES.has(value);
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
@@ -7,6 +7,7 @@ export type TerminalSocketRole = "control" | "viewer";
 
 export interface TerminalLike {
   readonly onData: (listener: (data: string) => void) => { readonly dispose: () => void };
+  readonly onBinary?: (listener: (data: string) => void) => { readonly dispose: () => void };
   readonly write: (data: Uint8Array) => void;
   readonly drain: (callback: () => void) => void;
 }
@@ -33,10 +34,19 @@ export interface TerminalConnectionOptions {
    * 서버 보유 scrollback을 재생하는 구간의 시작(true)과 끝(false)을 알린다. 재생 청크는 과거에 이미
    * 흘러간 바이트라, 그 안의 부수효과 시퀀스를 지금 다시 실행하면 안 되는 소비자를 위한 신호다.
    */
-  readonly onReplayStateChange?: (replaying: boolean) => void;
+  readonly onReplayStateChange?: (replaying: boolean, state?: TerminalReplayState) => void;
+  /** Called before retained output is parsed so a remount can select the PTY's current buffer first. */
+  readonly onReplayState?: (state: TerminalReplayState) => void;
   readonly onExit?: () => void;
   readonly location?: Pick<Location, "host" | "protocol">;
   readonly webSocketFactory?: (url: string) => WebSocketLike;
+}
+
+export interface TerminalReplayState {
+  /** Fields are undefined only when reconnecting to an older Console server that predates mode sideband. */
+  readonly alternateScreenActive?: boolean;
+  readonly mouseProtocol?: "none" | "x10" | "vt200" | "drag" | "any";
+  readonly mouseEncoding?: "default" | "sgr" | "sgr-pixels";
 }
 
 export interface TerminalCloseInfo {
@@ -102,7 +112,7 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
   const encoder = new TextEncoder();
   let reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
   let socket: WebSocketLike | null = null;
-  let inputSubscription: { readonly dispose: () => void } | null = null;
+  let inputSubscriptions: Array<{ readonly dispose: () => void }> = [];
   let pendingSize: { readonly cols: number; readonly rows: number } | null = null;
   // 실제로 이 소켓으로 나간 마지막 격자. 연결마다 비워 (재)연결이 항상 한 번은 크기를 협상하게 한다 —
   // 새 소켓 너머의 세션이 어떤 크기를 알고 있는지는 클라이언트가 가정할 수 없다.
@@ -117,8 +127,8 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
   let consecutiveFailures = 0;
 
   const disposeInput = () => {
-    inputSubscription?.dispose();
-    inputSubscription = null;
+    for (const subscription of inputSubscriptions) subscription.dispose();
+    inputSubscriptions = [];
   };
 
   const sendResize = (cols: number, rows: number) => {
@@ -187,22 +197,33 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
         } catch {
           return;
         }
+        if (isReplayStateFrame(frame)) {
+          connectionOptions.onReplayState?.(replayStateFromFrame(frame));
+          return;
+        }
         if (!isReplayEndFrame(frame)) return;
         connectionOptions.terminal.drain(() => {
           // 이 소켓이 아직 활성일 때만 재생 구간을 닫는다. drain은 출력 파싱을 기다리므로 소켓이 먼저
           // 닫히고 재접속이 새 재생을 시작한 뒤에 이 콜백이 도착할 수 있는데, 그때 창을 닫아버리면
           // 새 연결의 재생분이 클립보드를 덮는다. 다른 소켓이 주인이면 그 소켓이 자기 창을 닫는다.
           if (socket !== ws) return;
-          // 재생 바이트가 모두 파싱된 뒤다. 아래 입력 구독 조건과 무관하게 창은 닫는다.
-          connectionOptions.onReplayStateChange?.(false);
+          // 재생 바이트가 모두 파싱된 뒤다. 서버의 sideband는 scrollback 첫 진입 시퀀스가 잘려도
+          // 살아 있는 PTY의 mode를 전한다. 화면은 xterm의 공개 buffer 상태를 권위로 삼되 이 값으로
+          // 복원 누락을 검증하고, geometry 변경은 이 한 지점에서 합친다.
+          connectionOptions.onReplayStateChange?.(false, replayStateFromFrame(frame));
           // 입력 구독 자체를 만들지 않는 것이 관전의 실제 경계다. 서버도 viewer 소켓의 메시지를
           // 듣지 않지만, 보내지 않는 편이 화면과 전송을 같은 이야기로 만든다.
           if (role === "viewer") return;
-          if (ws.readyState !== OPEN_READY_STATE || inputSubscription) return;
+          if (ws.readyState !== OPEN_READY_STATE || inputSubscriptions.length > 0) return;
           disposeInput();
-          inputSubscription = connectionOptions.terminal.onData((data) => {
+          inputSubscriptions.push(connectionOptions.terminal.onData((data) => {
             if (ws.readyState === OPEN_READY_STATE) ws.send(encoder.encode(data));
-          });
+          }));
+          if (connectionOptions.terminal.onBinary) {
+            inputSubscriptions.push(connectionOptions.terminal.onBinary((data) => {
+              if (ws.readyState === OPEN_READY_STATE) ws.send(binaryStringToBytes(data));
+            }));
+          }
         });
       };
       ws.onerror = () => {
@@ -302,8 +323,45 @@ function defaultWebSocketFactory(url: string): WebSocketLike {
   return new WebSocket(url) as unknown as WebSocketLike;
 }
 
-function isReplayEndFrame(value: unknown): value is { readonly type: "replay_end" } {
-  return !!value && typeof value === "object" && (value as { readonly type?: unknown }).type === "replay_end";
+interface ReplayStateFrame {
+  readonly type: "replay_state" | "replay_end";
+  readonly alternateScreenActive?: boolean;
+  readonly mouseProtocol?: TerminalReplayState["mouseProtocol"];
+  readonly mouseEncoding?: TerminalReplayState["mouseEncoding"];
+}
+
+function isReplayStateFrame(value: unknown): value is ReplayStateFrame {
+  if (!value || typeof value !== "object") return false;
+  const frame = value as { readonly type?: unknown };
+  return frame.type === "replay_state";
+}
+
+function isReplayEndFrame(value: unknown): value is ReplayStateFrame {
+  if (!value || typeof value !== "object") return false;
+  const frame = value as { readonly type?: unknown };
+  return frame.type === "replay_end";
+}
+
+function replayStateFromFrame(frame: ReplayStateFrame): TerminalReplayState {
+  return {
+    ...(typeof frame.alternateScreenActive === "boolean" ? { alternateScreenActive: frame.alternateScreenActive } : {}),
+    ...(isMouseProtocol(frame.mouseProtocol) ? { mouseProtocol: frame.mouseProtocol } : {}),
+    ...(isMouseEncoding(frame.mouseEncoding) ? { mouseEncoding: frame.mouseEncoding } : {}),
+  };
+}
+
+function isMouseProtocol(value: unknown): value is NonNullable<TerminalReplayState["mouseProtocol"]> {
+  return value === "none" || value === "x10" || value === "vt200" || value === "drag" || value === "any";
+}
+
+function isMouseEncoding(value: unknown): value is NonNullable<TerminalReplayState["mouseEncoding"]> {
+  return value === "default" || value === "sgr" || value === "sgr-pixels";
+}
+
+function binaryStringToBytes(data: string): Uint8Array {
+  const bytes = new Uint8Array(data.length);
+  for (let index = 0; index < data.length; index += 1) bytes[index] = data.charCodeAt(index) & 0xff;
+  return bytes;
 }
 
 async function delay(ms: number, signal: AbortSignal): Promise<void> {

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
@@ -1,3 +1,10 @@
+.terminal-alternate-screen-edge-fill {
+  position: absolute;
+  inset: 0 auto auto 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
 /* On-screen terminal keys.
    Every colour here is a theme token, so the bar retunes with instrument, maritime, carbon, and
    whites rather than carrying a palette of its own — it sits directly against the terminal, which

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties } from "re
 import { NO_LATCHED_MODIFIERS, TerminalKeyBar, type TerminalKeyBarModifiers } from "./terminal-key-bar.js";
 import { applyTerminalModifiers, terminalKeySequence, type TerminalKeyId } from "./terminal-key-sequences.js";
 import { createImeShiftEnterHandler } from "./ime-shift-enter.js";
+import { createTerminalAlternateScreenController } from "./terminal-alternate-screen.js";
 import { createTerminalConnection, type TerminalConnection, type TerminalConnectionStatus } from "./terminal-connection.js";
 import { describeTerminalFailure } from "./terminal-failure.js";
 import { createTerminalCopyOnSelect } from "./terminal-copy-on-select.js";
@@ -334,6 +335,11 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
       terminal.open(container);
       syncTerminalViewportBackground(container, terminalTheme);
       const xtermScreen = container.querySelector<HTMLElement>(".xterm-screen");
+      // 정수 cols×rows 뒤에 남는 한 셀 미만의 오른쪽·아래 공간은 xterm canvas 밖이다. 전체 화면 TUI는
+      // 자기 화면을 마지막 셀까지 칠하므로, 그 셀의 배경색을 잉여까지 잇지 않으면 terminal field 색이
+      // 테두리처럼 보인다. 입력·cell geometry는 그대로 두고 별도 비상호작용 strip에 마지막 열·행의
+      // 배경색만 연장한다. Operation과 rail Shell이 공유하는 이 mount에서 처리해야 두 표면이 같은 계약을 가진다.
+      const alternateScreenEdgeFill = xtermScreen ? createTerminalAlternateScreenEdgeFill(terminal, container, xtermScreen) : null;
       // xterm's own touch inertia emits gesture changes without a client point. Under mouse tracking
       // it serializes those missing coordinates as `NaN` and sends them to the PTY. Guard the private
       // event at the public DOM boundary rather than patching or deep-importing xterm internals.
@@ -407,13 +413,17 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
         terminal,
         activeRef.current !== false,
         inactiveFlushMsRef.current,
-        scrollFollow.restoreAfterOutputParsing,
+        () => {
+          scrollFollow.restoreAfterOutputParsing();
+          alternateScreenEdgeFill?.schedulePaint();
+        },
       );
       outputSchedulerRef.current = outputScheduler;
       const statusDetailReporter = createTerminalStatusDetailReporter({
         report: (detail) => onStatusDetailRef.current?.(detail),
       });
       statusDetailReporterRef.current = statusDetailReporter;
+      let alternateScreenController: ReturnType<typeof createTerminalAlternateScreenController> | null = null;
       const connection = createTerminalConnection({
         operationId,
         ticketPath,
@@ -433,14 +443,32 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
             const { ctrl, alt } = consumeLatchedModifiersRef.current();
             listener(ctrl || alt ? applyTerminalModifiers(data, { ctrl, alt, shift: false }) : data);
           }),
+          // Legacy mouse encodings are binary strings rather than UTF-8 text. Preserve their bytes
+          // through the WebSocket; SGR mouse reporting continues to use onData above.
+          onBinary: (listener) => terminal.onBinary(listener),
           write: (data) => {
             statusDetailReporter.push(data);
             outputScheduler.write(data);
           },
           drain: outputScheduler.drain,
         },
-        onReplayStateChange: (replaying) => {
+        onReplayState: (replayState) => {
+          if (typeof replayState.alternateScreenActive !== "boolean") return;
+          alternateScreenController?.prepareReplay({
+            alternateScreenActive: replayState.alternateScreenActive,
+            ...(replayState.mouseProtocol ? { mouseProtocol: replayState.mouseProtocol } : {}),
+            ...(replayState.mouseEncoding ? { mouseEncoding: replayState.mouseEncoding } : {}),
+          });
+        },
+        onReplayStateChange: (replaying, replayState) => {
           replayingScrollback = replaying;
+          if (!replaying && typeof replayState?.alternateScreenActive === "boolean") {
+            alternateScreenController?.finishReplay({
+              alternateScreenActive: replayState.alternateScreenActive,
+              ...(replayState.mouseProtocol ? { mouseProtocol: replayState.mouseProtocol } : {}),
+              ...(replayState.mouseEncoding ? { mouseEncoding: replayState.mouseEncoding } : {}),
+            });
+          }
         },
         onExit: () => onExitRef.current?.(),
         onControlLockChange: (lock) => { setControlLocked(lock === "locked"); },
@@ -459,6 +487,7 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
           fitAddon.fit();
           connection.resize(terminal.cols, terminal.rows);
           if (refresh) terminal.refresh(0, terminal.rows - 1);
+          alternateScreenEdgeFill?.schedulePaint();
         });
       };
       const scheduleFitAndResize = (refresh = false) => {
@@ -473,6 +502,13 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
         }, RESIZE_DEBOUNCE_MS);
       };
       scheduleFitAndResizeRef.current = scheduleFitAndResize;
+      alternateScreenController = createTerminalAlternateScreenController({
+        terminal,
+        fitAddon,
+        resizePty: connection.resize,
+        isReplaying: () => replayingScrollback,
+        onAlternateScreenChange: alternateScreenEdgeFill?.setActive,
+      });
 
       const runInitialFit = async () => {
         await document.fonts?.ready;
@@ -502,11 +538,13 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
         imeEventTarget.removeEventListener("focusout", imeHandler.onCompositionCancel);
         imeHandler.dispose();
         connection.dispose();
+        alternateScreenController?.dispose();
         copyOnSelect.dispose();
         osc52Clipboard.dispose();
         scrollGesture.dispose();
         touchGestures.dispose();
         xtermGestureOriginGuard?.dispose();
+        alternateScreenEdgeFill?.dispose();
         outputScheduler.dispose();
         statusDetailReporter.dispose();
         scrollFollow.dispose();
@@ -887,6 +925,242 @@ export function syncTerminalViewportBackground(container: HTMLElement, theme: IT
   } else {
     viewport.style.removeProperty("background-color");
   }
+}
+
+interface TerminalAlternateScreenEdgeFill {
+  readonly setActive: (active: boolean) => void;
+  readonly schedulePaint: () => void;
+  readonly dispose: () => void;
+}
+
+interface TerminalAlternateScreenEdgeFillOptions {
+  readonly terminal: Pick<XtermTerminal, "buffer" | "cols" | "rows" | "onDimensionsChange" | "options">;
+  readonly container: HTMLElement;
+  readonly screen: HTMLElement;
+  readonly createCanvas?: (edge: "right" | "bottom") => HTMLCanvasElement;
+  readonly requestFrame?: (callback: FrameRequestCallback) => number;
+  readonly cancelFrame?: (handle: number) => void;
+  readonly devicePixelRatio?: () => number;
+}
+
+export function createTerminalAlternateScreenEdgeFill(
+  terminal: TerminalAlternateScreenEdgeFillOptions["terminal"],
+  container: HTMLElement,
+  screen: HTMLElement,
+): TerminalAlternateScreenEdgeFill;
+export function createTerminalAlternateScreenEdgeFill(options: TerminalAlternateScreenEdgeFillOptions): TerminalAlternateScreenEdgeFill;
+export function createTerminalAlternateScreenEdgeFill(
+  terminalOrOptions: TerminalAlternateScreenEdgeFillOptions["terminal"] | TerminalAlternateScreenEdgeFillOptions,
+  container?: HTMLElement,
+  screen?: HTMLElement,
+): TerminalAlternateScreenEdgeFill {
+  const options = "terminal" in terminalOrOptions
+    ? terminalOrOptions
+    : { terminal: terminalOrOptions, container: container!, screen: screen! };
+  const { terminal } = options;
+  const rightCanvas = options.createCanvas?.("right") ?? document.createElement("canvas");
+  const bottomCanvas = options.createCanvas?.("bottom") ?? document.createElement("canvas");
+  const requestFrame = options.requestFrame ?? ((callback: FrameRequestCallback) => window.requestAnimationFrame(callback));
+  const cancelFrame = options.cancelFrame ?? ((handle: number) => window.cancelAnimationFrame(handle));
+  const readDevicePixelRatio = options.devicePixelRatio ?? (() => window.devicePixelRatio || 1);
+  rightCanvas.className = "terminal-alternate-screen-edge-fill terminal-alternate-screen-edge-fill--right";
+  bottomCanvas.className = "terminal-alternate-screen-edge-fill terminal-alternate-screen-edge-fill--bottom";
+  rightCanvas.setAttribute("aria-hidden", "true");
+  bottomCanvas.setAttribute("aria-hidden", "true");
+  // xterm renderer의 screen 자식으로 canvas를 끼우지 않는다. WebGL/DOM renderer는 그 subtree를
+  // 자기 레이어로 소유한다. 두 strip은 TerminalSurface mount 단의 형제이며 남는 영역만 점유한다.
+  options.container.append(rightCanvas, bottomCanvas);
+
+  let active = false;
+  let disposed = false;
+  let frame: number | null = null;
+  let repaintRequested = false;
+  let settlePaintPending = false;
+
+  const hideCanvas = (canvas: HTMLCanvasElement) => {
+    canvas.hidden = true;
+    canvas.width = 0;
+    canvas.height = 0;
+  };
+  const hide = () => {
+    hideCanvas(rightCanvas);
+    hideCanvas(bottomCanvas);
+  };
+
+  const sizeCanvas = (
+    canvas: HTMLCanvasElement,
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+    dpr: number,
+  ): CanvasRenderingContext2D | null => {
+    if (width < 0.5 || height < 0.5) {
+      hideCanvas(canvas);
+      return null;
+    }
+    canvas.hidden = false;
+    canvas.style.left = `${left}px`;
+    canvas.style.top = `${top}px`;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    canvas.width = Math.max(1, Math.ceil(width * dpr));
+    canvas.height = Math.max(1, Math.ceil(height * dpr));
+    const context = canvas.getContext("2d");
+    if (!context) return null;
+    context.setTransform(dpr, 0, 0, dpr, 0, 0);
+    context.clearRect(0, 0, width, height);
+    return context;
+  };
+
+  const paint = () => {
+    frame = null;
+    const containerRect = options.container.getBoundingClientRect();
+    const screenRect = options.screen.getBoundingClientRect();
+    const canvasWidth = screenRect.width;
+    const canvasHeight = screenRect.height;
+    if (disposed || !active || canvasWidth <= 0 || canvasHeight <= 0) {
+      hide();
+      return;
+    }
+    const screenLeft = screenRect.left - containerRect.left;
+    const screenTop = screenRect.top - containerRect.top;
+    const rightRemainder = Math.max(0, containerRect.right - screenRect.right);
+    const bottomRemainder = Math.max(0, containerRect.bottom - screenRect.bottom);
+    if (rightRemainder < 0.5 && bottomRemainder < 0.5) {
+      hide();
+      return;
+    }
+
+    const dpr = readDevicePixelRatio();
+    // xterm의 public dimensions 이벤트는 resize 중 DOM screen rect보다 한 프레임 늦을 수 있다.
+    // fill은 실제로 보이는 grid 경계만 잇기 때문에 paint 시점의 screen rect를 geometry authority로 쓴다.
+    const rightContext = sizeCanvas(
+      rightCanvas,
+      screenLeft + canvasWidth,
+      screenTop,
+      rightRemainder,
+      canvasHeight + bottomRemainder,
+      dpr,
+    );
+    const bottomContext = sizeCanvas(
+      bottomCanvas,
+      screenLeft,
+      screenTop + canvasHeight,
+      canvasWidth,
+      bottomRemainder,
+      dpr,
+    );
+    const buffer = terminal.buffer.active;
+    const viewportY = buffer.viewportY;
+    const theme = terminal.options.theme ?? {};
+    const rowHeight = canvasHeight / terminal.rows;
+    const columnWidth = canvasWidth / terminal.cols;
+
+    if (rightContext) {
+      for (let row = 0; row < terminal.rows; row += 1) {
+        rightContext.fillStyle = terminalCellVisualBackground(
+          buffer.getLine(viewportY + row)?.getCell(terminal.cols - 1),
+          theme,
+        );
+        rightContext.fillRect(0, row * rowHeight, rightRemainder, rowHeight + 0.5);
+      }
+      rightContext.fillStyle = terminalCellVisualBackground(
+        buffer.getLine(viewportY + terminal.rows - 1)?.getCell(terminal.cols - 1),
+        theme,
+      );
+      rightContext.fillRect(0, canvasHeight, rightRemainder, bottomRemainder);
+    }
+
+    if (bottomContext) {
+      const lastLine = buffer.getLine(viewportY + terminal.rows - 1);
+      for (let column = 0; column < terminal.cols; column += 1) {
+        bottomContext.fillStyle = terminalCellVisualBackground(lastLine?.getCell(column), theme);
+        bottomContext.fillRect(column * columnWidth, 0, columnWidth + 0.5, bottomRemainder);
+      }
+    }
+  };
+
+  const schedulePaint = () => {
+    if (disposed || !active) return;
+    if (frame !== null) {
+      repaintRequested = true;
+      return;
+    }
+    repaintRequested = false;
+    frame = requestFrame(() => {
+      paint();
+      const shouldRepaint = repaintRequested;
+      const shouldSettle = settlePaintPending;
+      repaintRequested = false;
+      settlePaintPending = false;
+      // requestAnimationFrame 안에서 schedule하면 frame handle이 아직 남아 coalescing gate에 막힌다.
+      // 먼저 현재 frame을 비운 뒤, 겹친 변경이나 xterm의 다음-frame screen commit을 이어 칠한다.
+      if (!disposed && active && (shouldRepaint || shouldSettle)) schedulePaint();
+    });
+  };
+
+  const dimensionsSubscription = terminal.onDimensionsChange(() => {
+    settlePaintPending = true;
+    schedulePaint();
+  });
+  // xterm은 renderer canvas와 `.xterm-screen` CSS 크기를 dimensions 이벤트보다 늦게 commit할 수 있다.
+  // 실제 screen box의 변화 자체도 관찰해야 최대화 직후 옛 920×448 경계에 strip이 멈추지 않는다.
+  const screenResizeObserver = typeof ResizeObserver === "undefined"
+    ? null
+    : new ResizeObserver(() => schedulePaint());
+  screenResizeObserver?.observe(options.screen);
+
+  return {
+    setActive: (next) => {
+      active = next;
+      if (active) schedulePaint();
+      else hide();
+    },
+    schedulePaint,
+    dispose: () => {
+      disposed = true;
+      if (frame !== null) cancelFrame(frame);
+      dimensionsSubscription.dispose();
+      screenResizeObserver?.disconnect();
+      rightCanvas.remove();
+      bottomCanvas.remove();
+    },
+  };
+}
+
+function terminalCellVisualBackground(
+  cell: ReturnType<NonNullable<ReturnType<XtermTerminal["buffer"]["active"]["getLine"]>>["getCell"]> | undefined,
+  theme: ITheme,
+): string {
+  if (!cell) return theme.background ?? "transparent";
+  const useForeground = cell.isInverse() !== 0;
+  const color = useForeground ? cell.getFgColor() : cell.getBgColor();
+  const isRgb = useForeground ? cell.isFgRGB() : cell.isBgRGB();
+  const isPalette = useForeground ? cell.isFgPalette() : cell.isBgPalette();
+  if (isRgb) return `rgb(${color >> 16 & 0xff}, ${color >> 8 & 0xff}, ${color & 0xff})`;
+  if (isPalette) return terminalPaletteColor(color, theme);
+  return useForeground ? theme.foreground ?? theme.background ?? "transparent" : theme.background ?? "transparent";
+}
+
+const TERMINAL_ANSI_THEME_KEYS = [
+  "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+  "brightBlack", "brightRed", "brightGreen", "brightYellow", "brightBlue", "brightMagenta", "brightCyan", "brightWhite",
+] as const;
+
+function terminalPaletteColor(index: number, theme: ITheme): string {
+  if (index < TERMINAL_ANSI_THEME_KEYS.length) {
+    return theme[TERMINAL_ANSI_THEME_KEYS[index] ?? "black"] ?? theme.background ?? "transparent";
+  }
+  const extended = theme.extendedAnsi?.[index - TERMINAL_ANSI_THEME_KEYS.length];
+  if (extended) return extended;
+  if (index < 232) {
+    const value = index - 16;
+    const levels = [0, 95, 135, 175, 215, 255];
+    return `rgb(${levels[Math.floor(value / 36)] ?? 0}, ${levels[Math.floor(value / 6) % 6] ?? 0}, ${levels[value % 6] ?? 0})`;
+  }
+  const level = 8 + (index - 232) * 10;
+  return `rgb(${level}, ${level}, ${level})`;
 }
 
 function scrollTerminalToBottom(terminal: XtermTerminal | null): void {

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -5,6 +5,7 @@ import type { SessionIdentityResolver } from "../agent-api/session-identity.js";
 
 import { createOscTitleParser, type OscTitleParser } from "./osc-title-parser.js";
 import { startTerminalShell, type TerminalLaunchResolver } from "./pty.js";
+import { createTerminalModeTracker, type TerminalModeTracker } from "./terminal-mode-tracker.js";
 import type { TerminalPtyHandle, TerminalSessionManager, TerminalSocket, TerminalSocketData, TerminalTicketContext, TerminalTitleListener } from "./terminal-types.js";
 
 export interface TerminalSessionManagerDeps {
@@ -45,6 +46,7 @@ interface TerminalSession {
   // theater-shell(캔버스 순정 셸) 전용: 소켓 단절 후 PTY 정리까지의 grace 타이머. 재연결 시 취소된다.
   graceTimer: ReturnType<typeof setTimeout> | null;
   terminalQueryResidual: string;
+  readonly modeTracker: TerminalModeTracker;
   // 인메모리 유후 추적(서버 monotonic). 생성 시 시드되고 attach / PTY 출력 / binary 입력 / 서버 주입 write에서 갱신.
   lastActivityAt: number | undefined;
 }
@@ -98,10 +100,9 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     session.activeSocket = socket;
     touchActivity(session);
     session.pty.resize(session.cols, session.rows);
+    sendReplayState(session, socket);
     replayScrollback(session, socket);
-    if (socket.readyState === WS_OPEN_STATE) {
-      socket.send(Buffer.from(JSON.stringify({ type: "replay_end" }), "utf8"), { binary: false });
-    }
+    sendReplayEnd(session, socket);
     socket.on("message", (data, isBinary) => handleSocketMessage(session, data, isBinary));
     socket.once("close", () => detachSocket(session, socket));
   }
@@ -118,10 +119,9 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     const session = sessions.get(sessionId);
     if (!session) return false;
     session.viewers.add(socket);
+    sendReplayState(session, socket);
     replayScrollback(session, socket);
-    if (socket.readyState === WS_OPEN_STATE) {
-      socket.send(Buffer.from(JSON.stringify({ type: "replay_end" }), "utf8"), { binary: false });
-    }
+    sendReplayEnd(session, socket);
     socket.once("close", () => {
       session.viewers.delete(socket);
       scheduleTheaterShellCleanup(session);
@@ -270,6 +270,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       rows: DEFAULT_ROWS,
       graceTimer: null,
       terminalQueryResidual: "",
+      modeTracker: createTerminalModeTracker(),
       // 생성 시각으로 시드한다 — 조용한 PTY가 attach 전에 고아가 되어도 sweeper가 유후 판정할 수 있게 한다.
       lastActivityAt: now(),
     };
@@ -303,6 +304,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       for (const response of queryResponses) writeTerminalQueryResponse(session, response);
     }
     observeOscTitles(session, buffer);
+    session.modeTracker.push(buffer);
     session.scrollback.push(buffer);
     while (session.scrollback.length > scrollbackLimit) session.scrollback.shift();
     liveSocket?.send(buffer, { binary: true });
@@ -332,7 +334,9 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
   function handleSocketMessage(session: TerminalSession, data: TerminalSocketData, isBinary: boolean): void {
     if (isBinary) {
       touchActivity(session);
-      session.pty.write(toBuffer(data).toString("utf8"));
+      // xterm onBinary carries legacy mouse reports as a binary string. The WebSocket preserves those
+      // octets, so do not decode and re-encode them as UTF-8 before node-pty receives them.
+      session.pty.write(toBuffer(data));
       return;
     }
     handleControlFrame(session, toBuffer(data).toString("utf8"));
@@ -392,6 +396,22 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       if (socket.readyState !== WS_OPEN_STATE) return;
       socket.send(chunk, { binary: true });
     }
+  }
+
+  function sendReplayState(session: TerminalSession, socket: TerminalSocket): void {
+    if (socket.readyState !== WS_OPEN_STATE) return;
+    socket.send(Buffer.from(JSON.stringify({
+      type: "replay_state",
+      ...session.modeTracker.snapshot(),
+    }), "utf8"), { binary: false });
+  }
+
+  function sendReplayEnd(session: TerminalSession, socket: TerminalSocket): void {
+    if (socket.readyState !== WS_OPEN_STATE) return;
+    socket.send(Buffer.from(JSON.stringify({
+      type: "replay_end",
+      ...session.modeTracker.snapshot(),
+    }), "utf8"), { binary: false });
   }
 
   function removeSession(session: TerminalSession, options: KillSessionOptions = {}): void {

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-mode-tracker.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-mode-tracker.ts
@@ -1,0 +1,117 @@
+export type TerminalMouseProtocol = "none" | "x10" | "vt200" | "drag" | "any";
+export type TerminalMouseEncoding = "default" | "sgr" | "sgr-pixels";
+
+export interface TerminalModeSnapshot {
+  readonly alternateScreenActive: boolean;
+  readonly mouseProtocol: TerminalMouseProtocol;
+  readonly mouseEncoding: TerminalMouseEncoding;
+}
+
+export interface TerminalModeTracker {
+  readonly push: (data: Uint8Array) => void;
+  readonly snapshot: () => TerminalModeSnapshot;
+}
+
+const ESCAPE = 0x1b;
+const CSI_OPEN = 0x5b;
+const FULL_RESET = 0x63;
+const MAX_CSI_BODY_LENGTH = 128;
+const MOUSE_PROTOCOL_MODES = new Map<number, TerminalMouseProtocol>([
+  [9, "x10"],
+  [1000, "vt200"],
+  [1002, "drag"],
+  [1003, "any"],
+]);
+const MOUSE_ENCODING_MODES = new Map<number, TerminalMouseEncoding>([
+  [1006, "sgr"],
+  [1016, "sgr-pixels"],
+]);
+const ALTERNATE_SCREEN_MODES = new Set([47, 1047, 1049]);
+
+export function createTerminalModeTracker(): TerminalModeTracker {
+  let parserState: "ground" | "escape" | "csi" | "string" | "string-escape" = "ground";
+  let csiBody = "";
+  let stringAcceptsBel = false;
+  let alternateScreenActive = false;
+  let mouseProtocol: TerminalMouseProtocol = "none";
+  let mouseEncoding: TerminalMouseEncoding = "default";
+
+  const resetModes = () => {
+    alternateScreenActive = false;
+    mouseProtocol = "none";
+    mouseEncoding = "default";
+  };
+
+  const applyPrivateMode = (mode: number, enabled: boolean) => {
+    if (ALTERNATE_SCREEN_MODES.has(mode)) alternateScreenActive = enabled;
+    const protocol = MOUSE_PROTOCOL_MODES.get(mode);
+    if (protocol) mouseProtocol = enabled ? protocol : "none";
+    const encoding = MOUSE_ENCODING_MODES.get(mode);
+    if (encoding) mouseEncoding = enabled ? encoding : "default";
+  };
+
+  const finishCsi = (final: number) => {
+    if ((final !== 0x68 && final !== 0x6c) || !csiBody.startsWith("?")) return;
+    const enabled = final === 0x68;
+    for (const rawMode of csiBody.slice(1).split(";")) {
+      if (!/^\d+$/.test(rawMode)) continue;
+      applyPrivateMode(Number(rawMode), enabled);
+    }
+  };
+
+  const push = (data: Uint8Array) => {
+    for (const byte of data) {
+      if (parserState === "ground") {
+        if (byte === ESCAPE) parserState = "escape";
+        continue;
+      }
+      if (parserState === "escape") {
+        if (byte === CSI_OPEN) {
+          parserState = "csi";
+          csiBody = "";
+        } else if (byte === FULL_RESET) {
+          resetModes();
+          parserState = "ground";
+        } else if (byte === 0x5d || byte === 0x50 || byte === 0x58 || byte === 0x5e || byte === 0x5f) {
+          // OSC terminates with BEL or ST. DCS/SOS/PM/APC terminate only with ST. Ignore their
+          // payloads so literal ESC [ text in a title or application string cannot change modes.
+          stringAcceptsBel = byte === 0x5d;
+          parserState = "string";
+        } else if (byte !== ESCAPE) {
+          parserState = "ground";
+        }
+        continue;
+      }
+      if (parserState === "string") {
+        if (stringAcceptsBel && byte === 0x07) parserState = "ground";
+        else if (byte === ESCAPE) parserState = "string-escape";
+        continue;
+      }
+      if (parserState === "string-escape") {
+        parserState = byte === 0x5c ? "ground" : (byte === ESCAPE ? "string-escape" : "string");
+        continue;
+      }
+      if (byte >= 0x40 && byte <= 0x7e) {
+        finishCsi(byte);
+        parserState = "ground";
+        csiBody = "";
+      } else if (byte >= 0x20 && byte <= 0x3f && csiBody.length < MAX_CSI_BODY_LENGTH) {
+        csiBody += String.fromCharCode(byte);
+      } else if (byte === ESCAPE) {
+        parserState = "escape";
+        csiBody = "";
+      } else {
+        parserState = "ground";
+        csiBody = "";
+      }
+    }
+  };
+
+  const snapshot = (): TerminalModeSnapshot => ({
+    alternateScreenActive,
+    mouseProtocol,
+    mouseEncoding,
+  });
+
+  return { push, snapshot };
+}

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -86,7 +86,7 @@ export interface TerminalPtyHandle {
   readonly fd?: number;
   onData(callback: (data: string) => void): TerminalPtyDataDisposable;
   onExit(callback: () => void): TerminalPtyDataDisposable;
-  write(data: string): void;
+  write(data: string | Buffer): void;
   resize(cols: number, rows: number): void;
   kill(): void;
   destroy?(): void;

--- a/runtime/fleet-plugins/terminal/tests/session-manager-query-replay.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/session-manager-query-replay.test.ts
@@ -54,11 +54,13 @@ describe("session-manager terminal query replay", () => {
 
     await manager.attach(socket, CONTEXT);
 
-    expect(socket.sent).toHaveLength(2);
-    expect(socket.sent[0]).toMatchObject({ binary: true });
-    expect(socket.sent[0]?.data.toString("utf8")).toBe("detached-output");
-    expect(socket.sent[1]).toMatchObject({ binary: false });
-    expect(JSON.parse(socket.sent[1]?.data.toString("utf8") ?? "null")).toEqual({ type: "replay_end" });
+    expect(socket.sent).toHaveLength(3);
+    expect(socket.sent[0]).toMatchObject({ binary: false });
+    expect(JSON.parse(socket.sent[0]?.data.toString("utf8") ?? "null")).toEqual({ type: "replay_state", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" });
+    expect(socket.sent[1]).toMatchObject({ binary: true });
+    expect(socket.sent[1]?.data.toString("utf8")).toBe("detached-output");
+    expect(socket.sent[2]).toMatchObject({ binary: false });
+    expect(JSON.parse(socket.sent[2]?.data.toString("utf8") ?? "null")).toEqual({ type: "replay_end", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" });
     await manager.stop();
   });
 
@@ -68,16 +70,72 @@ describe("session-manager terminal query replay", () => {
 
     await manager.attach(socket, CONTEXT);
 
-    expect(socket.sent).toHaveLength(1);
+    expect(socket.sent).toHaveLength(2);
     expect(socket.sent[0]).toMatchObject({ binary: false });
-    expect(JSON.parse(socket.sent[0]?.data.toString("utf8") ?? "null")).toEqual({ type: "replay_end" });
+    expect(JSON.parse(socket.sent[0]?.data.toString("utf8") ?? "null")).toEqual({ type: "replay_state", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" });
+    expect(socket.sent[1]).toMatchObject({ binary: false });
+    expect(JSON.parse(socket.sent[1]?.data.toString("utf8") ?? "null")).toEqual({ type: "replay_end", alternateScreenActive: false, mouseProtocol: "none", mouseEncoding: "default" });
+    await manager.stop();
+  });
+
+  it("tracks a split alternate-screen sequence after its entry scrollback was evicted", async () => {
+    const { manager, pty } = await createHarness({ scrollbackLimit: 1 });
+    pty.emitData("\x1b[?10");
+    pty.emitData("49h");
+    pty.emitData("latest-paint");
+    const socket = createMockSocket();
+
+    await manager.attach(socket, CONTEXT);
+
+    expect(socket.sent.filter((frame) => frame.binary).map((frame) => frame.data.toString("utf8"))).toEqual(["latest-paint"]);
+    expect(JSON.parse(socket.sent[0]?.data.toString("utf8") ?? "null")).toMatchObject({
+      type: "replay_state",
+      alternateScreenActive: true,
+    });
+    expect(JSON.parse(socket.sent.at(-1)?.data.toString("utf8") ?? "null")).toEqual({
+      type: "replay_end",
+      alternateScreenActive: true,
+      mouseProtocol: "none",
+      mouseEncoding: "default",
+    });
+    await manager.stop();
+  });
+
+  it("returns the tracked mode to normal on full reset", async () => {
+    const { manager, pty } = await createHarness();
+    pty.emitData("\x1b[?1049h");
+    pty.emitData("\x1bc");
+    const socket = createMockSocket();
+
+    await manager.attach(socket, CONTEXT);
+
+    expect(JSON.parse(socket.sent.at(-1)?.data.toString("utf8") ?? "null")).toEqual({
+      type: "replay_end",
+      alternateScreenActive: false,
+      mouseProtocol: "none",
+      mouseEncoding: "default",
+    });
+    await manager.stop();
+  });
+
+  it("writes client binary input to the PTY without UTF-8 replacement", async () => {
+    const { manager, pty } = await createHarness();
+    const socket = createMockSocket();
+    await manager.attach(socket, CONTEXT);
+    const report = Buffer.from([0x1b, 0x5b, 0x4d, 0x80, 0xff, 0x00]);
+
+    socket.emitMessage(report, true);
+
+    expect(pty.written).toHaveLength(1);
+    expect(Buffer.isBuffer(pty.written[0])).toBe(true);
+    expect([...pty.written[0] as Buffer]).toEqual([...report]);
     await manager.stop();
   });
 
 });
 
 interface MockPty extends TerminalPtyHandle {
-  readonly written: string[];
+  readonly written: Array<string | Buffer>;
   emitData(data: string): void;
 }
 
@@ -92,11 +150,12 @@ interface MockSocket extends TerminalSocket {
   emitClose(): void;
 }
 
-async function createHarness(): Promise<{ readonly manager: ReturnType<typeof createTerminalSessionManager>; readonly pty: MockPty }> {
+async function createHarness(options: { readonly scrollbackLimit?: number } = {}): Promise<{ readonly manager: ReturnType<typeof createTerminalSessionManager>; readonly pty: MockPty }> {
   const pty = createMockPty();
   const manager = createTerminalSessionManager({
     launch: async (cwd) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: {} }),
     startShell: () => pty,
+    ...options,
   });
   await manager.createSession(CONTEXT);
   return { manager, pty };

--- a/runtime/fleet-plugins/terminal/tests/terminal-alternate-screen-edge-fill.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-alternate-screen-edge-fill.test.ts
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createTerminalAlternateScreenEdgeFill } from "../client/shared/terminal-surface.js";
+
+const dimensions = {
+  css: {
+    canvas: { width: 90, height: 47 },
+    cell: { width: 12, height: 16 },
+  },
+  device: {
+    canvas: { width: 192, height: 96 },
+    cell: { width: 24, height: 32 },
+    char: { width: 20, height: 28, left: 2, top: 2 },
+  },
+};
+
+describe("terminal alternate-screen edge fill", () => {
+  it("extends terminal cell backgrounds into right and bottom grid remainders", () => {
+    const screen = document.createElement("div");
+    const container = document.createElement("div");
+    container.append(screen);
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue(domRect(0, 0, 104, 53));
+    vi.spyOn(screen, "getBoundingClientRect").mockReturnValue(domRect(0, 0, 96, 48));
+    let dimensionsListener: ((value: typeof dimensions) => void) | undefined;
+    const right = canvasAndContext();
+    const bottom = canvasAndContext();
+    const cells = [
+      fakeCell({ rgb: 0x112233 }),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell({ rgb: 0x445566 }),
+      fakeCell({ palette: 1 }),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell(),
+      fakeCell({ rgb: 0x778899 }),
+    ];
+    let pendingFrame: FrameRequestCallback | undefined;
+    const controller = createTerminalAlternateScreenEdgeFill({
+      terminal: {
+        cols: 8,
+        rows: 3,
+        options: { theme: { background: "#000", red: "#f00" } },
+        buffer: {
+          active: {
+            viewportY: 0,
+            getLine: (row: number) => ({ getCell: (column: number) => cells[row * 8 + column] }),
+          },
+        },
+        onDimensionsChange: (listener: (value: typeof dimensions) => void) => {
+          dimensionsListener = listener;
+          return { dispose: vi.fn() };
+        },
+      } as never,
+      container,
+      screen,
+      createCanvas: (edge) => edge === "right" ? right.canvas : bottom.canvas,
+      requestFrame: (callback) => {
+        pendingFrame = callback;
+        return 1;
+      },
+      cancelFrame: vi.fn(),
+      devicePixelRatio: () => 2,
+    });
+
+    dimensionsListener?.(dimensions);
+    controller.setActive(true);
+    pendingFrame?.(0);
+
+    expect(Array.from(container.children)).toEqual(expect.arrayContaining([screen, right.canvas, bottom.canvas]));
+    expect(screen.querySelector("canvas")).toBeNull();
+    expect(right.canvas.hidden).toBe(false);
+    expect(right.canvas.style.left).toBe("96px");
+    expect(right.canvas.style.width).toBe("8px");
+    expect(right.canvas.style.height).toBe("53px");
+    expect(right.canvas.width).toBe(16);
+    expect(right.canvas.height).toBe(106);
+    expect(bottom.canvas.hidden).toBe(false);
+    expect(bottom.canvas.style.top).toBe("48px");
+    expect(bottom.canvas.style.width).toBe("96px");
+    expect(bottom.canvas.style.height).toBe("5px");
+    expect(bottom.canvas.width).toBe(192);
+    expect(bottom.canvas.height).toBe(10);
+    expect(right.context.fillRect).toHaveBeenCalledTimes(4);
+    expect(bottom.context.fillRect).toHaveBeenCalledTimes(8);
+    expect(right.context.fills).toEqual(["#000", "#f00", "rgb(119, 136, 153)", "rgb(119, 136, 153)"]);
+    expect(bottom.context.fills.at(-1)).toBe("rgb(119, 136, 153)");
+
+    controller.setActive(false);
+    expect(right.canvas.hidden).toBe(true);
+    expect(bottom.canvas.hidden).toBe(true);
+    expect(right.canvas.width).toBe(0);
+    expect(bottom.canvas.height).toBe(0);
+    controller.dispose();
+  });
+
+  it("repaints with the last geometry when resize schedules overlap", () => {
+    const screen = document.createElement("div");
+    const container = document.createElement("div");
+    container.append(screen);
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue(domRect(0, 0, 104, 53));
+    vi.spyOn(screen, "getBoundingClientRect").mockReturnValue(domRect(0, 0, 96, 48));
+    let dimensionsListener: ((value: typeof dimensions) => void) | undefined;
+    const right = canvasAndContext();
+    const bottom = canvasAndContext();
+    const frames: FrameRequestCallback[] = [];
+    const controller = createTerminalAlternateScreenEdgeFill({
+      terminal: {
+        cols: 8,
+        rows: 3,
+        options: { theme: { background: "#000" } },
+        buffer: { active: { viewportY: 0, getLine: () => undefined } },
+        onDimensionsChange: (listener: (value: typeof dimensions) => void) => {
+          dimensionsListener = listener;
+          return { dispose: vi.fn() };
+        },
+      } as never,
+      container,
+      screen,
+      createCanvas: (edge) => edge === "right" ? right.canvas : bottom.canvas,
+      requestFrame: (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+    });
+
+    dimensionsListener?.(dimensions);
+    controller.setActive(true);
+    controller.schedulePaint();
+    expect(frames).toHaveLength(1);
+
+    vi.mocked(screen.getBoundingClientRect).mockReturnValue(domRect(0, 0, 100, 50));
+    frames.shift()?.(0);
+    expect(frames).toHaveLength(1);
+    frames.shift()?.(0);
+
+    expect(right.canvas.style.left).toBe("100px");
+    expect(right.canvas.style.width).toBe("4px");
+    expect(bottom.canvas.style.top).toBe("50px");
+    expect(bottom.canvas.style.height).toBe("3px");
+    controller.dispose();
+  });
+
+  it("does not add a paint layer when the grid consumes the entire surface", () => {
+    const screen = document.createElement("div");
+    const container = document.createElement("div");
+    container.append(screen);
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue(domRect(0, 0, 96, 48));
+    vi.spyOn(screen, "getBoundingClientRect").mockReturnValue(domRect(0, 0, 96, 48));
+    let dimensionsListener: ((value: typeof dimensions) => void) | undefined;
+    const right = canvasAndContext();
+    const bottom = canvasAndContext();
+    let pendingFrame: FrameRequestCallback | undefined;
+    const controller = createTerminalAlternateScreenEdgeFill({
+      terminal: {
+        cols: 8,
+        rows: 3,
+        options: { theme: { background: "#000" } },
+        buffer: { active: { viewportY: 0, getLine: () => undefined } },
+        onDimensionsChange: (listener: (value: typeof dimensions) => void) => {
+          dimensionsListener = listener;
+          return { dispose: vi.fn() };
+        },
+      } as never,
+      container,
+      screen,
+      createCanvas: (edge) => edge === "right" ? right.canvas : bottom.canvas,
+      requestFrame: (callback) => {
+        pendingFrame = callback;
+        return 1;
+      },
+    });
+
+    dimensionsListener?.(dimensions);
+    controller.setActive(true);
+    pendingFrame?.(0);
+
+    expect(right.canvas.hidden).toBe(true);
+    expect(bottom.canvas.hidden).toBe(true);
+    controller.dispose();
+  });
+});
+
+function canvasAndContext() {
+  const canvas = document.createElement("canvas");
+  const fills: string[] = [];
+  let fillStyle = "";
+  const context = {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    fillRect: vi.fn(() => fills.push(fillStyle)),
+    fills,
+    get fillStyle() { return fillStyle; },
+    set fillStyle(value: string | CanvasGradient | CanvasPattern) { fillStyle = String(value); },
+  };
+  vi.spyOn(canvas, "getContext").mockReturnValue(context as never);
+  return { canvas, context };
+}
+
+function fakeCell(options: { readonly rgb?: number; readonly palette?: number; readonly inverse?: boolean } = {}) {
+  const color = options.rgb ?? options.palette ?? 0;
+  return {
+    getBgColor: () => color,
+    getFgColor: () => color,
+    isBgRGB: () => options.rgb !== undefined,
+    isFgRGB: () => options.rgb !== undefined,
+    isBgPalette: () => options.palette !== undefined,
+    isFgPalette: () => options.palette !== undefined,
+    isInverse: () => options.inverse ? 1 : 0,
+  };
+}
+
+function domRect(x: number, y: number, width: number, height: number): DOMRect {
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    right: x + width,
+    bottom: y + height,
+    left: x,
+    toJSON: () => ({}),
+  };
+}

--- a/runtime/fleet-plugins/terminal/tests/terminal-alternate-screen.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-alternate-screen.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTerminalAlternateScreenController } from "../client/shared/terminal-alternate-screen.js";
+
+interface FakeBuffer {
+  readonly type: "normal" | "alternate";
+}
+
+class FakeTerminal {
+  readonly cols = 80;
+  readonly rows = 24;
+  readonly options: { scrollbar: { showScrollbar: boolean } } = { scrollbar: { showScrollbar: true } };
+  readonly writes: string[] = [];
+  private activeBuffer: FakeBuffer = { type: "normal" };
+  private bufferListener: ((buffer: FakeBuffer) => void) | null = null;
+  private readonly csiHandlers = new Map<string, (params: Array<number | number[]>) => boolean>();
+  private readonly escHandlers = new Map<string, () => boolean>();
+
+  readonly buffer = {
+    get active() { return thisTerminal.activeBuffer; },
+    onBufferChange: (listener: (buffer: FakeBuffer) => void) => {
+      this.bufferListener = listener;
+      return { dispose: () => { this.bufferListener = null; } };
+    },
+  };
+
+  readonly parser = {
+    registerCsiHandler: (id: { readonly prefix?: string; readonly final: string }, handler: (params: Array<number | number[]>) => boolean) => {
+      const key = `${id.prefix ?? ""}${id.final}`;
+      this.csiHandlers.set(key, handler);
+      return { dispose: () => { this.csiHandlers.delete(key); } };
+    },
+    registerEscHandler: (id: { readonly final: string }, handler: () => boolean) => {
+      this.escHandlers.set(id.final, handler);
+      return { dispose: () => { this.escHandlers.delete(id.final); } };
+    },
+  };
+
+  write(data: string, callback?: () => void): void {
+    this.writes.push(data);
+    if (data.includes("?1049h")) this.activate("alternate");
+    if (data.includes("?1047l")) this.activate("normal");
+    callback?.();
+  }
+
+  activate(type: FakeBuffer["type"]): void {
+    this.activeBuffer = { type };
+    this.bufferListener?.(this.activeBuffer);
+  }
+
+  emitCsi(final: "h" | "l", params: number[]): void {
+    this.csiHandlers.get(`?${final}`)?.(params);
+    const mode = params.find((value) => value === 47 || value === 1047 || value === 1049);
+    if (mode !== undefined) this.activate(final === "h" ? "alternate" : "normal");
+  }
+
+  emitReset(): void {
+    this.escHandlers.get("c")?.();
+    this.activate("normal");
+  }
+}
+
+let thisTerminal: FakeTerminal;
+
+describe("terminal alternate screen controller", () => {
+  it("hides the scrollbar, refits, and resizes once on live alternate entry", () => {
+    const terminal = new FakeTerminal();
+    thisTerminal = terminal;
+    const fit = vi.fn();
+    const resizePty = vi.fn();
+    const onAlternateScreenChange = vi.fn();
+    const controller = createTerminalAlternateScreenController({
+      terminal: terminal as never,
+      fitAddon: { fit },
+      resizePty,
+      isReplaying: () => false,
+      onAlternateScreenChange,
+    });
+
+    terminal.emitCsi("h", [1049]);
+
+    expect(terminal.options.scrollbar.showScrollbar).toBe(false);
+    expect(onAlternateScreenChange).toHaveBeenLastCalledWith(true);
+    expect(fit).toHaveBeenCalledTimes(1);
+    expect(resizePty).toHaveBeenCalledWith(80, 24);
+
+    terminal.emitCsi("l", [1049]);
+    expect(terminal.options.scrollbar.showScrollbar).toBe(true);
+    expect(onAlternateScreenChange).toHaveBeenLastCalledWith(false);
+    expect(fit).toHaveBeenCalledTimes(2);
+    expect(resizePty).toHaveBeenCalledTimes(2);
+    controller.dispose();
+  });
+
+  it("coalesces replay transitions into the final sideband state", () => {
+    const terminal = new FakeTerminal();
+    thisTerminal = terminal;
+    const fit = vi.fn();
+    const resizePty = vi.fn();
+    let replaying = true;
+    const controller = createTerminalAlternateScreenController({
+      terminal: terminal as never,
+      fitAddon: { fit },
+      resizePty,
+      isReplaying: () => replaying,
+    });
+
+    terminal.emitCsi("h", [1049]);
+    terminal.emitCsi("l", [1049]);
+    terminal.emitCsi("h", [1049]);
+    expect(fit).not.toHaveBeenCalled();
+
+    replaying = false;
+    controller.finishReplay({ alternateScreenActive: true });
+
+    expect(terminal.options.scrollbar.showScrollbar).toBe(false);
+    expect(fit).toHaveBeenCalledTimes(1);
+    expect(resizePty).toHaveBeenCalledTimes(1);
+    controller.dispose();
+  });
+
+  it("restores missing alternate and mouse modes after bounded replay", () => {
+    const terminal = new FakeTerminal();
+    thisTerminal = terminal;
+    const fit = vi.fn();
+    const controller = createTerminalAlternateScreenController({
+      terminal: terminal as never,
+      fitAddon: { fit },
+      resizePty: vi.fn(),
+      isReplaying: () => false,
+    });
+
+    const state = {
+      alternateScreenActive: true,
+      mouseProtocol: "vt200" as const,
+      mouseEncoding: "sgr" as const,
+    };
+    controller.prepareReplay(state);
+    controller.finishReplay(state);
+
+    expect(terminal.writes).toEqual([
+      "\x1b[?1049h\x1b[?1006l\x1b[?1016l\x1b[?1003l\x1b[?1002l\x1b[?1000l\x1b[?9l\x1b[?1000h\x1b[?1006h",
+      "\x1b[?1006l\x1b[?1016l\x1b[?1003l\x1b[?1002l\x1b[?1000l\x1b[?9l\x1b[?1000h\x1b[?1006h",
+    ]);
+    expect(terminal.buffer.active.type).toBe("alternate");
+    expect(terminal.options.scrollbar.showScrollbar).toBe(false);
+    expect(fit).toHaveBeenCalledTimes(1);
+    controller.dispose();
+  });
+
+  it("returns to normal scrollbar policy on RIS", () => {
+    const terminal = new FakeTerminal();
+    thisTerminal = terminal;
+    const controller = createTerminalAlternateScreenController({
+      terminal: terminal as never,
+      fitAddon: { fit: vi.fn() },
+      resizePty: vi.fn(),
+      isReplaying: () => false,
+    });
+    terminal.emitCsi("h", [1049]);
+
+    terminal.emitReset();
+
+    expect(terminal.options.scrollbar.showScrollbar).toBe(true);
+    controller.dispose();
+  });
+});

--- a/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
@@ -34,11 +34,17 @@ describe("terminal connection replay input gate", () => {
     terminal.emitData("before-replay-end");
     expect(socket!.sent).toHaveLength(1);
 
+    socket!.receive(JSON.stringify({
+      type: "replay_state",
+      alternateScreenActive: false,
+      mouseProtocol: "none",
+      mouseEncoding: "default",
+    }));
     const replay = new TextEncoder().encode("replayed-output");
     socket!.receive(replay.buffer);
     expect(terminal.written).toEqual([replay]);
 
-    socket!.receive(JSON.stringify({ type: "replay_end" }));
+    socket!.receive(JSON.stringify({ type: "replay_end", alternateScreenActive: false }));
     expect(terminal.pendingDrains).toHaveLength(1);
     terminal.emitData("while-draining");
     expect(socket!.sent).toHaveLength(1);
@@ -50,6 +56,75 @@ describe("terminal connection replay input gate", () => {
     expect(socket!.sent[1]).toBeInstanceOf(Uint8Array);
     expect(new TextDecoder().decode(socket!.sent[1] as Uint8Array)).toBe("live-input");
 
+    connection.dispose();
+  });
+
+  it("preserves legacy onBinary mouse report bytes", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ ticket: "ticket-binary", ttlMs: 10_000 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+    const terminal = new FakeTerminal();
+    let socket: FakeWebSocket | undefined;
+    const connection = createTerminalConnection({
+      operationId: "session-binary",
+      terminal,
+      ticketPath: "/ticket",
+      wsPath: "/ws",
+      location: { host: "console.test", protocol: "http:" },
+      webSocketFactory: () => {
+        socket = new FakeWebSocket();
+        return socket;
+      },
+    });
+    connection.start();
+    await vi.waitFor(() => expect(socket).toBeDefined());
+    socket!.open();
+    socket!.receive(JSON.stringify({ type: "replay_end", alternateScreenActive: false }));
+    terminal.releaseDrain();
+
+    terminal.emitBinary("\x1b[M\x80\xff\x00");
+
+    expect(socket!.sent).toHaveLength(1);
+    expect([...socket!.sent[0] as Uint8Array]).toEqual([0x1b, 0x5b, 0x4d, 0x80, 0xff, 0x00]);
+    connection.dispose();
+  });
+
+  it("passes server modes before replay parsing and confirms them only after drain", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ ticket: "ticket-state", ttlMs: 10_000 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+    const terminal = new FakeTerminal();
+    const replayStates: Array<{ readonly replaying: boolean; readonly alternate?: boolean }> = [];
+    const initialModes: boolean[] = [];
+    let socket: FakeWebSocket | undefined;
+    const connection = createTerminalConnection({
+      operationId: "session-state",
+      terminal,
+      ticketPath: "/ticket",
+      wsPath: "/ws",
+      location: { host: "console.test", protocol: "http:" },
+      onReplayState: (state) => initialModes.push(state.alternateScreenActive === true),
+      onReplayStateChange: (replaying, state) => replayStates.push({ replaying, alternate: state?.alternateScreenActive }),
+      webSocketFactory: () => {
+        socket = new FakeWebSocket();
+        return socket;
+      },
+    });
+    connection.start();
+    await vi.waitFor(() => expect(socket).toBeDefined());
+    socket!.open();
+    socket!.receive(JSON.stringify({ type: "replay_state", alternateScreenActive: true }));
+    expect(initialModes).toEqual([true]);
+    socket!.receive(JSON.stringify({ type: "replay_end", alternateScreenActive: true }));
+
+    expect(replayStates).toEqual([{ replaying: true }]);
+    terminal.releaseDrain();
+    expect(replayStates).toEqual([
+      { replaying: true },
+      { replaying: false, alternate: true },
+    ]);
     connection.dispose();
   });
 
@@ -129,7 +204,7 @@ describe("terminal connection replay input gate", () => {
     sockets[0]!.receive(new TextEncoder().encode("replayed-output").buffer);
     expect(replayStates).toEqual([true]);
 
-    sockets[0]!.receive(JSON.stringify({ type: "replay_end" }));
+    sockets[0]!.receive(JSON.stringify({ type: "replay_end", alternateScreenActive: false }));
     expect(replayStates).toEqual([true]);
 
     // It closes only once the replayed bytes have actually been parsed.
@@ -170,7 +245,7 @@ describe("terminal connection replay input gate", () => {
     sockets[0]!.open();
 
     // The first socket asks to close its window, but its drain has not run yet.
-    sockets[0]!.receive(JSON.stringify({ type: "replay_end" }));
+    sockets[0]!.receive(JSON.stringify({ type: "replay_end", alternateScreenActive: false }));
     expect(terminal.pendingDrains).toHaveLength(1);
 
     // It dies first, and the reconnect opens a fresh replay window.
@@ -184,7 +259,7 @@ describe("terminal connection replay input gate", () => {
     expect(replayStates).toEqual([true, true]);
 
     // Only the live socket's own replay_end closes it.
-    sockets[1]!.receive(JSON.stringify({ type: "replay_end" }));
+    sockets[1]!.receive(JSON.stringify({ type: "replay_end", alternateScreenActive: false }));
     terminal.releaseDrain();
     expect(replayStates).toEqual([true, true, false]);
 
@@ -195,7 +270,17 @@ describe("terminal connection replay input gate", () => {
 class FakeTerminal {
   readonly written: Uint8Array[] = [];
   readonly pendingDrains: Array<() => void> = [];
+  private binaryListener: ((data: string) => void) | null = null;
   private dataListener: ((data: string) => void) | null = null;
+
+  readonly onBinary = (listener: (data: string) => void) => {
+    this.binaryListener = listener;
+    return {
+      dispose: () => {
+        if (this.binaryListener === listener) this.binaryListener = null;
+      },
+    };
+  };
 
   readonly onData = (listener: (data: string) => void) => {
     this.dataListener = listener;
@@ -213,6 +298,10 @@ class FakeTerminal {
   readonly drain = (callback: () => void) => {
     this.pendingDrains.push(callback);
   };
+
+  emitBinary(data: string): void {
+    this.binaryListener?.(data);
+  }
 
   emitData(data: string): void {
     this.dataListener?.(data);

--- a/runtime/fleet-plugins/terminal/tests/terminal-key-bar.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/terminal-key-bar.test.tsx
@@ -21,11 +21,18 @@ const terminalMocks = vi.hoisted(() => ({
 
 vi.mock("@xterm/xterm", () => ({
   Terminal: class Terminal {
-    readonly buffer = { active: { baseY: 0, viewportY: 0 } };
+    readonly buffer = {
+      active: { baseY: 0, viewportY: 0, type: "normal" },
+      onBufferChange: () => ({ dispose() {} }),
+    };
     readonly cols = 80;
     readonly rows = 24;
     readonly unicode = { activeVersion: "" };
-    readonly parser = { registerOscHandler: () => ({ dispose() {} }) };
+    readonly parser = {
+      registerCsiHandler: () => ({ dispose() {} }),
+      registerEscHandler: () => ({ dispose() {} }),
+      registerOscHandler: () => ({ dispose() {} }),
+    };
     readonly options: Record<string, unknown> = {};
     readonly modes = {
       get applicationCursorKeysMode() { return terminalMocks.applicationCursorKeysMode; },
@@ -42,6 +49,7 @@ vi.mock("@xterm/xterm", () => ({
       for (const listener of this.#listeners) listener(data);
     }
     loadAddon() {}
+    onBinary() { return { dispose() {} }; }
     onData(listener: (data: string) => void) {
       this.#listeners.push(listener);
       terminalMocks.emitData = (data: string) => {
@@ -49,6 +57,7 @@ vi.mock("@xterm/xterm", () => ({
       };
       return { dispose: () => { this.#listeners = []; } };
     }
+    onDimensionsChange() { return { dispose() {} }; }
     open() {}
     refresh() {}
     scrollToBottom() {}

--- a/runtime/fleet-plugins/terminal/tests/terminal-mode-tracker.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-mode-tracker.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { createTerminalModeTracker } from "../server/shared/terminal-mode-tracker.js";
+
+const bytes = (value: string) => Buffer.from(value, "utf8");
+
+describe("terminal mode tracker", () => {
+  it("tracks alternate screen and mouse modes across split PTY chunks", () => {
+    const tracker = createTerminalModeTracker();
+
+    tracker.push(bytes("\x1b[?10"));
+    tracker.push(bytes("49h\x1b[?1000;1006h"));
+
+    expect(tracker.snapshot()).toEqual({
+      alternateScreenActive: true,
+      mouseProtocol: "vt200",
+      mouseEncoding: "sgr",
+    });
+  });
+
+  it("accepts all standard alternate buffer modes and restores normal mode", () => {
+    for (const mode of [47, 1047, 1049]) {
+      const tracker = createTerminalModeTracker();
+      tracker.push(bytes(`\x1b[?${mode}h`));
+      expect(tracker.snapshot().alternateScreenActive).toBe(true);
+      tracker.push(bytes(`\x1b[?${mode}l`));
+      expect(tracker.snapshot().alternateScreenActive).toBe(false);
+    }
+  });
+
+  it("resets all tracked modes on RIS without mistaking OSC payloads for CSI", () => {
+    const tracker = createTerminalModeTracker();
+    tracker.push(bytes("\x1b]0;literal [ ? 1049 h title\x07"));
+    expect(tracker.snapshot().alternateScreenActive).toBe(false);
+    tracker.push(bytes("\x1b[?1049;1000;1006h"));
+
+    tracker.push(bytes("\x1bc"));
+
+    expect(tracker.snapshot()).toEqual({
+      alternateScreenActive: false,
+      mouseProtocol: "none",
+      mouseEncoding: "default",
+    });
+  });
+});

--- a/runtime/fleet-plugins/terminal/tests/terminal-surface-focus.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/terminal-surface-focus.test.tsx
@@ -17,11 +17,18 @@ const terminalMocks = vi.hoisted(() => ({
 
 vi.mock("@xterm/xterm", () => ({
   Terminal: class Terminal {
-    readonly buffer = { active: { baseY: 0, viewportY: 0 } };
+    readonly buffer = {
+      active: { baseY: 0, viewportY: 0, type: "normal" },
+      onBufferChange: () => ({ dispose() {} }),
+    };
     readonly cols = 80;
     readonly rows = 24;
     readonly unicode = { activeVersion: "" };
-    readonly parser = { registerOscHandler: () => ({ dispose() {} }) };
+    readonly parser = {
+      registerCsiHandler: () => ({ dispose() {} }),
+      registerEscHandler: () => ({ dispose() {} }),
+      registerOscHandler: () => ({ dispose() {} }),
+    };
     readonly options: Record<string, unknown> = {};
     readonly focus = terminalMocks.focus;
     attachCustomKeyEventHandler() {}
@@ -29,7 +36,9 @@ vi.mock("@xterm/xterm", () => ({
     getSelection() { return ""; }
     input() {}
     loadAddon() {}
+    onBinary() { return { dispose() {} }; }
     onData() { return { dispose() {} }; }
+    onDimensionsChange() { return { dispose() {} }; }
     open() {}
     refresh = terminalMocks.refresh;
     scrollToBottom() {}


### PR DESCRIPTION
## Summary

Teach shared Shell and Agent terminals to hand scrolling to alternate-screen applications, reclaim the xterm scrollbar and sub-cell grid remainder, and restore normal history on exit. Preserve alternate-screen and mouse modes across bounded replay/remount while keeping legacy mouse input byte-safe.

## Type of Change

- [x] feat — new feature or carrier capability
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] Fleet Console Terminal plugin (Shell / Agent PTY)

## Test Plan

- [x] `corepack pnpm --dir runtime/fleet-plugins/terminal typecheck`
- [x] `corepack pnpm --dir runtime/fleet-plugins/terminal test` — 101 files, 1125 tests
- [x] `corepack pnpm --filter @fleet-plugins/terminal build`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`
- [x] Browser E2E at 2000x1200: 6px right/bottom remainders filled, no repeated line artifacts, `pointer-events: none`, normal-screen inverse clears both strips, zero page errors/rejections

## Changelog

- Detect DEC alternate-screen transitions for shared Shell and Agent terminals.
- Hide the xterm scrollbar and refit the PTY while a TUI owns scrolling.
- Preserve alternate-screen and mouse state across retained-output replay.
- Fill only sub-cell right/bottom remainders from public buffer cell backgrounds; never duplicate renderer pixels or glyphs.
- Restore normal scrollbar/history and clear edge strips when the TUI exits.

## Notes for Reviewers

The edge strips live outside the xterm renderer subtree and derive colors from public buffer cells, including inverse, RGB, ANSI 16-color, and 256-color cases. This avoids the previous renderer-pixel extension failure mode where an internal cell line could become a long diagonal/ruled artifact after maximize.