### PR TITLE
feat(fleet-console): host one panel at a time on the Activity Rail

### DIFF
--- a/.changelog.d/full-bleed-chart-refit.md
+++ b/.changelog.d/full-bleed-chart-refit.md
@@ -8,8 +8,8 @@ branch: full-bleed-chart-refit
   ko: Cruise, Tactical, War Room 모두에서 작전 해도를 뷰포트 전면으로 확장하고, 사이드바와 Activity Rail을 그 위에 뜬 유리 카드로 바꾸며, 모든 모드 배치와 맞춤, 발사, 미니맵을 가려지지 않은 아레나 기준으로 계산합니다.
 - Unify the command band into one continuous plate: the sidebar cap seam is retired and the Cruise, Tactical, and War Room switch joins the left cluster at a fixed position.
   ko: 커맨드 밴드를 하나의 연속된 판으로 통일합니다. 사이드바 상단 캡 이음선을 퇴역시키고 Cruise, Tactical, War Room 스위치가 고정 위치의 좌측 클러스터에 합류합니다.
-- Turn the Activity Rail into a pinned stack: multiple panels stay resident at once with per-section collapse, panel opening no longer pushes the chart, and the push and overlay duality is retired in favor of the floating card.
-  ko: Activity Rail을 고정 스택으로 바꿉니다. 여러 패널이 섹션별 접기와 함께 동시에 상주하고, 패널을 열어도 해도를 밀어내지 않으며, push와 overlay 이원은 부유 카드로 단일화되어 퇴역합니다.
+- Host one panel at a time on the Activity Rail card: opening another panel replaces the current one, panel opening no longer pushes the chart, and the push and overlay duality is retired in favor of the floating card.
+  ko: Activity Rail 카드에는 패널이 한 번에 하나만 상주합니다. 다른 패널을 열면 현재 패널이 교체되고, 패널을 열어도 해도를 밀어내지 않으며, push와 overlay 이원은 부유 카드로 단일화되어 퇴역합니다.
 #### Added
 - Give the sidebar a self-contained card header with a Theater count, a new-Theater action, and an inline operation title filter.
   ko: 사이드바에 Theater 수와 새 Theater 동작, 인라인 Operation 제목 필터를 갖춘 자기 완결 카드 헤더를 추가합니다.

