### PR TITLE
fix(fleet-console): preserve Shell across surface toggles

### DIFF
--- a/.changelog.d/shell-toggle-input-investigation.md
+++ b/.changelog.d/shell-toggle-input-investigation.md
@@ -1,0 +1,8 @@
+---
+branch: shell-toggle-input-investigation
+---
+
+### fleet-console
+#### Fixed
+- Preserve the global Shell session and terminal contents when its sidebar surface is closed and reopened.
+  ko: 사이드바 표면을 닫았다가 다시 열어도 전역 Shell 세션과 터미널 내용을 보존합니다.

--- a/runtime/fleet-plugins/terminal/client/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/index.tsx
@@ -2,7 +2,7 @@ import { definePlugin } from "@fleet-console/sdk/plugin/browser";
 
 import { agentAttentionNotification, agentOperationKind, agentPlugin, agentSettingsSection, generalSettingsSection } from "./agent/index.js";
 import { globalShellPanel } from "./global-shell/rail-panel.js";
-import { shellSurface } from "./shell/index.js";
+import { PersistentShellHost, shellSurface } from "./shell/index.js";
 import { preloadTerminalFallbackFonts } from "./shared/terminal-fallback-fonts.js";
 import { connectTerminalSettings } from "./shared/terminal-preferences.js";
 import "./assets/fonts/symbols-nerd-font-mono.css";
