### PR TITLE
fix(fleet-console): mark the open rail gear with the shared active grammar

### DIFF
--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -344,7 +344,7 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
       <nav className="right-rail-icons" aria-label={t("rail.chrome.toolsAria")}>
         {/* 설정은 열 최상단에 서고 디바이더가 패널 탭과 갈라 놓는다 — 콘솔을 다스리는 일과
             작업 패널을 고르는 일은 다른 종류의 동작이다. 톱니는 이제 메뉴가 아니라 설정
-            표면의 문이고, 켜짐은 다른 패널과 같은 문법(brass)으로 "지금 여기"를 말한다. */}
+            표면의 문이고, 켜짐은 열의 다른 아이콘과 똑같은 활성 표식으로 "지금 여기"를 말한다. */}
         <button
           id="rail-settings-toggle"
           type="button"

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -235,17 +235,10 @@
   display: block;
 }
 
-/* 열린 상태는 brass 테두리로만 말한다 — 좌측 brass 바(.is-active::before)는 탭의
-   문법이고 톱니는 탭이 아니다. brass는 위치·포커스 채널이므로 열림 표시에 legal하다. */
-.right-rail-settings-btn.is-active {
-  color: var(--brass-ink);
-  border-color: color-mix(in oklch, var(--brass) 45%, transparent);
-  background: var(--brass-glow);
-}
-
-.right-rail-settings-btn.is-active::before {
-  content: none;
-}
+/* 열린 상태는 톱니만의 문법을 따로 두지 않는다 — 레일 아이콘 하나가 켜졌다는 사실은
+   열 전체에서 한 가지 모습으로만 말해야 한다(.right-rail-ico.is-active: 어두운 면·
+   rim-strong 테두리·좌측 brass 바). 톱니가 탭이 아니라는 사실은 role/aria가 이미
+   말하고 있고, 시각 표식까지 갈라놓으면 같은 열의 켜짐이 두 문법으로 읽힌다. */
 
 .right-rail-divider {
   flex: none;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2051,14 +2051,18 @@ describe("Instrument core design contract", () => {
     expect(rightRail).toContain('toggleRailPanel(SETTINGS_RAIL_ENTRY_ID)');
     expect(rightRail).toContain('binding.entry.id !== SETTINGS_RAIL_ENTRY_ID');
     expect(rail).toMatch(/\.right-rail-divider \{[^}]*background: var\(--surface-rim-strong\);/);
-    // Doctrine: brass is the location/focus channel, so the open gear may wear it — but not
-    // the tablist's left brass bar, because the gear is not a tab.
     // Doctrine: the gear carries an explicit glyph size. An SVG with only a viewBox fills its
     // button (30px inside the 32px control), which is how it first shipped oversized; plugin
     // icons bring their own sizes but this core-drawn glyph has to state one here.
     expect(rail).toMatch(/\.right-rail-settings-btn svg \{[^}]*width: \d+px;[^}]*height: \d+px;/);
-    expect(rail).toMatch(/\.right-rail-settings-btn\.is-active \{[^}]*background: var\(--brass-glow\);/);
-    expect(rail).toMatch(/\.right-rail-settings-btn\.is-active::before \{[^}]*content: none;/);
+    // Doctrine: one column, one "on" grammar. The gear wears the same active mark as every
+    // other rail icon (dark fill, rim-strong border, left brass bar) and declares no active
+    // rule of its own — it first shipped with a brass-glow fill and a suppressed bar, which
+    // read as a different kind of selection sitting right above the panel tabs. That the gear
+    // is a door and not a tab is already carried by role/aria, not by a second visual grammar.
+    expect(rail).not.toMatch(/\.right-rail-settings-btn\.is-active/);
+    expect(rail).toMatch(/\.right-rail-ico\.is-active \{[^}]*background: var\(--ink-deep\);/);
+    expect(rail).toMatch(/\.right-rail-ico\.is-active::before \{[^}]*background: var\(--brass\);/);
     // Doctrine: the gear menu is dismantled — no popup portals out of the rail any more,
     // and width reset became direct manipulation on the resize handle itself.
     expect(rightRail).not.toContain("RailSettingsMenu");


### PR DESCRIPTION
## Summary
- 우측 레일 톱니(설정)가 켜졌을 때만 쓰던 별도 활성 규칙(brass-glow 면 + brass 테두리 + 좌측 바 억제)을 제거해, 열의 다른 레일 아이콘과 똑같은 활성 표식(어두운 면 · rim-strong 테두리 · 좌측 2px brass 바)을 입도록 통일했습니다.
- 톱니가 탭이 아니라 문이라는 사실은 이미 role/aria가 말하고 있어, 시각 표식까지 갈라놓을 이유가 없습니다. 같은 열에서 켜짐이 두 문법으로 읽히던 것이 결함이었습니다.
- 디자인 계약에 "한 열, 한 켜짐 문법"을 못박았습니다 — 톱니는 자기 활성 규칙을 선언하지 않고, 공용 `.right-rail-ico.is-active`가 면과 좌측 바를 유지합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 192 파일 / 2335 테스트 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] 격리 콘솔 실측(headless): 톱니 켜짐과 "사용 한도" 패널 켜짐의 계산 스타일이 동일 — color `oklch(0.8 0.085 78)`, background `oklch(0.165 0.016 245)`, border `oklch(0.37 0.02 245)`, `::before` 2px `oklch(0.8 0.085 78)`
- [x] 스크린샷으로 좌측 brass 바와 어두운 면 육안 확인