### PR TITLE
feat(ai-gateway): add native Codex compaction

### DIFF
--- a/.changelog.d/claude-codex-compaction-probe.md
+++ b/.changelog.d/claude-codex-compaction-probe.md
@@ -1,0 +1,13 @@
+---
+branch: claude-codex-compaction-probe
+---
+
+### fleet-cli
+#### Added
+- Use OpenAI native compaction for Codex gateway models in Claude Code, including automatic and manual compaction, durable resume, and a safe plaintext fallback.
+  ko: Claude Code의 Codex Gateway 모델에서 자동 및 수동 압축, 영속 재개, 안전한 일반 텍스트 폴백을 포함한 OpenAI 네이티브 압축을 사용합니다.
+
+### fleet-console
+#### Added
+- Use OpenAI native compaction for Codex gateway Operations in Claude Code, including automatic and manual compaction, durable resume, and a safe plaintext fallback.
+  ko: Claude Code의 Codex Gateway 작전에서 자동 및 수동 압축, 영속 재개, 안전한 일반 텍스트 폴백을 포함한 OpenAI 네이티브 압축을 사용합니다.

--- a/packages/core-ai-gateway/package.json
+++ b/packages/core-ai-gateway/package.json
@@ -21,6 +21,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noEmit false -p tsconfig.build.json",
     "e2e:provider-loop": "node scripts/provider-loop-e2e.mjs",
     "probe:claude-auto-compact": "pnpm run build 1>&2 && node scripts/probe-claude-auto-compact.mjs",
+    "probe:claude-codex-compact": "pnpm run build 1>&2 && node scripts/probe-claude-codex-compact.mjs",
     "probe:cursor-context": "pnpm run build 1>&2 && node scripts/probe-cursor-context-windows.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"

