### PR TITLE
fix(fleet-console): preserve primary pane params

### DIFF
--- a/runtime/fleet-console/core/client/src/pane/pane-store.ts
+++ b/runtime/fleet-console/core/client/src/pane/pane-store.ts
@@ -5,9 +5,9 @@ import type { PaneCloseContext, PaneMount, PaneOpenRequest } from "@fleet-consol
 /**
  * 표면에 서 있는 페인 인스턴스들.
  *
- * primary 페인은 여기 없다 — 엔트리가 열리면 그 엔트리의 primary가 자동으로 서므로, 스토어가
- * 기억할 것은 **그 위에 추가로 열린 것들**뿐이다. 이 비대칭은 의도적이다: primary를 스토어에
- * 넣으면 "엔트리는 열렸는데 primary가 없는" 표현 가능한 잘못된 상태가 생긴다.
+ * primary 페인은 보통 여기 없다 — 엔트리가 열리면 그 엔트리의 primary가 자동으로 선다. 다만
+ * primary가 `replaceParams`로 주소를 얻었거나 팔레트·딥링크가 착지 params를 먼저 심은 뒤에는
+ * 그 주소만 기억하는 인스턴스가 선다. 표면은 이를 추가 열로 세지 않고 자동 primary에 합친다.
  *
  * keepAlive 페인은 닫혀도 목록에서 빠지지 않고 `visible: false`로 남는다. 그것이 PTY와 읽던
  * 자리를 지키는 방식이며, 지금 플러그인들이 portal parking·DOM relocate로 각자 하던 일이다.
@@ -152,10 +152,29 @@ export function resetSurfacePanes(
  */
 export function replacePaneParams(paneId: string, params: Readonly<Record<string, string>>): void {
   const target = state.rail.find((instance) => instance.paneId === paneId);
-  if (!target || sameParams(target.params, params)) return;
+  if (target) {
+    if (sameParams(target.params, params)) return;
+    emit({
+      ...state,
+      rail: state.rail.map((instance) => (instance.paneId === paneId ? { ...instance, params } : instance)),
+    });
+    return;
+  }
+
+  // primary는 엔트리와 함께 자동으로 서서 평소 스토어 인스턴스가 없다. 그 본문이 자기 주소를
+  // 갈아탈 때 무시하면(설정 섹션 칩이 대표 사례) ctx.params가 영원히 빈 값에 머문다. 주소를
+  // 처음 얻는 순간에만 인스턴스를 심고, RailSurface가 이를 자동 primary의 params로 합친다.
   emit({
-    ...state,
-    rail: state.rail.map((instance) => (instance.paneId === paneId ? { ...instance, params } : instance)),
+    rail: [...state.rail, {
+      paneId,
+      // RailSurface가 인스턴스 없는 자동 primary에 쓰던 값과 같아야 첫 주소 변경이 본문을
+      // 재마운트하지 않는다. 설정 검색어처럼 섹션 밖의 primary-로컬 상태도 그대로 남아야 한다.
+      instanceId: `pane-primary-${paneId}`,
+      params,
+      mount: "rail",
+      visible: true,
+    }],
+    focusedPaneId: state.focusedPaneId,
   });
 }
 

--- a/runtime/fleet-console/core/client/src/pane/pane-store.ts
+++ b/runtime/fleet-console/core/client/src/pane/pane-store.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 
-import type { PaneCloseContext, PaneMount, PaneOpenRequest } from "@fleet-console/sdk/pane";
+import type { PaneCloseContext, PaneMount, PaneOpenRequest, PaneRole } from "@fleet-console/sdk/pane";
 
 /**
  * 표면에 서 있는 페인 인스턴스들.
@@ -150,7 +150,11 @@ export function resetSurfacePanes(
  * 되살린다. 확대된 문서가 주소를 갱신할 때마다 레일에 주차돼 있던 같은 페인이 함께 튀어나와,
  * 한 페인의 두 사본이 서로 다른 주소를 들고 다투게 된다.
  */
