### PR TITLE
feat(fleet-console): move rail settings to a gear menu at the column top

### DIFF
--- a/.changelog.d/rail-settings-gear-menu.md
+++ b/.changelog.d/rail-settings-gear-menu.md
@@ -1,0 +1,12 @@
+---
+branch: rail-settings-gear-menu
+---
+
+### fleet-console
+#### Changed
+- Activity Rail settings now live behind a gear at the top of the icon column, split from the panel tabs by a divider, and open as a menu holding float over Map, panel opacity, reset panel width, and close panel.
+  ko: Activity Rail 설정을 아이콘 열 최상단의 톱니로 옮기고 디바이더로 패널 탭과 갈랐습니다. 톱니를 누르면 Map 위에 띄우기, 패널 불투명도, 패널 폭 초기화, 패널 닫기가 담긴 메뉴가 열립니다.
+
+#### Removed
+- The rail panel no longer summons a header when the pointer crosses the top of its body, so panel controls on the first row stay reachable and the body keeps the full slot.
+  ko: 레일 패널이 본문 상단을 지나는 포인터에 헤더를 띄우지 않습니다. 첫 줄의 패널 컨트롤이 가려지지 않고 본문이 슬롯 전체를 씁니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import type { Translate } from "@fleet-console/sdk/i18n";
@@ -14,6 +14,7 @@ import { COMMISSIONING_SEEN_KEY, openWhatsNew } from "../store.js";
 import { AddHostDialog } from "./add-host-dialog.js";
 import { EFFORT_CONFIRM_TIP_SEEN_KEY, forgetAllFeatureTours } from "./feature-tour.js";
 import { KeyboardShortcutsDialog } from "./keyboard-shortcuts-dialog.js";
+import { ENABLED_MENU_ITEM_SELECTOR, useMenuButtonKeyboard } from "./use-menu-button-keyboard.js";
 
 type UpdateApplyState = "idle" | "applying" | "armed" | "blocked" | "error";
 
@@ -36,7 +37,6 @@ const GITHUB_STARGAZERS_URL = "https://github.com/sbluemin/fleet-harness/stargaz
 const GITHUB_STARS_API_URL = "https://api.github.com/repos/sbluemin/fleet-harness";
 const GITHUB_STARS_CACHE_KEY = "fleet-console.github-stars";
 const GITHUB_STARS_TTL_MS = 6 * 60 * 60 * 1000;
-const ENABLED_MENU_ITEM_SELECTOR = '[role="menuitem"]:not([disabled]), [role="menuitemradio"]:not([disabled])';
 
 /**
  * Desktop 셸과의 계약 리터럴 — 셸이 이 항해를 가로채므로 요청은 기계를 떠나지 않는다.
@@ -691,45 +691,6 @@ function HelpMenu({ releaseDisabled, updateAvailable, latestVersion, version }: 
     </div> : null}
     {shortcutsOpen ? <KeyboardShortcutsDialog onClose={() => { setShortcutsOpen(false); triggerRef.current?.focus(); }} /> : null}
   </span>;
-}
-
-function useMenuButtonKeyboard(rootRef: RefObject<HTMLElement | null>, triggerRef: RefObject<HTMLButtonElement | null>, menuRef: RefObject<HTMLDivElement | null>, open: boolean, setOpen: Dispatch<SetStateAction<boolean>>) {
-  useEffect(() => {
-    if (!open) return;
-    // menu-button 패턴: 열리면 첫 menuitem으로 포커스 이동.
-    const frame = window.requestAnimationFrame(() => {
-      menuRef.current?.querySelector<HTMLElement>(ENABLED_MENU_ITEM_SELECTOR)?.focus();
-    });
-    const handlePointer = (event: PointerEvent) => {
-      if (event.target instanceof Node && rootRef.current?.contains(event.target)) return;
-      setOpen(false);
-    };
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setOpen(false);
-        triggerRef.current?.focus();
-        return;
-      }
-      if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
-      const items = [...(menuRef.current?.querySelectorAll<HTMLElement>(ENABLED_MENU_ITEM_SELECTOR) ?? [])];
-      if (items.length === 0) return;
-      event.preventDefault();
-      const currentIndex = items.findIndex((item) => item === document.activeElement);
-      const nextIndex = event.key === "Home" || (event.key === "ArrowDown" && currentIndex === items.length - 1)
-        ? 0
-        : event.key === "End" || (event.key === "ArrowUp" && currentIndex <= 0)
-          ? items.length - 1
-          : event.key === "ArrowDown" ? currentIndex + 1 : currentIndex - 1;
-      items[nextIndex]?.focus();
-    };
-    window.addEventListener("pointerdown", handlePointer, true);
-    window.addEventListener("keydown", handleKey, true);
-    return () => {
-      window.cancelAnimationFrame(frame);
-      window.removeEventListener("pointerdown", handlePointer, true);
-      window.removeEventListener("keydown", handleKey, true);
-    };
-  }, [menuRef, open, rootRef, setOpen, triggerRef]);
 }
 
 function UpdateApplyControl({ latestVersion, version, onStarted }: {

--- a/runtime/fleet-console/core/client/src/components/use-menu-button-keyboard.ts
+++ b/runtime/fleet-console/core/client/src/components/use-menu-button-keyboard.ts
@@ -1,0 +1,62 @@
+import { useEffect, type Dispatch, type RefObject, type SetStateAction } from "react";
+
+/**
+ * 콘솔 팝업 메뉴의 항목 선택자 — 방향키 순회와 최초 포커스가 같은 목록을 본다.
+ * 값 조절 행(슬라이더 등)은 menuitem 역할을 갖지 않으므로 순회에서 자연히 빠진다.
+ */
+export const ENABLED_MENU_ITEM_SELECTOR =
+  '[role="menuitem"]:not([disabled]), [role="menuitemradio"]:not([disabled]), [role="menuitemcheckbox"]:not([disabled])';
+
+/**
+ * menu-button 패턴의 키보드·바깥 클릭 계약. 커맨드 밴드 시스템 메뉴와 Activity Rail 설정
+ * 메뉴가 이 한 벌을 공유한다 — 콘솔 메뉴는 단일 방언이어야 하므로 사본을 만들지 않는다.
+ *
+ * `rootRef`는 트리거와 메뉴를 함께 담는 경계다. 메뉴가 포털로 문서 다른 곳에 그려지는
+ * 경우처럼 하나의 경계로 담기지 않을 때는 `extraRootRefs`로 메뉴 쪽 경계를 함께 넘긴다.
+ */
+export function useMenuButtonKeyboard(
+  rootRef: RefObject<HTMLElement | null>,
+  triggerRef: RefObject<HTMLButtonElement | null>,
+  menuRef: RefObject<HTMLElement | null>,
+  open: boolean,
+  setOpen: Dispatch<SetStateAction<boolean>>,
+): void {
+  useEffect(() => {
+    if (!open) return;
+    // menu-button 패턴: 열리면 첫 menuitem으로 포커스 이동.
+    const frame = window.requestAnimationFrame(() => {
+      menuRef.current?.querySelector<HTMLElement>(ENABLED_MENU_ITEM_SELECTOR)?.focus();
+    });
+    const handlePointer = (event: PointerEvent) => {
+      if (!(event.target instanceof Node)) return;
+      if (rootRef.current?.contains(event.target)) return;
+      if (menuRef.current?.contains(event.target)) return;
+      setOpen(false);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+        return;
+      }
+      if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+      const items = [...(menuRef.current?.querySelectorAll<HTMLElement>(ENABLED_MENU_ITEM_SELECTOR) ?? [])];
+      if (items.length === 0) return;
+      event.preventDefault();
+      const currentIndex = items.findIndex((item) => item === document.activeElement);
+      const nextIndex = event.key === "Home" || (event.key === "ArrowDown" && currentIndex === items.length - 1)
+        ? 0
+        : event.key === "End" || (event.key === "ArrowUp" && currentIndex <= 0)
+          ? items.length - 1
+          : event.key === "ArrowDown" ? currentIndex + 1 : currentIndex - 1;
+      items[nextIndex]?.focus();
+    };
+    window.addEventListener("pointerdown", handlePointer, true);
+    window.addEventListener("keydown", handleKey, true);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener("pointerdown", handlePointer, true);
+      window.removeEventListener("keydown", handleKey, true);
+    };
+  }, [menuRef, open, rootRef, setOpen, triggerRef]);
+}

--- a/runtime/fleet-console/core/client/src/components/use-menu-button-keyboard.ts
+++ b/runtime/fleet-console/core/client/src/components/use-menu-button-keyboard.ts
@@ -40,6 +40,14 @@ export function useMenuButtonKeyboard(
         return;
       }
       if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+      // 메뉴 안의 항목이 아닌 컨트롤(불투명도 슬라이더 등)은 이 키들을 스스로 쓴다 — 항목 순회가