--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -97,6 +97,22 @@ export const RailSurface = memo(function RailSurface({
     resetSurfacePanes(paneIndexRef.current, ownedIdsRef.current);
   }, [entryId]);
 
+  // 떠나는 표면의 잔재 정리(departing sweep) — 독점 레일에서 패널 교체·닫기는 이 표면의
+  // 언마운트로 온다. 자기 소유 중 **비-keepAlive detail만** 닫는다: primary 인스턴스는 주소
+  // 기억으로 남고(재열림 연속성 계약), keepAlive는 세워 둔 채 떠나야 돌아왔을 때 그 자리가
+  // 다시 선다(구 unpin 계약 승계). 남기면 keepAlive 없이 닫힌 detail이 재열림에서 옛 params째
+  // 되살아난다(닫기=언마운트 계약). React는 물러나는 트리의 passive cleanup을 도착 트리의
+  // mount effect보다 먼저 돌리므로 도착 본문이 마운트에서 여는 detail은 여기 걸리지 않고,
+  // StrictMode 예행에서도 효과가 세운 열은 재설치가 다시 세운다.
+  const panesRef = useRef(binding.panes);
+  panesRef.current = binding.panes;
+  useEffect(() => () => {
+    for (const pane of panesRef.current) {
+      if (pane.role === "primary" || pane.keepAlive === true) continue;
+      closePane(pane.id);
+    }
+  }, []);
+
   const primary = useMemo(
     () => binding.panes.find((pane) => pane.role === "primary") ?? binding.panes[0],
     [binding.panes],

--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -83,10 +83,17 @@ export const RailSurface = memo(function RailSurface({
   const ownedIdsRef = useRef(ownedIds);
   ownedIdsRef.current = ownedIds;
   const previousEntryRef = useRef<string | null>(null);
+  // 확장 폭 소유권 — 아래 폭 효과와 나눠 쓴다. 엔트리가 바뀌면 소유권도 떠나는 표면의 것이라
+  // 여기서 함께 걷는다: 남겨 두면 도착 렌더에서 standing 0을 본 폭 효과가 이미 도착 패널의
+  // 것이 된 창구로 null을 쏘고, 자식(도착 본문) 마운트 효과가 부모 효과보다 먼저 돌아 그
+  // 본문이 막 요청한 폭을 덮는다(Codex P2). 떠난 표면 몫의 정리는 창구 소유자(호스트)의
+  // 계약이므로 여기서 창구를 부르지는 않는다.
+  const ownsExtraRef = useRef(false);
   useEffect(() => {
     const previous = previousEntryRef.current;
     previousEntryRef.current = entryId;
     if (previous === null || previous === entryId) return;
+    ownsExtraRef.current = false;
     resetSurfacePanes(paneIndexRef.current, ownedIdsRef.current);
   }, [entryId]);
 
@@ -156,7 +163,6 @@ export const RailSurface = memo(function RailSurface({
     (sum, { descriptor }) => sum + (paneWidths[descriptor.id] ?? descriptor.defaultWidth ?? MIN_PANE_PX),
     0,
   );
-  const ownsExtraRef = useRef(false);
   useEffect(() => {
     if (standing.length > 0) {
       ownsExtraRef.current = true;

--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -109,7 +109,9 @@ export const RailSurface = memo(function RailSurface({
   useEffect(() => () => {
     for (const pane of panesRef.current) {
       if (pane.role === "primary" || pane.keepAlive === true) continue;
-      closePane(pane.id);
+      // 호스트가 닫는 모든 경로는 onClose를 통보한다(sdk/pane 계약) — 캡션 닫기와 같은 문.
+      // 빼먹으면 플러그인은 그 문서가 여전히 열려 있다 믿고 다음 상태 발행에서 되살린다.
+      closePane(pane.id, pane.onClose ? { onClose: pane.onClose } : {});
     }
   }, []);
 

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -1,17 +1,15 @@
 import { useSyncExternalStore } from "react";
 
-/* 레일은 단일 활성 패널 슬롯에서 다중 고정(pin) 스택으로 개편됐다(전면 해도 개편 P3).
-   - pinnedPanelIds: 카드에 상주하는 패널들. 순서가 곧 스택 순서다. localStorage에 영속.
-   - collapsedPanelIds: 접힌 섹션. 세션 메모리 전용 — 새 페이지 로드는 전부 펼침으로 시작한다
-     (사이드바 STATUS 축과 같은 비영속 계약).
-   - push/overlay 이원은 퇴역했다: 부유 카드 레일에는 밀어낼 그리드 트랙이 없다. 구 push의
-     "콘텐츠를 가리지 않는다"는 기대는 아레나 인셋이 승계한다 — 열린 패널 폭이 캔버스 아레나에서
-     항상 제외되므로 fit-all·Tactical 슬롯·War Room 무대가 패널을 피해 계산된다. */
+/* 레일은 다중 고정(pin) 스택에서 단일 독점 슬롯으로 회귀했다 — 카드에는 패널이 하나만 상주한다.
+   - activePanelId: 카드에 상주하는 유일한 패널. localStorage에 영속.
+   - 아이콘 클릭은 배타 전환이다: 켜진 패널을 다시 누르면 닫히고, 다른 패널을 누르면 교체된다.
+   - push/overlay 이원의 퇴역과 아레나 인셋 승계는 스택 시절 그대로다 — 열린 패널 폭이 캔버스
+     아레나에서 항상 제외되므로 fit-all·Tactical 슬롯·War Room 무대가 패널을 피해 계산된다. */
 interface RailStore {
-  readonly pinnedPanelIds: readonly string[];
-  readonly collapsedPanelIds: readonly string[];
+  readonly activePanelId: string | null;
   readonly railChromeExpanded: boolean;
-  readonly panelExtraWidths: Readonly<Record<string, number>>;
+  /** 활성 패널의 확장 폭 요구(px) — 독점 슬롯이라 요구도 하나다. 패널 교체·닫힘에 0으로 리셋. */
+  readonly panelExtraWidth: number;
   readonly overlayAlpha: RailOverlayAlpha;
   /** 레일 카드가 캔버스 위에서 점유하는 실측 폭(px) — RightRail이 보고하고 아레나 계산이 소비한다. */
   readonly railOccupiedPx: number;
@@ -24,17 +22,16 @@ export const RAIL_OVERLAY_ALPHA_MAX = 100;
 export const RAIL_OVERLAY_ALPHA_DEFAULT = 100;
 
 type Listener = () => void;
-const PREFS_PINNED_PANELS = "fleet-console.rail.pinnedPanels";
-const LEGACY_PREFS_ACTIVE_PANEL = "fleet-console.rail.activePanelId";
+const PREFS_ACTIVE_PANEL = "fleet-console.rail.activePanelId";
+const LEGACY_PREFS_PINNED_PANELS = "fleet-console.rail.pinnedPanels";
 const PREFS_CHROME_EXPANDED = "fleet-console.rail.chromeExpanded";
 const PREFS_OVERLAY_ALPHA = "fleet-console.rail.overlayAlpha";
 const PREFS_REPOSITORY_SOURCE = "fleet-console.repository.source";
 const listeners = new Set<Listener>();
 let store: RailStore = {
-  pinnedPanelIds: readStoredPinnedPanels(),
-  collapsedPanelIds: [],
+  activePanelId: readStoredActivePanelId(),
   railChromeExpanded: readStoredChromeExpanded(),
-  panelExtraWidths: {},
+  panelExtraWidth: 0,
   overlayAlpha: readStoredOverlayAlpha(),
   railOccupiedPx: 0,
 };
@@ -48,30 +45,23 @@ export function getRailStoreSnapshot(): RailStore {
   return store;
 }
 
-/** 아이콘 클릭의 토글 — 고정돼 있으면 내리고, 아니면 고정하고 펼친다. */
+/** 아이콘 클릭의 배타 토글 — 켜진 패널이면 닫고, 아니면 그 패널로 교체한다. */
 export function toggleRailPanel(id: string): void {
-  if (store.pinnedPanelIds.includes(id)) {
-    unpinRailPanel(id);
+  if (store.activePanelId === id) {
+    deactivateRailPanel();
     return;
   }
-  pinRailPanel(id);
+  activateRailPanel(id);
 }
 
-/** Ensure-open(팔레트·플러그인 capability): 고정을 보장하고 접혀 있으면 펼친다. 절대 닫지 않는다. */
+/** Ensure-open(팔레트·플러그인 capability): 그 패널이 활성임을 보장한다. 절대 닫지 않는다. */
 export function openRailPanel(id: string): void {
-  pinRailPanel(id);
+  activateRailPanel(id);
 }
 
 export function closeRailPanel(id: string): void {
-  unpinRailPanel(id);
-}
-
-export function toggleRailSectionCollapsed(id: string): void {
-  if (!store.pinnedPanelIds.includes(id)) return;
-  const collapsed = store.collapsedPanelIds.includes(id)
-    ? store.collapsedPanelIds.filter((panelId) => panelId !== id)
-    : [...store.collapsedPanelIds, id];
-  setStore({ ...store, collapsedPanelIds: collapsed });
+  if (store.activePanelId !== id) return;
+  deactivateRailPanel();
 }
 
 export function setRailChromeExpanded(expanded: boolean): void {
@@ -91,17 +81,14 @@ export function setRailOverlayAlpha(alpha: number): void {
   saveStoredOverlayAlpha(clamped);
 }
 
-// 폭 요구는 고정된 패널 전원이 말할 수 있다 — 단일 활성 가드는 스택에서 뒷섹션의 확장 요구를
-// 버리는 결함이었다(감사 blocker). 소비 측은 펼쳐진 고정 패널의 최댓값을 취한다.
+// 폭 요구는 활성 패널만 말할 수 있다 — 독점 슬롯에서 화면 밖 패널의 요구는 실체가 없다.
 export function requestRailPanelExtraWidth(panelId: string, px: number | null): void {
-  if (!store.pinnedPanelIds.includes(panelId)) return;
+  if (store.activePanelId !== panelId) return;
   const raw = (px === null || !Number.isFinite(px)) ? 0 : px;
   const normalized = Math.max(0, Math.round(raw));
   const clamped = typeof window !== "undefined" ? Math.min(normalized, Math.max(0, window.innerWidth - 548)) : normalized;
-  // 미등록 상태에서 0 요청도 항목을 심는다 — undefined와 0을 같다고 치면 첫 정규화 요청이
-  // 스냅샷에 흔적을 남기지 않아 상태 검사가 어긋난다.
-  if (store.panelExtraWidths[panelId] !== undefined && clamped === store.panelExtraWidths[panelId]) return;
-  setStore({ ...store, panelExtraWidths: { ...store.panelExtraWidths, [panelId]: clamped } });
+  if (clamped === store.panelExtraWidth) return;
+  setStore({ ...store, panelExtraWidth: clamped });
 }
 
 /** RightRail이 레이아웃 후 자기 점유 폭을 보고한다 — Operations 페이지의 아레나 계산 원료. */
@@ -111,20 +98,16 @@ export function reportRailOccupiedPx(px: number): void {
   setStore({ ...store, railOccupiedPx: normalized });
 }
 
-export function useRailPinnedPanelIds(): readonly string[] {
-  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).pinnedPanelIds;
-}
-
-export function useRailCollapsedPanelIds(): readonly string[] {
-  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).collapsedPanelIds;
+export function useRailActivePanelId(): string | null {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).activePanelId;
 }
 
 export function useRailChromeExpanded(): boolean {
   return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).railChromeExpanded;
 }
 
-export function useRailPanelExtraWidths(): Readonly<Record<string, number>> {
-  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelExtraWidths;
+export function useRailPanelExtraWidth(): number {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelExtraWidth;
 }
 
 export function useRailOverlayAlpha(): RailOverlayAlpha {
@@ -135,58 +118,66 @@ export function useRailOccupiedPx(): number {
   return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).railOccupiedPx;
 }
 
-function pinRailPanel(id: string): void {
-  const pinned = store.pinnedPanelIds.includes(id) ? store.pinnedPanelIds : [...store.pinnedPanelIds, id];
-  const collapsed = store.collapsedPanelIds.filter((panelId) => panelId !== id);
-  if (pinned === store.pinnedPanelIds && collapsed.length === store.collapsedPanelIds.length) return;
-  setStore({ ...store, pinnedPanelIds: pinned, collapsedPanelIds: collapsed });
-  saveStoredPinnedPanels(pinned);
+function activateRailPanel(id: string): void {
+  if (store.activePanelId === id) return;
+  // 교체는 이전 패널의 확장 폭 요구도 함께 내린다 — 화면에 없는 요구가 아레나를 점유하면 안 된다.
+  setStore({ ...store, activePanelId: id, panelExtraWidth: 0 });
+  saveStoredActivePanelId(id);
 }
 
-function unpinRailPanel(id: string): void {
-  if (!store.pinnedPanelIds.includes(id)) return;
-  const pinned = store.pinnedPanelIds.filter((panelId) => panelId !== id);
-  const { [id]: _dropped, ...extraWidths } = store.panelExtraWidths;
-  setStore({
-    ...store,
-    pinnedPanelIds: pinned,
-    collapsedPanelIds: store.collapsedPanelIds.filter((panelId) => panelId !== id),
-    panelExtraWidths: extraWidths,
-  });
-  saveStoredPinnedPanels(pinned);
+function deactivateRailPanel(): void {
+  if (store.activePanelId === null) return;
+  setStore({ ...store, activePanelId: null, panelExtraWidth: 0 });
+  saveStoredActivePanelId(null);
 }
 
-function readStoredPinnedPanels(): readonly string[] {
+function readStoredActivePanelId(): string | null {
   try {
-    const raw = localStorage.getItem(PREFS_PINNED_PANELS);
-    if (raw !== null) {
-      const parsed: unknown = JSON.parse(raw);
-      if (Array.isArray(parsed)) return parsed.filter((id): id is string => typeof id === "string" && id !== "");
-      return [];
+    const stored = localStorage.getItem(PREFS_ACTIVE_PANEL);
+    if (stored !== null) {
+      // 스택 키가 남아 있으면 함께 걷는다 — 활성 키가 지워진 뒤 옛 스택이 되살아나면 안 된다.
+      try { localStorage.removeItem(LEGACY_PREFS_PINNED_PANELS); } catch { /* ignore */ }
+      const active = normalizeStoredPanelId(stored);
+      // 1기 슬롯 값(diff/history/alerts)은 같은 키에 살아 있다. 정규화만 하고 다시 쓰지 않으면
+      // 매 로드가 history 소스를 되심고, alerts는 닫힌 레일을 유령 키로 남긴다(출시본 1회성 승격).
+      if (active !== stored) {
+        try {
+          if (active === null) localStorage.removeItem(PREFS_ACTIVE_PANEL);
+          else localStorage.setItem(PREFS_ACTIVE_PANEL, active);
+        } catch { /* best-effort migration */ }
+      }
+      return active;
     }
-    // 단일 활성 슬롯 시절의 기억을 스택의 첫 고정으로 승격한다(1회성 마이그레이션).
-    const legacy = readLegacyStoredPanelId();
-    const pinned = legacy === null ? [] : [legacy];
+    // 스택 시절의 기억을 독점 슬롯으로 승격한다 — 첫 고정(최상단 섹션)이 살아남는다(1회성 마이그레이션).
+    const raw = localStorage.getItem(LEGACY_PREFS_PINNED_PANELS);
+    if (raw === null) return null;
+    let active: string | null = null;
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      const first = parsed.find((id): id is string => typeof id === "string" && id !== "");
+      active = first === undefined ? null : normalizeStoredPanelId(first);
+    }
     try {
-      localStorage.setItem(PREFS_PINNED_PANELS, JSON.stringify(pinned));
-      localStorage.removeItem(LEGACY_PREFS_ACTIVE_PANEL);
+      if (active === null) localStorage.removeItem(PREFS_ACTIVE_PANEL);
+      else localStorage.setItem(PREFS_ACTIVE_PANEL, active);
+      localStorage.removeItem(LEGACY_PREFS_PINNED_PANELS);
     } catch { /* best-effort migration */ }
-    return pinned;
-  } catch { return []; }
+    return active;
+  } catch { return null; }
 }
 
-function readLegacyStoredPanelId(): string | null {
-  try {
-    const stored = localStorage.getItem(LEGACY_PREFS_ACTIVE_PANEL);
-    if (stored === "diff" || stored === "history") {
-      try {
-        if (stored === "history") localStorage.setItem(PREFS_REPOSITORY_SOURCE, "history");
-      } catch { /* best-effort migration */ }
-      return "repository";
-    }
-    if (stored === "alerts") return null;
-    return stored;
-  } catch { return null; }
+/* 단일 활성 슬롯 1기 시절 값 정규화 — diff/history는 repository 패널로 흡수됐고(history는
+   Repository 소스 시드 유지), alerts 패널은 퇴역했다. 스택 시절 값은 현대 id라 그대로 통과한다. */
+function normalizeStoredPanelId(stored: string): string | null {
+  if (stored === "") return null;
+  if (stored === "diff" || stored === "history") {
+    try {
+      if (stored === "history") localStorage.setItem(PREFS_REPOSITORY_SOURCE, "history");
+    } catch { /* best-effort migration */ }
+    return "repository";
+  }
+  if (stored === "alerts") return null;
+  return stored;
 }
 
 function readStoredChromeExpanded(): boolean {
@@ -206,8 +197,11 @@ function clampRailOverlayAlpha(alpha: number): RailOverlayAlpha {
   return Math.min(RAIL_OVERLAY_ALPHA_MAX, Math.max(RAIL_OVERLAY_ALPHA_MIN, Math.round(alpha)));
 }
 
-function saveStoredPinnedPanels(pinned: readonly string[]): void {
-  try { localStorage.setItem(PREFS_PINNED_PANELS, JSON.stringify(pinned)); } catch { /* ignore */ }
+function saveStoredActivePanelId(id: string | null): void {
+  try {
+    if (id === null) localStorage.removeItem(PREFS_ACTIVE_PANEL);
+    else localStorage.setItem(PREFS_ACTIVE_PANEL, id);
+  } catch { /* ignore */ }
 }
 
 function saveStoredChromeExpanded(expanded: boolean): void {

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -311,10 +311,12 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
           />
         )}
         {activeBinding !== null && (
-          // key가 패널 교체를 언마운트/재마운트로 만든다 — 스택 시절 unpin/re-pin과 같은
-          // 수명 계약이라, pane-store의 keepAlive 주차·복귀 경로가 그대로 이어진다.
+          // 의도적으로 key를 두지 않는다 — 섹션 인스턴스가 하나로 유지되어야 RailSurface가
+          // 엔트리 교체를 목격하고 pane 계약의 정리(resetSurfacePanes)를 돌린다: 떠나는 표면의
+          // 비-keepAlive 열은 내려가고 keepAlive는 주차된다. key 재마운트는 그 정리를 침묵시켜
+          // 닫힌 detail이 옛 params째 되살아난다(Codex P1). 명시적 닫기(X·아이콘 재클릭)는
+          // 섹션 언마운트로 남아 재열림 복원의 연속성을 그대로 잇는다.
           <RailSection
-            key={activeBinding.entry.id}
             binding={activeBinding}
             baseCtx={baseCtx}
             connection={connection}

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -311,12 +311,14 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
           />
         )}
         {activeBinding !== null && (
-          // 의도적으로 key를 두지 않는다 — 섹션 인스턴스가 하나로 유지되어야 RailSurface가
-          // 엔트리 교체를 목격하고 pane 계약의 정리(resetSurfacePanes)를 돌린다: 떠나는 표면의
-          // 비-keepAlive 열은 내려가고 keepAlive는 주차된다. key 재마운트는 그 정리를 침묵시켜
-          // 닫힌 detail이 옛 params째 되살아난다(Codex P1). 명시적 닫기(X·아이콘 재클릭)는
-          // 섹션 언마운트로 남아 재열림 복원의 연속성을 그대로 잇는다.
+          // key 재마운트가 패널 교체의 수명 계약이다: 떠나는 표면은 자기 언마운트 cleanup에서
+          // 비-keepAlive detail을 닫는다(RailSurface의 departing sweep). React가 물러나는
+          // 트리의 passive cleanup을 도착 트리의 mount effect보다 먼저 돌리므로, 도착 본문이
+          // 마운트에서 여는 detail(파일 문서 열·Codex 리더)은 정리에 걸리지 않는다. 인스턴스를
+          // 재사용하면 그 정리가 수동 effect로 밀려 도착 마운트 **뒤에** 돌아, 방금 연 열을
+          // 쓸어 내거나(Codex 3차 P1) 확장 폭 소유권이 새 패널로 샌다(Codex 2차 P2).
           <RailSection
+            key={activeBinding.entry.id}
             binding={activeBinding}
             baseCtx={baseCtx}
             connection={connection}

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -17,7 +17,7 @@ import { getState, subscribe } from "../store.js";
 import { useSideBarState } from "../sidebar/operations-side-bar-store.js";
 import type { ConnectionState } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
-import { closeRailPanel, reportRailOccupiedPx, requestRailPanelExtraWidth, toggleRailPanel, toggleRailSectionCollapsed, useRailChromeExpanded, useRailCollapsedPanelIds, useRailOverlayAlpha, useRailPanelExtraWidths, useRailPinnedPanelIds } from "./rail-store.js";
+import { closeRailPanel, reportRailOccupiedPx, requestRailPanelExtraWidth, toggleRailPanel, useRailActivePanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelExtraWidth } from "./rail-store.js";
 import { GearGlyph, SETTINGS_RAIL_ENTRY_ID } from "../settings/settings-entry.js";
 import { useRailEntries, type RailEntryBinding } from "../pane/pane-registry.js";
 import { RailSurface } from "../pane/rail-surface.js";
@@ -34,9 +34,8 @@ const MIN_PANEL_WIDTH = 240;
 const DEFAULT_PANEL_WIDTH = 312;
 /** 아이콘 열 폭 — rail.css .right-rail-icons와 한 값. */
 const RAIL_ICON_STRIP_WIDTH = 44;
-/* 스택 개편 후 카드 폭은 패널별이 아니라 카드 단일 값이다 — 두 패널이 동시에 상주하는
-   스택에서 패널별 폭 기억은 어느 값을 카드에 입힐지 결정 불능이었다(감사 high). 구 패널별
-   기억(panelWidths)은 첫 로드에 최댓값으로 승격해 카드 폭으로 흡수한다. */
+/* 카드 폭은 패널별이 아니라 카드 단일 값이다 — 어느 패널이 상주하든 카드는 한 폭을 기억한다.
+   구 패널별 기억(panelWidths)은 첫 로드에 최댓값으로 승격해 카드 폭으로 흡수한다(1회성). */
 const PREFS_CARD_WIDTH = "fleet-console.rail.cardWidth";
 const LEGACY_PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
 const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
@@ -106,15 +105,14 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   const globalSettings = useGlobalSettingsStore();
   const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
   const rootRef = useRef<HTMLDivElement>(null);
-  const pinnedIds = useRailPinnedPanelIds();
-  const collapsedIds = useRailCollapsedPanelIds();
-  const extraWidths = useRailPanelExtraWidths();
+  const activePanelId = useRailActivePanelId();
+  const extraWidth = useRailPanelExtraWidth();
   const railChromeExpanded = useRailChromeExpanded();
   const overlayAlpha = useRailOverlayAlpha();
   const previousRailChromeExpandedRef = useRef(railChromeExpanded);
   const bindings = useRailEntries();
   // 페인을 세우는 엔트리와 그냥 실행하는 엔트리의 구분은 "이 엔트리가 세우는 페인이 있는가"라는
-  // 사실 하나가 진다(pane 계약, #957). 고정 스택·폭 계산은 페인 엔트리만 본다.
+  // 사실 하나가 진다(pane 계약, #957). 활성 패널·폭 계산은 페인 엔트리만 본다.
   const paneEntries = bindings.filter((binding) => binding.panes.length > 0);
   // 합성 순서가 곧 레일 순서다(virtual:fleet-plugins). 동작 엔트리를 종류별로 앞세우면 등록
   // 순서가 렌더에서 뒤집히므로(Shell이 Codex 앞에 섰다), 순서는 바인딩 그대로 두고 연속한
@@ -133,18 +131,12 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
     () => new Set(openSurfaces.map((instance) => instance.surfaceId)),
     [openSurfaces],
   );
-  // 고정 순서(핀 순)가 곧 스택 순서다 — 등록 목록에 없는 id(내려간 플러그인)는 조용히 거른다.
-  const pinnedBindings = pinnedIds
-    .map((id) => paneEntries.find((binding) => binding.entry.id === id))
-    .filter((binding): binding is RailEntryBinding => binding !== undefined);
-  const expandedBindings = pinnedBindings.filter((binding) => !collapsedIds.includes(binding.entry.id));
-  const hasPanel = pinnedBindings.length > 0;
-  // 폭 요구는 펼쳐진 고정 패널들의 최댓값이다 — 합산하면 카드가 요구의 합만큼 부풀어
-  // 아레나를 과점유한다. 접힌 섹션의 요구는 화면에 없으므로 세지 않는다.
-  const extraWidth = expandedBindings.reduce(
-    (max, binding) => Math.max(max, extraWidths[binding.entry.id] ?? 0),
-    0,
-  );
+  // 등록 목록에 없는 id(내려간 플러그인)는 조용히 무시한다 — 저장된 id는 유지되어
+  // 플러그인이 돌아오면 그 패널이 다시 선다.
+  const activeBinding = activePanelId === null
+    ? null
+    : (paneEntries.find((binding) => binding.entry.id === activePanelId) ?? null);
+  const hasPanel = activeBinding !== null;
   const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   // 부유 사이드바 카드의 점유 폭 — 두 카드는 같은 층(z --z-rail)의 절대 배치라 그리드가
   // 겹침을 막아 주지 않는다. 레일 폭 상한이 이 점유를 빼지 않으면 드래그·End 키 한 번에
@@ -161,7 +153,7 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   // 않는다(Codex 리뷰 확정 — 구 폭 기억 effect의 restore-on-expansion 계약 승계).
   const [initialWidths] = useState(() => {
     const stored = readStoredCardWidth();
-    const fallback = defaultCardWidthFor(pinnedBindings.length > 0 ? pinnedBindings : paneEntries);
+    const fallback = defaultCardWidthFor(activeBinding !== null ? [activeBinding] : paneEntries);
     const desired = Math.max(MIN_PANEL_WIDTH, stored ?? fallback);
     return { desired, rendered: Math.min(maxPanelWidth, desired) };
   });
@@ -198,7 +190,7 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   }, [railChromeExpanded]);
 
   // 아레나 계산의 원료 — 레일이 캔버스 위에서 점유하는 실측 폭을 스토어로 보고한다.
-  // fit-all·Tactical 슬롯·War Room 무대가 이 값으로 열린 스택을 피해 계산된다.
+  // fit-all·Tactical 슬롯·War Room 무대가 이 값으로 열린 카드를 피해 계산된다.
   // 슬롯 총폭(카드+extra)도 예산으로 캡한다 — 카드 상한만 사이드바를 빼면 MIN 바닥(240)과
   // 가산 extra(예: Codex 리더 360)가 상한을 도로 뚫어 좁은 창에서 두 카드가 겹친다
   // (Codex 리뷰 확정). extra는 best-effort다: 페인 본문은 컨테이너 쿼리로 스스로 열화한다.
@@ -265,16 +257,16 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
     saveStoredCardWidth(desiredWidthRef.current);
   }, []);
 
-  // 메뉴의 "패널 폭 초기화" — 기억을 지우고 고정된 패널들의 선언 기본값(최대)으로 되돌린다.
+  // 메뉴의 "패널 폭 초기화" — 기억을 지우고 활성 패널의 선언 기본값으로 되돌린다.
   const handleResetCardWidth = useCallback(() => {
     clearStoredCardWidth();
     const currentMaxWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidthRef.current - sideBarOccupiedRef.current));
-    const next = Math.max(MIN_PANEL_WIDTH, Math.min(currentMaxWidth, defaultCardWidthFor(pinnedBindings.length > 0 ? pinnedBindings : paneEntries)));
+    const next = Math.max(MIN_PANEL_WIDTH, Math.min(currentMaxWidth, defaultCardWidthFor(activeBinding !== null ? [activeBinding] : paneEntries)));
     desiredWidthRef.current = next;
     cardWidthRef.current = next;
     setCardWidthState(next);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pinnedIds.join("\0"), paneEntries.length]);
+  }, [activePanelId, paneEntries.length]);
 
   const baseCtx: RailPanelContext = useMemo(() => ({
     theaterId,
@@ -318,20 +310,17 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
             aria-valuemax={maxPanelWidth}
           />
         )}
-        {hasPanel && (
-          <div className="right-rail-stack">
-            {pinnedBindings.map((binding) => (
-              <RailSection
-                key={binding.entry.id}
-                binding={binding}
-                collapsed={collapsedIds.includes(binding.entry.id)}
-                baseCtx={baseCtx}
-                connection={connection}
-                connectionLostAt={connectionLostAt}
-                language={language}
-              />
-            ))}
-          </div>
+        {activeBinding !== null && (
+          // key가 패널 교체를 언마운트/재마운트로 만든다 — 스택 시절 unpin/re-pin과 같은
+          // 수명 계약이라, pane-store의 keepAlive 주차·복귀 경로가 그대로 이어진다.
+          <RailSection
+            key={activeBinding.entry.id}
+            binding={activeBinding}
+            baseCtx={baseCtx}
+            connection={connection}
+            connectionLostAt={connectionLostAt}
+            language={language}
+          />
         )}
       </div>
       <nav className="right-rail-icons" aria-label={t("rail.chrome.toolsAria")}>
@@ -341,9 +330,9 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
         <button
           id="rail-settings-toggle"
           type="button"
-          className={`right-rail-ico right-rail-settings-btn${pinnedIds.includes(SETTINGS_RAIL_ENTRY_ID) ? " is-active" : ""}`}
-          aria-pressed={pinnedIds.includes(SETTINGS_RAIL_ENTRY_ID)}
-          aria-controls={pinnedIds.includes(SETTINGS_RAIL_ENTRY_ID) ? `rail-panel-${SETTINGS_RAIL_ENTRY_ID}` : undefined}
+          className={`right-rail-ico right-rail-settings-btn${activePanelId === SETTINGS_RAIL_ENTRY_ID ? " is-active" : ""}`}
+          aria-pressed={activePanelId === SETTINGS_RAIL_ENTRY_ID}
+          aria-controls={activePanelId === SETTINGS_RAIL_ENTRY_ID ? `rail-panel-${SETTINGS_RAIL_ENTRY_ID}` : undefined}
           aria-label={t("settings.title")}
           title={t("settings.title")}
           onClick={() => toggleRailPanel(SETTINGS_RAIL_ENTRY_ID)}
@@ -351,11 +340,11 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
           <GearGlyph />
         </button>
         <div className="right-rail-divider" role="separator" aria-orientation="horizontal" />
-        {/* 스택 개편 후 아이콘은 배타 탭이 아니라 고정(pin) 토글이다 — 여러 개가 동시에 켜진다.
+        {/* 아이콘은 배타 전환이다 — 한 번에 하나만 켜지고, 켜진 아이콘을 다시 누르면 닫힌다.
             설정은 문(톱니)으로만 열리므로 탭 목록에는 다시 서지 않는다. */}
         <div className="right-rail-tabs" role="group" aria-label={t("rail.chrome.panelsAria")}>
           {paneEntries.filter((binding) => binding.core && binding.entry.id !== SETTINGS_RAIL_ENTRY_ID).map(({ entry }) => (
-            <RailIcon key={entry.id} entry={entry} context={baseCtx} language={language} isActive={pinnedIds.includes(entry.id)} />
+            <RailIcon key={entry.id} entry={entry} context={baseCtx} language={language} isActive={activePanelId === entry.id} />
           ))}
         </div>
         {pluginRuns.map((run) => run.kind === "action"
@@ -377,7 +366,7 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
           : (
             <div key={run.key} className="right-rail-tabs" role="group" aria-label={t("rail.chrome.panelsAria")}>
               {run.bindings.map(({ entry }) => (
-                <RailIcon key={entry.id} entry={entry} context={baseCtx} language={language} isActive={pinnedIds.includes(entry.id)} />
+                <RailIcon key={entry.id} entry={entry} context={baseCtx} language={language} isActive={activePanelId === entry.id} />
               ))}
             </div>
           ))}
@@ -388,31 +377,21 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
 
 interface RailSectionProps {
   readonly binding: RailEntryBinding;
-  readonly collapsed: boolean;
   readonly baseCtx: RailPanelContext;
   readonly connection: ConnectionState;
   readonly connectionLostAt: number | null;
   readonly language: ConsoleLocale;
 }
 
-/** 스택의 한 칸 — 헤더(접기·닫기) + 상주 본문. 접힘은 본문을 숨길 뿐 마운트를 유지한다:
- *  파일 트리·diff·Codex의 내부 상태가 섹션 접기마다 리셋되면 스택은 배타 탭보다 나쁘다. */
-function RailSection({ binding, collapsed, baseCtx, connection, connectionLostAt, language }: RailSectionProps) {
+/** 카드의 독점 상주자 — 헤더(제목·닫기) + 본문. 패널은 하나만 상주하므로 접기는 없다:
+ *  안 볼 패널은 접는 게 아니라 닫거나 다른 패널로 교체한다. */
+function RailSection({ binding, baseCtx, connection, connectionLostAt, language }: RailSectionProps) {
   const t = useT();
   const title = resolveLocalizedText(binding.entry.title, language);
   return (
-    <section className={`right-rail-section${collapsed ? " is-collapsed" : ""}`}>
+    <section className="right-rail-section">
       <header className="right-rail-section-head">
-        <button
-          type="button"
-          className="right-rail-section-toggle"
-          aria-expanded={!collapsed}
-          aria-controls={`rail-panel-${binding.entry.id}`}
-          onClick={() => toggleRailSectionCollapsed(binding.entry.id)}
-        >
-          <span className="right-rail-section-caret" aria-hidden="true" />
-          <span className="right-rail-section-title">{title}</span>
-        </button>
+        <span className="right-rail-section-title">{title}</span>
         <button
           type="button"
           className="right-rail-section-close"
@@ -423,7 +402,11 @@ function RailSection({ binding, collapsed, baseCtx, connection, connectionLostAt
             // 위치를 잃는다(Codex 리뷰). 같은 패널의 레일 아이콘은 언핀 후에도 남는 안정
             // 좌표이므로 먼저 그리로 옮긴다.
             if (event.currentTarget === document.activeElement) {
-              document.getElementById(`rail-tab-${binding.entry.id}`)?.focus();
+              // 설정은 탭 목록에 서지 않는다 — 문(톱니)이 닫힌 뒤에도 남는 안정 좌표다.
+              const focusId = binding.entry.id === SETTINGS_RAIL_ENTRY_ID
+                ? "rail-settings-toggle"
+                : `rail-tab-${binding.entry.id}`;
+              document.getElementById(focusId)?.focus();
             }
             closeRailPanel(binding.entry.id);
           }}
@@ -431,7 +414,7 @@ function RailSection({ binding, collapsed, baseCtx, connection, connectionLostAt
           <CloseGlyph />
         </button>
       </header>
-      <div className="right-rail-section-body" hidden={collapsed} inert={collapsed || undefined}>
+      <div className="right-rail-section-body">
         <RailPanelBody binding={binding} ctx={baseCtx} connection={connection} connectionLostAt={connectionLostAt} language={language} />
       </div>
     </section>
@@ -493,7 +476,7 @@ const RailPanelBody = memo(function RailPanelBody({ binding, ctx, connection, co
     }
   }, [staleVisible]);
 
-  // 스택의 모든 섹션은 region이다. 설정은 탭이 아니라 문(톱니 토글)이 열므로 문을 라벨로
+  // 독점 섹션도 region이다. 설정은 탭이 아니라 문(톱니 토글)이 열므로 문을 라벨로
   // 삼고, 나머지 섹션은 자기 레일 탭(rail-tab-*)을 라벨로 삼는다.
   const doorSurface = binding.entry.id === SETTINGS_RAIL_ENTRY_ID;
   return (
@@ -553,7 +536,7 @@ function RailIcon({ entry, context, language, isActive }: RailIconProps) {
       id={`rail-tab-${entry.id}`}
       className={`right-rail-ico${isActive ? " is-active" : ""}`}
       type="button"
-      // 스택 개편 후 패널 아이콘은 배타 탭이 아니라 고정 토글이다 — 켜짐은 pressed로 말한다.
+      // 패널 아이콘은 배타 전환 토글이다 — 켜짐은 pressed로 말하고, 최대 하나만 true다.
       aria-pressed={isActive}
       aria-label={title}
       disabled={entry.activate !== undefined && context.theaterId === null}
@@ -568,5 +551,3 @@ function RailIcon({ entry, context, language, isActive }: RailIconProps) {
 function CloseGlyph() {
   return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" /></svg>;
 }
-
-/* 패널 접기 아이콘 — 우측 영역을 선으로 구분한 패널 모양(#44 시안, 우측 미러). */

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -11,7 +11,7 @@
 
 /* 부유 유리 카드 — 전면 해도 개편으로 레일은 그리드 열이 아니라 캔버스 위에 뜬 카드다.
    구 push/overlay 이원은 퇴역했다: 밀어낼 그리드 트랙이 더는 없고, "가리지 않는다"는 push의
-   기대는 아레나 인셋(캔버스 기하가 열린 스택 폭을 항상 제외)이 승계한다. */
+   기대는 아레나 인셋(캔버스 기하가 열린 카드 폭을 항상 제외)이 승계한다. */
 .right-rail {
   position: absolute;
   top: var(--space-3);
@@ -94,10 +94,10 @@
   pointer-events: none;
 }
 
-/* ── 스택 섹션 ─────────────────────────────────────────────────────
-   여러 패널이 병렬 상주한다(P3). 펼친 섹션들이 남은 높이를 균분하고, 접힌 섹션은 헤더만
-   남는다. 본문은 접혀도 마운트를 유지한다 — 숨김은 [hidden]+inert가 진다(right-rail.tsx). */
-.right-rail-stack {
+/* ── 독점 섹션 ─────────────────────────────────────────────────────
+   카드에는 패널이 하나만 상주한다 — 헤더(제목·닫기)와 본문이 슬롯 전체를 갖는다.
+   z-index 1은 슬롯 재질(::before, z 0) 위로 헤더까지 함께 띄운다(구 스택 래퍼의 몫 승계). */
+.right-rail-section {
   position: relative;
   z-index: 1;
   display: flex;
@@ -105,22 +105,6 @@
   min-height: 0;
   min-width: 240px;
   overflow: hidden;
-}
-
-.right-rail-section {
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0;
-  min-height: 0;
-  border-top: 1px solid var(--surface-rim);
-}
-
-.right-rail-section:first-child {
-  border-top: none;
-}
-
-.right-rail-section.is-collapsed {
-  flex: 0 0 auto;
 }
 
 .right-rail-section-head {
@@ -131,52 +115,20 @@
   padding: 3px 6px 3px 4px;
 }
 
-.right-rail-section-toggle {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+/* 제목은 더는 접기 버튼이 아니다 — 정적 라벨이 섹션의 정체만 말한다. */
+.right-rail-section-title {
   flex: 1;
   min-width: 0;
   padding: 3px 5px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-xs);
-  background: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  text-align: left;
-  cursor: pointer;
-}
-
-.right-rail-section-toggle:hover,
-.right-rail-section-toggle:focus-visible {
-  background: var(--control-hover-fill);
-  color: var(--text-primary);
-  outline: none;
-}
-
-.right-rail-section-caret {
-  flex: none;
-  width: 0;
-  height: 0;
-  border-left: 4px solid currentColor;
-  border-top: 3.5px solid transparent;
-  border-bottom: 3.5px solid transparent;
-  transition: transform var(--duration-fast) var(--ease-spring);
-}
-
-.right-rail-section-toggle[aria-expanded="true"] .right-rail-section-caret {
-  transform: rotate(90deg);
-}
-
-.right-rail-section-title {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .right-rail-section-close {

--- a/runtime/fleet-console/tests/host-picker-surface.test.tsx
+++ b/runtime/fleet-console/tests/host-picker-surface.test.tsx
@@ -411,7 +411,10 @@ describe("the manage door after the settings page retired", () => {
 
   it("summons the settings surface at connectivity from the home list", async () => {
     __resetPaneStoreForTests();
-    for (const id of [...getRailStoreSnapshot().pinnedPanelIds]) closeRailPanel(id);
+    {
+      const active = getRailStoreSnapshot().activePanelId;
+      if (active !== null) closeRailPanel(active);
+    }
     setRailChromeExpanded(false);
     stubHomeConsole();
 
@@ -419,7 +422,7 @@ describe("the manage door after the settings page retired", () => {
     await act(async () => { document.querySelector<HTMLButtonElement>(".host-switcher-chip")!.click(); });
     await act(async () => { manageLink().click(); });
 
-    expect(getRailStoreSnapshot().pinnedPanelIds).toContain("settings");
+    expect(getRailStoreSnapshot().activePanelId).toBe("settings");
     expect(getRailStoreSnapshot().railChromeExpanded).toBe(true);
     expect(getPaneStoreSnapshot().rail[0]?.paneId).toBe("settings");
     expect(getPaneStoreSnapshot().rail[0]?.params).toEqual({ section: "connectivity" });

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1962,11 +1962,13 @@ describe("Instrument core design contract", () => {
     // 전면 해도 개편: 설정 페인에서도 push/overlay 스위치는 퇴역했다 — 항상 부유 카드라
     // 남는 취향은 카드 불투명도 하나다.
     expect(settingsPane).not.toContain("toggleRailPanelBehavior");
-    // 스택 상주 계약: 고정 목록이 단일 activeId를 대체하고, 섹션 본문은 접혀도 마운트를 유지한다.
-    expect(railStore).toContain("fleet-console.rail.pinnedPanels");
+    // 독점 상주 계약: 카드에는 패널 하나만 상주한다 — 단일 activeId가 고정 목록을 대체하고
+    // 섹션 접기는 퇴역했다(안 볼 패널은 접는 게 아니라 닫거나 교체한다).
+    expect(railStore).toContain("fleet-console.rail.activePanelId");
     expect(railStore).not.toContain("panelBehavior");
-    expect(rightRail).toContain("toggleRailSectionCollapsed");
-    expect(rightRail).toContain('hidden={collapsed} inert={collapsed || undefined}');
+    expect(rightRail).not.toContain("toggleRailSectionCollapsed");
+    expect(rail).not.toContain(".right-rail-section-toggle");
+    expect(rail).not.toContain(".right-rail-section-caret");
     // Doctrine: Operation panels keep a 32px attached caption. The Activity Rail has no
     // panel head at all — its settings live behind the gear at the top of the icon column,
     // so the body owns the whole slot and no chrome can summon itself over it. The retired

--- a/runtime/fleet-console/tests/rail-search.test.tsx
+++ b/runtime/fleet-console/tests/rail-search.test.tsx
@@ -41,7 +41,10 @@ beforeEach(() => {
   document.body.replaceChildren();
   scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollIntoView");
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
-  for (const id of [...getRailStoreSnapshot().pinnedPanelIds]) closeRailPanel(id);
+  {
+    const active = getRailStoreSnapshot().activePanelId;
+    if (active !== null) closeRailPanel(active);
+  }
   setRailChromeExpanded(false);
   resetExpandedSurfacesForTest();
   setState({
@@ -226,7 +229,7 @@ describe("rail search fan-out", () => {
     act(() => option!.click());
     expect(activate).toHaveBeenCalledOnce();
     expect(pathname).toBe("/settings");
-    expect(getRailStoreSnapshot().pinnedPanelIds).not.toContain("files");
+    expect(getRailStoreSnapshot().activePanelId).not.toBe("files");
     expect(getRailStoreSnapshot()).toMatchObject({ railChromeExpanded: false });
 
     await act(async () => {
@@ -234,7 +237,7 @@ describe("rail search fan-out", () => {
       await Promise.resolve();
     });
     expect(pathname).toBe("/operations");
-    expect(getRailStoreSnapshot().pinnedPanelIds).toContain("files");
+    expect(getRailStoreSnapshot().activePanelId).toBe("files");
     expect(getRailStoreSnapshot()).toMatchObject({ railChromeExpanded: true });
   });
 
@@ -261,8 +264,8 @@ describe("rail search fan-out", () => {
     });
 
     expect(getExpandedSurfaceState().instances.map((instance) => instance.surfaceId)).toEqual(["repository"]);
-    // 레일에 고정되지도 않아야 한다 — 세울 페인이 없는 엔트리를 고정하면 빈 섹션이 선다.
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual([]);
+    // 레일에 서지도 않아야 한다 — 세울 페인이 없는 엔트리를 활성으로 삼으면 빈 섹션이 선다.
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
   });
 
   it("keeps matching Operations above panel groups", async () => {

--- a/runtime/fleet-console/tests/rail-store.test.ts
+++ b/runtime/fleet-console/tests/rail-store.test.ts
@@ -14,109 +14,98 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-/* 전면 해도 개편(P3): 레일은 단일 활성 슬롯이 아니라 다중 고정(pin) 스택이다.
+/* 레일은 단일 독점 슬롯이다 — 카드에는 패널이 하나만 상주하고, 다른 패널을 열면 교체된다.
    push/overlay 이원은 퇴역했다 — "가리지 않는다"는 구 push 기대는 아레나 인셋이 승계한다. */
 
-describe("pinned panel stack", () => {
-  it("toggleRailPanel은 고정/해제를 오간다", async () => {
+describe("exclusive active panel", () => {
+  it("toggleRailPanel은 열림/닫힘을 오간다", async () => {
     const { toggleRailPanel, getRailStoreSnapshot } = await freshStore();
     toggleRailPanel("panel-a");
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["panel-a"]);
+    expect(getRailStoreSnapshot().activePanelId).toBe("panel-a");
     toggleRailPanel("panel-a");
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual([]);
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
   });
 
-  it("복수 고정은 핀 순서를 유지한다", async () => {
+  it("다른 패널 토글은 교체다 — 스택으로 쌓이지 않는다", async () => {
     const { toggleRailPanel, getRailStoreSnapshot } = await freshStore();
     toggleRailPanel("panel-a");
     toggleRailPanel("panel-b");
+    expect(getRailStoreSnapshot().activePanelId).toBe("panel-b");
     toggleRailPanel("panel-c");
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["panel-a", "panel-b", "panel-c"]);
-    toggleRailPanel("panel-b");
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["panel-a", "panel-c"]);
+    expect(getRailStoreSnapshot().activePanelId).toBe("panel-c");
   });
 
-  it("openRailPanel은 ensure-open이다 — 이미 고정된 패널을 닫지 않고 접힘만 푼다", async () => {
-    const { openRailPanel, toggleRailSectionCollapsed, getRailStoreSnapshot } = await freshStore();
+  it("openRailPanel은 ensure-active다 — 이미 활성인 패널을 닫지 않는다", async () => {
+    const { openRailPanel, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
-    toggleRailSectionCollapsed("panel-a");
-    expect(getRailStoreSnapshot().collapsedPanelIds).toEqual(["panel-a"]);
     openRailPanel("panel-a");
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["panel-a"]);
-    expect(getRailStoreSnapshot().collapsedPanelIds).toEqual([]);
+    expect(getRailStoreSnapshot().activePanelId).toBe("panel-a");
+    openRailPanel("panel-b");
+    expect(getRailStoreSnapshot().activePanelId).toBe("panel-b");
   });
 
-  it("closeRailPanel은 해당 패널만 내린다", async () => {
+  it("closeRailPanel은 활성 패널일 때만 내린다 — 비활성 id는 노옵", async () => {
     const { openRailPanel, closeRailPanel, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
     openRailPanel("panel-b");
     closeRailPanel("panel-a");
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["panel-b"]);
-  });
-
-  it("섹션 접힘은 고정된 패널에만 걸리고, 해제 시 함께 걷힌다", async () => {
-    const { openRailPanel, closeRailPanel, toggleRailSectionCollapsed, getRailStoreSnapshot } = await freshStore();
-    toggleRailSectionCollapsed("panel-x");
-    expect(getRailStoreSnapshot().collapsedPanelIds).toEqual([]);
-    openRailPanel("panel-a");
-    toggleRailSectionCollapsed("panel-a");
-    expect(getRailStoreSnapshot().collapsedPanelIds).toEqual(["panel-a"]);
-    closeRailPanel("panel-a");
-    expect(getRailStoreSnapshot().collapsedPanelIds).toEqual([]);
+    expect(getRailStoreSnapshot().activePanelId).toBe("panel-b");
+    closeRailPanel("panel-b");
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
   });
 });
 
 describe("requestRailPanelExtraWidth", () => {
-  it("① 고정 패널 요청이 자기 항목에 반영된다", async () => {
+  it("① 활성 패널 요청이 반영된다", async () => {
     const { openRailPanel, requestRailPanelExtraWidth, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", 200);
-    expect(getRailStoreSnapshot().panelExtraWidths["panel-a"]).toBe(200);
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(200);
   });
 
-  it("② 비고정 panelId 요청은 무시된다", async () => {
+  it("② 비활성 panelId 요청은 무시된다", async () => {
     const { openRailPanel, requestRailPanelExtraWidth, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", 100);
     requestRailPanelExtraWidth("panel-b", 999);
-    expect(getRailStoreSnapshot().panelExtraWidths).toEqual({ "panel-a": 100 });
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(100);
   });
 
-  it("② 뒷섹션(비활성이던 층)도 고정돼 있으면 요구가 반영된다 — 스택 계약", async () => {
+  it("② 패널 교체는 이전 패널의 요구를 0으로 리셋한다 — 화면 밖 요구는 실체가 없다", async () => {
     const { openRailPanel, requestRailPanelExtraWidth, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
+    requestRailPanelExtraWidth("panel-a", 180);
     openRailPanel("panel-b");
-    requestRailPanelExtraWidth("panel-b", 180);
-    expect(getRailStoreSnapshot().panelExtraWidths["panel-b"]).toBe(180);
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(0);
   });
 
-  it("③ closeRailPanel 시 그 패널의 extraWidth가 사라진다", async () => {
+  it("③ closeRailPanel 시 extraWidth가 0으로 돌아간다", async () => {
     const { openRailPanel, closeRailPanel, requestRailPanelExtraWidth, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", 300);
     closeRailPanel("panel-a");
-    expect(getRailStoreSnapshot().panelExtraWidths["panel-a"]).toBeUndefined();
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(0);
   });
 
   it("④ 음수는 0으로 정규화", async () => {
     const { openRailPanel, requestRailPanelExtraWidth, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", -100);
-    expect(getRailStoreSnapshot().panelExtraWidths["panel-a"]).toBe(0);
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(0);
   });
 
   it("④ NaN은 0으로 정규화", async () => {
     const { openRailPanel, requestRailPanelExtraWidth, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", NaN);
-    expect(getRailStoreSnapshot().panelExtraWidths["panel-a"]).toBe(0);
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(0);
   });
 
   it("④ 소수점은 반올림된다", async () => {
     const { openRailPanel, requestRailPanelExtraWidth, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", 100.6);
-    expect(getRailStoreSnapshot().panelExtraWidths["panel-a"]).toBe(101);
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(101);
   });
 
   it("⑤ null은 0으로 처리(원복)", async () => {
@@ -124,7 +113,7 @@ describe("requestRailPanelExtraWidth", () => {
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", 200);
     requestRailPanelExtraWidth("panel-a", null);
-    expect(getRailStoreSnapshot().panelExtraWidths["panel-a"]).toBe(0);
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(0);
   });
 
   it("⑥ 클램프: innerWidth - 548 상한을 초과하지 않는다", async () => {
@@ -132,7 +121,7 @@ describe("requestRailPanelExtraWidth", () => {
     const { openRailPanel, requestRailPanelExtraWidth, getRailStoreSnapshot } = await freshStore();
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", 600);
-    expect(getRailStoreSnapshot().panelExtraWidths["panel-a"]).toBe(452);
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(452);
   });
 
   it("⑦ same-value 노옵: 동일 값 재요청 시 리스너가 호출되지 않는다", async () => {
@@ -172,81 +161,96 @@ describe("persistence and legacy migration", () => {
     return { values, setItem };
   }
 
-  it("고정 목록이 JSON 배열로 영속되고 재로드에 복원된다", async () => {
+  it("활성 패널이 평문으로 영속되고 재로드에 복원된다 — 마지막 열림이 남는다", async () => {
     const storage = stubStorage();
     const { openRailPanel } = await freshStore();
     openRailPanel("panel-a");
     openRailPanel("panel-b");
-    expect(JSON.parse(storage.values.get("fleet-console.rail.pinnedPanels") ?? "[]")).toEqual(["panel-a", "panel-b"]);
+    expect(storage.values.get("fleet-console.rail.activePanelId")).toBe("panel-b");
 
     vi.resetModules();
     const restored = await freshStore();
-    expect(restored.getRailStoreSnapshot().pinnedPanelIds).toEqual(["panel-a", "panel-b"]);
+    expect(restored.getRailStoreSnapshot().activePanelId).toBe("panel-b");
   });
 
-  it("접힘 상태는 영속되지 않는다 — 세션 전용", async () => {
+  it("닫으면 키가 지워져 재로드는 닫힌 레일로 시작한다", async () => {
     const storage = stubStorage();
-    const { openRailPanel, toggleRailSectionCollapsed } = await freshStore();
+    const { openRailPanel, closeRailPanel } = await freshStore();
     openRailPanel("panel-a");
-    toggleRailSectionCollapsed("panel-a");
-    expect([...storage.values.keys()].some((key) => key.includes("collapsed"))).toBe(false);
+    closeRailPanel("panel-a");
+    expect(storage.values.has("fleet-console.rail.activePanelId")).toBe(false);
 
     vi.resetModules();
     const restored = await freshStore();
-    expect(restored.getRailStoreSnapshot().collapsedPanelIds).toEqual([]);
+    expect(restored.getRailStoreSnapshot().activePanelId).toBeNull();
   });
 
-  it("구 단일 활성 기억이 스택의 첫 고정으로 승격된다", async () => {
-    const storage = stubStorage({ "fleet-console.rail.activePanelId": "terminal" });
+  it("스택 시절 고정 목록은 첫 고정이 독점 슬롯으로 승격된다", async () => {
+    const storage = stubStorage({ "fleet-console.rail.pinnedPanels": JSON.stringify(["terminal", "codex"]) });
     const { getRailStoreSnapshot } = await freshStore();
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["terminal"]);
-    expect(JSON.parse(storage.values.get("fleet-console.rail.pinnedPanels") ?? "[]")).toEqual(["terminal"]);
-    expect(storage.values.has("fleet-console.rail.activePanelId")).toBe(false);
+    expect(getRailStoreSnapshot().activePanelId).toBe("terminal");
+    expect(storage.values.get("fleet-console.rail.activePanelId")).toBe("terminal");
+    expect(storage.values.has("fleet-console.rail.pinnedPanels")).toBe(false);
   });
 
-  it.each(["diff", "history"])("legacy %s는 repository로 정규화되어 승격된다", async (legacy) => {
-    stubStorage({ "fleet-console.rail.activePanelId": legacy });
+  it("빈 스택 기억은 닫힌 레일로 승격되고 스택 키는 걷힌다", async () => {
+    const storage = stubStorage({ "fleet-console.rail.pinnedPanels": "[]" });
     const { getRailStoreSnapshot } = await freshStore();
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["repository"]);
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
+    expect(storage.values.has("fleet-console.rail.pinnedPanels")).toBe(false);
   });
 
-  it("legacy history는 Repository 소스 시드도 유지한다", async () => {
+  it.each(["diff", "history"])("legacy %s는 repository로 정규화되고 키가 1회 재기록된다", async (legacy) => {
+    const storage = stubStorage({ "fleet-console.rail.activePanelId": legacy });
+    const { getRailStoreSnapshot } = await freshStore();
+    expect(getRailStoreSnapshot().activePanelId).toBe("repository");
+    expect(storage.values.get("fleet-console.rail.activePanelId")).toBe("repository");
+  });
+
+  it("legacy history는 Repository 소스 시드도 유지한다 — 재로드가 사용자 소스를 덮지 않는다", async () => {
     const storage = stubStorage({ "fleet-console.rail.activePanelId": "history" });
     await freshStore();
     expect(storage.values.get("fleet-console.repository.source")).toBe("history");
+    expect(storage.values.get("fleet-console.rail.activePanelId")).toBe("repository");
+    storage.values.set("fleet-console.repository.source", "diff");
+    vi.resetModules();
+    await freshStore();
+    expect(storage.values.get("fleet-console.repository.source")).toBe("diff");
   });
 
-  it("legacy alerts는 빈 스택으로 승격된다", async () => {
-    stubStorage({ "fleet-console.rail.activePanelId": "alerts" });
+  it("legacy alerts는 닫힌 레일로 정규화되고 키가 걷힌다", async () => {
+    const storage = stubStorage({ "fleet-console.rail.activePanelId": "alerts" });
     const { getRailStoreSnapshot } = await freshStore();
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual([]);
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
+    expect(storage.values.has("fleet-console.rail.activePanelId")).toBe(false);
   });
 
-  it("이미 새 키가 있으면 legacy를 읽지 않는다", async () => {
-    stubStorage({
-      "fleet-console.rail.pinnedPanels": JSON.stringify(["panel-b"]),
+  it("활성 키가 이미 있으면 스택 키는 읽지 않고 함께 걷는다 — 지운 활성이 옛 스택으로 되살아나면 안 된다", async () => {
+    const storage = stubStorage({
       "fleet-console.rail.activePanelId": "terminal",
+      "fleet-console.rail.pinnedPanels": JSON.stringify(["panel-b"]),
     });
     const { getRailStoreSnapshot } = await freshStore();
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["panel-b"]);
+    expect(getRailStoreSnapshot().activePanelId).toBe("terminal");
+    expect(storage.values.has("fleet-console.rail.pinnedPanels")).toBe(false);
   });
 });
 
 describe("rail chrome state", () => {
-  it("collapses and reopens chrome without changing pinned or extra-width state", async () => {
+  it("collapses and reopens chrome without changing active-panel or extra-width state", async () => {
     const { getRailStoreSnapshot, requestRailPanelExtraWidth, openRailPanel, setRailChromeExpanded } = await freshStore();
     openRailPanel("panel-a");
     requestRailPanelExtraWidth("panel-a", 240);
     setRailChromeExpanded(false);
 
     expect(getRailStoreSnapshot()).toMatchObject({
-      pinnedPanelIds: ["panel-a"],
-      panelExtraWidths: { "panel-a": 240 },
+      activePanelId: "panel-a",
+      panelExtraWidth: 240,
       railChromeExpanded: false,
     });
 
     setRailChromeExpanded(true);
-    expect(getRailStoreSnapshot()).toMatchObject({ pinnedPanelIds: ["panel-a"], railChromeExpanded: true });
+    expect(getRailStoreSnapshot()).toMatchObject({ activePanelId: "panel-a", railChromeExpanded: true });
   });
 });
 

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act } from "react";
+import { act, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -54,7 +54,9 @@ const PLUGIN_FIXTURES: Record<string, unknown>[] = [
     id: "file-explorer",
     title: "FILES",
     icon: "F",
-    render: () => null,
+    // 마운트 효과에서 자기 확장 폭을 요구하는 본문 — 자식 효과가 부모(RailSurface) 효과보다
+    // 먼저 도는 실제 순서를 재현한다(Codex P2 판별 픽스처).
+    render: () => <FilesMountExtra />,
   },
   {
     id: "shell-action",
@@ -134,9 +136,17 @@ import {
   closeRailPanel,
   getRailStoreSnapshot,
   openRailPanel,
+  requestRailPanelExtraWidth,
   setRailChromeExpanded,
   setRailOverlayAlpha,
 } from "../core/client/src/rail/rail-store.js";
+
+function FilesMountExtra() {
+  useEffect(() => {
+    requestRailPanelExtraWidth("file-explorer", 360);
+  }, []);
+  return null;
+}
 import {
   closeExpandedSurfacesOf,
   openExpandedSurface,
@@ -276,6 +286,20 @@ describe("Right Rail exclusive panel", () => {
 
     const parked = getPaneStoreSnapshot().rail.find((instance) => instance.paneId === "repo-term");
     expect(parked?.visible).toBe(false);
+  });
+
+  it("keeps the arriving panel's mount-time extra-width request across the swap", () => {
+    renderRail();
+    // repository의 detail이 서서 표면이 확장 폭을 소유한 상태에서 교체한다.
+    act(() => openPane({ paneId: "repo-notes", mount: "rail" }));
+    expect(getRailStoreSnapshot().panelExtraWidth).toBeGreaterThan(0);
+
+    act(() => iconButton("FILES").click());
+
+    // 이전 표면의 소유권이 살아남으면 standing 0을 본 폭 효과가 도착 패널의 창구로 null을
+    // 쏴, 도착 본문이 마운트 효과에서 막 요청한 폭을 덮는다(Codex P2) — 소유권은 엔트리
+    // 교체에서 함께 걷혀야 한다.
+    expect(getRailStoreSnapshot().panelExtraWidth).toBe(360);
   });
 
   it("with nothing active the slot closes and the rail loses is-open", () => {

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -77,6 +77,15 @@ const PLUGIN_FIXTURES: Record<string, unknown>[] = [
     icon: "L",
     render: () => null,
   },
+  {
+    id: "ledger",
+    title: "LEDGER",
+    icon: "L",
+    // 마운트 효과에서 자기 detail을 여는 본문 — 팔레트 착지 직후의 파일 문서 열, Codex 리더가
+    // 실제로 하는 일이다(Codex 3차 P1 판별 픽스처).
+    details: [{ id: "ledger-doc", title: "DOC" }],
+    render: () => <LedgerMountDetail />,
+  },
 ];
 
 // 새 계약의 레지스트리를 모킹한다. 여기 적는 것은 여전히 "옛 패널 모양"이고, 아래 helper가
@@ -144,6 +153,13 @@ import {
 function FilesMountExtra() {
   useEffect(() => {
     requestRailPanelExtraWidth("file-explorer", 360);
+  }, []);
+  return null;
+}
+
+function LedgerMountDetail() {
+  useEffect(() => {
+    openPane({ paneId: "ledger-doc", mount: "rail", params: { path: "doc.md" } });
   }, []);
   return null;
 }
@@ -266,26 +282,44 @@ describe("Right Rail exclusive panel", () => {
     expect(document.activeElement).toBe(iconButton("REPOSITORY"));
   });
 
-  it("drops the leaving panel's non-keepAlive detail on switch — the swap runs the pane contract", () => {
+  it("drops the leaving panel's non-keepAlive detail on switch — the departing sweep closes it", () => {
     renderRail();
     act(() => openPane({ paneId: "repo-notes", mount: "rail", params: { path: "a.md" } }));
     expect(getPaneStoreSnapshot().rail.some((instance) => instance.paneId === "repo-notes")).toBe(true);
 
     act(() => iconButton("CODEX").click());
 
-    // 떠나는 표면의 비-keepAlive 열은 내려간다 — 섹션을 key로 재마운트하면 RailSurface가
-    // 엔트리 교체를 못 보고 이 정리가 침묵해, 돌아왔을 때 옛 params째 되살아난다(Codex P1).
+    // 떠나는 표면이 언마운트 cleanup에서 자기 비-keepAlive detail을 닫는다 — 남기면 돌아왔을 때
+    // 옛 params째 되살아난다(닫기=언마운트 계약, Codex 1차 P1).
     expect(getPaneStoreSnapshot().rail.some((instance) => instance.paneId === "repo-notes")).toBe(false);
   });
 
-  it("parks the leaving panel's keepAlive detail instead of dropping it", () => {
+  it("leaves the leaving panel's keepAlive detail standing so it returns on reopen", () => {
     renderRail();
     act(() => openPane({ paneId: "repo-term", mount: "rail" }));
 
     act(() => iconButton("CODEX").click());
 
-    const parked = getPaneStoreSnapshot().rail.find((instance) => instance.paneId === "repo-term");
-    expect(parked?.visible).toBe(false);
+    // keepAlive는 PTY·읽던 자리의 계약이다 — 떠나도 스토어에 세워 둔 채 두어야 돌아왔을 때
+    // 그 자리가 다시 선다(구 unpin/re-pin 계약 승계). 화면에는 서지 않는다: 도착 표면의
+    // owned 필터가 남의 페인을 걸러 낸다.
+    const kept = getPaneStoreSnapshot().rail.find((instance) => instance.paneId === "repo-term");
+    expect(kept?.visible).toBe(true);
+    expect([...container.querySelectorAll(".right-rail-section-title")].map((el) => el.textContent)).toEqual(["CODEX"]);
+  });
+
+  it("keeps a detail the arriving panel opens during its own mount", () => {
+    renderRail();
+    act(() => openPane({ paneId: "repo-notes", mount: "rail" }));
+
+    act(() => iconButton("LEDGER").click());
+
+    // 도착 본문은 마운트 효과에서 자기 detail을 연다(파일 문서 열·Codex 리더). 떠나는 표면의
+    // 정리가 도착 마운트 **뒤에** 도는 구조라면 방금 연 이 열이 쓸려 나간다(Codex 3차 P1) —
+    // key 재마운트 + 언마운트 cleanup은 정리를 도착보다 먼저 돌게 만든다.
+    const doc = getPaneStoreSnapshot().rail.find((instance) => instance.paneId === "ledger-doc");
+    expect(doc?.visible).toBe(true);
+    expect(getPaneStoreSnapshot().rail.some((instance) => instance.paneId === "repo-notes")).toBe(false);
   });
 
   it("keeps the arriving panel's mount-time extra-width request across the swap", () => {

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -75,12 +75,6 @@ const PLUGIN_FIXTURES: Record<string, unknown>[] = [
     id: "ledger",
     title: "LEDGER",
     icon: "L",
-    render: () => null,
-  },
-  {
-    id: "ledger",
-    title: "LEDGER",
-    icon: "L",
     // 마운트 효과에서 자기 detail을 여는 본문 — 팔레트 착지 직후의 파일 문서 열, Codex 리더가
     // 실제로 하는 일이다(Codex 3차 P1 판별 픽스처).
     details: [{ id: "ledger-doc", title: "DOC" }],

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -14,6 +14,11 @@ const CORE_PANELS: Record<string, unknown>[] = [
     title: "REPOSITORY",
     defaultWidth: 360,
     icon: "P",
+    // 교체 정리 계약을 재는 detail 짝 — keepAlive 없는 열과 keepAlive 열을 하나씩 둔다.
+    details: [
+      { id: "repo-notes", title: "NOTES" },
+      { id: "repo-term", title: "TERM", keepAlive: true },
+    ],
     render: (ctx: { readonly theme?: unknown }) => {
       railPanelContextMock.renderCount += 1;
       railPanelContextMock.themes.push(ctx.theme);
@@ -77,13 +82,14 @@ const PLUGIN_FIXTURES: Record<string, unknown>[] = [
 // 경로도 함께 지킨다(#957 상류 테스트와 같은 문법).
 function toBinding(panel: Record<string, unknown>, core: boolean) {
   const hasBody = typeof panel.render === "function";
+  const details = Array.isArray(panel.details) ? panel.details as readonly Record<string, unknown>[] : [];
   return {
     entry: {
       id: panel.id,
       title: panel.title,
       icon: panel.icon,
       ...(panel.surfaceId === undefined ? {} : { surfaceId: panel.surfaceId }),
-      ...(hasBody ? { panes: [panel.id] } : { activate: panel.activate }),
+      ...(hasBody ? { panes: [panel.id, ...details.map((detail) => detail.id)] } : { activate: panel.activate }),
     },
     panes: hasBody
       ? [{
@@ -93,7 +99,14 @@ function toBinding(panel: Record<string, unknown>, core: boolean) {
         title: () => panel.title,
         render: panel.render,
         ...(panel.defaultWidth === undefined ? {} : { defaultWidth: panel.defaultWidth }),
-      }]
+      }, ...details.map((detail) => ({
+        id: detail.id,
+        role: "detail",
+        mounts: ["rail"],
+        title: () => detail.title,
+        render: () => null,
+        ...(detail.keepAlive === true ? { keepAlive: true } : {}),
+      }))]
       : [],
     projected: true,
     core,
@@ -129,6 +142,7 @@ import {
   openExpandedSurface,
   resetExpandedSurfacesForTest,
 } from "../core/client/src/expanded-surface/store.js";
+import { __resetPaneStoreForTests, getPaneStoreSnapshot, openPane } from "../core/client/src/pane/pane-store.js";
 import { setState } from "../core/client/src/store.js";
 
 let container: HTMLDivElement;
@@ -154,6 +168,7 @@ beforeEach(() => {
   railPanelContextMock.activate.mockClear();
   setState({ connection: "live", connectionLostAt: null, activeTheme: "instrument" });
   resetExpandedSurfacesForTest();
+  __resetPaneStoreForTests();
   container = document.createElement("div");
   document.body.replaceChildren(container);
   root = createRoot(container);
@@ -239,6 +254,28 @@ describe("Right Rail exclusive panel", () => {
     act(() => { close!.focus(); close!.click(); });
     expect(getRailStoreSnapshot().activePanelId).toBeNull();
     expect(document.activeElement).toBe(iconButton("REPOSITORY"));
+  });
+
+  it("drops the leaving panel's non-keepAlive detail on switch — the swap runs the pane contract", () => {
+    renderRail();
+    act(() => openPane({ paneId: "repo-notes", mount: "rail", params: { path: "a.md" } }));
+    expect(getPaneStoreSnapshot().rail.some((instance) => instance.paneId === "repo-notes")).toBe(true);
+
+    act(() => iconButton("CODEX").click());
+
+    // 떠나는 표면의 비-keepAlive 열은 내려간다 — 섹션을 key로 재마운트하면 RailSurface가
+    // 엔트리 교체를 못 보고 이 정리가 침묵해, 돌아왔을 때 옛 params째 되살아난다(Codex P1).
+    expect(getPaneStoreSnapshot().rail.some((instance) => instance.paneId === "repo-notes")).toBe(false);
+  });
+
+  it("parks the leaving panel's keepAlive detail instead of dropping it", () => {
+    renderRail();
+    act(() => openPane({ paneId: "repo-term", mount: "rail" }));
+
+    act(() => iconButton("CODEX").click());
+
+    const parked = getPaneStoreSnapshot().rail.find((instance) => instance.paneId === "repo-term");
+    expect(parked?.visible).toBe(false);
   });
 
   it("with nothing active the slot closes and the rail loses is-open", () => {

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -123,7 +123,6 @@ import {
   openRailPanel,
   setRailChromeExpanded,
   setRailOverlayAlpha,
-  toggleRailSectionCollapsed,
 } from "../core/client/src/rail/rail-store.js";
 import {
   closeExpandedSurfacesOf,
@@ -139,7 +138,8 @@ let root: Root;
 
 /* 스토어는 모듈 싱글턴이다 — 파일 안에서 테스트끼리 새지 않게 공개 API로만 초기화한다. */
 function resetRailStore() {
-  for (const id of [...getRailStoreSnapshot().pinnedPanelIds]) closeRailPanel(id);
+  const active = getRailStoreSnapshot().activePanelId;
+  if (active !== null) closeRailPanel(active);
   setRailChromeExpanded(true);
   setRailOverlayAlpha(100);
 }
@@ -201,57 +201,47 @@ function gearButton(): HTMLButtonElement {
   return gear;
 }
 
-describe("Right Rail pinned stack", () => {
-  it("renders one section per pinned panel in pin order", () => {
+describe("Right Rail exclusive panel", () => {
+  it("renders only the active panel's section — opening another replaces it", () => {
     act(() => openRailPanel("codex"));
     renderRail();
 
     const titles = [...container.querySelectorAll(".right-rail-section-title")].map((el) => el.textContent);
-    expect(titles).toEqual(["REPOSITORY", "CODEX"]);
+    expect(titles).toEqual(["CODEX"]);
     expect(railRoot().classList.contains("is-open")).toBe(true);
   });
 
-  it("keeps a collapsed section mounted — the body hides but does not unmount", () => {
+  it("carries no collapse affordance — the body stands visible with the panel", () => {
     renderRail();
-    const renderedBefore = railPanelContextMock.renderCount;
-    expect(renderedBefore).toBeGreaterThan(0);
-
-    act(() => toggleRailSectionCollapsed("repository"));
+    expect(railPanelContextMock.renderCount).toBeGreaterThan(0);
+    expect(container.querySelector(".right-rail-section-toggle")).toBeNull();
+    expect(container.querySelector(".right-rail-section-caret")).toBeNull();
     const body = sectionOf("REPOSITORY").querySelector<HTMLElement>(".right-rail-section-body");
-    expect(body?.hidden).toBe(true);
-    // 본문 DOM은 남아 있다 — 접기가 플러그인 트리를 파괴하면 스택은 배타 탭보다 나쁘다.
+    expect(body?.hidden).toBe(false);
     expect(body?.querySelector(".test-panel-action")).not.toBeNull();
   });
 
-  it("closes one section from its header without touching the other", () => {
+  it("closes the section from its header", () => {
     act(() => openRailPanel("codex"));
     renderRail();
 
     const close = sectionOf("CODEX").querySelector<HTMLButtonElement>(".right-rail-section-close");
     act(() => close!.click());
 
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["repository"]);
-    expect([...container.querySelectorAll(".right-rail-section-title")].map((el) => el.textContent)).toEqual(["REPOSITORY"]);
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
+    expect(container.querySelector(".right-rail-section")).toBeNull();
   });
 
-  it("moves focus to the rail icon before a focused close button unpins its section", () => {
+  it("moves focus to the rail icon before a focused close button unmounts its section", () => {
     // 포커스를 쥔 닫기 버튼이 언마운트되면 포커스가 body로 떨어진다 — 아이콘 이관 계약(Codex 리뷰).
     renderRail();
     const close = sectionOf("REPOSITORY").querySelector<HTMLButtonElement>(".right-rail-section-close");
     act(() => { close!.focus(); close!.click(); });
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual([]);
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
     expect(document.activeElement).toBe(iconButton("REPOSITORY"));
   });
 
-  it("collapse toggle speaks aria-expanded on the section header", () => {
-    renderRail();
-    const toggle = sectionOf("REPOSITORY").querySelector<HTMLButtonElement>(".right-rail-section-toggle");
-    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
-    act(() => toggle!.click());
-    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
-  });
-
-  it("with nothing pinned the slot closes and the rail loses is-open", () => {
+  it("with nothing active the slot closes and the rail loses is-open", () => {
     act(() => closeRailPanel("repository"));
     renderRail();
 
@@ -261,30 +251,30 @@ describe("Right Rail pinned stack", () => {
 });
 
 describe("Right Rail icons", () => {
-  it("marks every pinned panel icon pressed — the stack has no exclusive tab", () => {
+  it("marks only the active panel icon pressed — exclusive grammar", () => {
     act(() => openRailPanel("codex"));
     renderRail();
 
-    expect(iconButton("REPOSITORY").getAttribute("aria-pressed")).toBe("true");
+    expect(iconButton("REPOSITORY").getAttribute("aria-pressed")).toBe("false");
     expect(iconButton("CODEX").getAttribute("aria-pressed")).toBe("true");
     expect(iconButton("ALERTS").getAttribute("aria-pressed")).toBe("false");
     expect(container.querySelector('[role="tab"]')).toBeNull();
   });
 
-  it("icon click pins and unpins", () => {
+  it("icon click replaces the active panel and a second click closes it", () => {
     renderRail();
     act(() => iconButton("CODEX").click());
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["repository", "codex"]);
+    expect(getRailStoreSnapshot().activePanelId).toBe("codex");
     act(() => iconButton("CODEX").click());
-    expect(getRailStoreSnapshot().pinnedPanelIds).toEqual(["repository"]);
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
   });
 });
 
 describe("Right Rail card width", () => {
-  it("uses the widest pinned default when nothing is stored", () => {
+  it("uses the active panel's declared default when nothing is stored", () => {
     act(() => openRailPanel("codex"));
     renderRail();
-    // repository 360 vs codex 420 → 카드 폭은 최댓값 420.
+    // 독점 슬롯이라 카드 기본 폭은 활성 패널의 선언값 하나다 — codex 420.
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("420px");
   });
 
@@ -363,16 +353,16 @@ describe("Right Rail settings gear", () => {
     expect(panelSlot().querySelector(".right-rail-panel-body")).not.toBeNull();
   });
 
-  it("toggles the settings surface as a pinned section and speaks pressed + brass", () => {
+  it("toggles the settings surface as the active section and speaks pressed + brass", () => {
     renderRail();
     expect(gearButton().getAttribute("aria-pressed")).toBe("false");
 
     act(() => gearButton().click());
 
-    expect(getRailStoreSnapshot().pinnedPanelIds).toContain("settings");
+    expect(getRailStoreSnapshot().activePanelId).toBe("settings");
     expect(gearButton().getAttribute("aria-pressed")).toBe("true");
     expect(gearButton().classList.contains("is-active")).toBe(true);
-    // 문은 표면을 그대로 연다 — 스택 섹션 본문은 문(토글)을 라벨로 삼는 region으로 서고,
+    // 문은 표면을 그대로 연다 — 섹션 본문은 문(토글)을 라벨로 삼는 region으로 서고,
     // 문은 자기 표면을 가리킨다.
     const panel = container.querySelector("#rail-panel-settings")!;
     expect(panel).not.toBeNull();
@@ -382,15 +372,15 @@ describe("Right Rail settings gear", () => {
     expect(gearButton().getAttribute("aria-controls")).toBe("rail-panel-settings");
 
     act(() => gearButton().click());
-    expect(getRailStoreSnapshot().pinnedPanelIds).not.toContain("settings");
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
     expect(gearButton().getAttribute("aria-pressed")).toBe("false");
   });
 
-  it("stacks the settings section alongside pinned work panels instead of evicting them", () => {
+  it("replaces the active work panel — the exclusive card never stacks sections", () => {
     renderRail();
     act(() => gearButton().click());
     const titles = [...container.querySelectorAll(".right-rail-section-title")].map((el) => el.textContent);
-    expect(titles).toEqual(["REPOSITORY", "SETTINGS"]);
+    expect(titles).toEqual(["SETTINGS"]);
   });
 
   it("keeps the settings entry out of the panel toggle lists", () => {
@@ -401,7 +391,16 @@ describe("Right Rail settings gear", () => {
     expect(container.querySelector("#rail-tab-settings")).toBeNull();
   });
 
-  it("resets the card width to the widest pinned default on a divider double-click", () => {
+  it("moves focus to the gear before a focused close button unmounts settings", () => {
+    renderRail();
+    act(() => gearButton().click());
+    const close = sectionOf("SETTINGS").querySelector<HTMLButtonElement>(".right-rail-section-close");
+    act(() => { close!.focus(); close!.click(); });
+    expect(getRailStoreSnapshot().activePanelId).toBeNull();
+    expect(document.activeElement).toBe(gearButton());
+  });
+
+  it("resets the card width to the active panel's default on a divider double-click", () => {
     window.localStorage.setItem("fleet-console.rail.cardWidth", "500");
     renderRail();
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("500px");
@@ -441,7 +440,7 @@ describe("Right Rail occupied width report", () => {
     expect(getRailStoreSnapshot().railOccupiedPx).toBe(0);
   });
 
-  it("shrinks the report to the icon strip when nothing is pinned", () => {
+  it("shrinks the report to the icon strip when nothing is active", () => {
     act(() => closeRailPanel("repository"));
     renderRail();
     expect(getRailStoreSnapshot().railOccupiedPx).toBe(44);

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -4,7 +4,7 @@ import { act, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const railPanelContextMock = vi.hoisted(() => ({ themes: [] as unknown[], renderCount: 0, activate: vi.fn() }));
+const railPanelContextMock = vi.hoisted(() => ({ themes: [] as unknown[], renderCount: 0, activate: vi.fn(), repoNotesOnClose: vi.fn() }));
 const BINDING_CACHE = vi.hoisted(() => ({ value: null as unknown }));
 const PANE_INDEX_CACHE = vi.hoisted(() => ({ value: null as unknown }));
 
@@ -16,7 +16,7 @@ const CORE_PANELS: Record<string, unknown>[] = [
     icon: "P",
     // 교체 정리 계약을 재는 detail 짝 — keepAlive 없는 열과 keepAlive 열을 하나씩 둔다.
     details: [
-      { id: "repo-notes", title: "NOTES" },
+      { id: "repo-notes", title: "NOTES", onClose: railPanelContextMock.repoNotesOnClose },
       { id: "repo-term", title: "TERM", keepAlive: true },
     ],
     render: (ctx: { readonly theme?: unknown }) => {
@@ -117,6 +117,7 @@ function toBinding(panel: Record<string, unknown>, core: boolean) {
         title: () => detail.title,
         render: () => null,
         ...(detail.keepAlive === true ? { keepAlive: true } : {}),
+        ...(typeof detail.onClose === "function" ? { onClose: detail.onClose } : {}),
       }))]
       : [],
     projected: true,
@@ -192,6 +193,7 @@ beforeEach(() => {
   railPanelContextMock.themes.length = 0;
   railPanelContextMock.renderCount = 0;
   railPanelContextMock.activate.mockClear();
+  railPanelContextMock.repoNotesOnClose.mockClear();
   setState({ connection: "live", connectionLostAt: null, activeTheme: "instrument" });
   resetExpandedSurfacesForTest();
   __resetPaneStoreForTests();
@@ -292,6 +294,9 @@ describe("Right Rail exclusive panel", () => {
     // 떠나는 표면이 언마운트 cleanup에서 자기 비-keepAlive detail을 닫는다 — 남기면 돌아왔을 때
     // 옛 params째 되살아난다(닫기=언마운트 계약, Codex 1차 P1).
     expect(getPaneStoreSnapshot().rail.some((instance) => instance.paneId === "repo-notes")).toBe(false);
+    // 호스트가 닫는 모든 경로는 onClose를 통보한다(sdk/pane 계약) — 통보가 없으면 플러그인이
+    // 다음 상태 발행에서 닫힌 문서를 되살린다(Codex 4차 P2).
+    expect(railPanelContextMock.repoNotesOnClose).toHaveBeenCalledWith({ paneId: "repo-notes", params: { path: "a.md" } });
   });
 
   it("leaves the leaving panel's keepAlive detail standing so it returns on reopen", () => {

--- a/runtime/fleet-console/tests/settings-pane.test.tsx
+++ b/runtime/fleet-console/tests/settings-pane.test.tsx
@@ -122,7 +122,10 @@ afterEach(() => {
   root = null;
   container = null;
   syncSettingsSearchPlugins([]);
-  for (const id of [...getRailStoreSnapshot().pinnedPanelIds]) closeRailPanel(id);
+  {
+    const active = getRailStoreSnapshot().activePanelId;
+    if (active !== null) closeRailPanel(active);
+  }
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
@@ -175,10 +178,10 @@ describe("settings pane body", () => {
     // 첫 Esc는 검색을 거둔다 — 질의를 지우려던 손이 페인째 닫으면 안 된다.
     pressEscape(searchInput());
     expect(document.querySelector(".settings-pane-results")).toBeNull();
-    expect(getRailStoreSnapshot().pinnedPanelIds).toContain("settings");
+    expect(getRailStoreSnapshot().activePanelId).toBe("settings");
 
     pressEscape(searchInput());
-    expect(getRailStoreSnapshot().pinnedPanelIds).not.toContain("settings");
+    expect(getRailStoreSnapshot().activePanelId).not.toBe("settings");
     expect(document.activeElement).toBe(gear);
 
     gear.remove();
@@ -188,7 +191,7 @@ describe("settings pane body", () => {
     renderPane({});
     pressEscape(searchInput(), true);
 
-    expect(getRailStoreSnapshot().pinnedPanelIds).toContain("settings");
+    expect(getRailStoreSnapshot().activePanelId).toBe("settings");
   });
 
   it("keeps the remote management out of the pane and opens it on the expanded surface", () => {

--- a/runtime/fleet-console/tests/settings-route-adapter.test.tsx
+++ b/runtime/fleet-console/tests/settings-route-adapter.test.tsx
@@ -53,7 +53,10 @@ beforeEach(() => {
   document.body.replaceChildren();
   window.localStorage.clear();
   __resetPaneStoreForTests();
-  for (const id of [...getRailStoreSnapshot().pinnedPanelIds]) closeRailPanel(id);
+  {
+    const active = getRailStoreSnapshot().activePanelId;
+    if (active !== null) closeRailPanel(active);
+  }
   setRailChromeExpanded(false);
 });
 
@@ -73,7 +76,7 @@ describe("SettingsRouteAdapter", () => {
   it("translates a legacy remote-access deep link onto the connectivity section", () => {
     mountAt("/settings?section=remote-access");
 
-    expect(getRailStoreSnapshot().pinnedPanelIds).toContain("settings");
+    expect(getRailStoreSnapshot().activePanelId).toBe("settings");
     expect(getRailStoreSnapshot().railChromeExpanded).toBe(true);
     const [instance] = getPaneStoreSnapshot().rail;
     expect(instance?.paneId).toBe("settings");


### PR DESCRIPTION
## Summary
- 우측 Activity Rail의 다중 Pin 스택과 섹션별 접기(▼ 캐럿)를 퇴역시키고, 카드에 패널이 한 번에 하나만 상주하는 독점 슬롯으로 되돌립니다. 아이콘은 배타 토글이 되어 다른 패널을 열면 현재 패널이 교체되고, 켜진 아이콘을 다시 누르면 닫힙니다. 확대 표면(캔버스 pane)의 다중 배치는 이번 변경 밖으로, 무접촉입니다.
- 저장 키는 스택 이전의 `fleet-console.rail.activePanelId`로 복귀합니다. 스택 키(`pinnedPanels`)는 첫 고정을 1회성으로 승격한 뒤 항상 걷어내고, 1기 슬롯 값(diff/history/alerts)은 정규화 후 키를 1회 재기록해 재로드가 Repository 소스를 되심지 않습니다.
- 헤더는 정적 제목+닫기(X)만 남습니다. 설정 섹션은 탭 목록에 서지 않으므로 닫기 버튼의 포커스 이관을 톱니(`rail-settings-toggle`)로 라우팅했습니다. 패널 교체는 섹션 key 재마운트로 만들어 기존 unpin/re-pin과 같은 수명 계약을 유지합니다(pane-store keepAlive 경로 무접촉).

Changelog-Amend: full-bleed-chart-refit.md

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] 전체 vitest 스위트 green (2338 passed), 리베이스 후 rail/pane 관련 9개 스위트 212 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] console-e2e 실브라우저 검증: 파일→스킬 교체, 켜짐 아이콘 1개, 톱니 교체/닫힘, 리로드 복원, 스택 키 `["skills","file-explorer"]` → `skills` 승격·키 제거, 페이지 에러 0
- [x] `node scripts/compile-changelog-fragments.mjs --check`