--- a/packages/core-ai-gateway/scripts/probe-claude-codex-compact.mjs
+++ b/packages/core-ai-gateway/scripts/probe-claude-codex-compact.mjs
@@ -1,0 +1,566 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CONFIRM_LIVE_PROVIDER = "--confirm-live-provider";
+const DEFAULT_MODEL = "claude-gateway--codex--gpt-5.6-luna";
+const DEFAULT_MODE = "both";
+const DEFAULT_TIMEOUT_MS = 300_000;
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = path.resolve(packageRoot, "../..");
+
+const HELP = `Usage: pnpm --filter @dotobokuri/core-ai-gateway probe:claude-codex-compact -- [options] ${CONFIRM_LIVE_PROVIDER}
+
+WARNING: this probe runs the installed Claude Code against the live ChatGPT Codex backend
+and spends real Luna quota. Build the package first:
+  pnpm --filter @dotobokuri/core-ai-gateway build
+
+Options:
+  --mode <mode>            auto|manual|both (default: ${DEFAULT_MODE})
+  --model <id>             Exact Codex Luna gateway id (default: ${DEFAULT_MODEL})
+  --timeout-ms <count>     Positive per-scenario timeout (default: ${DEFAULT_TIMEOUT_MS})
+  --output <path>          Optional JSON result file; stdout always prints the result
+  --simulate-compact-failure  Inject a pre-send compact failure and verify Claude fallback
+  ${CONFIRM_LIVE_PROVIDER}  Required explicit consent to spend live provider quota
+  --help                   Show this help before loading credentials, node-pty, or network code
+
+The probe installs isolated PreCompact/PostCompact hooks, runs a loopback Anthropic
+Messages proxy, converts Claude's auto or manual compact turn into the Codex Responses v2
+compaction_trigger contract, asks Luna to render the opaque compacted state as Claude's
+plain-text handoff summary, and proves the same blob is replayed on the following turn.
+Credentials, prompts, summaries, and opaque blobs are never written to the result.
+`;
+
+class UsageError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "UsageError";
+  }
+}
+
+class ProbeTimeoutError extends Error {
+  constructor(label) {
+    super(`${label} timed out`);
+    this.name = "ProbeTimeoutError";
+  }
+}
+
+function parseArguments(argv) {
+  const normalized = argv[0] === "--" ? argv.slice(1) : argv;
+  if (normalized.includes("--help")) return { help: true };
+  const options = {
+    mode: DEFAULT_MODE,
+    model: DEFAULT_MODEL,
+    output: undefined,
+    simulateCompactFailure: false,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+  };
+  const seen = new Set();
+  let confirmed = false;
+  for (let index = 0; index < normalized.length; index += 1) {
+    const argument = normalized[index];
+    if (argument === CONFIRM_LIVE_PROVIDER) {
+      if (confirmed) throw new UsageError(`${CONFIRM_LIVE_PROVIDER} may be provided only once`);
+      confirmed = true;
+      continue;
+    }
+    if (argument === "--simulate-compact-failure") {
+      if (options.simulateCompactFailure) throw new UsageError(`${argument} may be provided only once`);
+      options.simulateCompactFailure = true;
+      continue;
+    }
+    if (!["--mode", "--model", "--timeout-ms", "--output"].includes(argument)) {
+      throw new UsageError(`Unknown argument ${JSON.stringify(argument)}`);
+    }
+    if (seen.has(argument)) throw new UsageError(`${argument} may be provided only once`);
+    seen.add(argument);
+    const value = normalized[index + 1];
+    if (!value || value.startsWith("--")) throw new UsageError(`${argument} requires a value`);
+    index += 1;
+    if (argument === "--mode") options.mode = value;
+    else if (argument === "--model") options.model = value;
+    else if (argument === "--output") options.output = path.resolve(value);
+    else options.timeoutMs = positiveInteger(value, argument);
+  }
+  if (!new Set(["auto", "manual", "both"]).has(options.mode)) {
+    throw new UsageError("--mode must be auto, manual, or both");
+  }
+  if (!/^claude-gateway--codex--gpt-5\.6-luna(?:-(?:low|medium|high|xhigh|max))?$/.test(options.model)) {
+    throw new UsageError("--model must be an exact Codex gpt-5.6-luna gateway id");
+  }
+  if (!confirmed) throw new UsageError(`missing required ${CONFIRM_LIVE_PROVIDER}`);
+  return options;
+}
+
+function positiveInteger(value, option) {
+  if (!/^[1-9]\d*$/.test(value)) throw new UsageError(`${option} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new UsageError(`${option} must be a safe positive integer`);
+  return parsed;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function waitFor(predicate, timeoutMs, label) {
+  const startedAt = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      const value = predicate();
+      if (value) return resolve(value);
+      if (Date.now() - startedAt >= timeoutMs) return reject(new ProbeTimeoutError(label));
+      setTimeout(check, 50);
+    };
+    check();
+  });
+}
+
+function waitForExit(child) {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+async function removeClaudeSessionArtifacts(sessionId) {
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  let projectEntries;
+  try {
+    projectEntries = await readdir(projectsDir, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  await Promise.all(projectEntries
+    .filter((entry) => entry.isDirectory())
+    .map(async (entry) => {
+      const projectDir = path.join(projectsDir, entry.name);
+      let entries;
+      try {
+        entries = await readdir(projectDir, { withFileTypes: true });
+      } catch (error) {
+        if (error?.code === "ENOENT") return;
+        throw error;
+      }
+      await Promise.all(entries
+        .filter((candidate) => candidate.name === `${sessionId}.jsonl` || candidate.name === sessionId)
+        .map((candidate) => rm(path.join(projectDir, candidate.name), { recursive: true, force: true })));
+    }));
+}
+
+function safeError(error) {
+  return {
+    name: error instanceof Error ? error.name : "Error",
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+/** Stable semantic fingerprint for a redraw-heavy ANSI terminal tail. */
+function terminalFingerprint(value) {
+  return value
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/[^A-Za-z0-9?+/]/g, "")
+    .toLowerCase();
+}
+
+async function createIsolatedClaudeEnvironment(options) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "fleet-claude-codex-compact-"));
+  const homeDir = path.join(directory, "home");
+  const configDir = path.join(homeDir, ".claude");
+  const settingsPath = path.join(directory, "settings.json");
+  const hookPath = path.join(directory, "compact-hook.mjs");
+  await mkdir(configDir, { recursive: true, mode: 0o700 });
+  const hookSource = `let text = "";\nfor await (const chunk of process.stdin) text += chunk;\nconst input = JSON.parse(text);\nconst response = await fetch(process.env.FLEET_COMPACT_PROBE_HOOK_URL, {\n  method: "POST",\n  headers: {"content-type":"application/json","x-probe-token":process.env.FLEET_COMPACT_PROBE_TOKEN,"x-fleet-compact-token":process.env.FLEET_COMPACT_PROBE_TOKEN},\n  body: JSON.stringify(input),\n});\nif (!response.ok) process.exitCode = 1;\n`;
+  await writeFile(hookPath, hookSource, { mode: 0o700 });
+  const canonicalDirectory = await realpath(directory);
+  const canonicalRepositoryRoot = await realpath(repositoryRoot);
+  const projectState = {
+    allowedTools: [],
+    disabledMcpjsonServers: [],
+    hasTrustDialogAccepted: true,
+    hasClaudeMdExternalIncludesApproved: false,
+    hasClaudeMdExternalIncludesWarningShown: false,
+  };
+  await writeFile(path.join(homeDir, ".claude.json"), JSON.stringify({
+    numStartups: 1,
+    installMethod: "native",
+    hasCompletedOnboarding: true,
+    lastOnboardingVersion: "2.1.251",
+    customApiKeyResponses: { approved: ["sk-ant-fleet-compact-probe"], rejected: [] },
+    projects: {
+      [directory]: projectState,
+      [canonicalDirectory]: projectState,
+      [repositoryRoot]: projectState,
+      [canonicalRepositoryRoot]: projectState,
+    },
+  }), { mode: 0o600 });
+  await writeFile(settingsPath, JSON.stringify({
+    hooks: {
+      PreCompact: [{ matcher: "manual|auto", hooks: [{ type: "command", command: `${JSON.stringify(process.execPath)} ${JSON.stringify(hookPath)}`, timeout: 30 }] }],
+      PostCompact: [{ matcher: "manual|auto", hooks: [{ type: "command", command: `${JSON.stringify(process.execPath)} ${JSON.stringify(hookPath)}`, timeout: 30 }] }],
+    },
+    permissions: { defaultMode: "dontAsk" },
+  }), { mode: 0o600 });
+  return { directory, homeDir, configDir, settingsPath };
+}
+
+function claudeEnvironment(base, isolated, hookUrl, hookToken) {
+  const env = { ...base };
+  for (const name of [
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE",
+    "CLAUDE_CODE_AUTO_COMPACT",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+    "CLAUDE_CODE_CHILD_SESSION",
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT",
+    "CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT",
+    "CLAUDE_CODE_MAX_CONTEXT_TOKENS",
+    "INIT_CWD",
+  ]) delete env[name];
+  Object.assign(env, {
+    ANTHROPIC_API_KEY: "sk-ant-fleet-compact-probe",
+    HOME: isolated.homeDir,
+    CLAUDE_CONFIG_DIR: isolated.configDir,
+    CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: "1",
+    CLAUDE_CODE_SKIP_PROMPT_HISTORY: "1",
+    CLAUDE_SECURESTORAGE_CONFIG_DIR: "",
+    FLEET_COMPACT_PROBE_HOOK_URL: hookUrl,
+    FLEET_COMPACT_PROBE_TOKEN: hookToken,
+  });
+  return env;
+}
+
+async function createProbeRuntime(gateway, options, trigger) {
+  const { createProductProbeRuntime } = await import("./probe-claude-codex-product-runtime.mjs");
+  return createProductProbeRuntime(gateway, options, trigger);
+}
+
+async function runAutoScenario(gateway, options) {
+  const runtime = await createProbeRuntime(gateway, options, "auto");
+  const isolated = await createIsolatedClaudeEnvironment(options);
+  const sessionId = randomUUID();
+  const canary = `AUTO-${randomUUID().slice(0, 8).toUpperCase()}`;
+  runtime.setExpectedCanary(canary);
+  const hookUrl = `http://127.0.0.1:${runtime.port}/v1/compact-events`;
+  const env = claudeEnvironment(process.env, isolated, hookUrl, runtime.hookToken);
+  env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${runtime.port}`;
+  const outputEvents = [];
+  let child;
+  let timedOut = false;
+  try {
+    child = spawn("claude", [
+      "--print",
+      "--model", options.model,
+      "--input-format", "stream-json",
+      "--output-format", "stream-json",
+      "--verbose",
+      "--include-hook-events",
+      "--session-id", sessionId,
+      "--tools", "",
+      "--settings", isolated.settingsPath,
+      "--setting-sources", "user",
+      "--autocompact", "auto",
+    ], { cwd: isolated.directory, env, stdio: ["pipe", "pipe", "pipe"] });
+    const prompts = [
+      `Remember the exact canary MODEL_CANARY=${canary}. Reply exactly STORED_AUTO.`,
+      `The durable session state is MODEL_CANARY=${canary}; preserve it across any context compaction. FLEET_PRESSURE_CHECKPOINT. Reply exactly PRESSURE_READY.`,
+      "Continue after the pressure checkpoint. Reply exactly AFTER_AUTO_COMPACT.",
+      "Reply exactly RECALL_AUTO=<the exact MODEL_CANARY value from before compaction>.",
+    ];
+    let sent = 0;
+    const sendNext = () => {
+      const content = prompts[sent++];
+      if (content === undefined) child.stdin.end();
+      else child.stdin.write(`${JSON.stringify({ type: "user", session_id: sessionId, message: { role: "user", content } })}\n`);
+    };
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      const lines = stdout.split("\n");
+      stdout = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line);
+          outputEvents.push(event);
+          if (event.type === "result") sendNext();
+        } catch { /* stream-json 외 진단 텍스트는 판정에 쓰지 않는다. */ }
+      }
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.exitCode === null && child.kill("SIGKILL"), 2_000).unref();
+    }, options.timeoutMs);
+    sendNext();
+    const exit = await waitForExit(child);
+    clearTimeout(timeout);
+    const statuses = outputEvents.filter((event) => event.type === "system" && event.subtype === "status");
+    const resultText = outputEvents.filter((event) => event.type === "result").map((event) => String(event.result ?? "")).join("\n");
+    const compactPathSucceeded = options.simulateCompactFailure
+      ? runtime.diagnostics.some((event) => event.event === "openai_compact_failure_injected")
+        && runtime.diagnostics.some((event) => event.event === "claude_summary_fallback")
+        && runtime.diagnostics.some(
+          (event) => event.event === "claude_fallback_summary_rendered" && event.containsCanary,
+        )
+        && !runtime.diagnostics.some((event) => event.event === "openai_compact_completed")
+      : runtime.diagnostics.some((event) => event.event === "openai_compact_completed")
+        && runtime.diagnostics.some((event) => event.event === "openai_compaction_replayed" && event.outputContainsCanary);
+    const success = !timedOut
+      && exit.code === 0
+      && statuses.some((event) => event.status === "compacting")
+      && statuses.some((event) => event.compact_result === "success")
+      && runtime.diagnostics.some((event) => event.event === "pre_compact_hook" && event.trigger === "auto")
+      && runtime.diagnostics.some((event) => event.event === "post_compact_hook" && event.trigger === "auto")
+      && compactPathSucceeded
+      && resultText.includes(canary);
+    return {
+      mode: "auto",
+      success,
+      claudeCodeVersion: outputEvents.find((event) => event.type === "system" && event.subtype === "init")?.claude_code_version ?? null,
+      timedOut,
+      exit,
+      compactingObserved: statuses.some((event) => event.status === "compacting"),
+      compactResult: statuses.findLast((event) => Object.hasOwn(event, "compact_result"))?.compact_result ?? null,
+      resultContainsCanary: resultText.includes(canary),
+      stderrPresent: stderr.trim().length > 0,
+      diagnostics: runtime.diagnostics,
+    };
+  } finally {
+    if (child?.exitCode === null) child.kill("SIGKILL");
+    await runtime.close();
+    await rm(isolated.directory, { recursive: true, force: true });
+  }
+}
+
+async function runManualScenario(gateway, options) {
+  const runtime = await createProbeRuntime(gateway, options, "manual");
+  const isolated = await createIsolatedClaudeEnvironment(options);
+  const canary = `MANUAL-${randomUUID().slice(0, 8).toUpperCase()}`;
+  const manualDirective = `DIRECTIVE-${randomUUID().slice(0, 8).toUpperCase()}`;
+  runtime.setExpectedCanary(canary);
+  runtime.setExpectedManualDirective(manualDirective);
+  const hookUrl = `http://127.0.0.1:${runtime.port}/v1/compact-events`;
+  const env = claudeEnvironment(process.env, isolated, hookUrl, runtime.hookToken);
+  env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${runtime.port}`;
+  // Manual slash commands require the interactive TUI. Reuse only the real Claude
+  // installation's onboarding/auth state; config, hooks, transcript and provider routing
+  // remain isolated, and the caller credential terminates at this loopback proxy.
+  env.HOME = os.homedir();
+  delete env.ANTHROPIC_API_KEY;
+  delete env.CLAUDE_CONFIG_DIR;
+  delete env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+  const sessionId = randomUUID();
+  const require = createRequire(path.join(repositoryRoot, "runtime/fleet-console/package.json"));
+  const nodePty = require("node-pty");
+  let pty;
+  let terminalBytes = 0;
+  let terminalTail = "";
+  let lastTerminalDataAt = Date.now();
+  let exited = false;
+  try {
+    pty = nodePty.spawn("claude", [
+      "--model", options.model,
+      "--tools", "",
+      "--permission-mode", "dontAsk",
+      "--settings", isolated.settingsPath,
+      "--setting-sources", "",
+      "--session-id", sessionId,
+      "--autocompact", "auto",
+    ], {
+      cols: 120,
+      rows: 40,
+      cwd: repositoryRoot,
+      env,
+      name: "xterm-256color",
+    });
+    pty.onData((data) => {
+      terminalBytes += Buffer.byteLength(data);
+      terminalTail = (terminalTail + data).slice(-16_384);
+      lastTerminalDataAt = Date.now();
+    });
+    const exitPromise = new Promise((resolve) => pty.onExit((event) => {
+      exited = true;
+      resolve({ code: event.exitCode, signal: event.signal });
+    }));
+    const composerReady = () => {
+      const fingerprint = terminalFingerprint(terminalTail);
+      return fingerprint.includes("?forshortcuts")
+        || fingerprint.includes("shift+tabtocycle")
+        || fingerprint.includes("bypasspermissionson")
+        || fingerprint.includes("howcanclaudehelpyou");
+    };
+    const submitInteractiveText = async (text, expectedKind, label) => {
+      const hasExpectedIngress = () => runtime.diagnostics.some(
+        (event) => event.event === "anthropic_request" && event.kind === expectedKind,
+      );
+      pty.write("\x15");
+      pty.write(`${text}\r`);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      if (!hasExpectedIngress()) pty.write("\r");
+      await waitFor(hasExpectedIngress, 30_000, label);
+    };
+    await waitFor(composerReady, 30_000, "manual Claude TUI readiness");
+    await submitInteractiveText(
+      `Remember the exact canary MODEL_CANARY=${canary}. Reply exactly STORED_MANUAL.`,
+      "initial",
+      "manual initial ingress",
+    );
+    await waitFor(
+      () => runtime.diagnostics.filter((event) => event.event === "openai_turn_completed" && event.kind === "initial").length >= 1,
+      options.timeoutMs,
+      "manual initial turn",
+    );
+    await waitFor(() => Date.now() - lastTerminalDataAt >= 1_000, 30_000, "manual initial composer settle");
+    await submitInteractiveText(
+      `The durable session state is MODEL_CANARY=${canary}; preserve it across manual compaction. Reply exactly MANUAL_READY.`,
+      "boundary",
+      "manual boundary ingress",
+    );
+    await waitFor(
+      () => runtime.diagnostics.some((event) => event.event === "openai_turn_completed" && event.kind === "boundary"),
+      options.timeoutMs,
+      "manual boundary turn",
+    );
+    await waitFor(() => Date.now() - lastTerminalDataAt >= 1_000, 30_000, "manual boundary composer settle");
+    pty.write("\x15");
+    pty.write("/compact");
+    await waitFor(
+      () => terminalFingerprint(terminalTail).includes("freeupcontextbysummarizingtheconversationsofar"),
+      10_000,
+      "manual compact completion menu",
+    );
+    pty.write(" ");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    pty.write(`Preserve MODEL_CANARY=${canary} exactly, preserve the current task state, and preserve ${manualDirective}.`);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    pty.write("\r");
+    await waitFor(
+      () => runtime.diagnostics.some((event) => event.event === "pre_compact_hook" && event.trigger === "manual"),
+      30_000,
+      "manual PreCompact hook",
+    );
+    await waitFor(
+      () => runtime.diagnostics.some((event) => event.event === "post_compact_hook" && event.trigger === "manual"),
+      options.timeoutMs,
+      "manual PostCompact hook",
+    );
+    await waitFor(() => Date.now() - lastTerminalDataAt >= 1_000, 30_000, "manual post-compact composer settle");
+    await submitInteractiveText(
+      "Reply exactly RECALL_MANUAL=<the exact MODEL_CANARY value> DIRECTIVE=<the exact DIRECTIVE value from the compact instructions>.",
+      "recall",
+      "manual recall ingress",
+    );
+    await waitFor(
+      () => runtime.diagnostics.some((event) => event.event === "openai_compaction_replayed" && event.outputContainsCanary),
+      options.timeoutMs,
+      "manual compact replay",
+    );
+    pty.write("/exit\r");
+    const exit = await Promise.race([
+      exitPromise,
+      new Promise((resolve) => setTimeout(() => resolve({ code: null, signal: "timeout" }), 10_000)),
+    ]);
+    if (!exited) pty.kill();
+    const compactPathSucceeded = options.simulateCompactFailure
+      ? runtime.diagnostics.some((event) => event.event === "openai_compact_failure_injected")
+        && runtime.diagnostics.some((event) => event.event === "claude_summary_fallback")
+        && runtime.diagnostics.some(
+          (event) => event.event === "claude_fallback_summary_rendered" && event.containsCanary,
+        )
+        && !runtime.diagnostics.some((event) => event.event === "openai_compact_completed")
+      : runtime.diagnostics.some(
+          (event) => event.event === "openai_compact_request" && event.customInstructionsApplied,
+        )
+        && runtime.diagnostics.some((event) => event.event === "openai_compact_completed")
+        && runtime.diagnostics.some(
+          (event) => event.event === "openai_compaction_replayed"
+            && event.outputContainsCanary
+            && event.outputContainsManualDirective,
+        );
+    const success = runtime.diagnostics.some(
+      (event) => event.event === "pre_compact_hook"
+        && event.trigger === "manual"
+        && event.customInstructionsPresent,
+    )
+      && runtime.diagnostics.some((event) => event.event === "post_compact_hook" && event.trigger === "manual")
+      && compactPathSucceeded;
+    return {
+      mode: "manual",
+      success,
+      exit,
+      terminalBytes,
+      terminalTailSha256: sha256(terminalTail),
+      diagnostics: runtime.diagnostics,
+    };
+  } catch (error) {
+    if (process.env.FLEET_COMPACT_PROBE_TUI_LOG) {
+      await writeFile(path.resolve(process.env.FLEET_COMPACT_PROBE_TUI_LOG), terminalTail, { mode: 0o600 });
+    }
+    const recentDiagnostics = runtime.diagnostics.slice(-20);
+    const diagnostic = new Error(`${error instanceof Error ? error.message : String(error)}; terminalTailSha256=${sha256(terminalTail)}; terminalBytes=${terminalBytes}; recentDiagnostics=${JSON.stringify(recentDiagnostics)}`);
+    diagnostic.name = error instanceof Error ? error.name : "Error";
+    throw diagnostic;
+  } finally {
+    if (pty && !exited) {
+      try { pty.kill(); } catch { /* 이미 종료된 PTY다. */ }
+    }
+    await runtime.close();
+    await removeClaudeSessionArtifacts(sessionId);
+    await rm(isolated.directory, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  const gateway = await import("../dist/index.js");
+  const scenarios = [];
+  if (options.mode === "auto" || options.mode === "both") {
+    scenarios.push(await runAutoScenario(gateway, options));
+  }
+  if (options.mode === "manual" || options.mode === "both") {
+    scenarios.push(await runManualScenario(gateway, options));
+  }
+  const result = {
+    observedAt: new Date().toISOString(),
+    model: options.model,
+    provider: "codex",
+    compactContract: "responses-v2-compaction-trigger",
+    simulatedCompactFailure: options.simulateCompactFailure,
+    legacyCompactEndpointExpected: false,
+    successful: scenarios.every((scenario) => scenario.success),
+    scenarios,
+  };
+  const serialized = `${JSON.stringify(result)}\n`;
+  if (options.output) await writeFile(options.output, serialized, { mode: 0o600 });
+  process.stdout.write(serialized);
+  if (!result.successful) process.exitCode = 1;
+}
+
+try {
+  await main();
+} catch (error) {
+  if (error instanceof UsageError) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  } else {
+    process.stderr.write(`claude-codex compact probe failed: ${JSON.stringify(safeError(error))}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/core-ai-gateway/scripts/probe-claude-codex-product-runtime.mjs
+++ b/packages/core-ai-gateway/scripts/probe-claude-codex-product-runtime.mjs
@@ -1,0 +1,231 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const PRESSURE_INPUT_TOKENS = 256_000;
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function textFromInput(input) {
+  if (!Array.isArray(input)) return "";
+  return input.map((item) => {
+    if (typeof item?.content === "string") return item.content;
+    if (!Array.isArray(item?.content)) return "";
+    return item.content.map((part) => part?.text ?? "").join("");
+  }).join("\n");
+}
+
+function classify(body) {
+  const input = Array.isArray(body?.input) ? body.input : [];
+  const text = textFromInput(input.slice(-1));
+  if (input.at(-1)?.type === "compaction_trigger") return "compact";
+  if (input[0]?.type === "compaction" && input.length === 2) return "summary";
+  if (text.includes("Create a detailed plaintext handoff summary for another coding agent")) return "summary";
+  if (text.includes("FLEET_PRESSURE_CHECKPOINT")) return "pressure";
+  if (text.includes("The durable session state is MODEL_CANARY=")) return "boundary";
+  if (text.includes("Remember the exact canary MODEL_CANARY=")) return "initial";
+  if (text.includes("RECALL_AUTO=") || text.includes("RECALL_MANUAL=")) return "recall";
+  if (input[0]?.type === "compaction") return "replay";
+  return "other";
+}
+
+function parseEvents(text) {
+  const events = [];
+  for (const frame of text.split(/\r?\n\r?\n/)) {
+    const data = frame.split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trimStart())
+      .join("\n");
+    if (!data || data === "[DONE]") continue;
+    try { events.push(JSON.parse(data)); } catch {}
+  }
+  return events;
+}
+
+function rewritePressureUsage(text) {
+  const frames = [];
+  for (const frame of text.split(/(\r?\n\r?\n)/)) {
+    if (!frame || /^\r?\n\r?\n$/.test(frame)) {
+      frames.push(frame);
+      continue;
+    }
+    const lines = frame.split(/\r?\n/);
+    const dataIndex = lines.findIndex((line) => line.startsWith("data:"));
+    if (dataIndex === -1) {
+      frames.push(frame);
+      continue;
+    }
+    const raw = lines[dataIndex].slice(5).trimStart();
+    try {
+      const event = JSON.parse(raw);
+      if ((event.type === "response.created" || event.type === "response.completed") && event.response) {
+        event.response.usage = {
+          ...(event.response.usage ?? {}),
+          input_tokens: PRESSURE_INPUT_TOKENS,
+          cached_tokens: 0,
+          output_tokens: event.response.usage?.output_tokens ?? 0,
+        };
+        lines[dataIndex] = `data: ${JSON.stringify(event)}`;
+      }
+    } catch {}
+    frames.push(lines.join("\n"));
+  }
+  return frames.join("");
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") reject(new Error("product probe server did not expose a port"));
+      else resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server) {
+  if (!server.listening) return Promise.resolve();
+  server.closeAllConnections?.();
+  return new Promise((resolve) => server.close(resolve));
+}
+
+export async function createProductProbeRuntime(gateway, options, trigger) {
+  const target = gateway.findGatewayModel(options.model);
+  if (!target || target.provider !== "codex" || gateway.upstreamModelId(target) !== "gpt-5.6-luna") {
+    throw new Error(`model is not the live Luna target: ${options.model}`);
+  }
+  const auth = await gateway.readCodexSubscriptionAuth();
+  if (!auth) throw new Error("Codex subscription credential is unavailable");
+  const stateDir = await mkdtemp(path.join(os.tmpdir(), "fleet-product-compact-"));
+  const durable = gateway.createClaudeCodexCompactionStore({ directory: stateDir });
+  const hookToken = randomUUID();
+  const diagnostics = [];
+  let expectedCanary = "";
+  let expectedManualDirective = "";
+  const record = (event, fields = {}) => diagnostics.push({ sequence: diagnostics.length + 1, event, ...fields });
+  const store = {
+    ...durable,
+    recordPreCompact(input) {
+      durable.recordPreCompact(input);
+      record("pre_compact_hook", {
+        trigger: input.trigger,
+        customInstructionsPresent: !!input.customInstructions,
+      });
+    },
+    recordPostCompact(input) {
+      durable.recordPostCompact(input);
+      record("post_compact_hook", {
+        trigger,
+        summaryBytes: Buffer.byteLength(input.summary ?? ""),
+        summarySha256: input.summary ? sha256(input.summary) : null,
+      });
+    },
+  };
+
+  const fetchImpl = async (input, init) => {
+    let requestBody;
+    try { requestBody = JSON.parse(String(init?.body ?? "{}")); } catch { requestBody = {}; }
+    const kind = classify(requestBody);
+    record("anthropic_request", { kind });
+    if (kind === "compact" && options.simulateCompactFailure) {
+      record("openai_compact_failure_injected", { trigger });
+      return new Response('{"error":{"type":"invalid_request_error","message":"simulated compact failure"}}', {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (kind === "compact") {
+      record("openai_compact_request", {
+        trigger,
+        inputItems: requestBody.input?.length ?? 0,
+        inputTypes: requestBody.input?.map((item) => item?.type) ?? [],
+        instructionBytes: Buffer.byteLength(requestBody.instructions ?? ""),
+        customInstructionsApplied: expectedManualDirective.length > 0
+          && String(requestBody.instructions ?? "").includes(expectedManualDirective),
+      });
+    }
+    const upstream = await globalThis.fetch(input, init);
+    const originalText = await upstream.text();
+    const text = kind === "pressure" ? rewritePressureUsage(originalText) : originalText;
+    const events = parseEvents(text);
+    const completed = events.findLast((event) => event?.type === "response.completed");
+    if (completed) {
+      record("openai_turn_completed", {
+        kind,
+        inputTokens: completed.response?.usage?.input_tokens ?? null,
+        outputTokens: completed.response?.usage?.output_tokens ?? null,
+      });
+    }
+    if (kind === "compact") {
+      const items = events.filter((event) => event?.type === "response.output_item.done" && event.item?.type === "compaction");
+      if (items.length === 1) {
+        const encrypted = items[0].item.encrypted_content;
+        record("openai_compact_completed", {
+          status: upstream.status,
+          compactionItems: 1,
+          encryptedBytes: Buffer.byteLength(encrypted),
+          encryptedSha256: sha256(encrypted),
+        });
+      }
+    }
+    const outputText = events.filter((event) => event?.type === "response.output_text.delta").map((event) => event.delta).join("");
+    if (kind === "summary") {
+      const fallback = options.simulateCompactFailure;
+      if (fallback) record("claude_summary_fallback", { name: "Error", message: "simulated compact failure" });
+      record(fallback ? "claude_fallback_summary_rendered" : "claude_summary_rendered", {
+        outputBytes: Buffer.byteLength(outputText),
+        outputSha256: sha256(outputText),
+        containsCanary: expectedCanary.length > 0 && outputText.includes(expectedCanary),
+        containsManualDirective: expectedManualDirective.length > 0 && outputText.includes(expectedManualDirective),
+      });
+    } else if (kind === "replay" || kind === "recall") {
+      const compactItem = requestBody.input?.find((item) => item?.type === "compaction");
+      record("openai_compaction_replayed", {
+        encryptedSha256: typeof compactItem?.encrypted_content === "string" ? sha256(compactItem.encrypted_content) : null,
+        outputContainsCanary: expectedCanary.length > 0 && outputText.includes(expectedCanary),
+        outputContainsManualDirective: expectedManualDirective.length > 0 && outputText.includes(expectedManualDirective),
+      });
+    }
+    return new Response(text, { status: upstream.status, headers: upstream.headers });
+  };
+
+  const router = gateway.createAiGatewayRouter({
+    originator: "fleet-console",
+    readAuth: () => auth,
+    readCursorToken: () => null,
+    readXaiToken: () => null,
+    readAntigravityToken: () => null,
+    fetch: fetchImpl,
+    compactionStore: store,
+    compactionHookToken: hookToken,
+  });
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+      const handled = await router.handle({ req, res, pathname });
+      if (!handled && !res.writableEnded) res.writeHead(404).end();
+    })().catch(() => {
+      if (!res.headersSent) res.writeHead(500).end();
+      else if (!res.writableEnded) res.end();
+    });
+  });
+  const port = await listen(server);
+  return {
+    port,
+    hookToken,
+    diagnostics,
+    setExpectedCanary(value) { expectedCanary = value; },
+    setExpectedManualDirective(value) { expectedManualDirective = value; },
+    async close() {
+      await closeServer(server);
+      router.dispose();
+      await rm(stateDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/core-ai-gateway/src/canonical/index.ts
+++ b/packages/core-ai-gateway/src/canonical/index.ts
@@ -277,11 +277,18 @@ export interface CanonicalReasoningOutputItem {
   encrypted_content?: string;
 }
 
+export interface CanonicalCompactionOutputItem {
+  id?: string;
+  type: "compaction";
+  encrypted_content: string;
+}
+
 export type CanonicalOutputItem =
   | CanonicalMessageOutputItem
   | CanonicalFunctionCallOutputItem
   | CanonicalWebSearchCallOutputItem
-  | CanonicalReasoningOutputItem;
+  | CanonicalReasoningOutputItem
+  | CanonicalCompactionOutputItem;
 
 export type CanonicalResponseEvent =
   | {

--- a/packages/core-ai-gateway/src/downstream/harness/claude-code/context.ts
+++ b/packages/core-ai-gateway/src/downstream/harness/claude-code/context.ts
@@ -111,6 +111,66 @@ export function stripClaudeOneMillionMarker(modelId: string): string {
   return modelId.replace(/\[1m\]$/i, "");
 }
 
+/** Stable sentinels in Claude Code's own client-side compact request and replacement history. */
+export const CLAUDE_COMPACT_PROMPT_MARKER =
+  "CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.";
+export const CLAUDE_COMPACT_CONTINUATION_MARKER =
+  "This session is being continued from a previous conversation that ran out of context.";
+
+interface ClaudeCompactMessageLike {
+  readonly role?: unknown;
+  readonly content: unknown;
+}
+
+export function isClaudeCompactSummaryRequest(
+  messages: readonly ClaudeCompactMessageLike[],
+): boolean {
+  return messages.some((message) => message.role === "user"
+    && messageTextIncludes(message.content, CLAUDE_COMPACT_PROMPT_MARKER));
+}
+
+export function hasClaudeCompactContinuation(
+  messages: readonly ClaudeCompactMessageLike[],
+): boolean {
+  return messages.some((message) => message.role === "user"
+    && messageTextIncludes(message.content, CLAUDE_COMPACT_CONTINUATION_MARKER));
+}
+
+/** Remove only Claude's private compact instruction block; preserve the conversation it follows. */
+export function stripClaudeCompactPrompt<M extends ClaudeCompactMessageLike>(messages: readonly M[]): M[] {
+  return stripClaudeMessageBlocks(messages, CLAUDE_COMPACT_PROMPT_MARKER);
+}
+
+/** Remove Claude's plaintext replacement summary before replaying the provider's opaque checkpoint. */
+export function stripClaudeCompactContinuation<M extends ClaudeCompactMessageLike>(messages: readonly M[]): M[] {
+  return stripClaudeMessageBlocks(messages, CLAUDE_COMPACT_CONTINUATION_MARKER);
+}
+
+function stripClaudeMessageBlocks<M extends ClaudeCompactMessageLike>(
+  messages: readonly M[],
+  marker: string,
+): M[] {
+  return messages.flatMap((message) => {
+    if (message.role !== "user") return [message];
+    if (typeof message.content === "string") return message.content.includes(marker) ? [] : [message];
+    if (!Array.isArray(message.content)) return [message];
+    const content = message.content.filter((block) => !(
+      isRecord(block)
+      && block.type === "text"
+      && typeof block.text === "string"
+      && block.text.includes(marker)
+    ));
+    return content.length === 0 ? [] : [{ ...message, content } as M];
+  });
+}
+
+function messageTextIncludes(content: unknown, marker: string): boolean {
+  if (typeof content === "string") return content.includes(marker);
+  return Array.isArray(content) && content.some((block) => (
+    isRecord(block) && block.type === "text" && typeof block.text === "string" && block.text.includes(marker)
+  ));
+}
+
 /**
  * Map a provider model's occupied input onto the fixed coordinate Claude Code assigns
  * from its model id: 200k without `[1m]`, 1M with it.

--- a/packages/core-ai-gateway/src/downstream/wire/anthropic-messages/inbound.ts
+++ b/packages/core-ai-gateway/src/downstream/wire/anthropic-messages/inbound.ts
@@ -53,6 +53,14 @@ export interface AnthropicGatewayResponse {
 export class AnthropicMessagesGateway {
   constructor(private readonly adapter: AiGatewayAdapter = new OpenAIResponsesAdapter()) {}
 
+  async streamCanonical(
+    request: AnthropicMessagesRequest,
+    canonical: CanonicalResponseRequest,
+    options: AnthropicGatewayCallOptions,
+  ): Promise<AnthropicGatewayResponse> {
+    return this.streamTranslated(request, canonical, options);
+  }
+
   async stream(
     request: AnthropicMessagesRequest,
     options: AnthropicGatewayCallOptions
@@ -80,6 +88,14 @@ export class AnthropicMessagesGateway {
         ? { nativeTools: this.adapter.capabilities.nativeTools }
         : {}),
     });
+    return this.streamTranslated(request, canonical, options);
+  }
+
+  private async streamTranslated(
+    request: AnthropicMessagesRequest,
+    canonical: CanonicalResponseRequest,
+    options: AnthropicGatewayCallOptions,
+  ): Promise<AnthropicGatewayResponse> {
     wireLog("canonical.request", {
       model: canonical.model,
       tool_choice: canonical.tool_choice,
@@ -218,6 +234,7 @@ function estimateCanonicalRequestTokens(
     } else {
       parts.push(item.output);
     }
+
   }
   for (const tool of wireTools) {
     parts.push(tool.name);

--- a/packages/core-ai-gateway/src/router/router.ts
+++ b/packages/core-ai-gateway/src/router/router.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   AnthropicMessagesGateway,
   ContextWindowExceededError,
@@ -8,11 +10,14 @@ import {
 } from "../upstream/anthropic/native.js";
 import { claudeCodeHarnessProfile } from "../downstream/harness/claude-code/profile.js";
 import type { GatewayHarnessProfile } from "../downstream/harness/contract.js";
+import { translateAnthropicRequest } from "../downstream/wire/anthropic-messages/protocol.js";
 import type { AnthropicMessagesRequest } from "../downstream/wire/anthropic-messages/protocol.js";
 import { AntigravityGenerateContentAdapter } from "../upstream/antigravity/generate-content/adapter.js";
 import { resolveAntigravityCredentials } from "../upstream/antigravity/credentials.js";
 import { UnsupportedReasoningEffortError } from "../canonical/index.js";
 import { CodexResponsesAdapter } from "../upstream/codex/responses/adapter.js";
+import { compactCodexConversation } from "../upstream/codex/compaction.js";
+import type { ClaudeCodexCompactionStore } from "../upstream/codex/compaction-store.js";
 import { resolveCodexCredentials } from "../upstream/codex/credentials.js";
 import {
   CursorAdapter,
@@ -35,6 +40,12 @@ import {
 import type { GatewayModel } from "../models.js";
 import { DEFAULT_XAI_ENDPOINT_PREFERENCE, resolveAiGatewaySelection } from "../settings/index.js";
 import type { AiGatewayStoredSettings, XaiEndpointPreference } from "../settings/index.js";
+import {
+  hasClaudeCompactContinuation,
+  isClaudeCompactSummaryRequest,
+  stripClaudeCompactContinuation,
+  stripClaudeCompactPrompt,
+} from "../downstream/harness/claude-code/context.js";
 import type { CompactCeiling } from "../downstream/harness/claude-code/context.js";
 import { defaultCredentialDeps } from "../transport/credentials.js";
 import { findCauseCode } from "../transport/upstream-sse.js";
@@ -81,7 +92,7 @@ export const AI_GATEWAY_MODEL_ENV = "FLEET_AI_GATEWAY_MODEL";
  * `/v1/messages`를 떼면 남는 마지막 조각이 `grok`이다. 마운트 경로에 우연히 같은 이름이
  * 들어 있어도 그것은 접미 바로 앞이 아니므로 선택자가 되지 않는다.
  */
-const WIRE_ENDPOINT_SUFFIXES = ["/v1/messages", "/v1/models"] as const;
+const WIRE_ENDPOINT_SUFFIXES = ["/v1/messages", "/v1/models", "/v1/compact-events"] as const;
 
 /**
  * `/v1/messages` 본문의 상한.
@@ -195,6 +206,10 @@ export interface AiGatewayRouteDeps {
   readonly readKimiApiKey?: () => Promise<string | undefined>;
   readonly readOpencodeApiKey?: () => Promise<string | undefined>;
   readonly readModelOverride?: () => string | undefined;
+  /** Host-owned durable state for Claude Code -> Codex compaction. Absent keeps legacy behavior. */
+  readonly compactionStore?: ClaudeCodexCompactionStore;
+  /** Process-local hook credential injected into Fleet-launched Claude children. */
+  readonly compactionHookToken?: string;
   readonly cursorDiagnostics?: CursorDiagnosticSink;
   readonly fetch?: typeof fetch;
   /**
@@ -280,6 +295,13 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
   // 창을 감당 못 해 본문이 한 번 보류된 스킬들. 이 라우터가 사는 동안 유지해야
   // 다음 세션의 첫 요청부터 목록에서 빠진다 — 프로세스당 한 번만 낭비되는 턴이 된다.
   const withheldSkills = new Set<string>();
+  // Claude Code may retry the same summary request while the first compaction is still
+  // in flight. One provider checkpoint per session is the semantic operation; duplicate
+  // callers await it rather than spending and racing a second checkpoint into storage.
+  const codexCompactionFlights = new Map<
+    string,
+    ReturnType<typeof compactCodexConversation>
+  >();
   // 설정 리더가 있으면 노출은 opt-in(켠 모델만)이다. 미주입(테스트 하네스 등)일 때만
   // 전체 카탈로그로 동작한다 — Console 배선(routes.ts)은 항상 리더를 주입한다.
   const gatewaySettings = (): AiGatewayStoredSettings | undefined => (
@@ -337,6 +359,44 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
     if (servedHarnesses.some((profile) => profile.probePaths.some((probePath) => pathname.endsWith(probePath)))) {
       res.writeHead(200, { "content-type": "application/json" });
       res.end("{}");
+      return true;
+    }
+    if (pathname.endsWith("/v1/compact-events")) {
+      if (req.method !== "POST") {
+        writeAnthropicError(res, 405, "invalid_request_error", "Method not allowed");
+        return true;
+      }
+      const hookToken = req.headers["x-fleet-compact-token"];
+      if (!deps.compactionStore || !deps.compactionHookToken || hookToken !== deps.compactionHookToken) {
+        writeAnthropicError(res, 401, "authentication_error", "Invalid compact hook credential");
+        return true;
+      }
+      try {
+        const event = await readJsonBody<Record<string, unknown>>(req, 4 * 1024 * 1024);
+        if (!event || typeof event.session_id !== "string") {
+          writeAnthropicError(res, 400, "invalid_request_error", "Invalid compact event");
+          return true;
+        }
+        if (event.hook_event_name === "PreCompact") {
+          deps.compactionStore.recordPreCompact({
+            sessionId: event.session_id,
+            trigger: event.trigger === "manual" ? "manual" : "auto",
+            customInstructions: typeof event.custom_instructions === "string" ? event.custom_instructions : "",
+          });
+        } else if (event.hook_event_name === "PostCompact") {
+          deps.compactionStore.recordPostCompact({
+            sessionId: event.session_id,
+            summary: typeof event.compact_summary === "string" ? event.compact_summary : "",
+          });
+        } else {
+          writeAnthropicError(res, 400, "invalid_request_error", "Unknown compact event");
+          return true;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end('{"ok":true}');
+      } catch {
+        writeAnthropicError(res, 400, "invalid_request_error", "Invalid compact event");
+      }
       return true;
     }
     // 하네스의 gateway model discovery. 이게 있어야 Claude Code의 /model picker에 GPT가 뜬다.
@@ -401,6 +461,14 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
       writeAnthropicError(res, 403, "permission_error", `AI gateway model is not enabled: ${requested}`);
       return true;
     }
+
+    const sessionId = claudeSessionId(body.metadata?.user_id);
+    const compactSummary = target?.provider === "codex"
+      && sessionId !== undefined
+      && isClaudeCompactSummaryRequest(body.messages)
+      ? deps.compactionStore?.readPending(sessionId)
+      : undefined;
+    if (compactSummary) body = { ...body, messages: stripClaudeCompactPrompt(body.messages) };
 
     // 대상을 가리지 않고 모든 요청에 닿아야 하는 다듬기는 하네스가 선언한다. 게이트웨이 대상이
     // 없는 네이티브 Anthropic까지 덮어야 하므로 아래 공급자 정책으로 내려갈 수 없다.
@@ -512,6 +580,13 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
         );
         return true;
       }
+      const codexAdapter = target.provider === "codex"
+        ? new CodexResponsesAdapter({
+            accountId: chatgptAccountId,
+            headers: { originator: deps.originator },
+            fetch: fetchImpl,
+          })
+        : undefined;
       const gateway = deps.gateway
         ?? (target.provider === "cursor"
           ? ownedCursorGateway!
@@ -527,7 +602,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
               }))
               : target.provider === "antigravity"
                 ? antigravityGateway()
-                : createGatewayFor(target, chatgptAccountId, deps.originator, fetchImpl));
+                : new AnthropicMessagesGateway(codexAdapter!));
       const diagnosticsEnabled = target.provider === "cursor"
         ? cursorDiagnosticsEnabled()
         : undefined;
@@ -538,7 +613,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
         && target.contextWindow > 0
         ? target.contextWindow
         : undefined;
-      const upstream = await gateway.stream(body, {
+      const callOptions = {
         apiKey: credential,
         ...(claudeContextWindow ? { contextWindow: claudeContextWindow } : {}),
         ...(projection === undefined ? {} : { projectInputTokens: projection }),
@@ -554,7 +629,81 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
         ...(target.provider !== "cursor" && target.effort.supported
           ? { reasoningEfforts: target.effort.levels }
           : {}),
-      });
+      };
+
+      if (compactSummary && codexAdapter && sessionId) {
+        const binding = compactBinding(target.id, chatgptAccountId);
+        const completedRetry = deps.compactionStore?.readReady(sessionId, binding);
+        if (completedRetry) {
+          writeClaudeCompactMessage(res, body, completedRetry.summary, {
+            id: "msg_fleet_compact_retry",
+            model: upstreamModelId(target),
+            usage: null,
+          });
+          return true;
+        }
+        const canonical = translateAnthropicRequest(body, {
+          model: upstreamModelId(target),
+          ...(target.serviceTier ? { serviceTier: target.serviceTier } : {}),
+          ...(target.effort.supported ? { reasoningEfforts: target.effort.levels } : {}),
+          nativeTools: codexAdapter.capabilities.nativeTools,
+        });
+        let compactFlight = codexCompactionFlights.get(sessionId);
+        if (!compactFlight) {
+          compactFlight = compactCodexConversation({
+            adapter: codexAdapter,
+            request: canonical,
+            call: {
+              apiKey: credential,
+              ...(modelContextWindow === undefined ? {} : { modelContextWindow }),
+              signal: controller.signal,
+            },
+            customInstructions: compactSummary.customInstructions,
+            supportedEfforts: target.effort.supported ? target.effort.levels : undefined,
+          });
+          codexCompactionFlights.set(sessionId, compactFlight);
+          void compactFlight.finally(() => {
+            if (codexCompactionFlights.get(sessionId) === compactFlight) {
+              codexCompactionFlights.delete(sessionId);
+            }
+          }).catch(() => undefined);
+        }
+        const compacted = await compactFlight;
+        if (compacted.encryptedContent) {
+          deps.compactionStore?.writeReady(sessionId, {
+            binding,
+            encryptedContent: compacted.encryptedContent,
+            summary: compacted.summary,
+          });
+        }
+        // PostCompact is the authority that the client installed this response. Keep
+        // pending until then so a transport retry is still classified as compaction.
+        // PreCompact already invalidated any older ready checkpoint, so plaintext
+        // fallback cannot accidentally replay stale provider state.
+        writeClaudeCompactMessage(res, body, compacted.summary, compacted.summaryResponse);
+        return true;
+      }
+
+      let upstream;
+      if (target.provider === "codex" && sessionId && hasClaudeCompactContinuation(body.messages)) {
+        const ready = deps.compactionStore?.readReady(sessionId, compactBinding(target.id, chatgptAccountId));
+        if (ready) {
+          body = { ...body, messages: stripClaudeCompactContinuation(body.messages) };
+          const canonical = translateAnthropicRequest(body, {
+            model: upstreamModelId(target),
+            ...(target.serviceTier ? { serviceTier: target.serviceTier } : {}),
+            ...(target.effort.supported ? { reasoningEfforts: target.effort.levels } : {}),
+            nativeTools: codexAdapter?.capabilities.nativeTools,
+          });
+          canonical.input = [
+            { type: "compaction", encrypted_content: ready.encryptedContent },
+            ...canonical.input,
+          ] as typeof canonical.input;
+          upstream = await gateway.streamCanonical(body, canonical, callOptions);
+        }
+      }
+
+      upstream ??= await gateway.stream(body, callOptions);
       res.writeHead(upstream.status, headerEntries(upstream.headers));
       for await (const chunk of upstream.body) {
         if (!res.write(chunk)) await drain(res);
@@ -624,6 +773,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
     upstreamStats: () => upstreamGate.stats(),
     dispose: () => {
       upstreamGate.dispose();
+      codexCompactionFlights.clear();
       ownedCursorAdapter?.dispose();
     },
   };
@@ -679,24 +829,6 @@ async function proxyToKimi(
   });
 }
 
-function createGatewayFor(
-  model: GatewayModel,
-  chatgptAccountId: string,
-  originator: string,
-  fetchImpl: typeof fetch,
-): AnthropicMessagesGateway {
-  if (model.provider !== "codex") {
-    throw new TypeError(`Unsupported translated gateway provider: ${model.provider}`);
-  }
-  // 어댑터가 fetch를 받지 않으면 globalThis.fetch로 떨어져 게이트 밖에서 소켓을 연다.
-  // 그러면 이 라우터의 상한과 점유 보고가 이 공급자만 보지 못한다.
-  return new AnthropicMessagesGateway(new CodexResponsesAdapter({
-    accountId: chatgptAccountId,
-    headers: { originator },
-    fetch: fetchImpl,
-  }));
-}
-
 /**
  * Anthropic Messages 와이어가 자격증명을 싣는 두 자리의 값을, 실린 순서대로 꺼낸다.
  *
@@ -715,6 +847,94 @@ function createGatewayFor(
  * 이미 값이 있으면 덮지 않는다. 본문에 직접 싣는 클라이언트(Claude Code)의 값이 언제나
  * 이기며, 그래야 기존 동작이 글자 하나 바뀌지 않는다.
  */
+function claudeSessionId(rawUserId: unknown): string | undefined {
+  if (typeof rawUserId !== "string" || rawUserId.trim().length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(rawUserId) as { readonly session_id?: unknown };
+    if (typeof parsed.session_id === "string" && parsed.session_id.trim().length > 0) {
+      return parsed.session_id;
+    }
+  } catch {
+    // Non-JSON clients may already use a stable session id directly.
+  }
+  return rawUserId;
+}
+
+function compactBinding(modelId: string, accountId: string): string {
+  return createHash("sha256")
+    .update("fleet:codex-compaction:v1:")
+    .update(modelId)
+    .update("\0")
+    .update(accountId)
+    .digest("hex");
+}
+
+function writeClaudeCompactMessage(
+  res: GatewayProxyResponse,
+  request: AnthropicMessagesRequest,
+  summary: string,
+  response: import("../canonical/index.js").CanonicalResponseSnapshot,
+): void {
+  const usage = {
+    input_tokens: response.usage?.input_tokens ?? 0,
+    cache_read_input_tokens: response.usage?.cached_input_tokens ?? 0,
+    cache_creation_input_tokens: response.usage?.cache_write_input_tokens ?? 0,
+    output_tokens: response.usage?.output_tokens ?? 0,
+  };
+  if (request.stream === true) {
+    const frames = [
+      ["message_start", {
+        type: "message_start",
+        message: {
+          id: response.id,
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: request.model,
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { ...usage, output_tokens: 0 },
+        },
+      }],
+      ["content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }],
+      ["content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: summary },
+      }],
+      ["content_block_stop", { type: "content_block_stop", index: 0 }],
+      ["message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage,
+      }],
+      ["message_stop", { type: "message_stop" }],
+    ] as const;
+    res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8", "cache-control": "no-cache" });
+    const encoder = new TextEncoder();
+    for (const [event, data] of frames) {
+      res.write(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+    }
+    res.end();
+    return;
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({
+    id: response.id,
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text: summary }],
+    model: request.model,
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage,
+  }));
+}
+
 function withSessionIdentity(
   body: AnthropicMessagesRequest,
   harness: GatewayHarnessProfile,

--- a/packages/core-ai-gateway/src/upstream/codex/compaction-store.ts
+++ b/packages/core-ai-gateway/src/upstream/codex/compaction-store.ts
@@ -131,15 +131,19 @@ export function createClaudeCodexCompactionStore(options: {
       if (!ready || ready.binding !== binding || now() - ready.updatedAt > READY_TTL_MS) return undefined;
       return ready;
     },
-    writeReady: (sessionId, ready) => updateSession(sessionId, (current) => ({
-      ...current,
-      ready: {
-        binding: normalizeText(ready.binding, 256),
-        encryptedContent: normalizeText(ready.encryptedContent, MAX_ENCRYPTED_CONTENT_CHARS),
-        summary: normalizeText(ready.summary, MAX_SUMMARY_CHARS),
-        updatedAt: now(),
-      },
-    })),
+    writeReady: (sessionId, ready) => {
+      const encryptedContent = normalizeOpaqueCheckpoint(ready.encryptedContent);
+      if (!encryptedContent) return;
+      updateSession(sessionId, (current) => ({
+        ...current,
+        ready: {
+          binding: normalizeText(ready.binding, 256),
+          encryptedContent,
+          summary: normalizeText(ready.summary, MAX_SUMMARY_CHARS),
+          updatedAt: now(),
+        },
+      }));
+    },
     clear: (sessionId) => updateSession(sessionId, () => undefined),
   };
 }
@@ -170,7 +174,7 @@ function sanitizePending(value: unknown): ClaudeCompactPendingState | undefined 
 function sanitizeReady(value: unknown): ClaudeCompactReadyState | undefined {
   if (!isRecord(value) || typeof value.updatedAt !== "number" || !Number.isFinite(value.updatedAt)) return undefined;
   const binding = normalizeText(value.binding, 256);
-  const encryptedContent = normalizeText(value.encryptedContent, MAX_ENCRYPTED_CONTENT_CHARS);
+  const encryptedContent = normalizeOpaqueCheckpoint(value.encryptedContent);
   const summary = normalizeText(value.summary, MAX_SUMMARY_CHARS);
   if (!binding || !encryptedContent) return undefined;
   return { binding, encryptedContent, summary, updatedAt: value.updatedAt };
@@ -212,6 +216,12 @@ function normalizeSessionId(value: unknown): string {
 
 function normalizeText(value: unknown, maxChars: number): string {
   return typeof value === "string" ? value.slice(0, maxChars) : "";
+}
+
+function normalizeOpaqueCheckpoint(value: unknown): string {
+  return typeof value === "string" && value.length <= MAX_ENCRYPTED_CONTENT_CHARS
+    ? value
+    : "";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/core-ai-gateway/src/upstream/codex/compaction-store.ts
+++ b/packages/core-ai-gateway/src/upstream/codex/compaction-store.ts
@@ -1,0 +1,219 @@
+import path from "node:path";
+
+import { createDurableJsonStore } from "@dotobokuri/core-infra";
+
+export type ClaudeCompactTrigger = "auto" | "manual";
+
+export interface ClaudeCompactPendingState {
+  readonly trigger: ClaudeCompactTrigger;
+  readonly customInstructions: string;
+  readonly updatedAt: number;
+}
+
+export interface ClaudeCompactReadyState {
+  readonly binding: string;
+  readonly encryptedContent: string;
+  readonly summary: string;
+  readonly updatedAt: number;
+}
+
+export interface ClaudeCompactSessionState {
+  readonly pending?: ClaudeCompactPendingState;
+  readonly ready?: ClaudeCompactReadyState;
+}
+
+interface StoredClaudeCompactState {
+  readonly version: 1;
+  readonly sessions: Readonly<Record<string, ClaudeCompactSessionState>>;
+}
+
+export interface ClaudeCodexCompactionStore {
+  readonly path: string;
+  recordPreCompact(input: {
+    readonly sessionId: string;
+    readonly trigger: ClaudeCompactTrigger;
+    readonly customInstructions?: string;
+  }): void;
+  recordPostCompact(input: {
+    readonly sessionId: string;
+    readonly summary?: string;
+  }): void;
+  readPending(sessionId: string): ClaudeCompactPendingState | undefined;
+  clearPending(sessionId: string): void;
+  readReady(sessionId: string, binding: string): ClaudeCompactReadyState | undefined;
+  writeReady(sessionId: string, ready: Omit<ClaudeCompactReadyState, "updatedAt">): void;
+  clear(sessionId: string): void;
+}
+
+const STATE_FILE_NAME = "claude-codex-compaction.json";
+const MAX_SESSIONS = 16;
+const PENDING_TTL_MS = 10 * 60_000;
+const READY_TTL_MS = 30 * 24 * 60 * 60_000;
+const MAX_SESSION_ID_CHARS = 256;
+const MAX_CUSTOM_INSTRUCTIONS_CHARS = 16_000;
+const MAX_SUMMARY_CHARS = 512_000;
+const MAX_ENCRYPTED_CONTENT_CHARS = 1_000_000;
+
+export function createClaudeCodexCompactionStore(options: {
+  readonly directory: string;
+  readonly now?: () => number;
+}): ClaudeCodexCompactionStore {
+  const filePath = path.join(options.directory, STATE_FILE_NAME);
+  const now = options.now ?? Date.now;
+  const durable = createDurableJsonStore<StoredClaudeCompactState>({
+    filePath,
+    lockDir: `${filePath}.lock`,
+    sanitize: sanitizeStoredState,
+    sensitivity: "sensitive",
+  });
+
+  const updateSession = (
+    sessionId: string,
+    mutate: (current: ClaudeCompactSessionState) => ClaudeCompactSessionState | undefined,
+  ): void => {
+    const safeSessionId = normalizeSessionId(sessionId);
+    if (!safeSessionId) return;
+    durable.update((stored) => {
+      const sessions = pruneSessions(stored.sessions, now());
+      const next = mutate(sessions[safeSessionId] ?? {});
+      if (next === undefined || (next.pending === undefined && next.ready === undefined)) {
+        delete sessions[safeSessionId];
+      } else {
+        sessions[safeSessionId] = next;
+      }
+      return limitSessions({ version: 1, sessions });
+    });
+  };
+
+  return {
+    path: filePath,
+    recordPreCompact: (input) => {
+      const updatedAt = now();
+      updateSession(input.sessionId, () => ({
+        // A new compact invalidates the previous checkpoint immediately. If the new
+        // native attempt falls back to plaintext, replaying the old blob would silently
+        // restore a history the client has just replaced.
+        pending: {
+          trigger: input.trigger,
+          customInstructions: normalizeText(input.customInstructions, MAX_CUSTOM_INSTRUCTIONS_CHARS),
+          updatedAt,
+        },
+      }));
+    },
+    recordPostCompact: (input) => {
+      const summary = normalizeText(input.summary, MAX_SUMMARY_CHARS);
+      updateSession(input.sessionId, (current) => ({
+        ...current,
+        pending: undefined,
+        ...(current.ready === undefined
+          ? {}
+          : {
+              ready: {
+                ...current.ready,
+                ...(summary.length > 0 ? { summary } : {}),
+                updatedAt: now(),
+              },
+            }),
+      }));
+    },
+    readPending: (sessionId) => {
+      const safeSessionId = normalizeSessionId(sessionId);
+      if (!safeSessionId) return undefined;
+      const pending = sanitizeStoredState(durable.load()).sessions[safeSessionId]?.pending;
+      if (!pending || now() - pending.updatedAt > PENDING_TTL_MS) return undefined;
+      return pending;
+    },
+    clearPending: (sessionId) => updateSession(sessionId, (current) => ({ ...current, pending: undefined })),
+    readReady: (sessionId, binding) => {
+      const safeSessionId = normalizeSessionId(sessionId);
+      if (!safeSessionId) return undefined;
+      const ready = sanitizeStoredState(durable.load()).sessions[safeSessionId]?.ready;
+      if (!ready || ready.binding !== binding || now() - ready.updatedAt > READY_TTL_MS) return undefined;
+      return ready;
+    },
+    writeReady: (sessionId, ready) => updateSession(sessionId, (current) => ({
+      ...current,
+      ready: {
+        binding: normalizeText(ready.binding, 256),
+        encryptedContent: normalizeText(ready.encryptedContent, MAX_ENCRYPTED_CONTENT_CHARS),
+        summary: normalizeText(ready.summary, MAX_SUMMARY_CHARS),
+        updatedAt: now(),
+      },
+    })),
+    clear: (sessionId) => updateSession(sessionId, () => undefined),
+  };
+}
+
+function sanitizeStoredState(value: unknown): StoredClaudeCompactState {
+  const sessions: Record<string, ClaudeCompactSessionState> = {};
+  if (!isRecord(value) || !isRecord(value.sessions)) return { version: 1, sessions };
+  for (const [rawSessionId, rawState] of Object.entries(value.sessions)) {
+    const sessionId = normalizeSessionId(rawSessionId);
+    if (!sessionId || !isRecord(rawState)) continue;
+    const pending = sanitizePending(rawState.pending);
+    const ready = sanitizeReady(rawState.ready);
+    if (pending || ready) sessions[sessionId] = { ...(pending ? { pending } : {}), ...(ready ? { ready } : {}) };
+  }
+  return limitSessions({ version: 1, sessions });
+}
+
+function sanitizePending(value: unknown): ClaudeCompactPendingState | undefined {
+  if (!isRecord(value) || (value.trigger !== "auto" && value.trigger !== "manual")) return undefined;
+  if (typeof value.updatedAt !== "number" || !Number.isFinite(value.updatedAt)) return undefined;
+  return {
+    trigger: value.trigger,
+    customInstructions: normalizeText(value.customInstructions, MAX_CUSTOM_INSTRUCTIONS_CHARS),
+    updatedAt: value.updatedAt,
+  };
+}
+
+function sanitizeReady(value: unknown): ClaudeCompactReadyState | undefined {
+  if (!isRecord(value) || typeof value.updatedAt !== "number" || !Number.isFinite(value.updatedAt)) return undefined;
+  const binding = normalizeText(value.binding, 256);
+  const encryptedContent = normalizeText(value.encryptedContent, MAX_ENCRYPTED_CONTENT_CHARS);
+  const summary = normalizeText(value.summary, MAX_SUMMARY_CHARS);
+  if (!binding || !encryptedContent) return undefined;
+  return { binding, encryptedContent, summary, updatedAt: value.updatedAt };
+}
+
+function pruneSessions(
+  source: Readonly<Record<string, ClaudeCompactSessionState>>,
+  currentTime: number,
+): Record<string, ClaudeCompactSessionState> {
+  const sessions: Record<string, ClaudeCompactSessionState> = {};
+  for (const [sessionId, state] of Object.entries(source)) {
+    const pending = state.pending && currentTime - state.pending.updatedAt <= PENDING_TTL_MS
+      ? state.pending
+      : undefined;
+    const ready = state.ready && currentTime - state.ready.updatedAt <= READY_TTL_MS
+      ? state.ready
+      : undefined;
+    if (pending || ready) sessions[sessionId] = { ...(pending ? { pending } : {}), ...(ready ? { ready } : {}) };
+  }
+  return sessions;
+}
+
+function limitSessions(state: StoredClaudeCompactState): StoredClaudeCompactState {
+  const entries = Object.entries(state.sessions)
+    .sort((left, right) => sessionUpdatedAt(right[1]) - sessionUpdatedAt(left[1]))
+    .slice(0, MAX_SESSIONS);
+  return { version: 1, sessions: Object.fromEntries(entries) };
+}
+
+function sessionUpdatedAt(state: ClaudeCompactSessionState): number {
+  return Math.max(state.pending?.updatedAt ?? 0, state.ready?.updatedAt ?? 0);
+}
+
+function normalizeSessionId(value: unknown): string {
+  return typeof value === "string" && value.length > 0 && value.length <= MAX_SESSION_ID_CHARS
+    ? value
+    : "";
+}
+
+function normalizeText(value: unknown, maxChars: number): string {
+  return typeof value === "string" ? value.slice(0, maxChars) : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/core-ai-gateway/src/upstream/codex/compaction.ts
+++ b/packages/core-ai-gateway/src/upstream/codex/compaction.ts
@@ -1,0 +1,206 @@
+import type {
+  AdapterCallOptions,
+  CanonicalCompactionOutputItem,
+  CanonicalInputItem,
+  CanonicalResponseRequest,
+  CanonicalResponseSnapshot,
+  ReasoningEffort,
+} from "../../canonical/index.js";
+import { clampReasoningEffort } from "../../canonical/index.js";
+
+import type { CodexResponsesAdapter } from "./responses/adapter.js";
+
+export interface CodexCompactionResult {
+  readonly encryptedContent?: string;
+  readonly nativeCompaction: boolean;
+  readonly summary: string;
+  readonly summaryResponse: CanonicalResponseSnapshot;
+}
+
+const SUMMARY_INSTRUCTION = [
+  "Create a detailed plaintext handoff summary for another coding agent.",
+  "Preserve exact identifiers, durable state, user constraints, completed work, pending work, and errors.",
+  "Return only the handoff summary.",
+].join(" ");
+
+const OPAQUE_SUMMARY_INSTRUCTION = [
+  "Render the compacted conversation as a detailed plaintext handoff summary for another coding agent.",
+  "Preserve exact identifiers, durable state, user constraints, completed work, pending work, and errors.",
+  "Return only the handoff summary and do not mention opaque provider state.",
+].join(" ");
+
+export async function compactCodexConversation(options: {
+  readonly adapter: CodexResponsesAdapter;
+  readonly request: CanonicalResponseRequest;
+  readonly call: AdapterCallOptions;
+  readonly customInstructions?: string;
+  readonly supportedEfforts?: readonly ReasoningEffort[];
+}): Promise<CodexCompactionResult> {
+  let encryptedContent: string | undefined;
+  try {
+    encryptedContent = await requestNativeCompaction(options);
+  } catch {
+    // The plaintext fallback is an explicit second contract. Claude Code's own compact
+    // prompt was measured to produce a 14-byte summary on Luna and lose durable state.
+  }
+
+  const rendered = encryptedContent
+    ? await renderOpaqueSummary(options, encryptedContent).catch(() => summarizePlaintext(options))
+    : await summarizePlaintext(options);
+  return {
+    ...(encryptedContent ? { encryptedContent } : {}),
+    nativeCompaction: encryptedContent !== undefined,
+    summary: rendered.summary,
+    summaryResponse: rendered.response,
+  };
+}
+
+async function requestNativeCompaction(options: {
+  readonly adapter: CodexResponsesAdapter;
+  readonly request: CanonicalResponseRequest;
+  readonly call: AdapterCallOptions;
+  readonly customInstructions?: string;
+}): Promise<string> {
+  const customInstructions = options.customInstructions?.trim();
+  const request = {
+    ...options.request,
+    input: [
+      ...options.request.input,
+      ...(customInstructions
+        ? [{
+            type: "message",
+            role: "user",
+            content: `Additional compact instructions. Obey these instructions and preserve their durable content in the checkpoint:\n${customInstructions}`,
+          }]
+        : []),
+      { type: "compaction_trigger" },
+    ],
+    instructions: joinInstructions(options.request.instructions, customInstructions),
+  } as unknown as CanonicalResponseRequest;
+  const response = await options.adapter.stream(request, options.call);
+  if (!response.ok) throw new Error(`Codex compaction failed with status ${response.status}`);
+
+  let completed = false;
+  const compacted: CanonicalCompactionOutputItem[] = [];
+  for await (const event of response.events) {
+    if (event.type === "response.output_item.done" && event.item.type === "compaction") {
+      compacted.push(event.item);
+    } else if (event.type === "response.completed") {
+      completed = true;
+    } else if (event.type === "response.failed") {
+      throw new Error(event.response.error.message);
+    } else if (event.type === "error") {
+      throw new Error(event.error.message);
+    }
+  }
+  if (!completed || compacted.length !== 1 || compacted[0]!.encrypted_content.length === 0) {
+    throw new Error(`Codex compaction expected one completed item, got ${compacted.length}`);
+  }
+  return compacted[0]!.encrypted_content;
+}
+
+async function renderOpaqueSummary(
+  options: {
+    readonly adapter: CodexResponsesAdapter;
+    readonly request: CanonicalResponseRequest;
+    readonly call: AdapterCallOptions;
+    readonly customInstructions?: string;
+    readonly supportedEfforts?: readonly ReasoningEffort[];
+  },
+  encryptedContent: string,
+): Promise<{ readonly summary: string; readonly response: CanonicalResponseSnapshot }> {
+  return collectSummary(
+    options.adapter,
+    {
+      model: options.request.model,
+      input: [
+        { type: "compaction", encrypted_content: encryptedContent },
+        {
+          type: "message",
+          role: "user",
+          content: options.customInstructions?.trim()
+            ? `${OPAQUE_SUMMARY_INSTRUCTION}\n\nPreserve this compact instruction in the handoff:\n${options.customInstructions.trim()}`
+            : OPAQUE_SUMMARY_INSTRUCTION,
+        },
+      ] as unknown as CanonicalInputItem[],
+      instructions: "Render the authoritative compacted state for another coding-agent harness.",
+      parallel_tool_calls: false,
+      tool_choice: "none",
+      reasoning: {
+        summary: "auto",
+        effort: lowEffort(options.supportedEfforts),
+      },
+      metadata: options.request.metadata,
+      stream: true,
+    },
+    options.call,
+  );
+}
+
+async function summarizePlaintext(options: {
+  readonly adapter: CodexResponsesAdapter;
+  readonly request: CanonicalResponseRequest;
+  readonly call: AdapterCallOptions;
+  readonly customInstructions?: string;
+  readonly supportedEfforts?: readonly ReasoningEffort[];
+}): Promise<{ readonly summary: string; readonly response: CanonicalResponseSnapshot }> {
+  const instruction = options.customInstructions?.trim();
+  return collectSummary(
+    options.adapter,
+    {
+      model: options.request.model,
+      input: [
+        ...options.request.input,
+        {
+          type: "message",
+          role: "user",
+          content: instruction
+            ? `${SUMMARY_INSTRUCTION}\n\nAdditional compact instructions:\n${instruction}`
+            : SUMMARY_INSTRUCTION,
+        },
+      ],
+      instructions: options.request.instructions,
+      parallel_tool_calls: false,
+      tool_choice: "none",
+      reasoning: {
+        summary: "auto",
+        effort: lowEffort(options.supportedEfforts),
+      },
+      metadata: options.request.metadata,
+      stream: true,
+    },
+    options.call,
+  );
+}
+
+async function collectSummary(
+  adapter: CodexResponsesAdapter,
+  request: CanonicalResponseRequest,
+  call: AdapterCallOptions,
+): Promise<{ readonly summary: string; readonly response: CanonicalResponseSnapshot }> {
+  const response = await adapter.stream(request, call);
+  if (!response.ok) throw new Error(`Codex summary failed with status ${response.status}`);
+  let summary = "";
+  let completed: CanonicalResponseSnapshot | undefined;
+  for await (const event of response.events) {
+    if (event.type === "response.output_text.delta") summary += event.delta;
+    else if (event.type === "response.output_text.done" && summary.length === 0) summary = event.text;
+    else if (event.type === "response.completed") completed = event.response;
+    else if (event.type === "response.failed") throw new Error(event.response.error.message);
+    else if (event.type === "error") throw new Error(event.error.message);
+  }
+  if (!completed || summary.trim().length === 0) throw new Error("Codex summary returned no text");
+  return { summary, response: completed };
+}
+
+function joinInstructions(base: string | undefined, custom: string | undefined): string | undefined {
+  const compact = custom?.trim();
+  if (!compact) return base;
+  return [base, `Compact instructions:\n${compact}`].filter(Boolean).join("\n\n");
+}
+
+function lowEffort(
+  supported: readonly ReasoningEffort[] | undefined,
+): ReasoningEffort {
+  return clampReasoningEffort("low", supported);
+}

--- a/packages/core-ai-gateway/src/upstream/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/codex/responses/adapter.ts
@@ -592,6 +592,10 @@ function forOpenAIResponsesBackend(
   // rather than at each producer. `reasoning_content` is replay metadata only the Chat
   // Completions path consumes; this backend takes reasoning back as its own items.
   payload.input = request.input.map((item) => {
+    const wireType = (item as { type?: unknown }).type;
+    if (wireType === "compaction" || wireType === "compaction_trigger") {
+      return item;
+    }
     if (item.type === "function_call_output") {
       const {
         is_error: _isError,
@@ -600,7 +604,9 @@ function forOpenAIResponsesBackend(
       } = item;
       return wireItem;
     }
-    const { reasoning_content: _reasoningContent, ...wireItem } = item;
+    const { reasoning_content: _reasoningContent, ...wireItem } = item as CanonicalResponseRequest["input"][number] & {
+      reasoning_content?: string;
+    };
     return wireItem;
   });
 
@@ -1117,6 +1123,13 @@ function outputItem(value: unknown): CanonicalOutputItem | undefined {
       call_id: typeof item.call_id === "string" ? item.call_id : id,
       name: string(item.name, "item.name"),
       arguments: typeof item.arguments === "string" ? stripNullArguments(item.arguments) : ""
+    };
+  }
+  if (item.type === "compaction" || item.type === "compaction_summary") {
+    return {
+      type: "compaction",
+      ...(typeof item.id === "string" ? { id: item.id } : {}),
+      encrypted_content: string(item.encrypted_content, "item.encrypted_content"),
     };
   }
   if (item.type === "web_search_call") {

--- a/packages/core-ai-gateway/src/upstream/codex/responses/index.ts
+++ b/packages/core-ai-gateway/src/upstream/codex/responses/index.ts
@@ -1,1 +1,3 @@
 export * from "./adapter.js";
+export * from "../compaction.js";
+export * from "../compaction-store.js";

--- a/packages/core-ai-gateway/src/upstream/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/xai/responses/adapter.ts
@@ -913,6 +913,9 @@ async function* salvageXaiPendingCalls(
 
   for (const [key, call] of pending) {
     const args = completeXaiArguments(call) ?? "";
+    // Pending entries are created only for function_call items; keep that runtime
+    // invariant visible after CanonicalOutputItem gains another opaque item type.
+    if (call.added.item.type !== "function_call") continue;
     const item = { ...call.added.item, arguments: args } as typeof call.added.item;
     yield call.added;
     yield {

--- a/packages/core-ai-gateway/tests/downstream/harness/claude-code/compaction.test.ts
+++ b/packages/core-ai-gateway/tests/downstream/harness/claude-code/compaction.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CLAUDE_COMPACT_CONTINUATION_MARKER,
+  CLAUDE_COMPACT_PROMPT_MARKER,
+  hasClaudeCompactContinuation,
+  isClaudeCompactSummaryRequest,
+  stripClaudeCompactContinuation,
+  stripClaudeCompactPrompt,
+} from "../../../../src/index.js";
+
+describe("Claude Code compact request shapes", () => {
+  it("classifies and strips only the private compact prompt block", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "keep this" }] },
+      { role: "assistant", content: [{ type: "text", text: "kept" }] },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "boundary" },
+          { type: "text", text: `${CLAUDE_COMPACT_PROMPT_MARKER}\nSummarize the conversation.` },
+        ],
+      },
+    ];
+    expect(isClaudeCompactSummaryRequest(messages)).toBe(true);
+    expect(stripClaudeCompactPrompt(messages)).toEqual([
+      messages[0],
+      messages[1],
+      { role: "user", content: [{ type: "text", text: "boundary" }] },
+    ]);
+  });
+
+  it("classifies and removes Claude's replacement summary message", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: `${CLAUDE_COMPACT_CONTINUATION_MARKER}\n\nsummary` }],
+      },
+      { role: "assistant", content: [{ type: "text", text: "after compact" }] },
+      { role: "user", content: "continue" },
+    ];
+    expect(hasClaudeCompactContinuation(messages)).toBe(true);
+    expect(stripClaudeCompactContinuation(messages)).toEqual(messages.slice(1));
+  });
+
+  it("does not classify near-match user prose", () => {
+    const messages = [{ role: "user", content: "Please compact this conversation manually." }];
+    expect(isClaudeCompactSummaryRequest(messages)).toBe(false);
+    expect(hasClaudeCompactContinuation(messages)).toBe(false);
+    expect(stripClaudeCompactPrompt(messages)).toEqual(messages);
+  });
+});

