### PR TITLE
feat(fleet-console): align mention rows with operation status

### DIFF
--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type DragEvent as ReactDragEvent, type FocusEvent as ReactFocusEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type ClipboardEvent as ReactClipboardEvent, type DragEvent as ReactDragEvent, type FocusEvent as ReactFocusEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import type { OperationCatalogPlugin, OperationLaunchVariantRow } from "@fleet-console/sdk/operations";
@@ -6,7 +6,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 
 import { useConsoleState } from "../hooks/use-store.js";
 import { useT } from "../i18n/index.js";
-import { operationActivityLabel } from "../operation-activity.js";
+import { resolveOperationMarkVisual } from "../operation-activity.js";
 import type { OperationSearchEntry } from "../operation-search.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { readQuickLaunchSelection, writeQuickLaunchMentionFocused, writeQuickLaunchModelEffort, writeQuickLaunchSelection, writeQuickLaunchStartView, writeQuickLaunchTheater, type QuickLaunchStartView } from "../quick-launch-preferences.js";
@@ -17,6 +17,8 @@ import type { QuickLaunchDraftAttachment } from "../types.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { isTriageActive } from "../canvas/triage-store.js";
 import { clearQuickLaunchRejection, closeQuickLaunch, consumeQuickLaunchDraft, consumeQuickLaunchMentionSeed, getState, isQuickLaunchDocked, preserveQuickLaunchDraft, requestQuickLaunch, setActiveTheater, setQuickLaunchDockSuppressed, setQuickLaunchPinned } from "../store.js";
+import { getIdleArrivalIds, subscribeIdleArrival } from "../operation-marks.js";
+import { OperationNameMark } from "./operation-name-mark.js";
 import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph, type LaunchProviderGlyphId } from "./launch-provider-glyphs.js";
 import { EffortTrack, gatedEffortNames, resolveRowEffort } from "./effort-track.js";
 import { ComposerAttachControl, ComposerBar, ComposerChip, ComposerField, ComposerInput, ComposerRestStrip, ComposerSubmitButton, renderUltracodeHighlight, syncComposerHighlight } from "./composer-blocks.js";
@@ -95,6 +97,9 @@ export function QuickLaunch() {
   const navigate = useNavigate();
   const location = useLocation();
   const registry = usePluginRegistry();
+  // Cmd+K·사이드바·커맨드 밴드와 같은 마크 축. 미확인 완료도 어느 Operation을 고르는
+  // 표면인가에 따라 사라지지 않아야 하므로 멘션 덱이 같은 외부 원장을 구독한다.
+  const idleArrivalIds = useSyncExternalStore(subscribeIdleArrival, getIdleArrivalIds, getIdleArrivalIds);
 
   const cardRef = useRef<HTMLElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -1430,15 +1435,17 @@ export function QuickLaunch() {
                       onClick={() => { if (selectable) pickMention({ kind: "operation", entry }); }}
                     >
                       <span className="quick-launch-mark" aria-hidden="true">{theaterInitials(entry.theaterLabel)}</span>
-                      {entry.launchProvider ? (
-                        <span className={`quick-launch-kind-icon is-${entry.launchProvider}`} aria-hidden="true">
-                          {launchProviderGlyph(entry.launchProvider)}
-                        </span>
-                      ) : null}
+                      <span className="quick-launch-mention-operation-mark">
+                        <OperationNameMark
+                          operation={entry}
+                          status={resolveOperationMarkVisual({
+                            activity: entry.activity,
+                            operationId: entry.operationId,
+                            idleArrivalIds,
+                          })}
+                        />
+                      </span>
                       <span className="quick-launch-mention-name">{entry.operationName}</span>
-                      {entry.activity !== "idle" ? (
-                        <span className={`operation-search-status operation-search-status--${entry.activity}`}>{operationActivityLabel(entry.activity)}</span>
-                      ) : null}
                     </button>
                   );
                 })}
