### PR TITLE
fix(fleet-console): build the light terminal atlas with the compensated weight

### DIFF
--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2637,6 +2637,10 @@ describe("Instrument core design contract", () => {
     expect(surface).not.toMatch(/terminalFontWeightsFor\([^)]*terminalRenderer\)/);
     expect(surface).not.toMatch(/terminalForegroundFor\([^)]*terminalRenderer\)/);
     expect(surface).toContain("setWebglActive(false);");
+    // 초깃값은 선호에서 씨딩해야 한다. WebGL 아틀라스는 addon이 붙는 순간의 옵션으로 구워지고
+    // 이후 옵션 할당은 아틀라스를 다시 굽지 않으므로, false로 시작하면 보정 웨이트가 영영
+    // 반영되지 않는다 — 게이트는 열려 있는데 획만 얇은 상태가 된다.
+    expect(surface).toContain('useState(terminalRenderer === "webgl")');
     // 뷰포트 인라인 배경이 먼저다 — 순서가 뒤집히면 xterm의 :not(.allow-transparency) 규칙이
     // background-color:#000을 한 프레임 드러낸다.
     const applyBlock = surface.slice(surface.indexOf("const applyTerminalTheme = () => {"));

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -250,7 +250,14 @@ export function TerminalSurface({ operationId, ticketPath, ticketFields, wsPath,
   const connectionRef = useRef<TerminalConnection | null>(null);
   const webglAddonRef = useRef<WebglAddon | null>(null);
   // 보정 게이트의 진실 — 선호가 아니라 addon이 실제로 살아 있는지. ref는 리렌더를 못 부르므로 state다.
-  const [webglActive, setWebglActive] = useState(false);
+  /* 보정 게이트의 진실 — 선호가 아니라 addon이 실제로 살아 있는지. ref는 리렌더를 못 부르므로 state다.
+     초깃값을 선호에서 씨딩하는 이유가 이 파일에서 가장 미묘한 자리다: WebGL 글리프 아틀라스는
+     addon이 붙는 **그 순간의 옵션**으로 구워지고, 그 뒤의 terminal.options.fontWeight 할당은
+     아틀라스를 다시 굽지 않는다. false로 시작하면 터미널이 웨이트 없이 생성되고 addon이 그 상태를
+     구워 버려서, 나중에 게이트가 열려도 획은 영영 얇은 채로 남는다(실측: 잉크 픽셀 58063 vs 62028).
+     반대 방향은 이 씨딩 없이도 안전하다 — addon이 죽으면 DOM 렌더러가 옵션을 매 프레임 읽으므로
+     초기화 실패·컨텍스트 유실에서 보정은 그대로 걷힌다(실측으로 확인). */
+  const [webglActive, setWebglActive] = useState(terminalRenderer === "webgl");
   const outputSchedulerRef = useRef<TerminalOutputScheduler | null>(null);
   const statusDetailReporterRef = useRef<TerminalStatusDetailReporter | null>(null);
   const scrollFollowRef = useRef<TerminalScrollFollowController | null>(null);


### PR DESCRIPTION
## Summary

#955에서 넣은 서브픽셀 AA 보정이 **웨이트만 화면에 도달하지 않고 있었습니다.** 사용자가 병합된 canary에서 "완화책이 작동하지 않는다"고 지적해 재현했습니다.

WebGL 글리프 아틀라스는 **addon이 붙는 순간의 옵션으로 구워지고, 이후 `terminal.options.fontWeight` 할당은 아틀라스를 다시 굽지 않습니다.** 리뷰 지적(#955 P2)을 고치며 게이트를 선호값에서 `webglActive` state로 바꿀 때 초깃값을 `false`로 둔 것이 정확히 그 순서를 만들었습니다.

1. `webglActive=false` → 터미널이 기본 웨이트로 생성
2. addon 로드 → 아틀라스가 그 상태로 구워짐
3. `setWebglActive(true)` → 테마 이펙트가 `fontWeight=500` 할당
4. 아틀라스는 재생성되지 않음 → 획은 얇은 채로 유지

전경색은 `options.theme` 경로라 반영됐습니다. 그래서 **색은 보정되고 굵기는 안 된 상태**였고, 가장 어두운 픽셀만 보는 측정으로는 "보정 적용됨"으로 읽혔습니다 — 제가 그렇게 오판했습니다.

**수정**: 초깃값을 렌더러 선호에서 씨딩해 터미널이 처음부터 보정 웨이트로 생성되게 합니다. 반대 방향은 씨딩이 필요 없습니다 — addon이 죽으면 DOM 렌더러가 옵션을 매 프레임 읽으므로 초기화 실패·컨텍스트 유실에서 보정이 그대로 걷힙니다.

## 실측 (같은 밴드·같은 내용, 유리 OFF 기준선은 세 빌드 바이트 동일)

| 상태 | 잉크 픽셀 | 정규화 잉크 | 질량 |
|---|---|---|---|
| 유리 OFF (기준선) | 59173 | 36876 | 49320 |
| canary (깨진 상태) | 58063 | −15.6% | −18.1% |
| **이 PR** | **62028** | **−2.5%** | **−9.2%** |

- 컨텍스트 유실 강제(`WEBGL_lose_context`) 후: fg 23.94, solid 31575 / mid 17476 — 기준선 프로필(31542 / 17778)과 일치. #955 P2 리뷰 수정의 의도가 그대로 유지됩니다.

## 릴리스 노트

**프래그먼트를 추가하거나 고치지 않습니다.** #955는 아직 미출시(`.changelog.d/light-liquid-glass.md` 잔존)라 이 수정은 사용자가 겪은 적 없는 동작의 정정이고, 릴리스 베이스라인 규칙상 독립 항목을 내면 안 됩니다. 기존 문안("draws its terminal text a step heavier and a shade denser")은 원래 의도를 정확히 서술하고 있으며 이 수정이 그 문장을 참으로 만듭니다.

## Test Plan

- [x] `pnpm typecheck` · `pnpm build` (워크스페이스 전체)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 189 files / 2327 passed
- [x] `pnpm --filter @fleet-plugins/terminal test` — 102 files / 1137 passed
- [x] 격리 콘솔 실측: 병합본 vs 수정본 4상태 통제 비교, 컨텍스트 유실 폴백
- [x] 계약: 초깃값 씨딩이 깨지면 실패하도록 `instrument-design-contract`에 고정