--- a/packages/core-ai-gateway/tests/router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/router/routes.test.ts
@@ -1,8 +1,11 @@
 import {
   AnthropicMessagesGateway,
   CURSOR_TOOL_BYTES_LIMIT,
+  createClaudeCodexCompactionStore,
   ContextWindowExceededError,
   CursorAdapter,
+  CLAUDE_COMPACT_CONTINUATION_MARKER,
+  CLAUDE_COMPACT_PROMPT_MARKER,
 } from "../../src/index.js";
 import type {
   AdapterResponse,
@@ -13,6 +16,9 @@ import type {
 } from "../../src/index.js";
 import type { GatewayFailureRecord } from "../../src/index.js";
 import type { GatewayHttpHandlerContext } from "../../src/router/types.js";
+import { createHash } from "node:crypto";
+import path from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -108,6 +114,198 @@ describe("router lifecycle", () => {
     } finally {
       disposeSpy.mockRestore();
     }
+  });
+});
+
+describe("Claude Codex compaction routing", () => {
+  it("records hook events, compacts the summary request, and replays the opaque item", async () => {
+    const stored = new Map<string, any>();
+    const pending = new Map<string, any>();
+    const compactionStore = {
+      path: "/state.json",
+      recordPreCompact: ({ sessionId, trigger, customInstructions }: any) => pending.set(sessionId, { trigger, customInstructions, updatedAt: 1 }),
+      recordPostCompact: ({ sessionId, summary }: any) => {
+        const ready = stored.get(sessionId);
+        if (ready) stored.set(sessionId, { ...ready, summary });
+      },
+      readPending: (sessionId: string) => pending.get(sessionId),
+      clearPending: (sessionId: string) => pending.delete(sessionId),
+      readReady: (sessionId: string, binding: string) => stored.get(sessionId)?.binding === binding ? stored.get(sessionId) : undefined,
+      writeReady: (sessionId: string, ready: any) => stored.set(sessionId, { ...ready, updatedAt: 1 }),
+      clear: (sessionId: string) => { pending.delete(sessionId); stored.delete(sessionId); },
+    };
+    const upstreamBodies: any[] = [];
+    const fetchMock = vi.fn<typeof fetch>(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      upstreamBodies.push(body);
+      const isCompact = body.input?.at(-1)?.type === "compaction_trigger";
+      const isSummary = body.input?.[0]?.type === "compaction" && body.input?.length === 2;
+      const events = isCompact
+        ? [
+            { type: "response.created", response: { id: "compact", model: "gpt-5.6-luna", usage: null } },
+            { type: "response.output_item.done", output_index: 0, item: { type: "compaction", encrypted_content: "opaque-state" } },
+            { type: "response.completed", response: { id: "compact", model: "gpt-5.6-luna", usage: { input_tokens: 10, output_tokens: 5 } } },
+          ]
+        : isSummary
+          ? [
+              { type: "response.created", response: { id: "summary", model: "gpt-5.6-luna", usage: null } },
+              { type: "response.output_text.delta", item_id: "m", output_index: 0, content_index: 0, delta: "handoff CANARY" },
+              { type: "response.completed", response: { id: "summary", model: "gpt-5.6-luna", usage: { input_tokens: 2, output_tokens: 2 } } },
+            ]
+          : [
+              { type: "response.created", response: { id: "turn", model: "gpt-5.6-luna", usage: null } },
+              { type: "response.output_text.delta", item_id: "m", output_index: 0, content_index: 0, delta: "recalled CANARY" },
+              { type: "response.completed", response: { id: "turn", model: "gpt-5.6-luna", usage: { input_tokens: 3, output_tokens: 2 } } },
+            ];
+      return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), { status: 200 });
+    });
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      compactionStore,
+      compactionHookToken: "hook-token",
+    });
+    const userId = JSON.stringify({ session_id: "session-compact" });
+
+    const pre = response();
+    await router.handle(ctx({
+      res: pre,
+      pathname: `${BASE}/v1/compact-events`,
+      headers: { "x-fleet-compact-token": "hook-token" },
+      rawBody: {
+        hook_event_name: "PreCompact",
+        session_id: "session-compact",
+        trigger: "manual",
+        custom_instructions: "Preserve DIRECTIVE",
+      },
+    }));
+    expect(pre.status).toBe(200);
+
+    const compact = response();
+    await router.handle(ctx({
+      res: compact,
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-luna",
+      metadata: { user_id: userId },
+      messages: [
+        { role: "user", content: "CANARY" },
+        { role: "assistant", content: [{ type: "text", text: "stored" }] },
+        { role: "user", content: [{ type: "text", text: `boundary\n\n${CLAUDE_COMPACT_PROMPT_MARKER}` }] },
+      ],
+    }));
+    expect(compact.status).toBe(200);
+    expect(compact.headers["content-type"]).toContain("text/event-stream");
+    expect(compact.body).toContain("handoff CANARY");
+    expect(upstreamBodies[0].input.at(-1)).toEqual({ type: "compaction_trigger" });
+    expect(upstreamBodies[0].instructions).toContain("Preserve DIRECTIVE");
+
+    // A response-body retry before PostCompact returns the stored summary and does not
+    // spend another provider compaction or summary turn.
+    const compactRetry = response();
+    await router.handle(ctx({
+      res: compactRetry,
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-luna",
+      metadata: { user_id: userId },
+      messages: [
+        { role: "user", content: "CANARY" },
+        { role: "assistant", content: [{ type: "text", text: "stored" }] },
+        { role: "user", content: [{ type: "text", text: `boundary\n\n${CLAUDE_COMPACT_PROMPT_MARKER}` }] },
+      ],
+    }));
+    expect(compactRetry.body).toContain("handoff CANARY");
+    expect(upstreamBodies).toHaveLength(2);
+
+    const post = response();
+    await router.handle(ctx({
+      res: post,
+      pathname: `${BASE}/v1/compact-events`,
+      headers: { "x-fleet-compact-token": "hook-token" },
+      rawBody: {
+        hook_event_name: "PostCompact",
+        session_id: "session-compact",
+        trigger: "manual",
+        compact_summary: "handoff CANARY",
+      },
+    }));
+    expect(post.status).toBe(200);
+
+    const continuation = response();
+    await router.handle(ctx({
+      res: continuation,
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-luna",
+      metadata: { user_id: userId },
+      messages: [
+        { role: "user", content: `${CLAUDE_COMPACT_CONTINUATION_MARKER}\n\nhandoff CANARY` },
+        { role: "assistant", content: [{ type: "text", text: "after compact" }] },
+        { role: "user", content: "recall" },
+      ],
+    }));
+    expect(continuation.status).toBe(200);
+    expect(continuation.body).toContain("recalled CANARY");
+    expect(upstreamBodies.at(-1).input[0]).toEqual({ type: "compaction", encrypted_content: "opaque-state" });
+    expect(JSON.stringify(upstreamBodies.at(-1).input)).not.toContain(CLAUDE_COMPACT_CONTINUATION_MARKER);
+  });
+
+  it("replays a durable checkpoint after the router and store are recreated", async () => {
+    const fixture = wireLogFixture("compact-resume-");
+    const directory = path.dirname(fixture.path);
+    const firstStore = createClaudeCodexCompactionStore({ directory });
+    firstStore.writeReady("resumed-session", {
+      binding: createHash("sha256")
+        .update("fleet:codex-compaction:v1:")
+        .update("codex--gpt-5.6-luna")
+        .update("\0")
+        .update(ACCOUNT_ID)
+        .digest("hex"),
+      encryptedContent: "durable-opaque",
+      summary: "durable summary",
+    });
+    const bodies: any[] = [];
+    const fetchMock = vi.fn<typeof fetch>(async (_url, init) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return new Response([
+        `data: ${JSON.stringify({ type: "response.created", response: { id: "turn", model: "gpt-5.6-luna", usage: null } })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.output_text.delta", item_id: "m", output_index: 0, content_index: 0, delta: "resumed" })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.completed", response: { id: "turn", model: "gpt-5.6-luna", usage: { input_tokens: 1, output_tokens: 1 } } })}\n\n`,
+      ].join(""), { status: 200 });
+    });
+    const router = createAiGatewayRouter({
+      fetch: fetchMock,
+      readAuth,
+      compactionStore: createClaudeCodexCompactionStore({ directory }),
+      compactionHookToken: "new-process-token",
+    });
+    const res = response();
+    await router.handle(ctx({
+      res,
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-luna",
+      metadata: { user_id: JSON.stringify({ session_id: "resumed-session" }) },
+      messages: [
+        { role: "user", content: `${CLAUDE_COMPACT_CONTINUATION_MARKER}\n\ndurable summary` },
+        { role: "user", content: "continue after restart" },
+      ],
+    }));
+    expect(res.status).toBe(200);
+    expect(bodies[0].input[0]).toEqual({ type: "compaction", encrypted_content: "durable-opaque" });
+    fixture.cleanup();
+  });
+
+  it("refuses compact events without the process token", async () => {
+    const router = createAiGatewayRouter({
+      readAuth,
+      compactionStore: {} as any,
+      compactionHookToken: "hook-token",
+    });
+    const res = response();
+    await router.handle(ctx({
+      res,
+      pathname: `${BASE}/v1/compact-events`,
+      rawBody: { hook_event_name: "PreCompact", session_id: "session", trigger: "auto" },
+    }));
+    expect(res.status).toBe(401);
   });
 });
 