-export function replacePaneParams(paneId: string, params: Readonly<Record<string, string>>): void {
+export function replacePaneParams(
+  paneId: string,
+  params: Readonly<Record<string, string>>,
+  role: PaneRole,
+): void {
   const target = state.rail.find((instance) => instance.paneId === paneId);
   if (target) {
     if (sameParams(target.params, params)) return;
@@ -160,6 +164,10 @@ export function replacePaneParams(paneId: string, params: Readonly<Record<string
     });
     return;
   }
+
+  // missing target은 자동 primary 외에도 이미 닫힌 detail의 늦은 콜백에서 생긴다. 후자를
+  // 되살리면 닫기 계약이 뒤집히므로, 호출한 서술자가 primary라고 말한 경로만 씨앗을 만든다.
+  if (role !== "primary") return;
 
   // primary는 엔트리와 함께 자동으로 서서 평소 스토어 인스턴스가 없다. 그 본문이 자기 주소를
   // 갈아탈 때 무시하면(설정 섹션 칩이 대표 사례) ctx.params가 영원히 빈 값에 머문다. 주소를

--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -282,6 +282,13 @@ function PaneHost({
   width,
 }: PaneHostProps) {
   const bodyRef = useRef<HTMLDivElement>(null);
+  // ctx.panes는 params가 바뀌어도 안정적이라 비동기 작업이 오래 쥘 수 있다. 호스트가 헐린 뒤
+  // 도착한 콜백까지 받으면 닫힌 primary의 주소가 다음 열림에 되살아나므로 수명을 함께 확인한다.
+  const mountedRef = useRef(true);
+  useLayoutEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
   const paneIndex = usePaneIndex();
 
   // 요청받은 마운트가 확대면 확대 표면으로 보낸다. 스토어는 레일 열만 알고 있어서, 여기서
@@ -320,6 +327,7 @@ function PaneHost({
   }, [descriptor]);
 
   const handleReplaceParams = useCallback((next: Readonly<Record<string, string>>) => {
+    if (!mountedRef.current) return;
     replacePaneParams(descriptor.id, next, descriptor.role);
   }, [descriptor.id, descriptor.role]);
 

--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -320,8 +320,8 @@ function PaneHost({
   }, [descriptor]);
 
   const handleReplaceParams = useCallback((next: Readonly<Record<string, string>>) => {
-    replacePaneParams(descriptor.id, next);
-  }, [descriptor.id]);
+    replacePaneParams(descriptor.id, next, descriptor.role);
+  }, [descriptor.id, descriptor.role]);
 
   // 확대는 페인마다 만드는 기능이 아니라 표면 계약의 공통 동작이다 — 호스트 내장 표면이
   // paneId를 받아 같은 본문을 캔버스 위에 세운다. 그래서 이 버튼은 어떤 detail 페인에도

--- a/runtime/fleet-console/tests/pane-store-reset.test.ts
+++ b/runtime/fleet-console/tests/pane-store-reset.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   __resetPaneStoreForTests,
+  closePane,
   getPaneStoreSnapshot,
   openPane,
+  replacePaneParams,
   resetSurfacePanes,
 } from "../core/client/src/pane/pane-store.js";
 
@@ -60,6 +62,17 @@ describe("resetSurfacePanes arriving exemption", () => {
     // 없이 닫힌 detail이 옛 params째 되살아난다(닫기=언마운트 계약 위반, 리뷰 적발).
     openPane({ paneId: "repo-doc", params: { path: "old.md" } });
     resetSurfacePanes(new Map([["repo-doc", { role: "detail" }]]), new Set(["repo-doc"]));
+
+    expect(getPaneStoreSnapshot().rail).toHaveLength(0);
+  });
+
+  it("does not resurrect a closed detail through a stale parameter callback", () => {
+    openPane({ paneId: "repo-doc", params: { path: "old.md" } });
+    closePane("repo-doc");
+
+    // 닫히기 전 비동기 작업이 쥔 콜백을 흉내 낸다. 대상이 없다는 이유만으로 새 visible
+    // 인스턴스를 만들면, 닫기 이후 도착한 응답이 사용자의 닫힘을 뒤집는다.
+    replacePaneParams("repo-doc", { path: "late.md" }, "detail");
 
     expect(getPaneStoreSnapshot().rail).toHaveLength(0);
   });