@@ -1591,11 +1598,8 @@ export function QuickLaunch() {
         <ComposerField className="quick-launch-field" inert={showStrip || undefined}>
           {mentionTarget ? (
             <span className="quick-launch-mention" title={mentionTargetName(mentionTarget)}>
-              {mentionTarget.kind === "operation" && mentionTarget.entry.launchProvider ? (
-                <span className={`quick-launch-kind-icon is-${mentionTarget.entry.launchProvider}`} aria-hidden="true">
-                  {launchProviderGlyph(mentionTarget.entry.launchProvider)}
-                </span>
-              ) : null}
+              {/* Operation은 선택 뒤에도 공급자 출처를 되살리지 않는다 — 이름과 하단 행선지 태그가
+                  대상을 말한다. 플러그인 대상의 mark는 공급자가 아니라 그 대상 자체의 정체성이다. */}
               {mentionTarget.kind === "plugin" && mentionTarget.row.renderMark ? (
                 <span className="quick-launch-mention-mark" aria-hidden="true">{mentionTarget.row.renderMark()}</span>
               ) : null}

--- a/runtime/fleet-console/core/client/src/operation-search.ts
+++ b/runtime/fleet-console/core/client/src/operation-search.ts
@@ -20,8 +20,8 @@ export interface OperationSearchEntry {
   readonly pluginId: string;
   readonly activity: OperationActivityVisual;
   /**
-   * 실행된 공급자. 기록하지 않는 플러그인의 Operation은 null이다. Quick Launch 멘션 덱은
-   * 글리프로, 팔레트는 메타 캡션 텍스트로 그린다 — 목록 표면의 이름 왼쪽 슬롯은 활동 상태 소유.
+   * 실행된 공급자. 기록하지 않는 플러그인의 Operation은 null이다. Operation 목록 표면에서는
+   * 메타 캡션에만 남는다 — 이름 왼쪽 슬롯은 활동 상태가 소유한다.
    */
   readonly launchProvider: LaunchProviderGlyphId | null;
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8626,9 +8626,9 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .quick-launch-kind-icon.is-opencode { --launch-provider-tone: var(--provider-opencode); }
 .quick-launch-kind-icon.is-xai { --launch-provider-tone: var(--provider-xai); }
 
-/* .operation-provider-mark 대조표는 퇴역했다 — 목록 표면(사이드바 칩·커맨드 밴드·팔레트)의
-   이름 왼쪽 슬롯은 활동 상태(tenant-beacon)가 소유하고, 공급자 글리프가 남는 실행 표면
-   (Quick Launch·실행 메뉴)의 톤은 --launch-provider-tone 축이 이미 맡는다. */
+/* .operation-provider-mark 대조표는 퇴역했다 — 기존 Operation을 고르는 목록 표면(사이드바 칩·
+   커맨드 밴드·팔레트·Quick Launch 멘션)의 이름 왼쪽 슬롯은 활동 상태(tenant-beacon)가 소유한다.
+   새 Operation의 실행 좌표를 고르는 표면의 공급자 톤은 --launch-provider-tone 축이 맡는다. */
 
 .operation-launch-variant-entry {
   padding: 1px var(--space-1);
@@ -10297,34 +10297,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
-}
-
-/* Quick Launch 멘션 덱 행의 활동 뱃지. 상태 채널은 signal 토큰만 쓴다(디자인 불변식).
-   팔레트 Operation 행은 이 뱃지를 떠나 사이드바와 같은 tenant-beacon 마크로 말한다. */
-.operation-search-status {
-  flex: none;
-  padding: 2px 8px;
-  border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-xs);
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--t-2xs);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.operation-search-status--awaiting {
-  border-color: color-mix(in oklch, var(--coral) 45%, var(--surface-rim));
-  color: var(--coral-ink);
-}
-
-.operation-search-status--running {
-  border-color: color-mix(in oklch, var(--warn) 45%, var(--surface-rim));
-  color: var(--warn-ink);
-}
-
-.operation-search-status--ended {
-  color: var(--ink-muted);
 }
 
 .operation-search-result mark,
@@ -14475,6 +14447,16 @@ body[data-expanded-surface="true"] .operations-canvas .expanded-surface {
 .quick-launch-mention-row.is-dim {
   opacity: 0.45;
   cursor: not-allowed;
+}
+
+/* Cmd+K Operation 행의 16px 마크 슬롯과 같은 활동 축. Theater 이니셜 다음에 붙어도
+   8px 비콘이 자기 치수를 유지하고, 공급자 글리프가 있던 14px 열보다 좁게 이름을 당긴다. */
+.quick-launch-mention-operation-mark {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 10px;
+  height: 16px;
 }
 
 .quick-launch-mention-name {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1433,23 +1433,29 @@ describe("Instrument core design contract", () => {
   });
 
   it("pins the Operation list-surface mark grammar — activity owns the name-left slot, provider stays off list surfaces", () => {
-    // 공급자 마크는 실행 표면(Quick Launch·실행 메뉴)에만 남는다 — 목록 표면(사이드바 칩·
-    // 커맨드 밴드·검색 팔레트)의 이름 왼쪽 슬롯은 활동 상태가 소유한다. 목록에서 먼저 읽혀야
-    // 하는 것은 무엇으로 띄웠는지가 아니라 지금 무엇을 하고 있는지다. 마지막 소비자였던
-    // 팔레트가 떠나면서 .operation-provider-mark 대조표는 퇴역했다 — 실행 표면의 톤은
-    // --launch-provider-tone 축이 맡는다(아래 provider tone 테스트가 그 축을 고정한다).
+    // 공급자 마크는 새 Operation의 실행 좌표를 고르는 표면에만 남는다 — 이미 존재하는 Operation을
+    // 고르는 목록(사이드바 칩·커맨드 밴드·검색 팔레트·Quick Launch 멘션)의 이름 왼쪽 슬롯은
+    // 활동 상태가 소유한다. 목록에서 먼저 읽혀야 하는 것은 무엇으로 띄웠는지가 아니라 지금 무엇을
+    // 하고 있는지다. 마지막 공용 소비자였던 팔레트가 떠나면서 .operation-provider-mark 대조표는
+    // 퇴역했다 — 실행 좌표의 톤은 --launch-provider-tone 축이 맡는다(아래 테스트가 그 축을 고정한다).
     const css = source("styles/components.css");
+    const quickLaunch = source("components/quick-launch.tsx");
     // 행 시작의 셀렉터만 잡는다 — 퇴역 사실을 기록한 독트린 주석이 클래스 이름을 언급해도 무방하다.
     expect(css).not.toMatch(/(^|\n)\.operation-provider-mark/);
     // 목록 표면은 공급자를 세지 않는다 — 그 자리는 활동 상태가 소유한다.
     expect(source("sidebar/operations-side-bar-chip.tsx")).not.toContain("operation-provider-mark");
     expect(source("components/command-band.tsx")).not.toContain("operation-provider-mark");
     expect(source("components/operation-search.tsx")).not.toContain("operation-provider-mark");
-    // 팔레트 Operation 행은 사이드바 칩과 같은 마크 하나로 상태를 말한다 — 별도 활동 뱃지를
-    // 되살리면 같은 사실이 한 행에서 두 번 발화된다(Quick Launch 멘션 덱은 마크 없는 다른 표면).
+    expect(quickLaunch).not.toContain("launchProviderGlyph(entry.launchProvider)");
+    expect(quickLaunch).not.toContain("launchProviderGlyph(mentionTarget.entry.launchProvider)");
+    // 팔레트와 Quick Launch 멘션 행은 사이드바 칩과 같은 마크 하나로 상태를 말한다 — 별도 활동
+    // 뱃지를 되살리면 같은 사실이 한 행에서 두 번 발화된다.
     expect(source("components/operation-search.tsx")).toContain("<OperationNameMark");
     expect(source("components/operation-search.tsx")).toContain("resolveOperationMarkVisual");
     expect(source("components/operation-search.tsx")).not.toContain("operation-search-status--");
+    expect(quickLaunch).toContain("<OperationNameMark");
+    expect(quickLaunch).toContain("resolveOperationMarkVisual");
+    expect(quickLaunch).not.toContain("operation-search-status--");
   });
 
   it("pins the provider tone table as one axis — every gateway provider named on both surfaces", () => {
@@ -4097,9 +4103,10 @@ describe("Effort track interaction grammar", () => {
       /\.quick-launch-command-group\.is-banded \.quick-launch-command-row \{\s*padding-left: calc\(var\(--space-2\) \+ 22px\);/,
     );
 
-    // '@' 멘션 덱의 행 마크는 남는다 — 그쪽 밴드는 Theater 이름이라 공급자를 말하지 않고,
-    // 행 글리프가 유일한 출처 표식이다. 모델 덱과 같은 이유로 지우면 그쪽이 회귀한다.
-    expect(composer).toContain("launchProviderGlyph(entry.launchProvider)");
+    // '@' 멘션 덱은 실행 좌표가 아니라 기존 Operation 목록이다. 공급자 밴드가 없는 대신
+    // Cmd+K와 같은 활동 상태 마크가 이름 왼쪽 슬롯을 소유한다.
+    expect(composer).not.toContain("launchProviderGlyph(entry.launchProvider)");
+    expect(composer).toContain("<OperationNameMark");
   });
 
   it("pins the shared effort track's pointer preview motion", () => {


### PR DESCRIPTION
## Summary
- Quick Launch의 `@` Operation 목록에서 공급자 글리프를 제거하고 Cmd+K와 같은 활동 상태 비콘을 표시합니다.
- Operation을 멘션으로 확정한 뒤에도 공급자 글리프를 되살리지 않습니다.
- 목록 표면의 상태 문법과 퇴역한 활동 텍스트 배지를 디자인 계약으로 고정합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test`
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p core/client/tsconfig.json`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] 격리 Console에서 `@` 목록 및 선택 후 렌더를 확인
- [ ] `pnpm --filter @dotobokuri/fleet-console typecheck` (선존 `tests/server.test.ts:3016`의 `string | Buffer` 타입 오류)