@@ -2505,8 +2703,10 @@ function ctx(options: {
   readonly messages?: ReadonlyArray<Record<string, unknown>>;
   readonly tools?: ReadonlyArray<Record<string, unknown>>;
   readonly toolChoice?: Record<string, unknown>;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly rawBody?: unknown;
 }): GatewayHttpHandlerContext {
-  const payload = JSON.stringify({
+  const payload = JSON.stringify(options.rawBody ?? {
     model: options.model ?? "claude-gateway--codex--gpt-5.6-sol",
     messages: options.messages ?? [{ role: "user", content: "Hello" }],
     max_tokens: 128,
@@ -2524,6 +2724,7 @@ function ctx(options: {
     headers: {
       ...(options.token === undefined ? {} : { authorization: `Bearer ${options.token}` }),
       ...(options.apiKey === undefined ? {} : { "x-api-key": options.apiKey }),
+      ...options.headers,
     },
     once: () => undefined,
     off: () => undefined,

--- a/packages/core-ai-gateway/tests/scripts/claude-codex-compact-probe.test.ts
+++ b/packages/core-ai-gateway/tests/scripts/claude-codex-compact-probe.test.ts
@@ -1,0 +1,76 @@
+import { copyFileSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+const packageRoot = path.resolve(import.meta.dirname, "../..");
+const sourceScript = path.join(packageRoot, "scripts/probe-claude-codex-compact.mjs");
+
+function runScript(scriptPath: string, ...args: string[]) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_HOME: path.join(packageRoot, "credential-path-must-not-be-read"),
+    },
+  });
+}
+
+function copyScriptWithoutDist() {
+  const directory = mkdtempSync(path.join(tmpdir(), "claude-codex-compact-probe-"));
+  temporaryDirectories.push(directory);
+  const scriptPath = path.join(directory, "probe-claude-codex-compact.mjs");
+  copyFileSync(sourceScript, scriptPath);
+  return { directory, scriptPath };
+}
+
+afterEach(() => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+    if (directory) rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Claude Code Codex compact probe", () => {
+  it("shows help before loading dist, credentials, node-pty, or network code", () => {
+    const fixture = copyScriptWithoutDist();
+    const result = runScript(fixture.scriptPath, "--help");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("compaction_trigger");
+    expect(result.stdout).toContain("real Luna quota");
+    expect(result.stdout).toContain("Credentials, prompts, summaries, and opaque blobs are never written");
+    const source = readFileSync(sourceScript, "utf8");
+    expect(source).toContain('CLAUDE_CODE_SKIP_PROMPT_HISTORY: "1"');
+    expect(source).toContain("removeClaudeSessionArtifacts(sessionId)");
+    expect(result.stderr).toBe("");
+  });
+
+  it("requires explicit live-provider consent before importing dist or reading credentials", () => {
+    const fixture = copyScriptWithoutDist();
+    const result = runScript(fixture.scriptPath, "--mode", "auto");
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--confirm-live-provider");
+    expect(result.stdout).toBe("");
+  });
+
+  it("rejects unsupported modes and non-Luna models as usage errors", () => {
+    const unsupportedMode = runScript(sourceScript, "--mode", "fixture");
+    expect(unsupportedMode.status).toBe(2);
+    expect(unsupportedMode.stderr).toContain("auto, manual, or both");
+
+    const wrongModel = runScript(
+      sourceScript,
+      "--model",
+      "claude-gateway--codex--gpt-5.6-sol",
+      "--confirm-live-provider",
+    );
+    expect(wrongModel.status).toBe(2);
+    expect(wrongModel.stderr).toContain("gpt-5.6-luna");
+  });
+});

--- a/packages/core-ai-gateway/tests/upstream/codex/compaction-store.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/codex/compaction-store.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createClaudeCodexCompactionStore } from "../../../src/index.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function root(): string {
+  const value = mkdtempSync(path.join(tmpdir(), "fleet-compact-store-"));
+  roots.push(value);
+  return value;
+}
+
+describe("Claude Codex compaction store", () => {
+  it("persists pending, ready, and post-compact summary state across instances", () => {
+    let now = 1_000;
+    const directory = root();
+    const first = createClaudeCodexCompactionStore({ directory, now: () => now });
+    first.recordPreCompact({ sessionId: "session-1", trigger: "manual", customInstructions: "keep directive" });
+    expect(first.readPending("session-1")).toMatchObject({ trigger: "manual", customInstructions: "keep directive" });
+    first.clearPending("session-1");
+    expect(first.readPending("session-1")).toBeUndefined();
+    first.writeReady("session-1", { binding: "binding-1", encryptedContent: "opaque", summary: "initial" });
+    now += 1;
+    first.recordPostCompact({ sessionId: "session-1", summary: "authoritative summary" });
+
+    const second = createClaudeCodexCompactionStore({ directory, now: () => now });
+    expect(second.readReady("session-1", "binding-1")).toMatchObject({
+      binding: "binding-1",
+      encryptedContent: "opaque",
+      summary: "authoritative summary",
+    });
+    expect(second.readReady("session-1", "wrong-binding")).toBeUndefined();
+  });
+
+  it("expires pending state and bounds the number of stored sessions", () => {
+    let now = 0;
+    const directory = root();
+    const store = createClaudeCodexCompactionStore({ directory, now: () => now });
+    store.recordPreCompact({ sessionId: "expired", trigger: "auto" });
+    now = 11 * 60_000;
+    expect(store.readPending("expired")).toBeUndefined();
+
+    for (let index = 0; index < 40; index += 1) {
+      now += 1;
+      store.writeReady(`session-${index}`, {
+        binding: "binding",
+        encryptedContent: `opaque-${index}`,
+        summary: `summary-${index}`,
+      });
+    }
+    const raw = JSON.parse(readFileSync(store.path, "utf8"));
+    expect(Object.keys(raw.sessions)).toHaveLength(16);
+    expect(raw.sessions["session-39"]).toBeDefined();
+    expect(raw.sessions["session-0"]).toBeUndefined();
+  });
+
+  it("sanitizes malformed state instead of exposing it", () => {
+    const directory = root();
+    const store = createClaudeCodexCompactionStore({ directory });
+    store.writeReady("session-1", { binding: "binding", encryptedContent: "opaque", summary: "summary" });
+    expect(store.readReady("session-1", "binding")?.encryptedContent).toBe("opaque");
+    store.clear("session-1");
+    expect(store.readReady("session-1", "binding")).toBeUndefined();
+  });
+});

--- a/packages/core-ai-gateway/tests/upstream/codex/compaction-store.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/codex/compaction-store.test.ts
@@ -62,6 +62,18 @@ describe("Claude Codex compaction store", () => {
     expect(raw.sessions["session-0"]).toBeUndefined();
   });
 
+  it("rejects oversized opaque checkpoints instead of persisting truncated ciphertext", () => {
+    const directory = root();
+    const store = createClaudeCodexCompactionStore({ directory });
+    store.writeReady("session-1", {
+      binding: "binding",
+      encryptedContent: "x".repeat(1_000_001),
+      summary: "plaintext fallback",
+    });
+
+    expect(store.readReady("session-1", "binding")).toBeUndefined();
+  });
+
   it("sanitizes malformed state instead of exposing it", () => {
     const directory = root();
     const store = createClaudeCodexCompactionStore({ directory });

--- a/packages/core-ai-gateway/tests/upstream/codex/compaction.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/codex/compaction.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CodexResponsesAdapter,
+  compactCodexConversation,
+  type CanonicalResponseRequest,
+} from "../../../src/index.js";
+
+function request(): CanonicalResponseRequest {
+  return {
+    model: "gpt-5.6-luna",
+    input: [
+      { type: "message", role: "user", content: "Remember CANARY-1" },
+      { type: "message", role: "assistant", content: "Stored CANARY-1" },
+      { type: "message", role: "user", content: "Continue" },
+    ],
+    instructions: "base instructions",
+    metadata: { user_id: "session-1" },
+    reasoning: { summary: "auto", effort: "high" },
+    stream: true,
+  };
+}
+
+function sse(events: unknown[]): Response {
+  return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function created(id: string) {
+  return { type: "response.created", response: { id, model: "gpt-5.6-luna", usage: null } };
+}
+
+function completed(id: string) {
+  return {
+    type: "response.completed",
+    response: { id, model: "gpt-5.6-luna", usage: { input_tokens: 10, output_tokens: 5 } },
+  };
+}
+
+describe("Codex conversation compaction", () => {
+  it("uses the v2 trigger, renders the opaque item, and preserves compact instructions", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse([
+        created("compact-response"),
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { type: "compaction", encrypted_content: "opaque-compact" },
+        },
+        completed("compact-response"),
+      ]))
+      .mockResolvedValueOnce(sse([
+        created("summary-response"),
+        { type: "response.output_text.delta", item_id: "m", output_index: 0, content_index: 0, delta: "CANARY-1 summary" },
+        completed("summary-response"),
+      ]));
+    const adapter = new CodexResponsesAdapter({ fetch: fetchMock });
+
+    const result = await compactCodexConversation({
+      adapter,
+      request: request(),
+      call: { apiKey: "test" },
+      customInstructions: "Preserve DIRECTIVE-1",
+      supportedEfforts: ["low", "medium", "high"],
+    });
+
+    expect(result).toMatchObject({
+      encryptedContent: "opaque-compact",
+      nativeCompaction: true,
+      summary: "CANARY-1 summary",
+      summaryResponse: { id: "summary-response" },
+    });
+    const compactBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(compactBody.input.at(-1)).toEqual({ type: "compaction_trigger" });
+    expect(compactBody.instructions).toContain("Preserve DIRECTIVE-1");
+    const summaryBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(summaryBody.input[0]).toEqual({ type: "compaction", encrypted_content: "opaque-compact" });
+  });
+
+  it("falls back to a dedicated plaintext summarizer when native compaction fails", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('{"error":{"message":"unsupported"}}', { status: 400 }))
+      .mockResolvedValueOnce(sse([
+        created("fallback-response"),
+        { type: "response.output_text.delta", item_id: "m", output_index: 0, content_index: 0, delta: "CANARY-1 fallback" },
+        completed("fallback-response"),
+      ]));
+    const adapter = new CodexResponsesAdapter({ fetch: fetchMock });
+
+    const result = await compactCodexConversation({
+      adapter,
+      request: request(),
+      call: { apiKey: "test" },
+      customInstructions: "Preserve DIRECTIVE-1",
+      supportedEfforts: ["low", "medium", "high"],
+    });
+
+    expect(result).toMatchObject({
+      nativeCompaction: false,
+      summary: "CANARY-1 fallback",
+    });
+    expect(result).not.toHaveProperty("encryptedContent");
+    const fallbackBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(JSON.stringify(fallbackBody.input)).toContain("Additional compact instructions");
+    expect(JSON.stringify(fallbackBody.input)).toContain("Preserve DIRECTIVE-1");
+  });
+
+  it("rejects a native stream with zero or multiple compaction items and uses fallback", async () => {
+    for (const count of [0, 2]) {
+      const compactItems = Array.from({ length: count }, (_, index) => ({
+        type: "response.output_item.done",
+        output_index: index,
+        item: { type: "compaction", encrypted_content: `opaque-${index}` },
+      }));
+      const fetchMock = vi.fn<typeof fetch>()
+        .mockResolvedValueOnce(sse([created("bad"), ...compactItems, completed("bad")]))
+        .mockResolvedValueOnce(sse([
+          created("fallback"),
+          { type: "response.output_text.delta", item_id: "m", output_index: 0, content_index: 0, delta: "fallback" },
+          completed("fallback"),
+        ]));
+
+      const result = await compactCodexConversation({
+        adapter: new CodexResponsesAdapter({ fetch: fetchMock }),
+        request: request(),
+        call: { apiKey: "test" },
+        supportedEfforts: ["low", "medium", "high"],
+      });
+      expect(result.nativeCompaction).toBe(false);
+      expect(result.summary).toBe("fallback");
+    }
+  });
+});