--- a/runtime/fleet-console/tests/rail-surface-split.test.tsx
+++ b/runtime/fleet-console/tests/rail-surface-split.test.tsx
@@ -193,6 +193,18 @@ describe("레일 표면의 2단", () => {
     expect(container.querySelectorAll(".rail-pane")).toHaveLength(1);
   });
 
+  it("물러난 primary의 늦은 주소 갱신은 다음 열림에 남기지 않는다", () => {
+    render();
+    const stalePanes = listCtx!.panes;
+
+    // 레일 섹션을 닫아 PaneHost가 헐린 상황. 그 전에 시작한 비동기 작업만 옛 창구를 쥔다.
+    act(() => { root.render(<div data-testid="rail-closed" />); });
+    act(() => { stalePanes.replaceParams({ section: "late" }); });
+
+    // 늦은 응답이 씨앗을 만들면 다음에 같은 primary를 열 때 닫힌 뒤 생긴 주소가 되살아난다.
+    expect(getPaneStoreSnapshot().rail).toHaveLength(0);
+  });
+
   it("확대된 페인을 다시 열면 그 자리에서 갈아탄다 — 레일에 사본을 세우지 않는다", () => {
     render();
     openExpandedSurface({ surfaceId: "pane", params: { paneId: "doc", path: "a.ts" } });

--- a/runtime/fleet-console/tests/rail-surface-split.test.tsx
+++ b/runtime/fleet-console/tests/rail-surface-split.test.tsx
@@ -177,6 +177,22 @@ describe("레일 표면의 2단", () => {
     expect(new Set(seenPanes).size).toBe(1);
   });
 
+  it("자동으로 선 primary도 자기 params를 갈아탈 수 있다", () => {
+    render();
+    expect(listCtx?.params).toEqual({});
+
+    act(() => { listCtx?.panes.replaceParams({ section: "language" }); });
+
+    // primary는 처음에 스토어 인스턴스가 없다. 주소 갱신이 그 이유로 버려지면 설정 칩처럼
+    // ctx.params로 선택을 읽는 본문은 클릭을 받아도 영원히 첫 화면에 머문다.
+    expect(listCtx?.params).toEqual({ section: "language" });
+    expect(getPaneStoreSnapshot().rail.find((instance) => instance.paneId === "list")?.params)
+      .toEqual({ section: "language" });
+    // 주소를 기억한 primary를 detail 열로 오인해 분할하면 안 된다.
+    expect(container.querySelector(".rail-pane-divider")).toBeNull();
+    expect(container.querySelectorAll(".rail-pane")).toHaveLength(1);
+  });
+
   it("확대된 페인을 다시 열면 그 자리에서 갈아탄다 — 레일에 사본을 세우지 않는다", () => {
     render();
     openExpandedSurface({ surfaceId: "pane", params: { paneId: "doc", path: "a.ts" } });


### PR DESCRIPTION
## Summary

- 자동 마운트된 primary 페인이 `replaceParams`로 갱신한 주소를 보존합니다.
- 설정 섹션 칩이 활성 섹션과 본문을 실제로 전환하도록 복구합니다.
- primary 주소 인스턴스가 detail 열로 오인되거나 본문을 재마운트하지 않도록 계약 테스트를 추가합니다.

## Test Plan

- [x] `corepack pnpm --filter @dotobokuri/fleet-console test`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] 격리된 실제 브라우저에서 `겉모습 → 언어 → 겉모습` 양방향 전환 및 단일 열 유지 확인