+      // 가로채면 값 조절이 죽고 포커스까지 빼앗겨 키보드로는 손댈 수 없는 컨트롤이 된다.
+      const target = event.target;
+      if (
+        target instanceof Element
+        && menuRef.current?.contains(target) === true
+        && target.closest(ENABLED_MENU_ITEM_SELECTOR) === null
+      ) return;
       const items = [...(menuRef.current?.querySelectorAll<HTMLElement>(ENABLED_MENU_ITEM_SELECTOR) ?? [])];
       if (items.length === 0) return;
       event.preventDefault();

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -178,10 +178,13 @@ export const canvasEn = {
   "rail.chrome.toolsAria": "Activity tools",
   "rail.chrome.panelsAria": "Activity panels",
   "rail.chrome.resizePanel": "Resize {title} panel",
-  "rail.chrome.floatToggle": "Float panel over the Map",
+  "rail.chrome.settings": "Rail settings",
   "rail.chrome.floatLabel": "Float over Map",
   "rail.chrome.opacityAria": "Panel opacity",
+  "rail.chrome.resetWidth": "Reset panel width",
   "rail.chrome.closePanel": "Close {title}",
+  "rail.chrome.closePanelGeneric": "Close panel",
+  "rail.chrome.noPanel": "No panel open",
   "rail.theater.fallback": "Theater",
 
 } as const;
@@ -365,10 +368,13 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "rail.chrome.toolsAria": "Activity 도구",
   "rail.chrome.panelsAria": "Activity 패널",
   "rail.chrome.resizePanel": "{title} 패널 크기 조절",
-  "rail.chrome.floatToggle": "패널을 Map 위에 띄우기",
+  "rail.chrome.settings": "레일 설정",
   "rail.chrome.floatLabel": "Map 위에 띄우기",
   "rail.chrome.opacityAria": "패널 불투명도",
+  "rail.chrome.resetWidth": "패널 폭 초기화",
   "rail.chrome.closePanel": "{title} 닫기",
+  "rail.chrome.closePanelGeneric": "패널 닫기",
+  "rail.chrome.noPanel": "열린 패널 없음",
   "rail.theater.fallback": "Theater",
 
 };

--- a/runtime/fleet-console/core/client/src/rail/rail-settings-menu.tsx
+++ b/runtime/fleet-console/core/client/src/rail/rail-settings-menu.tsx
@@ -82,9 +82,16 @@ export function RailSettingsMenu({ panelBehavior, overlayAlpha, activePanelTitle
   }, [railChromeExpanded]);
 
   // 창이 움직이면 좌표가 낡는다 — 다시 계산하는 대신 닫는다(group-context-menu와 같은 계약).