--- a/packages/fleet-admiral/assets/hooks/fleet-compact-event.mjs
+++ b/packages/fleet-admiral/assets/hooks/fleet-compact-event.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Relay Claude Code's compact lifecycle to the Fleet AI Gateway that launched this process.
+// The token and base URL exist only on Fleet gateway sessions; every other Claude session is a no-op.
+
+const baseUrl = process.env.FLEET_COMPACT_BASE_URL;
+const token = process.env.FLEET_COMPACT_HOOK_TOKEN;
+if (!baseUrl || !token) process.exit(0);
+
+let input = "";
+for await (const chunk of process.stdin) input += chunk;
+if (input.length === 0) process.exit(0);
+
+try {
+  const response = await fetch(`${baseUrl.replace(/\/+$/, "")}/v1/compact-events`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-fleet-compact-token": token,
+    },
+    body: input,
+    signal: AbortSignal.timeout(1_500),
+  });
+  await response.body?.cancel();
+} catch {
+  // Compaction must remain available when the host is shutting down. The gateway's
+  // dedicated plaintext fallback applies only after the event was recorded.
+}

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -12,6 +12,7 @@ export const assetBundle: AssetPluginBundle = {
 };
 
 const MODEL_GUARD_SCRIPT_NAME = "fleet-gateway-model-guard.mjs";