@@ -23,6 +23,9 @@ const terminalPlugin = definePlugin({
   notificationKinds: [agentAttentionNotification],
   railPanels: [globalShellPanel],
   expandedSurfaces: [shellSurface],
+  // Shell은 한 번 열린 뒤 슬롯을 닫아도 xterm과 WebSocket을 보존한다. 표면 본문은 portal
+  // 목적지만 내주고, 실제 소유자는 콘솔 수명에 붙는 이 상주 기여다.
+  persistentComponents: [{ id: "terminal-shell-host", render: (ctx) => <PersistentShellHost language={ctx.language} theme={ctx.theme} /> }],
   install: (ctx) => { void preloadTerminalFallbackFonts(); connectTerminalSettings(ctx.settings); return agentPlugin.install?.(ctx); },
   closeOperation: async (operationId) => {
     const operation = await fetchOperation(operationId);

--- a/runtime/fleet-plugins/terminal/client/shell/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/shell/index.tsx
@@ -44,8 +44,18 @@ function subscribeShellMount(listener: () => void): () => void {
 }
 
 function attachShellMount(target: HTMLElement, context: ExpandedSurfaceContext): void {
-  // 새 슬롯의 layout effect가 이전 슬롯의 cleanup보다 먼저 올 수 있다. 이 시점에 DOM을 바로
-  // 옮겨 두면 뒤늦은 cleanup은 target 불일치로 무시되고, React effect가 0×0 주차장을 거치지 않는다.
+  if (
+    shellMountState.target
+    && shellMountState.target !== target
+    && shellMountState.context?.instanceId !== context.instanceId
+  ) {
+    // Shell은 콘솔 전체에 하나뿐이다. 범용 표면 API의 split 요청으로 둘째 슬롯이 들어와도
+    // 기존 터미널을 빼앗지 않고 새 인스턴스만 즉시 거둔다.
+    context.close();
+    return;
+  }
+  // 같은 인스턴스의 새 target layout effect가 이전 target cleanup보다 먼저 올 수 있다. 이 시점에
+  // DOM을 바로 옮겨 두면 뒤늦은 cleanup은 target 불일치로 무시되고 0×0 주차장을 거치지 않는다.
   if (shellPersistentHost && shellPersistentHost.parentElement !== target) target.append(shellPersistentHost);
   publishShellMount({ activated: true, target, context });
 }

--- a/runtime/fleet-plugins/terminal/client/shell/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/shell/index.tsx
@@ -1,8 +1,11 @@
 import type { ExpandedSurfaceContext, ExpandedSurfaceDescriptor } from "@fleet-console/sdk/expanded-surface";
+import type { PersistentComponentContext } from "@fleet-console/sdk/plugin";
 import { React } from "@fleet-console/sdk/plugin/browser";
+import { createPortal } from "react-dom";
 
 import { getT } from "../i18n/index.js";
 import { TerminalSurface } from "../shared/index.js";
+import "./shell.css";
 
 /**
  * Shell은 Operation이 아니라 콘솔 전역 표면이다.
@@ -16,6 +19,55 @@ const SHELL_TICKET_PATH = "/plugins/terminal/shell/ticket";
 const SHELL_WS_PATH = "/plugins/terminal/ws";
 /** 80열이 서지 않는 폭에서는 셸이 셸 노릇을 못 한다. */
 const SHELL_MIN_SLOT_WIDTH = 360;
+
+interface ShellMountState {
+  readonly activated: boolean;
+  readonly target: HTMLElement | null;
+  readonly context: ExpandedSurfaceContext | null;
+}
+
+const EMPTY_SHELL_MOUNT: ShellMountState = { activated: false, target: null, context: null };
+let shellMountState = EMPTY_SHELL_MOUNT;
+let shellPersistentHost: HTMLDivElement | null = null;
+let shellParkingNode: HTMLDivElement | null = null;
+const shellMountListeners = new Set<() => void>();
+
+function publishShellMount(next: ShellMountState): void {
+  if (shellMountState === next) return;
+  shellMountState = next;
+  for (const listener of shellMountListeners) listener();
+}
+
+function subscribeShellMount(listener: () => void): () => void {
+  shellMountListeners.add(listener);
+  return () => shellMountListeners.delete(listener);
+}
+
+function attachShellMount(target: HTMLElement, context: ExpandedSurfaceContext): void {
+  // 새 슬롯의 layout effect가 이전 슬롯의 cleanup보다 먼저 올 수 있다. 이 시점에 DOM을 바로
+  // 옮겨 두면 뒤늦은 cleanup은 target 불일치로 무시되고, React effect가 0×0 주차장을 거치지 않는다.
+  if (shellPersistentHost && shellPersistentHost.parentElement !== target) target.append(shellPersistentHost);
+  publishShellMount({ activated: true, target, context });
+}
+
+function updateShellMount(target: HTMLElement, context: ExpandedSurfaceContext): void {
+  if (shellMountState.target !== target) return;
+  publishShellMount({ activated: true, target, context });
+}
+
+function detachShellMount(target: HTMLElement): void {
+  if (shellMountState.target !== target) return;
+  // 닫기는 터미널을 끝내는 것이 아니다. 마지막 가시 크기를 주차장에 보존하고 DOM을 지금
+  // 옮긴다 — target이 React 커밋에서 제거된 뒤 effect가 돌면 host도 함께 detached되어
+  // ResizeObserver와 포커스 의미가 흔들린다.
+  if (shellPersistentHost && shellParkingNode) {
+    const rect = shellPersistentHost.getBoundingClientRect();
+    if (rect.width > 0) shellParkingNode.style.width = `${rect.width}px`;
+    if (rect.height > 0) shellParkingNode.style.height = `${rect.height}px`;
+    shellParkingNode.append(shellPersistentHost);
+  }
+  publishShellMount({ ...shellMountState, target: null });
+}
 
 /**
  * 슬롯을 닫는 것은 셸을 **치우는** 것이지 끝내는 것이 아니다. PTY는 서버에 살아 있고
@@ -33,22 +85,94 @@ export const shellSurface: ExpandedSurfaceDescriptor = {
   render: (ctx) => React.createElement(ShellSurfaceBody, { ctx }),
 };
 
+/**
+ * Shell 본문은 터미널을 직접 소유하지 않고 상주 호스트가 들어설 자리만 내준다.
+ * 슬롯이 사라져도 상주 호스트의 portal container는 주차장으로 이동할 뿐 unmount되지 않는다.
+ */
 function ShellSurfaceBody({ ctx }: { readonly ctx: ExpandedSurfaceContext }) {
-  return (
+  const targetRef = React.useRef<HTMLDivElement>(null);
+
+  React.useLayoutEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+    attachShellMount(target, ctx);
+    return () => detachShellMount(target);
+    // target DOM의 수명만 소유한다. ctx 갱신은 아래 effect가 같은 target에 따로 흘린다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useLayoutEffect(() => {
+    const target = targetRef.current;
+    if (target) updateShellMount(target, ctx);
+  }, [ctx]);
+
+  return <div ref={targetRef} className="global-shell-mount" />;
+}
+
+/**
+ * 콘솔 수명에 붙는 Shell 소유자. 첫 열기 전에는 터미널을 만들지 않고, 한 번 열린 뒤에는
+ * 슬롯을 닫아도 같은 portal과 TerminalSurface를 주차해 WebSocket·xterm 상태를 보존한다.
+ */
+export function PersistentShellHost({ language, theme }: PersistentComponentContext) {
+  const mount = React.useSyncExternalStore(subscribeShellMount, () => shellMountState, () => EMPTY_SHELL_MOUNT);
+  const [host] = React.useState(() => {
+    const node = document.createElement("div");
+    node.className = "global-shell-persistent-host";
+    return node;
+  });
+  const [parking] = React.useState(() => {
+    const node = document.createElement("div");
+    node.className = "global-shell-parking";
+    node.setAttribute("aria-hidden", "true");
+    node.inert = true;
+    return node;
+  });
+
+  React.useLayoutEffect(() => {
+    shellPersistentHost = host;
+    shellParkingNode = parking;
+    document.body.append(parking);
+    if (shellMountState.target) shellMountState.target.append(host);
+    return () => {
+      if (shellPersistentHost === host) shellPersistentHost = null;
+      if (shellParkingNode === parking) shellParkingNode = null;
+      host.remove();
+      parking.remove();
+      shellMountState = EMPTY_SHELL_MOUNT;
+    };
+  }, [host, parking]);
+
+  React.useLayoutEffect(() => {
+    if (!mount.activated || !mount.target || host.parentElement === mount.target) return;
+    mount.target.append(host);
+  }, [host, mount]);
+
+  if (!mount.activated || !mount.context) return null;
+  const context = mount.context;
+  const handleExit = () => {
+    const close = shellMountState.context?.close;
+    // PTY가 실제로 끝난 경우에는 보존할 세션이 없다. portal을 내려 다음 열기가 새
+    // TerminalSurface와 새 PTY를 만들게 하고, 아직 보이는 슬롯도 함께 거둔다.
+    publishShellMount(EMPTY_SHELL_MOUNT);
+    close?.();
+  };
+
+  return createPortal(
     <TerminalSurface
       operationId={SHELL_SURFACE_ID}
       ticketPath={SHELL_TICKET_PATH}
       wsPath={SHELL_WS_PATH}
       surface="shell"
-      theme={ctx.theme ?? "instrument"}
-      active={ctx.focused}
+      theme={theme ?? context.theme ?? "instrument"}
+      active={mount.target !== null && context.focused}
       zoom={1}
-      locale={ctx.language ?? "en"}
+      locale={language ?? context.language ?? "en"}
       // 첫 기동에서만 서버가 읽는다 — 이후 cwd는 서버가 못 박아 두므로 Theater를
       // 옮겨 다녀도 셸의 발밑은 움직이지 않는다.
-      ticketFields={ctx.theaterId ? { theaterId: ctx.theaterId } : undefined}
-      onExit={ctx.close}
-    />
+      ticketFields={context.theaterId ? { theaterId: context.theaterId } : undefined}
+      onExit={handleExit}
+    />,
+    host,
   );
 }
 

--- a/runtime/fleet-plugins/terminal/client/shell/shell.css
+++ b/runtime/fleet-plugins/terminal/client/shell/shell.css
@@ -1,0 +1,25 @@
+.global-shell-mount,
+.global-shell-persistent-host {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* 닫힌 Shell은 DOM과 WebSocket을 보존하되 화면·접근성 트리·입력에서 완전히 빠진다.
+   display:none은 ResizeObserver를 0×0으로 떨어뜨려 xterm fit을 흔드므로 마지막 가시 크기를
+   visibility:hidden 주차장에 유지한다. */
+.global-shell-parking {
+  position: fixed;
+  inset: auto auto 0 0;
+  overflow: hidden;
+  visibility: hidden;
+  pointer-events: none;
+  contain: strict;
+}
+
+.global-shell-parking .global-shell-persistent-host {
+  width: 100%;
+  height: 100%;
+}

--- a/runtime/fleet-plugins/terminal/tests/global-shell-persistent-mount.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/global-shell-persistent-mount.test.tsx
@@ -79,9 +79,31 @@ describe("persistent Shell mount", () => {
     expect(document.querySelector(".slot .global-shell-persistent-host")).not.toBeNull();
     expect(document.querySelector("[data-testid='terminal-surface']")?.getAttribute("data-active")).toBe("true");
   });
+
+  it("closes a split Shell instance without moving the shared terminal", () => {
+    const first = shellContext();
+    const second = shellContext({ instanceId: "shell#2" });
+
+    act(() => {
+      root.render(
+        <>
+          <PersistentShellHost language="en" theme="instrument" />
+          <div className="first-slot">{shellSurface.render(first)}</div>
+          <div className="second-slot">{shellSurface.render(second)}</div>
+        </>,
+      );
+    });
+
+    expect(second.close).toHaveBeenCalledTimes(1);
+    expect(first.close).not.toHaveBeenCalled();
+    expect(terminalMocks.mounted).toHaveBeenCalledTimes(1);
+    expect(terminalMocks.unmounted).not.toHaveBeenCalled();
+    expect(document.querySelector(".first-slot .global-shell-persistent-host")).not.toBeNull();
+    expect(document.querySelector(".second-slot .global-shell-persistent-host")).toBeNull();
+  });
 });
 
-function shellContext(): ExpandedSurfaceContext {
+function shellContext(overrides: Partial<ExpandedSurfaceContext> = {}): ExpandedSurfaceContext {
   return {
     surfaceId: "shell",
     instanceId: "shell#1",
@@ -99,5 +121,6 @@ function shellContext(): ExpandedSurfaceContext {
     close: vi.fn(),
     focus: vi.fn(),
     replaceParams: vi.fn(),
+    ...overrides,
   };
 }

--- a/runtime/fleet-plugins/terminal/tests/global-shell-persistent-mount.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/global-shell-persistent-mount.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import type { ExpandedSurfaceContext } from "@fleet-console/sdk/expanded-surface";
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const terminalMocks = vi.hoisted(() => ({ mounted: vi.fn(), unmounted: vi.fn() }));
+
+vi.mock("../client/shared/index.js", () => ({
+  TerminalSurface: ({ active }: { readonly active?: boolean }) => {
+    useEffect(() => {
+      terminalMocks.mounted();
+      return () => terminalMocks.unmounted();
+    }, []);
+    return <div data-testid="terminal-surface" data-active={active ? "true" : "false"} />;
+  },
+}));
+
+import { PersistentShellHost, shellSurface } from "../client/shell/index.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  terminalMocks.mounted.mockClear();
+  terminalMocks.unmounted.mockClear();
+  container = document.createElement("div");
+  document.body.replaceChildren(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("persistent Shell mount", () => {
+  it("parks one terminal subtree while the slot is closed and reuses it when reopened", () => {
+    const context = shellContext();
+
+    act(() => {
+      root.render(
+        <>
+          <PersistentShellHost language="en" theme="instrument" />
+          <div className="slot">{shellSurface.render(context)}</div>
+        </>,
+      );
+    });
+
+    expect(terminalMocks.mounted).toHaveBeenCalledTimes(1);
+    expect(terminalMocks.unmounted).not.toHaveBeenCalled();
+    expect(document.querySelector(".slot .global-shell-persistent-host")).not.toBeNull();
+    expect(document.querySelector("[data-testid='terminal-surface']")?.getAttribute("data-active")).toBe("true");
+
+    act(() => {
+      root.render(<PersistentShellHost language="en" theme="instrument" />);
+    });
+
+    expect(terminalMocks.mounted).toHaveBeenCalledTimes(1);
+    expect(terminalMocks.unmounted).not.toHaveBeenCalled();
+    expect(document.querySelector(".global-shell-parking .global-shell-persistent-host")).not.toBeNull();
+    expect(document.querySelector("[data-testid='terminal-surface']")?.getAttribute("data-active")).toBe("false");
+
+    act(() => {
+      root.render(
+        <>
+          <PersistentShellHost language="en" theme="instrument" />
+          <div className="slot">{shellSurface.render(context)}</div>
+        </>,
+      );
+    });
+
+    expect(terminalMocks.mounted).toHaveBeenCalledTimes(1);
+    expect(terminalMocks.unmounted).not.toHaveBeenCalled();
+    expect(document.querySelector(".slot .global-shell-persistent-host")).not.toBeNull();
+    expect(document.querySelector("[data-testid='terminal-surface']")?.getAttribute("data-active")).toBe("true");
+  });
+});
+
+function shellContext(): ExpandedSurfaceContext {
+  return {
+    surfaceId: "shell",
+    instanceId: "shell#1",
+    params: {},
+    slotIndex: 0,
+    slotCount: 1,
+    slotWidth: 900,
+    focused: true,
+    theaterId: "theater-a",
+    api: {} as ExpandedSurfaceContext["api"],
+    lifecycle: {} as ExpandedSurfaceContext["lifecycle"],
+    preferences: {} as ExpandedSurfaceContext["preferences"],
+    language: "en",
+    theme: "instrument",
+    close: vi.fn(),
+    focus: vi.fn(),
+    replaceParams: vi.fn(),
+  };
+}


### PR DESCRIPTION
## Summary
- keep the global Shell xterm and WebSocket mounted when its expanded surface is closed
- park the hidden terminal at its last visible geometry and restore the same subtree when reopened
- add a lifecycle regression test and a bilingual Fleet Console release note

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --dir runtime/fleet-plugins/terminal typecheck`
- [x] `pnpm --dir runtime/fleet-plugins/terminal test`
- [x] `pnpm --dir runtime/fleet-plugins/terminal build`
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p core/client/tsconfig.json`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] repeat Shell close/reopen in an isolated production Console and confirm one xterm, one open WebSocket, no keyboard input, and preserved terminal contents