+  //
+  // 이때 메뉴가 포커스를 쥐고 있었다면 톱니로 돌려준다. 포커스를 쥔 요소를 그냥 걷어내면
+  // body로 떨어져 키보드 사용자가 자리를 잃는다. 레일 접힘과 달리 톱니는 그대로 서 있으므로
+  // 돌아갈 자리는 트리거다. 쥐고 있지 않았다면(다른 곳을 보다가 스크롤한 경우) 건드리지 않는다.
   useEffect(() => {
     if (!open) return;
-    const dismiss = () => setOpen(false);
+    const dismiss = () => {
+      if (menuRef.current?.contains(document.activeElement) === true) triggerRef.current?.focus();
+      setOpen(false);
+    };
     window.addEventListener("resize", dismiss);
     window.addEventListener("scroll", dismiss, true);
     return () => {

--- a/runtime/fleet-console/core/client/src/rail/rail-settings-menu.tsx
+++ b/runtime/fleet-console/core/client/src/rail/rail-settings-menu.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProp
 import { createPortal } from "react-dom";
 
 import { useMenuButtonKeyboard } from "../components/use-menu-button-keyboard.js";
+import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../shortcuts.js";
 import { useT } from "../i18n/index.js";
 import {
   closeRailPanel,
@@ -68,9 +69,16 @@ export function RailSettingsMenu({ panelBehavior, overlayAlpha, activePanelTitle
   }, [open]);
 
   // 레일이 접히면 톱니는 inert가 되지만 포털된 메뉴는 문서에 그대로 남는다 — 앵커 없는
-  // 메뉴가 조작 가능한 채 떠 있지 않도록 함께 거둔다. 포커스는 돌려주지 않는다(갈 곳이 없다).
+  // 메뉴가 조작 가능한 채 떠 있지 않도록 함께 거둔다.
+  //
+  // 포커스는 레일이 접힐 때의 기존 계약 그대로 커맨드 밴드 토글로 넘긴다. RightRail의 같은
+  // 호출은 레일 DOM만 보므로 body로 포털된 이 메뉴를 영영 알아보지 못한다 — 메뉴를 컨테이너로
+  // 넘겨 같은 헬퍼를 여기서 한 번 더 태운다. 메뉴가 사라지기 전에 옮겨야 하므로 setOpen보다
+  // 먼저 부른다(이 시점의 activeElement는 아직 메뉴 안이다).
   useEffect(() => {
-    if (!railChromeExpanded) setOpen(false);
+    if (railChromeExpanded) return;
+    focusCommandBandToggleWhenPanelContainsActiveElement(menuRef.current, ".command-band-rail-toggle");
+    setOpen(false);
   }, [railChromeExpanded]);
 
   // 창이 움직이면 좌표가 낡는다 — 다시 계산하는 대신 닫는다(group-context-menu와 같은 계약).

--- a/runtime/fleet-console/core/client/src/rail/rail-settings-menu.tsx
+++ b/runtime/fleet-console/core/client/src/rail/rail-settings-menu.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
+
+import { useMenuButtonKeyboard } from "../components/use-menu-button-keyboard.js";
+import { useT } from "../i18n/index.js";
+import {
+  closeRailPanel,
+  RAIL_OVERLAY_ALPHA_DEFAULT,
+  RAIL_OVERLAY_ALPHA_MAX,
+  RAIL_OVERLAY_ALPHA_MIN,
+  setRailOverlayAlpha,
+  toggleRailPanelBehavior,
+  type RailOverlayAlpha,
+} from "./rail-store.js";
+
+interface RailSettingsMenuProps {
+  readonly panelBehavior: "push" | "overlay";
+  readonly overlayAlpha: RailOverlayAlpha;
+  /** 열려 있는 패널의 표시 이름. 패널이 없으면 null — 패널 범위 항목이 꺼진다. */
+  readonly activePanelTitle: string | null;
+  /** 레일 크롬이 펼쳐져 있는가. 접히면 톱니가 inert가 되므로 떠 있는 메뉴를 함께 거둔다. */
+  readonly railChromeExpanded: boolean;
+  readonly onResetWidth: () => void;
+}
+
+/** 메뉴와 톱니 사이 간격. group-context-menu와 같은 값을 쓴다. */
+const MENU_GAP = 8;
+const MENU_MIN_MARGIN = 8;
+
+/**
+ * Activity Rail 설정 진입점.
+ *
+ * 레일의 설정은 전부 저빈도 set-and-forget인데, 예전 호버-리빌 헤더는 콘솔에서 가장 흔한
+ * 포인터 경로(패널 상단 횡단)를 방아쇠로 써서 본문을 쓰는 동안 스스로 열리고 상단 컨트롤을
+ * 덮었다. 진입을 아이콘 열 최상단의 톱니로 옮겨 크롬은 부를 때만 오게 한다.
+ *
+ * 메뉴는 포털로 문서에 그린다 — `.right-rail`은 push 모드에서 `overflow: hidden`이라
+ * 레일 안에 그리면 왼쪽으로 펼쳐지지 못하고 잘린다.
+ */
+export function RailSettingsMenu({ panelBehavior, overlayAlpha, activePanelTitle, railChromeExpanded, onResetWidth }: RailSettingsMenuProps) {
+  const t = useT();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [style, setStyle] = useState<CSSProperties | null>(null);
+
+  // 트리거가 곧 메뉴 밖 경계다 — 메뉴는 포털로 따로 서므로 훅이 둘을 각각 본다.
+  useMenuButtonKeyboard(triggerRef, triggerRef, menuRef, open, setOpen);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  // 톱니는 레일 우현 최상단에 선다 — 메뉴는 그 왼쪽으로 펼치고 위끝을 톱니에 맞춘다.
+  useLayoutEffect(() => {
+    if (!open) {
+      setStyle(null);
+      return;
+    }
+    const anchor = triggerRef.current?.getBoundingClientRect();
+    if (anchor === undefined) return;
+    setStyle({
+      position: "fixed",
+      right: Math.max(MENU_MIN_MARGIN, Math.round(window.innerWidth - anchor.left + MENU_GAP)),
+      top: Math.max(MENU_MIN_MARGIN, Math.round(anchor.top)),
+    });
+  }, [open]);
+
+  // 레일이 접히면 톱니는 inert가 되지만 포털된 메뉴는 문서에 그대로 남는다 — 앵커 없는
+  // 메뉴가 조작 가능한 채 떠 있지 않도록 함께 거둔다. 포커스는 돌려주지 않는다(갈 곳이 없다).
+  useEffect(() => {
+    if (!railChromeExpanded) setOpen(false);
+  }, [railChromeExpanded]);
+
+  // 창이 움직이면 좌표가 낡는다 — 다시 계산하는 대신 닫는다(group-context-menu와 같은 계약).
+  useEffect(() => {
+    if (!open) return;
+    const dismiss = () => setOpen(false);
+    window.addEventListener("resize", dismiss);
+    window.addEventListener("scroll", dismiss, true);
+    return () => {
+      window.removeEventListener("resize", dismiss);
+      window.removeEventListener("scroll", dismiss, true);
+    };
+  }, [open]);
+
+  const hasPanel = activePanelTitle !== null;
+  const floating = panelBehavior === "overlay";
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`right-rail-ico right-rail-settings-btn${open ? " is-open" : ""}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t("rail.chrome.settings")}
+        title={t("rail.chrome.settings")}
+        onClick={() => setOpen((previous) => !previous)}
+      >
+        <GearGlyph />
+      </button>
+      {open && style !== null ? createPortal(
+        <div
+          ref={menuRef}
+          className="right-rail-menu"
+          role="menu"
+          aria-label={t("rail.chrome.settings")}
+          style={style}
+        >
+          {/* 플로팅·불투명도는 레일 차원의 상시 취향이라 패널이 없어도 정할 수 있다. */}
+          <button
+            type="button"
+            role="menuitemcheckbox"
+            className="right-rail-menu-item"
+            aria-checked={floating}
+            onClick={toggleRailPanelBehavior}
+          >
+            <CheckGlyph checked={floating} />
+            <span>{t("rail.chrome.floatLabel")}</span>
+          </button>
+          {floating ? (
+            <div className="right-rail-menu-row">
+              <span className="right-rail-menu-row-label">{t("rail.chrome.opacityAria")}</span>
+              <input
+                className="right-rail-alpha-slider fleet-slider"
+                type="range"
+                min={RAIL_OVERLAY_ALPHA_MIN}
+                max={RAIL_OVERLAY_ALPHA_MAX}
+                step={1}
+                value={overlayAlpha}
+                aria-label={t("rail.chrome.opacityAria")}
+                onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
+                onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
+                style={{ "--slider-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
+              />
+              <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
+            </div>
+          ) : null}
+
+          <div className="right-rail-menu-divider" role="separator" />
+          {/* 아래 둘은 열려 있는 패널을 겨눈다 — 이름을 붙여 범위를 밝힌다. */}
+          <p className="right-rail-menu-label">{hasPanel ? activePanelTitle : t("rail.chrome.noPanel")}</p>
+          <button
+            type="button"
+            role="menuitem"
+            className="right-rail-menu-item"
+            disabled={!hasPanel}
+            onClick={() => { onResetWidth(); close(); }}
+          >
+            <span className="right-rail-menu-check" aria-hidden="true" />
+            <span>{t("rail.chrome.resetWidth")}</span>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="right-rail-menu-item"
+            disabled={!hasPanel}
+            onClick={() => { closeRailPanel(); close(); }}
+          >
+            <span className="right-rail-menu-check" aria-hidden="true" />
+            <span>{activePanelTitle === null ? t("rail.chrome.closePanelGeneric") : t("rail.chrome.closePanel", { title: activePanelTitle })}</span>
+          </button>
+        </div>,
+        document.body,
+      ) : null}
+    </>
+  );
+}
+
+/** 체크 자리는 켜짐과 무관하게 늘 차지한다 — 라벨이 좌우로 흔들리지 않는다. */
+function CheckGlyph({ checked }: { readonly checked: boolean }) {
+  return (
+    <svg className="right-rail-menu-check" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      {checked ? <path d="m3.4 8.4 3 3 6.2-6.6" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" /> : null}
+    </svg>
+  );
+}
+
+/**
+ * 톱니 — 이가 링에 붙은 쐐기여야 16px에서 톱니로 읽힌다. 링에서 떨어진 방사선으로 그리면
+ * 같은 크기에서 태양(밝기)으로 읽혀 뜻이 바뀐다. 콘솔의 설정 화면 표식(페이더)과는 일부러
+ * 다른 마크다 — 이 톱니는 레일을 손보는 자리이지 설정 화면으로 가는 문이 아니다.
+ */
+function GearGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M6.33 3.66L6.36 1.87L9.64 1.87L9.67 3.66L10.93 4.39L12.49 3.51L14.13 6.36L12.59 7.27L12.59 8.73L14.13 9.64L12.49 12.49L10.93 11.61L9.67 12.34L9.64 14.13L6.36 14.13L6.33 12.34L5.07 11.61L3.51 12.49L1.87 9.64L3.41 8.73L3.41 7.27L1.87 6.36L3.51 3.51L5.07 4.39Z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <circle cx="8" cy="8" r="2.1" stroke="currentColor" strokeWidth="1.2" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -17,7 +17,8 @@ import { ReconnectButton } from "../components/reconnect-button.js";
 import { getState, subscribe } from "../store.js";
 import type { ConnectionState } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
-import { closeRailPanel, RAIL_OVERLAY_ALPHA_DEFAULT, RAIL_OVERLAY_ALPHA_MAX, RAIL_OVERLAY_ALPHA_MIN, requestRailPanelExtraWidth, setRailOverlayAlpha, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelBehavior, useRailPanelExtraWidth, type RailOverlayAlpha } from "./rail-store.js";
+import { requestRailPanelExtraWidth, toggleRailPanel, useActiveRailPanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelBehavior, useRailPanelExtraWidth } from "./rail-store.js";
+import { RailSettingsMenu } from "./rail-settings-menu.js";
 import { useRailPanels } from "./rail-registry.js";
 
 interface RightRailProps {
@@ -30,14 +31,6 @@ interface RightRailProps {
 const STABLE_RAIL_SURFACES = createHostCapabilities().surfaces;
 const MIN_PANEL_WIDTH = 240;
 const DEFAULT_PANEL_WIDTH = 312;
-// 호버-리빌 헤더 입력 계약: 진입은 pointermove로만 판정하고(스크롤-언더-포인터 오발화 방지)
-// 의도 지연을 거친다. 진입 띠와 64px 이탈 경계 사이는 히스테리시스 중립 지대다.
-// 진입 띠는 패널 본문 상단 컨트롤(저장소 동기화·Skills 탭 등)의 클릭을 방해하지 않도록
-// 가장자리 12px로 좁게 잡는다 — 24px에서는 상단 첫 줄 컨트롤로 향하는 호버가 헤더를 오발화했다.
-const HEAD_REVEAL_ZONE_PX = 12;
-const HEAD_REVEAL_TOUCH_ZONE_PX = 28;
-const HEAD_HIDE_BOUNDARY_PX = 64;
-const HEAD_REVEAL_INTENT_DELAY_MS = 120;
 const PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
 const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
 
@@ -88,6 +81,15 @@ function resolvePanelWidth(
     return rememberedWidth;
   }
   return Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, Math.round(defaultWidth ?? DEFAULT_PANEL_WIDTH)));
+}
+
+function clearStoredPanelWidth(panelId: string): void {
+  try {
+    const widths = readStoredPanelWidths();
+    if (!(panelId in widths)) return;
+    delete widths[panelId];
+    localStorage.setItem(PREFS_PANEL_WIDTHS, JSON.stringify(widths));
+  } catch { /* ignore */ }
 }
 
 function saveStoredPanelWidth(activePanelId: string | null, width: number): void {
@@ -152,89 +154,6 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
-  const [headRevealed, setHeadRevealed] = useState(false);
-  const headRevealedRef = useRef(headRevealed);
-  headRevealedRef.current = headRevealed;
-  const revealIntentTimerRef = useRef<number | null>(null);
-
-  const cancelRevealIntent = useCallback(() => {
-    if (revealIntentTimerRef.current === null) return;
-    window.clearTimeout(revealIntentTimerRef.current);
-    revealIntentTimerRef.current = null;
-  }, []);
-
-  const holdHeadOpen = useCallback(() => {
-    cancelRevealIntent();
-    if (!headRevealedRef.current) setHeadRevealed(true);
-  }, [cancelRevealIntent]);
-
-  const hideHeadUnlessFocused = useCallback(() => {
-    // 키보드 포커스(:focus-visible)가 헤더 안에 남아 있는 동안만 숨기지 않는다 — 숨기면
-    // 포커스가 투명한 컨트롤에 갇힌다. 마우스 클릭·드래그가 남긴 잔류 포커스는 리빌을
-    // 붙잡는 근거가 아니므로, 블러로 걷어내고 즉시 숨긴다.
-    const active = document.activeElement;
-    if (active instanceof HTMLElement && active.closest(".right-rail-panel-head-reveal") !== null) {
-      if (active.matches(":focus-visible")) return;
-      active.blur();
-    }
-    setHeadRevealed(false);
-  }, []);
-
-  // 이탈은 지연 없이 즉시 숨긴다 — 리빌 진입만 의도 지연을 거친다.
-  const releaseHead = useCallback(() => {
-    cancelRevealIntent();
-    if (!headRevealedRef.current) return;
-    hideHeadUnlessFocused();
-  }, [cancelRevealIntent, hideHeadUnlessFocused]);
-
-  // 패널이 바뀌거나 닫히면 리빌 상태를 초기화한다.
-  useLayoutEffect(() => {
-    cancelRevealIntent();
-    setHeadRevealed(false);
-  }, [activeId, cancelRevealIntent]);
-
-  useLayoutEffect(() => () => {
-    cancelRevealIntent();
-  }, [cancelRevealIntent]);
-
-  const handleSlotPointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    // 진입 판정은 hover 포인터에만 적용한다. 터치는 pointerdown 폴백이 담당한다.
-    if (event.pointerType === "touch") return;
-    const slotTop = event.currentTarget.getBoundingClientRect().top;
-    const y = event.clientY - slotTop;
-    if (y <= HEAD_REVEAL_ZONE_PX) {
-      if (headRevealedRef.current || revealIntentTimerRef.current !== null) return;
-      revealIntentTimerRef.current = window.setTimeout(() => {
-        revealIntentTimerRef.current = null;
-        setHeadRevealed(true);
-      }, HEAD_REVEAL_INTENT_DELAY_MS);
-      return;
-    }
-    cancelRevealIntent();
-    if (y > HEAD_HIDE_BOUNDARY_PX) releaseHead();
-  }, [cancelRevealIntent, releaseHead]);
-
-  const handleSlotPointerLeave = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    // 터치 탭은 pointerup 뒤에 pointerleave가 따라온다. 그걸 숨김으로 받으면
-    // 방금 연 헤더가 접혀 두 번째 탭(플로팅·닫기)이 닿지 않는다.
-    if (event.pointerType === "touch") return;
-    releaseHead();
-  }, [releaseHead]);
-
-  const handleSlotPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    if (event.pointerType !== "touch") return;
-    const slotTop = event.currentTarget.getBoundingClientRect().top;
-    const y = event.clientY - slotTop;
-    if (!headRevealedRef.current) {
-      // 상단 가장자리 탭 = 리빌. preventDefault 없이 콘텐츠 탭도 그대로 통과시킨다.
-      if (y <= HEAD_REVEAL_TOUCH_ZONE_PX) holdHeadOpen();
-      return;
-    }
-    const target = event.target instanceof Element ? event.target : null;
-    if (target?.closest(".right-rail-panel-head-reveal") === null) {
-      hideHeadUnlessFocused();
-    }
-  }, [hideHeadUnlessFocused, holdHeadOpen]);
 
   useLayoutEffect(() => {
     const onResize = () => {
@@ -353,6 +272,19 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
     saveStoredPanelWidth(activeIdRef.current, desiredWidthRef.current);
   }, []);
 
+  // 메뉴의 "패널 폭 초기화" — 기억된 폭을 지우고 패널이 선언한 기본값으로 되돌린다.
+  // 폭 기억 effect는 저장값이 없으면 손대지 않으므로, 지운 뒤 상태를 직접 세우면 충돌하지 않는다.
+  const handleResetPanelWidth = useCallback(() => {
+    const panelId = activeIdRef.current;
+    if (panelId === null) return;
+    clearStoredPanelWidth(panelId);
+    const currentMaxWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidthRef.current));
+    const next = resolvePanelWidth(panelId, activePanel?.defaultWidth, currentMaxWidth, Object.create(null) as Record<string, number>);
+    desiredWidthRef.current = next;
+    panelWidthRef.current = next;
+    setPanelWidthState(next);
+  }, [activePanel?.defaultWidth]);
+
   const baseCtx: RailPanelContext = useMemo(() => ({
     theaterId,
     pathContext: { kind: "root", relPath: null, label: theaterLabel },
@@ -384,9 +316,6 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
         style={panelBehavior === "overlay"
           ? { "--right-rail-overlay-alpha": overlayAlpha / 100 } as CSSProperties
           : undefined}
-        onPointerMove={hasPanel ? handleSlotPointerMove : undefined}
-        onPointerLeave={hasPanel ? handleSlotPointerLeave : undefined}
-        onPointerDown={hasPanel ? handleSlotPointerDown : undefined}
       >
         {activePanel && (
           <div
@@ -404,21 +333,20 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
           />
         )}
         {activePanel && (
-          <>
-            <RailPanelHead
-              activePanelTitle={activePanelTitle}
-              panelBehavior={panelBehavior}
-              overlayAlpha={overlayAlpha}
-              revealed={headRevealed}
-              onHoldOpen={holdHeadOpen}
-              onRelease={releaseHead}
-            />
-            <div className="right-rail-panel-peek" aria-hidden="true" />
-            <RailPanelBody activePanel={activePanel} activeId={activeId} ctx={ctx} connection={connection} connectionLostAt={connectionLostAt} language={language} />
-          </>
+          <RailPanelBody activePanel={activePanel} activeId={activeId} ctx={ctx} connection={connection} connectionLostAt={connectionLostAt} language={language} />
         )}
       </div>
       <nav className="right-rail-icons" aria-label={t("rail.chrome.toolsAria")}>
+        {/* 설정은 열 최상단에 서고 디바이더가 패널 탭과 갈라 놓는다 — 패널을 고르는 일과
+            레일을 손보는 일은 다른 종류의 동작이다. */}
+        <RailSettingsMenu
+          panelBehavior={panelBehavior}
+          overlayAlpha={overlayAlpha}
+          activePanelTitle={activePanel === null ? null : activePanelTitle}
+          railChromeExpanded={railChromeExpanded}
+          onResetWidth={handleResetPanelWidth}
+        />
+        <div className="right-rail-divider" role="separator" aria-orientation="horizontal" />
         <div className="right-rail-tabs" role="tablist" aria-label={t("rail.chrome.panelsAria")}>
           {builtInPanels.map((panel) => (
             <RailIcon key={panel.id} panel={panel} context={baseCtx} language={language} isActive={activeId === panel.id} />
@@ -441,94 +369,6 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
           ))}
         </div>
       </nav>
-    </div>
-  );
-}
-
-interface RailPanelHeadProps {
-  readonly activePanelTitle: string;
-  readonly panelBehavior: "push" | "overlay";
-  readonly overlayAlpha: RailOverlayAlpha;
-  readonly revealed: boolean;
-  readonly onHoldOpen: () => void;
-  readonly onRelease: () => void;
-}
-
-// 헤더의 세 통제(타이틀·플로팅·닫기)는 전부 저빈도라 상주 캡션 대신 호버-리빌
-// 오버레이로 소환한다. 숨김 상태에서도 DOM에 남아 Tab 진입(focus)이 리빌 경로가 된다.
-function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha, revealed, onHoldOpen, onRelease }: RailPanelHeadProps) {
-  const t = useT();
-
-  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
-    // slot의 진입/이탈 판정으로 버블되면 32px 헤더 하단부(y>12px)가 이탈로 오판된다.
-    event.stopPropagation();
-    onHoldOpen();
-  };
-
-  const handlePointerLeave = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (event.pointerType === "touch") return;
-    onRelease();
-  };
-
-  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
-    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
-    onRelease();
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "Escape") return;
-    // Esc 닫기는 헤더 포커스 범위로 한정한다 — 패널 본문(Shell PTY 등)의 Esc 어휘를 뺏지 않는다.
-    event.stopPropagation();
-    closeRailPanel();
-  };
-
-  return (
-    <div
-      className={`right-rail-panel-head-reveal${revealed ? " is-revealed" : ""}`}
-      onPointerMove={handlePointerMove}
-      onPointerLeave={handlePointerLeave}
-      onFocusCapture={onHoldOpen}
-      onBlurCapture={handleBlur}
-      onKeyDown={handleKeyDown}
-    >
-      <div className="right-rail-panel-head">
-        <span className="right-rail-panel-title">{activePanelTitle}</span>
-        <button
-          className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
-          type="button"
-          aria-pressed={panelBehavior === "overlay"}
-          aria-label={t("rail.chrome.floatToggle")}
-          title={t("rail.chrome.floatLabel")}
-          onClick={toggleRailPanelBehavior}
-        >
-          <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
-        </button>
-        {panelBehavior === "overlay" ? (
-          <div className="right-rail-alpha">
-            <input
-              className="right-rail-alpha-slider fleet-slider"
-              type="range"
-              min={RAIL_OVERLAY_ALPHA_MIN}
-              max={RAIL_OVERLAY_ALPHA_MAX}
-              step={1}
-              value={overlayAlpha}
-              aria-label={t("rail.chrome.opacityAria")}
-              onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
-              onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
-              style={{ "--slider-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
-            />
-            <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
-          </div>
-        ) : null}
-        <button
-          className="right-rail-close-btn"
-          type="button"
-          aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
-          onClick={closeRailPanel}
-        >
-          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" /></svg>
-        </button>
-      </div>
     </div>
   );
 }

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -4,6 +4,9 @@
 :root {
   --z-rail: 10;
   --z-codex-side: 20;
+  /* 설정 메뉴는 body로 포털되어 .console-shell 밖에 선다 — 셸이 여는 --z-floating을
+     물려받지 못하므로 같은 부유 팝오버 층(60)을 여기서 직접 연다. */
+  --z-rail-menu: 60;
 }
 
 .right-rail {
@@ -108,176 +111,6 @@
   backdrop-filter: var(--glass-backdrop-strong);
   opacity: var(--right-rail-overlay-alpha, 1);
   pointer-events: none;
-}
-
-/* ── 호버-리빌 헤더 ─────────────────────────────────────────────────
-   세 통제(타이틀·플로팅·닫기)는 전부 저빈도 set-and-forget이라 상주 캡션 대신
-   상단 접근 시에만 본문 위 오버레이로 소환한다(진입 판정은 right-rail.tsx의
-   pointermove+의도 지연 계약). 숨김은 opacity+transform으로만 처리해 Tab
-   포커스 진입이 리빌 경로로 남는다. */
-.right-rail-panel-head-reveal {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 3;
-  transform: translateY(-100%);
-  opacity: 0;
-  pointer-events: none;
-  border-bottom: 1px solid var(--surface-rim);
-  /* 본문 위에 얹히는 오버레이라 glass 카드와 같은 불투명 언더레이가 필요하다. */
-  background: color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
-  /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
-  box-shadow: 0 10px 26px oklch(0% 0 0 / 40%);
-  transition: transform 180ms var(--ease-spring), opacity 140ms ease;
-}
-
-.right-rail-panel-head-reveal.is-revealed {
-  transform: none;
-  opacity: 1;
-  pointer-events: auto;
-}
-
-/* 리빌 힌트 — 헤더가 숨어 있음을 알리는 유일한 상주 크롬(3px 대시). */
-.right-rail-panel-peek {
-  position: absolute;
-  top: 5px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 30px;
-  height: 3px;
-  border-radius: 2px;
-  z-index: 2;
-  background: var(--text-tertiary);
-  opacity: 0.32;
-  pointer-events: none;
-  transition: opacity 140ms ease;
-}
-
-.right-rail-panel-head-reveal.is-revealed + .right-rail-panel-peek {
-  opacity: 0;
-}
-
-.right-rail-panel-head {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: center;
-  gap: 6px;
-  height: 32px;
-  min-height: 32px;
-  min-width: 0;
-  padding: 0 8px;
-}
-
-.right-rail-panel-title {
-  flex: 0 1 auto;
-  max-width: 50%;
-  font-family: var(--font-mono);
-  font-size: var(--t-xs);
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.right-rail-float-toggle {
-  flex: none;
-  width: 20px;
-  height: 20px;
-  display: inline-grid;
-  place-items: center;
-  padding: 0;
-  border-radius: var(--radius-xs);
-  border: 1px solid var(--surface-rim-strong);
-  background: transparent;
-  color: var(--text-tertiary);
-  cursor: pointer;
-  transition: color 140ms, background 140ms, border-color 140ms;
-}
-
-.right-rail-float-toggle svg {
-  width: 12px;
-  height: 12px;
-  display: block;
-}
-
-.right-rail-float-toggle:hover {
-  color: var(--text-primary);
-  background: var(--ink-veil);
-}
-
-.right-rail-float-toggle.is-active {
-  color: var(--brass-ink);
-  background: var(--brass-glow);
-  border-color: color-mix(in oklch, var(--brass) 45%, transparent);
-}
-
-/* 활성 hover는 brass 채널을 유지한 채 테두리만 강화한다(비활성 hover의 veil 덮기 방지). */
-.right-rail-float-toggle.is-active:hover {
-  color: var(--brass-ink);
-  background: var(--brass-glow);
-  border-color: color-mix(in oklch, var(--brass) 70%, transparent);
-}
-
-.right-rail-alpha {
-  flex: 0 1 auto;
-  min-width: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-xs);
-  padding: 0 6px;
-  height: 20px;
-}
-
-.right-rail-alpha-slider {
-  flex: 1 1 44px;
-  width: 64px;
-  min-width: 44px;
-}
-
-.right-rail-alpha-value {
-  flex: none;
-  font-family: var(--font-mono);
-  font-size: var(--t-2xs);
-  color: var(--brass-ink);
-  width: 30px;
-  text-align: right;
-}
-
-.right-rail-close-btn {
-  margin-left: auto;
-  width: 20px;
-  height: 20px;
-  flex: none;
-  display: inline-grid;
-  place-items: center;
-  border-radius: var(--radius-xs);
-  background: none;
-  border: 1px solid transparent;
-  color: var(--text-tertiary);
-  cursor: pointer;
-  transition: color 140ms, background 140ms, border-color 140ms;
-}
-
-.right-rail-close-btn svg {
-  width: 12px;
-  height: 12px;
-  display: block;
-}
-
-.right-rail-close-btn:hover,
-.right-rail-close-btn:focus-visible {
-  color: var(--brass-bright);
-  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
-  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
-  outline-offset: 2px;
 }
 
 .right-rail-panel-body {
@@ -388,6 +221,144 @@
   background: var(--brass);
 }
 
+/* ── 레일 설정 톱니 + 컨텍스트 메뉴 ──────────────────────────────
+   레일의 설정(플로팅·불투명도·폭·닫기)은 전부 저빈도 set-and-forget이라 상주 크롬이
+   아니라 부를 때만 오는 메뉴가 진다. 톱니는 아이콘 열 최상단에 서고 디바이더가 패널
+   탭과 갈라 놓는다 — 패널을 고르는 일과 레일을 손보는 일은 다른 종류의 동작이다. */
+/* 열린 상태는 brass 테두리로만 말한다 — 좌측 brass 바(.is-active)는 탭의 문법이고
+   톱니는 탭이 아니다. brass는 위치·포커스 채널이므로 열림 표시에 legal하다. */
+.right-rail-settings-btn.is-open {
+  color: var(--brass-ink);
+  border-color: color-mix(in oklch, var(--brass) 45%, transparent);
+  background: var(--brass-glow);
+}
+
+.right-rail-divider {
+  flex: none;
+  width: 20px;
+  height: 1px;
+  margin: 2px 0;
+  background: var(--surface-rim-strong);
+}
+
+/* 메뉴는 포털로 문서에 그린다(.right-rail은 push 모드에서 overflow: hidden).
+   유리 판독성 계약: glass 층 + 불투명 --ink-deep 언더레이 — command-band-system-menu와
+   같은 한 벌이다(콘솔 메뉴 단일 방언). */
+.right-rail-menu {
+  z-index: var(--z-rail-menu);
+  display: flex;
+  flex-direction: column;
+  min-width: 214px;
+  max-width: min(292px, calc(100vw - 16px));
+  padding: 4px;
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-xs);
+  background:
+    var(--glass-sheen),
+    linear-gradient(var(--glass-tint-strong), var(--glass-tint-strong)),
+    var(--glass-underlay);
+  -webkit-backdrop-filter: var(--glass-backdrop-strong);
+  backdrop-filter: var(--glass-backdrop-strong);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift);
+}
+
+.right-rail-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: none;
+  border-radius: var(--radius-xs);
+  background: none;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  font-weight: var(--weight-bold);
+  text-align: left;
+  cursor: pointer;
+}
+
+.right-rail-menu-item:hover,
+.right-rail-menu-item:focus-visible {
+  background: var(--surface-pillar);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.right-rail-menu-item:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--brass);
+}
+
+.right-rail-menu-item:disabled {
+  color: var(--text-tertiary);
+  opacity: 0.5;
+  cursor: default;
+}
+
+.right-rail-menu-item:disabled:hover {
+  background: none;
+  color: var(--text-tertiary);
+}
+
+/* 체크 자리는 켜짐과 무관하게 늘 차지한다 — 라벨이 좌우로 흔들리지 않는다. */
+.right-rail-menu-check {
+  flex: none;
+  width: 13px;
+  height: 13px;
+  color: var(--brass-ink);
+}
+
+.right-rail-menu-label {
+  margin: 0;
+  padding: 6px 10px 2px;
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.right-rail-menu-divider {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--surface-rim);
+}
+
+/* 값 조절 행은 menuitem 역할을 갖지 않는다 — 방향키 순회가 슬라이더 조작과 싸우지 않도록. */
+.right-rail-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px 8px;
+}
+
+.right-rail-menu-row-label {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.right-rail-alpha-slider {
+  flex: 1 1 auto;
+  min-width: 56px;
+}
+
+.right-rail-alpha-value {
+  flex: none;
+  width: 34px;
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  color: var(--brass-ink);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 /* ── 레일 패널 리사이즈 핸들 ────────────────────────────────────── */
 .right-rail-resize-handle {
   position: absolute;
@@ -452,14 +423,11 @@
 /* ── prefers-reduced-motion 단락 ───────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .right-rail,
-  .right-rail-panel-slot,
-  .right-rail-panel-head-reveal,
-  .right-rail-panel-peek {
+  .right-rail-panel-slot {
     transition: none !important;
   }
 
   .right-rail-ico,
-  .right-rail-float-toggle,
   .right-rail-resize-handle {
     transition-duration: 0.01ms !important;
   }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1955,6 +1955,7 @@ describe("Instrument core design contract", () => {
   it("pins the selectable Right Rail panel behavior contract", () => {
     const rail = source("styles/rail.css");
     const rightRail = source("rail/right-rail.tsx");
+    const railMenu = source("rail/rail-settings-menu.tsx");
     const railStore = source("rail/rail-store.ts");
     expect(rail).toContain(".right-rail.is-overlay");
     expect(rail).toContain(".right-rail.is-switching");
@@ -1969,25 +1970,37 @@ describe("Instrument core design contract", () => {
     // keeps only its own layout.
     expect(source("styles/components.css")).toContain(".fleet-slider::-moz-range-progress");
     expect(rail).not.toContain(".right-rail-alpha-slider::-moz-range-progress");
-    expect(rightRail).toContain("right-rail-alpha-slider fleet-slider");
+    expect(railMenu).toContain("right-rail-alpha-slider fleet-slider");
     expect(rightRail).toContain("useRailPanelBehavior");
-    expect(rightRail).toContain("right-rail-float-toggle");
-    expect(rightRail).toContain("right-rail-alpha-slider");
+    expect(railMenu).toContain("right-rail-alpha-slider");
     expect(rightRail).toContain("is-switching");
     expect(railStore).toContain("fleet-console.rail.panelBehavior");
-    // Doctrine: Operation panels keep a 32px attached caption. The Activity Rail
-    // does not — its head is hover-reveal chrome so the body uses the full slot.
-    // Hide with opacity+transform only (never display/visibility) so keyboard
-    // focus can still enter and reveal it; reveal entry stays pointermove-gated
-    // with an intent delay so scroll-under-pointer never triggers it.
-    expect(rail).toContain(".right-rail-panel-head-reveal");
-    expect(rail).toMatch(/\.right-rail-panel-head-reveal \{[^}]*pointer-events:\s*none/);
-    expect(rail).toMatch(/\.right-rail-panel-head-reveal\.is-revealed \{[^}]*pointer-events:\s*auto/);
-    expect(rail).toMatch(/@media \(prefers-reduced-motion: reduce\) \{[^{]*\.right-rail-panel-head-reveal/);
-    expect(rail).toContain(".right-rail-panel-peek");
+    // Doctrine: Operation panels keep a 32px attached caption. The Activity Rail has no
+    // panel head at all — its settings live behind the gear at the top of the icon column,
+    // so the body owns the whole slot and no chrome can summon itself over it. The retired
+    // hover-reveal head is pinned negatively: it fired from the most common pointer path
+    // across the panel top and then covered the very controls that path was aiming for.
+    expect(rail).not.toContain(".right-rail-panel-head-reveal");
+    expect(rail).not.toContain(".right-rail-panel-peek");
     expect(rail).not.toContain("grid-template-rows: 32px minmax(0, 1fr);");
-    expect(rightRail).toContain("HEAD_REVEAL_INTENT_DELAY_MS");
-    expect(rightRail).not.toMatch(/onPointerEnter=\{(?:handleSlotPointerMove|holdHeadOpen)/);
+    expect(rightRail).not.toContain("HEAD_REVEAL");
+    expect(rightRail).not.toMatch(/onPointerMove=\{(?:hasPanel \? )?handleSlotPointer/);
+    // Doctrine: the gear stands first in the icon column and a divider splits it from the
+    // panel tablist — choosing a panel and tuning the rail are different kinds of act.
+    expect(rightRail).toMatch(/<RailSettingsMenu[\s\S]{0,400}right-rail-divider[\s\S]{0,200}right-rail-tabs/);
+    expect(rail).toMatch(/\.right-rail-divider \{[^}]*background: var\(--surface-rim-strong\);/);
+    // Doctrine: brass is the location/focus channel, so the open gear may wear it — but not
+    // the tablist's left brass bar, because the gear is not a tab.
+    expect(rail).toMatch(/\.right-rail-settings-btn\.is-open \{[^}]*background: var\(--brass-glow\);/);
+    expect(rail).not.toContain(".right-rail-settings-btn.is-open::before");
+    // Doctrine: the menu is portaled to the document because .right-rail clips its own
+    // children in push mode — drawn inside the rail it could never open to the left.
+    expect(railMenu).toContain("createPortal");
+    expect(rail).toMatch(/\.right-rail \{[^}]*overflow: hidden;/);
+    // Doctrine: one menu-button dialect for the whole console — the rail menu and the
+    // command band system menu share the keyboard and dismissal contract, never a copy.
+    expect(railMenu).toContain('from "../components/use-menu-button-keyboard.js"');
+    expect(source("components/command-band-system-cluster.tsx")).toContain('from "./use-menu-button-keyboard.js"');
     expect(source("styles/components.css")).toContain(".canvas-operation.is-top-edge .canvas-operation-titlebar");
     expect(source("styles/components.css")).toContain(".canvas-operation.is-top-edge .canvas-operation-resize--n");
     expect(source("canvas/operation-frame.tsx")).toContain("DRAG_THRESHOLD_PX");
@@ -2034,6 +2047,9 @@ describe("Instrument core design contract", () => {
       expect(components).toMatch(new RegExp(`${scoped} \\{[^}]*backdrop-filter: var\\(--glass-backdrop-strong\\);`));
     }
     expect(layout).toMatch(/\.command-band-menu \{[^}]*\),\s*var\(--glass-underlay\);/);
+    // Activity Rail 설정 메뉴도 같은 재질을 탄다 — 밴드 메뉴와 한 벌이다.
+    expect(source("styles/rail.css")).toMatch(/\.right-rail-menu \{[^}]*\),\s*var\(--glass-underlay\);/);
+    expect(source("styles/rail.css")).toMatch(/\.right-rail-menu \{[^}]*backdrop-filter: var\(--glass-backdrop-strong\);/);
     // 밴드에 앵커된 두 메뉴는 같은 재질이어야 한다 — 환경 팝오버만 --surface-band 불투명으로
     // 남아 있던 유리 전환 누락(Move E)의 재발 방지.
     expect(layout).toMatch(/\.command-band-environment-popover \{[^}]*\),\s*var\(--glass-underlay\);/);

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -570,6 +570,34 @@ describe("Right Rail settings menu", () => {
     expect(railMenu()).toBeNull();
   });
 
+  it.each([
+    ["a window resize", () => window.dispatchEvent(new Event("resize"))],
+    ["a captured scroll", () => document.body.dispatchEvent(new Event("scroll"))],
+  ])("hands focus back to the gear when %s dismisses the menu", (_label, jolt) => {
+    renderRail();
+    openRailMenu();
+    const firstItem = menuItem("Float over Map");
+    act(() => firstItem.focus());
+
+    act(() => { jolt(); });
+
+    // 포커스를 쥔 요소를 그냥 걷어내면 body로 떨어진다 — 톱니는 그대로 서 있으므로 그리로.
+    expect(railMenu()).toBeNull();
+    expect(document.activeElement).toBe(gearButton());
+  });
+
+  it("leaves focus alone when the menu is dismissed while something else holds it", () => {
+    renderRail();
+    openRailMenu();
+    const outside = container.querySelector<HTMLButtonElement>("#rail-tab-codex")!;
+    act(() => outside.focus());
+
+    act(() => { window.dispatchEvent(new Event("resize")); });
+
+    expect(railMenu()).toBeNull();
+    expect(document.activeElement).toBe(outside);
+  });
+
   it("takes the floating menu down with the rail chrome and hands focus to the band toggle", () => {
     const railToggle = document.createElement("button");
     railToggle.className = "command-band-rail-toggle";

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -536,6 +536,40 @@ describe("Right Rail settings menu", () => {
     expect(railMenu()).toBeNull();
   });
 
+  it("leaves the opacity slider its own arrow and Home/End keys", () => {
+    setRailPanelBehavior("overlay");
+    renderRail();
+    openRailMenu();
+
+    const slider = opacitySlider()!;
+    act(() => slider.focus());
+    expect(document.activeElement).toBe(slider);
+
+    // 항목 순회가 이 키들을 가로채면 값 조절이 죽고 포커스까지 빼앗겨 슬라이더가 키보드로
+    // 손댈 수 없는 컨트롤이 된다 — 메뉴 안이라도 항목이 아닌 컨트롤은 자기 키를 갖는다.
+    for (const key of ["ArrowDown", "ArrowUp", "Home", "End"]) {
+      const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+      act(() => { slider.dispatchEvent(event); });
+      expect(event.defaultPrevented, `${key} must reach the slider`).toBe(false);
+      expect(document.activeElement, `${key} must not move focus`).toBe(slider);
+    }
+
+    // 메뉴 항목 위에서는 순회가 그대로 살아 있어야 한다.
+    const floatItem = menuItem("Float over Map");
+    act(() => floatItem.focus());
+    act(() => {
+      floatItem.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
+    });
+    expect(document.activeElement).not.toBe(floatItem);
+
+    // Esc는 슬라이더에 포커스가 있어도 메뉴를 닫는다.
+    act(() => slider.focus());
+    act(() => {
+      slider.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    });
+    expect(railMenu()).toBeNull();
+  });
+
   it("takes the floating menu down with the rail chrome, so no anchorless menu survives", () => {
     renderRail();
     openRailMenu();

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -67,9 +67,11 @@ vi.mock("../core/client/src/rail/rail-registry.js", () => ({
 
 import { RightRail } from "../core/client/src/rail/right-rail.js";
 import {
+  closeRailPanel,
   getRailStoreSnapshot,
   requestRailPanelExtraWidth,
   setActiveRailPanel,
+  setRailChromeExpanded,
   setRailOverlayAlpha,
   setRailPanelBehavior,
 } from "../core/client/src/rail/rail-store.js";
@@ -89,6 +91,7 @@ beforeEach(() => {
   Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
   window.localStorage.clear();
   setActiveRailPanel("repository");
+  setRailChromeExpanded(true);
   requestRailPanelExtraWidth("repository", null);
   setRailPanelBehavior("push");
   setRailOverlayAlpha(100);
@@ -111,16 +114,18 @@ afterEach(() => {
 describe("Right Rail overlay opacity slider", () => {
   it("renders no opacity slider or alpha variable in push mode", () => {
     renderRail();
+    openRailMenu();
 
-    expect(container.querySelector('input[aria-label="Panel opacity"]')).toBeNull();
+    expect(opacitySlider()).toBeNull();
     expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("");
   });
 
   it("renders the slider in overlay mode, applies changes, and resets on double-click", () => {
     setRailPanelBehavior("overlay");
     renderRail();
+    openRailMenu();
 
-    const slider = container.querySelector<HTMLInputElement>('input[aria-label="Panel opacity"]');
+    const slider = opacitySlider();
     expect(slider).not.toBeNull();
     expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("1");
 
@@ -143,8 +148,9 @@ describe("Right Rail overlay opacity slider", () => {
   it("does not re-render the panel body while the opacity slider changes", () => {
     setRailPanelBehavior("overlay");
     renderRail();
+    openRailMenu();
 
-    const slider = container.querySelector<HTMLInputElement>('input[aria-label="Panel opacity"]')!;
+    const slider = opacitySlider()!;
     const renderCountBeforeChange = railPanelContextMock.renderCount;
     const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
     act(() => {
@@ -443,86 +449,117 @@ describe("Right Rail panel width", () => {
   });
 });
 
-describe("Right Rail hover-reveal header", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("keeps the header hidden until a delayed pointer approach, then hides immediately on leave", () => {
+describe("Right Rail settings menu", () => {
+  it("puts the settings gear first in the icon column, split from the panel tabs by a divider", () => {
     renderRail();
-    const reveal = panelHeadReveal();
-    expect(reveal.classList.contains("is-revealed")).toBe(false);
-    expect(container.querySelector(".right-rail-panel-peek")).not.toBeNull();
+    const column = container.querySelector<HTMLElement>(".right-rail-icons")!;
+    const children = [...column.children];
 
-    dispatchSlotPointer("pointermove", { clientY: 104 });
-    expect(reveal.classList.contains("is-revealed")).toBe(false);
+    expect(children[0]).toBe(gearButton());
+    expect(children[1]?.className).toBe("right-rail-divider");
+    expect(children[1]?.getAttribute("role")).toBe("separator");
+    // 디바이더 다음부터가 패널 탭이다 — 레일을 손보는 일과 패널을 고르는 일의 경계.
+    expect(children[2]?.className).toBe("right-rail-tabs");
+  });
+
+  it("carries no hover-reveal chrome, so the body owns the whole slot", () => {
+    renderRail();
+
+    expect(container.querySelector(".right-rail-panel-head-reveal")).toBeNull();
+    expect(container.querySelector(".right-rail-panel-peek")).toBeNull();
+    expect(panelSlot().querySelector(".right-rail-panel-body")).not.toBeNull();
+  });
+
+  it("opens on click and closes on Escape, returning focus to the gear", () => {
+    renderRail();
+    expect(railMenu()).toBeNull();
+    expect(gearButton().getAttribute("aria-expanded")).toBe("false");
+
+    openRailMenu();
+    expect(railMenu()).not.toBeNull();
+    expect(gearButton().getAttribute("aria-expanded")).toBe("true");
+    expect(gearButton().classList.contains("is-open")).toBe(true);
 
     act(() => {
-      vi.advanceTimersByTime(119);
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });
-    expect(reveal.classList.contains("is-revealed")).toBe(false);
 
-    act(() => {
-      vi.advanceTimersByTime(1);
-    });
-    expect(reveal.classList.contains("is-revealed")).toBe(true);
-
-    dispatchSlotPointer("pointermove", { clientY: 180 });
-    expect(reveal.classList.contains("is-revealed")).toBe(false);
+    expect(railMenu()).toBeNull();
+    expect(document.activeElement).toBe(gearButton());
   });
 
-  it("does not start a reveal from a touch pointermove", () => {
+  it("closes on a pointer press outside the menu", () => {
     renderRail();
-    dispatchSlotPointer("pointermove", { clientY: 104, pointerType: "touch" });
-    act(() => {
-      vi.advanceTimersByTime(200);
-    });
-    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(false);
-  });
-
-  it("reveals from a touch on the top edge and hides when the body is tapped", () => {
-    renderRail();
-    dispatchSlotPointer("pointerdown", { clientY: 120, pointerType: "touch" });
-    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
-
-    dispatchSlotPointer("pointerdown", { clientY: 240, pointerType: "touch" });
-    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(false);
-  });
-
-  it("keeps a touch reveal open through the lift so a second tap can reach the chrome", () => {
-    renderRail();
-    dispatchSlotPointer("pointerdown", { clientY: 120, pointerType: "touch" });
-    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
-
-    dispatchSlotPointer("pointerleave", { clientY: 120, pointerType: "touch" });
-    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
+    openRailMenu();
 
     act(() => {
-      panelHeadReveal().dispatchEvent(new PointerEvent("pointerleave", {
-        bubbles: true,
-        cancelable: true,
-        clientX: 980,
-        clientY: 110,
-        pointerType: "touch",
-      }));
+      document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
     });
-    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
+
+    expect(railMenu()).toBeNull();
   });
 
-  it("resets the reveal when the active panel changes", () => {
+  it("toggles the float behavior from the checkbox item", () => {
     renderRail();
-    dispatchSlotPointer("pointermove", { clientY: 104 });
-    act(() => {
-      vi.advanceTimersByTime(120);
-    });
-    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(true);
+    openRailMenu();
 
-    act(() => setActiveRailPanel("codex"));
-    expect(panelHeadReveal().classList.contains("is-revealed")).toBe(false);
+    const floatItem = menuItem("Float over Map");
+    expect(floatItem.getAttribute("aria-checked")).toBe("false");
+
+    act(() => floatItem.click());
+
+    expect(getRailStoreSnapshot().panelBehavior).toBe("overlay");
+    expect(menuItem("Float over Map").getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("resets a remembered panel width to the panel default and forgets the stored value", () => {
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ repository: 520 }));
+    renderRail();
+    expect(renderedPanelWidth()).toBe(520);
+
+    openRailMenu();
+    act(() => menuItem("Reset panel width").click());
+
+    expect(renderedPanelWidth()).toBe(360);
+    expect(window.localStorage.getItem("fleet-console.rail.panelWidths")).toBe("{}");
+    // 초기화는 메뉴를 닫고 톱니로 포커스를 돌려준다.
+    expect(railMenu()).toBeNull();
+  });
+
+  it("closes the active panel from the menu", () => {
+    renderRail();
+    openRailMenu();
+
+    act(() => menuItem("Close REPOSITORY").click());
+
+    expect(getRailStoreSnapshot().activeRailPanelId).toBeNull();
+    expect(railMenu()).toBeNull();
+  });
+
+  it("takes the floating menu down with the rail chrome, so no anchorless menu survives", () => {
+    renderRail();
+    openRailMenu();
+
+    act(() => setRailChromeExpanded(false));
+
+    // 톱니는 inert 안으로 들어가지만 포털된 메뉴는 문서에 남는다 — 함께 거둬야 한다.
+    expect(container.querySelector(".right-rail")!.hasAttribute("inert")).toBe(true);
+    expect(railMenu()).toBeNull();
+
+    act(() => setRailChromeExpanded(true));
+    expect(railMenu()).toBeNull();
+  });
+
+  it("disables the panel-scoped items and names the empty state when no panel is open", () => {
+    act(() => closeRailPanel());
+    renderRail();
+    openRailMenu();
+
+    expect(railMenu()!.querySelector(".right-rail-menu-label")!.textContent).toBe("No panel open");
+    expect(menuItem("Reset panel width").disabled).toBe(true);
+    expect(menuItem("Close panel").disabled).toBe(true);
+    // 플로팅은 레일 차원의 상시 취향이라 패널이 없어도 정할 수 있다.
+    expect(menuItem("Float over Map").disabled).toBe(false);
   });
 });
 
@@ -538,37 +575,31 @@ function panelSlot(): HTMLDivElement {
   return slot!;
 }
 
-function panelHeadReveal(): HTMLDivElement {
-  const reveal = container.querySelector<HTMLDivElement>(".right-rail-panel-head-reveal");
-  expect(reveal).not.toBeNull();
-  return reveal!;
+function gearButton(): HTMLButtonElement {
+  const gear = container.querySelector<HTMLButtonElement>(".right-rail-settings-btn");
+  expect(gear).not.toBeNull();
+  return gear!;
 }
 
-function dispatchSlotPointer(
-  type: "pointermove" | "pointerdown" | "pointerleave",
-  init: { readonly clientY: number; readonly pointerType?: string },
-): void {
-  const slot = panelSlot();
-  vi.spyOn(slot, "getBoundingClientRect").mockReturnValue({
-    x: 800,
-    y: 100,
-    top: 100,
-    left: 800,
-    right: 1160,
-    bottom: 700,
-    width: 360,
-    height: 600,
-    toJSON: () => ({}),
-  });
-  act(() => {
-    slot.dispatchEvent(new PointerEvent(type, {
-      bubbles: true,
-      cancelable: true,
-      clientX: 980,
-      clientY: init.clientY,
-      pointerType: init.pointerType ?? "mouse",
-    }));
-  });
+/** 메뉴는 body로 포털된다 — 레일이 push 모드에서 자기 안의 팝업을 잘라내기 때문이다. */
+function railMenu(): HTMLElement | null {
+  return document.body.querySelector<HTMLElement>(".right-rail-menu");
+}
+
+function openRailMenu(): void {
+  act(() => gearButton().click());
+  expect(railMenu()).not.toBeNull();
+}
+
+function menuItem(labelPrefix: string): HTMLButtonElement {
+  const item = [...railMenu()!.querySelectorAll<HTMLButtonElement>(".right-rail-menu-item")]
+    .find((button) => (button.textContent ?? "").startsWith(labelPrefix));
+  expect(item, `menu item starting with "${labelPrefix}"`).toBeDefined();
+  return item!;
+}
+
+function opacitySlider(): HTMLInputElement | null {
+  return document.body.querySelector<HTMLInputElement>('input[aria-label="Panel opacity"]');
 }
 
 function panelBody(): HTMLDivElement {

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -570,18 +570,31 @@ describe("Right Rail settings menu", () => {
     expect(railMenu()).toBeNull();
   });
 
-  it("takes the floating menu down with the rail chrome, so no anchorless menu survives", () => {
-    renderRail();
-    openRailMenu();
+  it("takes the floating menu down with the rail chrome and hands focus to the band toggle", () => {
+    const railToggle = document.createElement("button");
+    railToggle.className = "command-band-rail-toggle";
+    document.body.append(railToggle);
+    try {
+      renderRail();
+      openRailMenu();
+      const firstItem = menuItem("Float over Map");
+      act(() => firstItem.focus());
+      expect(document.activeElement).toBe(firstItem);
 
-    act(() => setRailChromeExpanded(false));
+      act(() => setRailChromeExpanded(false));
 
-    // 톱니는 inert 안으로 들어가지만 포털된 메뉴는 문서에 남는다 — 함께 거둬야 한다.
-    expect(container.querySelector(".right-rail")!.hasAttribute("inert")).toBe(true);
-    expect(railMenu()).toBeNull();
+      // 톱니는 inert 안으로 들어가지만 포털된 메뉴는 문서에 남는다 — 함께 거둬야 한다.
+      expect(container.querySelector(".right-rail")!.hasAttribute("inert")).toBe(true);
+      expect(railMenu()).toBeNull();
+      // 레일 DOM만 보는 RightRail의 복귀는 body로 포털된 메뉴를 못 본다 — 메뉴가 직접
+      // 넘기지 않으면 포커스가 body로 떨어진다.
+      expect(document.activeElement).toBe(railToggle);
 
-    act(() => setRailChromeExpanded(true));
-    expect(railMenu()).toBeNull();
+      act(() => setRailChromeExpanded(true));
+      expect(railMenu()).toBeNull();
+    } finally {
+      railToggle.remove();
+    }
   });
 
   it("disables the panel-scoped items and names the empty state when no panel is open", () => {


### PR DESCRIPTION
## Summary

- Activity Rail 설정 진입을 호버-리빌 헤더에서 **아이콘 열 최상단의 톱니**로 옮기고, 그 아래 디바이더로 패널 탭과 분리했습니다. 톱니를 누르면 `Map 위에 띄우기` · `패널 불투명도` · `패널 폭 초기화` · `패널 닫기`가 담긴 컨텍스트 메뉴가 열립니다.
- 호버-리빌 헤더를 전면 폐기했습니다. 진입 띠는 세로 12px이지만 **패널 폭 전체(실측 391px)** 를 가로질러, 패널 상단을 지나가기만 해도 131ms 지점에서 크롬이 스스로 열리고 33px 헤더가 바로 그 경로가 겨눈 첫 줄 컨트롤(저장소 `Fetch/Pull/Push/Stash` 7–36px, 스킬 `설치됨/찾기` 0–30px, 원장 `오늘/7일/이번 달` 15–45px)을 덮었습니다. 이제 본문이 슬롯 전체를 씁니다.
- peek 대시(30×3px, `aria-hidden`)·터치 `pointerdown` 리빌 경로·리빌 타이머를 함께 걷어냈습니다. 패널 이름은 아이콘 툴팁이 이미 말하고, 닫기는 활성 아이콘 재클릭이 이미 1클릭으로 합니다.
- 메뉴는 문서로 포털합니다 — `.right-rail`은 push 모드에서 `overflow: hidden`이라 레일 안에 그리면 왼쪽으로 펼쳐지지 못합니다. 자체 z 층을 두고, 레일 크롬이 접히면 앵커 없는 메뉴가 남지 않도록 함께 거둡니다.
- 콘솔의 menu-button 키보드·해제 계약을 공유 훅으로 뽑아 레일 메뉴와 커맨드 밴드 시스템 메뉴가 사본 둘이 아니라 한 벌을 쓰게 했습니다.
- `패널 폭 초기화`를 새로 넣었습니다 — 기억된 패널별 폭을 지우고 패널이 선언한 기본값으로 되돌립니다.

의도한 맞바꿈: 설정 도달이 0클릭(호버)에서 2클릭(톱니→항목)이 됩니다. 실제 설정은 영구 저장되는 set-and-forget 둘뿐이고, 닫기는 아이콘 재클릭 1클릭 경로가 그대로 남습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` — 신규 오류 없음 (`tests/server.test.ts` 1건은 canary 선존)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] `vitest run` (서버 기동 스위트 제외) — 184 files / 2158 tests 통과
- [x] `tests/right-rail.test.tsx` — 리빌 테스트 7건을 톱니·메뉴 계약 8건으로 교체 (배치·리빌 부재·Esc 포커스 복귀·바깥 클릭·플로팅 토글·폭 초기화·패널 닫기·빈 상태·레일 접힘 시 메뉴 거둠)
- [x] `tests/instrument-design-contract.test.ts` — 리빌 단언을 부정 단언으로 전환 + 톱니/디바이더 배치·brass 채널·포털·유리 재질·단일 메뉴 방언 못박음
- [x] `pnpm check:core-boundary`, `pnpm check:localized-attributes` — 위반 없음
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 7 entries 통과
- [x] 격리 콘솔 헤디드 실측 (dist `index-BA_BnUMX.js`): 예전 오발화 경로(패널 상단 6px 횡단)에서 크롬이 열리지 않고 Pull 버튼이 상단 y=7에서 그대로 잡힘 · 메뉴 뷰포트 내 위치 · 플로팅→슬라이더 60% 반영·저장 · 폭 516→420 초기화 및 저장값 `{}` · 방향키가 슬라이더 행을 건너뜀 · 레일 접힘 시 메뉴 동반 소멸 · 페이지 오류 0건