+const COMPACT_EVENT_SCRIPT_NAME = "fleet-compact-event.mjs";
 
 /** 스냅숏에 들어갈 파일 하나. relativePath는 `/` 구분의 스냅숏 루트 상대 경로다. */
 export interface AssetPluginFile {
@@ -36,6 +37,9 @@ export function buildAssetPluginFiles(
   const guardAsset = EMBEDDED_AGENT_CLI_HOOK_ASSETS.find((entry) => entry.relativePath === MODEL_GUARD_SCRIPT_NAME);
   if (!guardAsset) throw new Error(`Missing embedded ${MODEL_GUARD_SCRIPT_NAME} hook asset`);
   files.push({ relativePath: `hooks/${MODEL_GUARD_SCRIPT_NAME}`, content: guardAsset.content });
+  const compactAsset = EMBEDDED_AGENT_CLI_HOOK_ASSETS.find((entry) => entry.relativePath === COMPACT_EVENT_SCRIPT_NAME);
+  if (!compactAsset) throw new Error(`Missing embedded ${COMPACT_EVENT_SCRIPT_NAME} hook asset`);
+  files.push({ relativePath: `hooks/${COMPACT_EVENT_SCRIPT_NAME}`, content: compactAsset.content });
   files.push({ relativePath: "hooks/hooks.json", content: toJsonContent(claudeHooks(options, version)) });
   for (const file of buildGatewayAgentFiles(options.gatewayDelegationModels ?? [], options.gatewayEffortExposure)) {
     files.push({ relativePath: `agents/${file.fileName}`, content: file.content });
@@ -56,6 +60,13 @@ function modelGuardHook(subcommand: string, ...args: readonly string[]): FleetHo
   return {
     command: process.execPath,
     args: [`\${CLAUDE_PLUGIN_ROOT}/hooks/${MODEL_GUARD_SCRIPT_NAME}`, subcommand, ...args],
+  };
+}
+
+function compactEventHook(): FleetHookExec {
+  return {
+    command: process.execPath,
+    args: [`\${CLAUDE_PLUGIN_ROOT}/hooks/${COMPACT_EVENT_SCRIPT_NAME}`],
   };
 }
 
@@ -128,6 +139,14 @@ function claudeHooks(options: CreateAgentCliPluginOptions, version: string): unk
           hooks: [claudeCommandHook(options.backgroundReportHookExec)],
         }],
       } : {}),
