### PR TITLE
feat(fleet-console): enable Artifact for chat view sessions

### DIFF
--- a/.changelog.d/chat-artifact-tool.md
+++ b/.changelog.d/chat-artifact-tool.md
@@ -1,0 +1,8 @@
+---
+branch: chat-artifact-tool
+---
+
+### fleet-console
+#### Added
+- Chat view sessions can now publish Artifacts, and the composer deck lists the artifact skills alongside the rest.
+  ko: 채팅뷰 세션에서도 Artifact를 게시할 수 있고, 컴포저 덱에 artifact 스킬이 함께 섭니다.

--- a/runtime/fleet-plugins/terminal/server/shared/launch-env.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/launch-env.ts
@@ -40,5 +40,17 @@ export function stripConsoleInternalEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessE
 export function chatChildEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const next = stripConsoleInternalEnv(env);
   delete next.FLEET_CONSOLE_SESSION_ID;
+  // vendor SDK가 자식의 `CLAUDE_CODE_ENTRYPOINT`를 `sdk-ts`로 세우고, Claude Code는 SDK 진입점에서
+  // Artifact를 기본으로 끈다(2.1.251 실측: `CLAUDE_CODE_ARTIFACT`가 참이 아니면서 진입점이 `sdk-*`
+  // 이면 비활성). 그 판정은 도구 하나로 끝나지 않는다 — `artifact-design`·`artifact-diagramming`·
+  // `artifact-capabilities` 세 스킬이 같은 게이트에 묶여 자식의 스킬 목록에서 통째로 빠지므로,
+  // 채팅 컴포저의 덱은 그 이름들을 그릴 근거조차 받지 못한다. 같은 Operation을 터미널로 열면
+  // 진입점이 `cli`라 넷 다 있으므로, 켜지 않으면 두 표면의 능력이 화면 어디에도 드러나지 않은 채
+  // 갈린다.
+  //
+  // 상속된 값이 있으면 그대로 둔다 — 운영자가 끈 것을 여기서 되살리지 않는다. 끄는 다른 축인
+  // `CLAUDE_CODE_DISABLE_ARTIFACT`와 `enableArtifact` 설정은 자식이 별도로 보므로 여기서 다루지
+  // 않는다.
+  next.CLAUDE_CODE_ARTIFACT ??= "1";
   return next;
 }

--- a/runtime/fleet-plugins/terminal/tests/launch-env.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/launch-env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { stripConsoleInternalEnv } from "../server/shared/launch-env.js";
+import { chatChildEnv, stripConsoleInternalEnv } from "../server/shared/launch-env.js";
 
 describe("stripConsoleInternalEnv", () => {
   it("removes desktop protocol markers and internal hints while keeping hook-required keys", () => {
@@ -33,5 +33,33 @@ describe("stripConsoleInternalEnv", () => {
     const source: NodeJS.ProcessEnv = { FLEET_CONSOLE_OWNER_KIND: "desktop" };
     stripConsoleInternalEnv(source);
     expect(source.FLEET_CONSOLE_OWNER_KIND).toBe("desktop");
+  });
+});
+
+describe("chatChildEnv", () => {
+  it("drops the inherited session id and turns Artifact on for the SDK child", () => {
+    const env = chatChildEnv({
+      PATH: "/usr/bin",
+      FLEET_CONSOLE_SESSION_ID: "terminal-session-1",
+      FLEET_CONSOLE_DIR: "/Users/op/.fleet/console",
+    });
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.FLEET_CONSOLE_DIR).toBe("/Users/op/.fleet/console");
+    // 상속된 터미널 세션 id를 따라가면 이 자식의 훅이 남의 세션 축에 보고한다.
+    expect(env.FLEET_CONSOLE_SESSION_ID).toBeUndefined();
+    // SDK 진입점의 기본값은 Artifact 비활성이고, 그러면 도구와 함께 artifact-* 스킬 셋이
+    // 자식의 목록에서 사라져 컴포저 덱에도 서지 못한다.
+    expect(env.CLAUDE_CODE_ARTIFACT).toBe("1");
+  });
+
+  it("keeps an operator's explicit Artifact choice", () => {
+    expect(chatChildEnv({ CLAUDE_CODE_ARTIFACT: "0" }).CLAUDE_CODE_ARTIFACT).toBe("0");
+  });
+
+  it("does not mutate the source environment", () => {
+    const source: NodeJS.ProcessEnv = { FLEET_CONSOLE_SESSION_ID: "terminal-session-1" };
+    chatChildEnv(source);
+    expect(source.FLEET_CONSOLE_SESSION_ID).toBe("terminal-session-1");
+    expect(source.CLAUDE_CODE_ARTIFACT).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- 채팅뷰의 SDK 자식은 vendor Agent SDK가 `CLAUDE_CODE_ENTRYPOINT=sdk-ts`를 세우고, Claude Code는 SDK 진입점에서 Artifact를 기본으로 끕니다. 그 게이트에 `artifact-design`·`artifact-diagramming`·`artifact-capabilities` 세 스킬이 함께 묶여 있어 컴포저 덱은 그 이름들을 그릴 근거조차 받지 못했습니다 — 같은 Operation을 터미널로 열면(진입점 `cli`) 넷 다 있었습니다.
- `chatChildEnv`에서 `CLAUDE_CODE_ARTIFACT`를 세워 두 표면의 능력을 맞춥니다. 상속된 값이 있으면 그대로 두어 운영자가 끈 선택을 되살리지 않습니다.
- 채팅뷰 SDK 자식 전용 환경에만 손대므로 Analyst·위임 서브에이전트 등 다른 SDK 자식의 도구 정의 비용은 그대로입니다.

## Test Plan
- [x] `pnpm --filter ./runtime/fleet-plugins/terminal test` — 102 files / 1135 tests green
- [x] `pnpm --filter ./runtime/fleet-plugins/terminal typecheck`
- [x] `pnpm --filter ./runtime/fleet-plugins/terminal build` + `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Fleet SDK 경로 실측(`createClaudeGatewaySdk` + `chatChildEnv`, 사용자 실제 Claude 홈): `supportedCommands` 43 → 45, `artifact-design`·`artifact-capabilities`가 목록에 섬. 대조군(기본 env)은 0건
- [x] CLI 게이트 실측(2.1.251): `CLAUDE_CODE_ENTRYPOINT=sdk-cli`에서 Artifact 도구 없음/artifact 스킬 0건 → `CLAUDE_CODE_ARTIFACT=1` 추가 시 `Artifact` 도구 + 스킬 3건, 격리 config dir에서도 동일
- [ ] 게시(publish)가 게이트웨이 경유 세션에서 끝까지 성공하는지는 미검증 — 도구가 실리는 것과 claude.ai 게시가 뚫리는 것은 별개