+      PreCompact: [{
+        matcher: "manual|auto",
+        hooks: [claudeCommandHook(compactEventHook())],
+      }],
+      PostCompact: [{
+        matcher: "manual|auto",
+        hooks: [claudeCommandHook(compactEventHook())],
+      }],
     },
   };
 }

--- a/packages/fleet-admiral/src/ai-gateway/launch-env.ts
+++ b/packages/fleet-admiral/src/ai-gateway/launch-env.ts
@@ -16,6 +16,7 @@ export interface AiGatewayLaunchEnvOptions {
 	readonly baseUrl: string;
 	readonly selection?: AiGatewaySelection;
 	readonly homeDir?: string;
+	readonly compactHookToken?: string;
 }
 
 export function prepareAiGatewayLaunchProfile(
@@ -36,6 +37,12 @@ export function prepareAiGatewayLaunchProfile(
 		// Gateway가 tool_reference 계약을 보존한다. Cursor는 이를 지연 catalog 선택에 쓰고,
 		// 호환 프로바이더 경계는 각자의 eager wire 형식으로 정규화한다.
 		ENABLE_TOOL_SEARCH: "true",
+		...(options.compactHookToken
+			? {
+				FLEET_COMPACT_BASE_URL: options.baseUrl,
+				FLEET_COMPACT_HOOK_TOKEN: options.compactHookToken,
+			}
+			: {}),
 	};
 	writeClaudeGatewayModelCache(
 		options.baseUrl,

--- a/packages/fleet-admiral/tests/agent-cli-plugin-sessions.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-sessions.test.ts
@@ -185,6 +185,16 @@ describe("agent CLI shared plugin store", () => {
     expect(hooksJson.hooks.Notification).toEqual([
       { matcher: "permission_prompt|elicitation_dialog", hooks: [{ type: "command", command: "node", args: ["cli.mjs", "hook", "attention"] }] },
     ]);
+    const compactHook = [{
+      matcher: "manual|auto",
+      hooks: [{
+        type: "command",
+        command: process.execPath,
+        args: ["${CLAUDE_PLUGIN_ROOT}/hooks/fleet-compact-event.mjs"],
+      }],
+    }];
+    expect(hooksJson.hooks.PreCompact).toEqual(compactHook);
+    expect(hooksJson.hooks.PostCompact).toEqual(compactHook);
   });
 
   it("wires capture, turn-start, and auto-name onto Claude UserPromptSubmit in order", async () => {
@@ -223,6 +233,7 @@ describe("agent CLI shared plugin store", () => {
     }
     expect(existsSync(path.join(plugin.pluginRoot, "agents"))).toBe(true);
     expect(existsSync(path.join(plugin.pluginRoot, "hooks", "fleet-gateway-model-guard.mjs"))).toBe(true);
+    expect(existsSync(path.join(plugin.pluginRoot, "hooks", "fleet-compact-event.mjs"))).toBe(true);
   });
 
   it("renders the latest gateway roster into the shared tree", async () => {

--- a/packages/fleet-admiral/tests/ai-gateway-launch-env.test.ts
+++ b/packages/fleet-admiral/tests/ai-gateway-launch-env.test.ts
@@ -34,6 +34,7 @@ describe("prepareAiGatewayLaunchProfile", () => {
 		const prepared = prepareAiGatewayLaunchProfile(profile, {
 			baseUrl: "http://127.0.0.1:4310/plugins/terminal/ai-gateway",
 			homeDir,
+			compactHookToken: "compact-token",
 		});
 
 		expect(prepared).not.toBe(profile);
@@ -49,6 +50,8 @@ describe("prepareAiGatewayLaunchProfile", () => {
 			CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: "1",
 			CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1000000",
 			ENABLE_TOOL_SEARCH: "true",
+			FLEET_COMPACT_BASE_URL: "http://127.0.0.1:4310/plugins/terminal/ai-gateway",
+			FLEET_COMPACT_HOOK_TOKEN: "compact-token",
 		});
 
 		const cachePath = path.join(homeDir, ".claude", "cache", "gateway-models.json");
@@ -60,6 +63,15 @@ describe("prepareAiGatewayLaunchProfile", () => {
 		expect(cache.models.length).toBeGreaterThan(0);
 		expect(cache.models.every((model) => /^(claude|anthropic)/i.test(model.id))).toBe(true);
 		expect(statSync(cachePath).mode & 0o777).toBe(0o600);
+	});
+
+	it("omits compact hook env when the host did not provide a process token", () => {
+		const prepared = prepareAiGatewayLaunchProfile(makeProfile(), {
+			baseUrl: "http://127.0.0.1:4310/gateway",
+			homeDir: makeTemporaryDirectory(),
+		});
+		expect(prepared.env.FLEET_COMPACT_BASE_URL).toBeUndefined();
+		expect(prepared.env.FLEET_COMPACT_HOOK_TOKEN).toBeUndefined();
 	});
 
 	it("preserves an explicit auto-compact ceiling", () => {

--- a/runtime/fleet-console/cli/gateway/launch.ts
+++ b/runtime/fleet-console/cli/gateway/launch.ts
@@ -46,6 +46,7 @@ export async function launchClaudeGateway(options: LaunchClaudeGatewayOptions): 
     const launchProfile = prepareAiGatewayLaunchProfile(injected, {
       baseUrl: options.gatewayServer.origin() + options.gatewayServer.routePath,
       selection,
+      compactHookToken: options.gatewayServer.compactHookToken,
     });
     const child = spawn(launchProfile.bin, launchProfile.args, {
       cwd: launchProfile.cwd,

--- a/runtime/fleet-console/cli/gateway/server.ts
+++ b/runtime/fleet-console/cli/gateway/server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import http from "node:http";
 import path from "node:path";
 
@@ -6,6 +7,7 @@ import {
   createAiGatewayRouter,
   createCursorDiagnosticLog,
   createFailureJournal,
+  createClaudeCodexCompactionStore,
   readAntigravitySubscriptionToken,
   readCodexSubscriptionAuth,
   readCursorSubscriptionToken,
@@ -17,11 +19,11 @@ import {
   KIMI_AUTH_PROVIDER_ID,
   OPENCODE_AUTH_PROVIDER_ID,
 } from "@dotobokuri/fleet-admiral";
-import { getFleetDataDir } from "@dotobokuri/core-infra";
 
 export interface FleetCliGatewayServer {
   origin(): string;
   readonly routePath: string;
+  readonly compactHookToken?: string;
   close(): Promise<void>;
 }
 
@@ -35,11 +37,15 @@ export async function startGatewayHttpServer(deps: {
    */
   readonly port?: number;
 }): Promise<FleetCliGatewayServer> {
-  const diagnostics = createCursorDiagnosticLog(path.join(getFleetDataDir(), "fleet-cli", "ai-gateway"));
+  const gatewayDir = path.join(path.dirname(deps.store.path), "fleet-cli", "ai-gateway");
+  const diagnostics = createCursorDiagnosticLog(gatewayDir);
   const failureJournal = createFailureJournal({
-    filePath: path.join(getFleetDataDir(), "fleet-cli", "ai-gateway", "failures.jsonl"),
+    filePath: path.join(gatewayDir, "failures.jsonl"),
   });
+  const compactHookToken = randomUUID();
   const router = createAiGatewayRouter({
+    compactionStore: createClaudeCodexCompactionStore({ directory: gatewayDir }),
+    compactionHookToken: compactHookToken,
     failureJournal: failureJournal.write,
     readAiGatewaySettings: () => deps.store.read(),
     readKimiApiKey: () => deps.authService.getApiKey(KIMI_AUTH_PROVIDER_ID),
@@ -91,6 +97,7 @@ export async function startGatewayHttpServer(deps: {
   let closePromise: Promise<void> | undefined;
   return {
     routePath,
+    compactHookToken,
     origin() {
       const address = server.address();
       if (!address || typeof address === "string") {

--- a/runtime/fleet-console/tests/api-catalog.test.ts
+++ b/runtime/fleet-console/tests/api-catalog.test.ts
@@ -173,6 +173,7 @@ POST|/plugins/terminal/agent/sessions/:sessionId/resume|http
 POST|/plugins/terminal/agent/sessions/:sessionId/turn|http
 POST|/plugins/terminal/agent/sessions|http
 POST|/plugins/terminal/agent/ticket|http
+POST|/plugins/terminal/ai-gateway/v1/compact-events|http
 POST|/plugins/terminal/ai-gateway/v1/messages|proxy
 POST|/plugins/terminal/analysis/:operationId/message|http
 POST|/plugins/terminal/analysis/:operationId/start|http
@@ -216,7 +217,7 @@ describe("api catalog", () => {
 
     expect(response.status).toBe(200);
     expect(body.version).toBe("test");
-    expect(body.routes).toHaveLength(146);
+    expect(body.routes).toHaveLength(147);
     expect(body.routes).toEqual(expect.arrayContaining(buildApiCatalog()));
     const identities = body.routes.map(apiCatalogIdentity);
     expect(identities.slice().sort()).toEqual(EXPECTED_API_CATALOG_IDENTITIES);

--- a/runtime/fleet-plugins/terminal/routes.ts
+++ b/runtime/fleet-plugins/terminal/routes.ts
@@ -99,7 +99,7 @@ export default definePlugin({
       wireLogRuntime: wireLog,
     });
     registerTerminalModelAuthRoutes(ctx, { authService });
-    registerAiGatewayRoutes(ctx, {
+    const aiGatewayRuntime = registerAiGatewayRoutes(ctx, {
       readAiGatewaySettings: aiGatewayStore.read,
       readKimiApiKey: () => authService.getApiKey(KIMI_AUTH_PROVIDER_ID),
       readOpencodeApiKey: () => authService.getApiKey(OPENCODE_AUTH_PROVIDER_ID),
@@ -117,6 +117,7 @@ export default definePlugin({
       aiGateway: {
         routePath: `${ctx.basePath}/${AI_GATEWAY_ROUTE_SEGMENT}`,
         origin: () => ctx.host.server.origin(),
+        compactHookToken: aiGatewayRuntime.compactHookToken,
       },
     });
     registerLaunchCatalog(ctx, async () => agentLaunchKinds());

--- a/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/chat-session.ts
@@ -71,6 +71,7 @@ export type AgentChatSessionOrigin =
 
 export interface AgentChatSessionSeed {
   readonly baseUrl: string;
+  readonly compactHookToken?: string;
   readonly model: string;
   /**
    * 이 모델의 **실제** 문맥 창(카탈로그 값). 자식이 재는 창이 아니다 — 자식은 좌표가 둘뿐이라
@@ -1449,7 +1450,13 @@ class AgentChatSession {
             ...(this.seed.ultracode ? { ultracode: true } : {}),
             // 플러그인이 실은 훅은 세션 식별자로 자기 축을 찾는다. 이 자식에게는 그 식별자가
             // 없어야 한다 — 상속된 값이 남으면 남의 세션 축에 보고한다.
-            env: chatChildEnv(process.env),
+            env: {
+              ...chatChildEnv(process.env),
+              FLEET_COMPACT_BASE_URL: this.seed.baseUrl,
+              ...(this.seed.compactHookToken
+                ? { FLEET_COMPACT_HOOK_TOKEN: this.seed.compactHookToken }
+                : {}),
+            },
           });
           if (this.disposed) {
             await sdk.dispose().catch(() => undefined);

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -42,6 +42,8 @@ export interface AiGatewayLaunchBinding {
   readonly routePath: string;
   /** Console이 리슨 중인 origin. MCP는 별도 포트라 여기서 유도하면 안 된다. */
   origin(): string | null;
+  /** Process-local credential accepted only by the compact lifecycle endpoint. */
+  readonly compactHookToken?: string;
 }
 
 export interface TerminalLaunchResolverDeps {
@@ -361,6 +363,7 @@ async function createAgentCliLaunchSpec(options: {
       launchProfile = prepareAiGatewayLaunchProfile(injectedProfile, {
         baseUrl: `${origin}${options.aiGateway.routePath}`,
         selection: gatewaySelection,
+        compactHookToken: options.aiGateway.compactHookToken,
       });
     }
     const sessionIdentityResolver = options.createSessionIdentityResolver({ cwd: launchProfile.cwd });

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -1461,6 +1461,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       ok: true,
       seed: {
         baseUrl: gatewayBaseUrl,
+        compactHookToken: deps.aiGateway?.compactHookToken,
         model,
         // 자식은 창이 500k인 모델도 자기 200k 좌표로 재고, 그 좌표를 물어보는 모든 표면에 그대로
         // 말한다. 실제 창과 투영에 쓰인 압축 정책을 함께 실어야 세션이 그것을 되돌릴 수 있다.

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import {
@@ -6,6 +7,7 @@ import {
   createAiGatewayRouter,
   createCursorDiagnosticLog,
   createFailureJournal,
+  createClaudeCodexCompactionStore,
   readAntigravitySubscriptionToken,
   readCodexSubscriptionAuth,
   readCursorSubscriptionToken,
@@ -42,7 +44,7 @@ export type ConsoleAiGatewayRouteDeps = Omit<
 export function registerAiGatewayRoutes(
   ctx: FleetPluginServerContext,
   deps: ConsoleAiGatewayRouteDeps = {},
-): void {
+): { readonly compactHookToken: string } {
   const ownedDiagnostics = deps.cursorDiagnostics
     ? undefined
     : createCursorDiagnosticLog(path.join(
@@ -60,9 +62,15 @@ export function registerAiGatewayRoutes(
           "failures.jsonl",
         ),
       });
+  const compactHookToken = randomUUID();
+  const compactionStore = createClaudeCodexCompactionStore({
+    directory: path.join(ctx.host.paths.pluginDataDir(ctx.pluginId), "ai-gateway"),
+  });
   const router = createAiGatewayRouter({
     ...deps,
     originator: "fleet-console",
+    compactionStore,
+    compactionHookToken: compactHookToken,
     failureJournal: deps.failureJournal ?? ownedFailureJournal?.write,
     // 자격증명 조달은 호스트 결정이다 — Console은 core-ai-gateway가 export한 기본 reader를 주입한다.
     readAuth: deps.readAuth ?? (() => readCodexSubscriptionAuth()),
@@ -83,5 +91,7 @@ export function registerAiGatewayRoutes(
     { method: "*", path: "/api/hello", summary: "Read the AI Gateway health response.", category: "Terminal Plugin", gate: "loopback", transport: "http" },
     { method: "*", path: "/v1/models", summary: "Proxy the AI Gateway model listing.", category: "Terminal Plugin", gate: "anthropic-credential", transport: "proxy" },
     { method: "POST", path: "/v1/messages", summary: "Proxy an Anthropic Messages request through the AI Gateway.", category: "Terminal Plugin", gate: "anthropic-credential", transport: "proxy" },
+    { method: "POST", path: "/v1/compact-events", summary: "Receive a Claude compact lifecycle event.", category: "Terminal Plugin", gate: "lock-token", transport: "http" },
   ]);
+  return { compactHookToken };
 }

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -12,7 +12,7 @@ describe("AI gateway Console route adapter", () => {
     let cleanup: (() => void | Promise<void>) | undefined;
     const pluginDataDir = "/tmp/fleet-console-test/plugins/terminal";
 
-    registerAiGatewayRoutes({
+    const runtime = registerAiGatewayRoutes({
       pluginId: "terminal",
       basePath: "/plugins/terminal",
       registerRouter,
@@ -31,6 +31,7 @@ describe("AI gateway Console route adapter", () => {
     expect(registerRouter).toHaveBeenCalledTimes(1);
     expect(registerRouter.mock.calls[0]?.[0]).toBe("ai-gateway");
     expect(cleanup).toBeTypeOf("function");
+    expect(runtime.compactHookToken).toMatch(/^[0-9a-f-]{36}$/);
     await cleanup?.();
     expect(path.join(pluginDataDir, "ai-gateway")).toContain("plugins/terminal/ai-gateway");
   });


### PR DESCRIPTION
## Summary

- Bridge Claude Code automatic and manual compact lifecycle events to Codex Responses v2 native compaction.
- Persist model/account-bound opaque checkpoints for durable replay, with single-flight handling and a safe plaintext fallback.
- Wire the lifecycle through the `fleet` launcher, Fleet Console PTY and Chat sessions, and add real Claude Code/Luna product probes.

## Test Plan

- [x] Core AI Gateway: 50 test files / 997 tests, typecheck, and build
- [x] Fleet Admiral: 14 test files / 195 tests, typecheck, and build
- [x] Terminal plugin: 101 test files / 1,125 tests, typecheck, and build
- [x] Fleet Console: 189 test files / 2,318 tests, production build, API catalog, published external checks, and Desktop protocol compatibility
- [x] Live Claude Code 2.1.251 + Luna auto/manual compact, native checkpoint persistence, and replay
- [x] Live native-compaction failure arm with plaintext fallback and no stale checkpoint replay
- [x] Live Opus manual compact control verifying the non-Codex path remains native to Claude Code
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`