### PR TITLE
fix(fleet-console): mark the active Theater on channels hover does not use

### DIFF
--- a/.changelog.d/theater-active-marker.md
+++ b/.changelog.d/theater-active-marker.md
@@ -1,0 +1,8 @@
+---
+branch: theater-active-marker
+---
+
+### fleet-console
+#### Fixed
+- Mark the active Theater in the sidebar with a brass spine, a filled initial badge, and a brighter name, so hovering another Theater no longer looks more active than the one you are working in.
+  ko: 사이드바의 활성 Theater를 brass 스파인과 채워진 이니셜 배지, 밝은 이름으로 표시해 다른 Theater에 마우스를 올려도 작업 중인 Theater보다 강조되지 않습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5588,10 +5588,16 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding: 2px 0;
 }
 
+/* 활성 Theater는 구역 왼쪽의 2px brass 스파인으로 표시한다. 이전의 상하 1px rim은 목록 안
+   다른 구분선과 같은 무게(실측 대비 1.28~1.42:1)라 활성 신호로 읽히지 않았고, 헤더 채움은
+   호버와 같은 값이어서(4테마 전부 ΔL 0.000) 커서를 얹은 비활성 Theater가 활성보다 강해졌다.
+   스파인은 호버가 쓰지 않는 채널이며 헤더가 아니라 **구역**에 붙으므로 헤더가 스크롤 밖으로
+   밀려나도 아래 칩들의 소속이 유지된다.
+   [왜 ::before가 아니라 background인가] 이 섹션의 ::before/::after는 드래그 재정렬의
+   drop-before/drop-after 표시가 이미 점유하고 있다 — 활성 Theater를 끌면 두 규칙이 같은
+   의사요소를 다투므로 스파인은 배경 레이어로 그린다. */
 .side-bar-theater-section--active {
-  border-top: 1px solid var(--surface-rim);
-  border-bottom: 1px solid var(--surface-rim);
-  background: transparent;
+  background: linear-gradient(var(--brass), var(--brass)) 0 4px / 2px calc(100% - 8px) no-repeat;
 }
 
 /* 행 안의 Theater 선택 버튼. 남은 자리를 채우되 아코디언은 오른쪽의 독립 버튼이 맡는다. */
@@ -5651,10 +5657,15 @@ body[data-side-bar-animating="true"] .canvas-operation {
   user-select: none;
 }
 
+/* 호버는 행 배경 채움 하나만 쓴다. rim 테두리까지 얹으면 활성(테두리 없음)보다 강해져
+   "커서가 있는 곳"이 "지금 열려 있는 곳"을 덮는다 — focus-visible은 아래에서 자기 brass
+   테두리를 따로 지므로 여기서 테두리를 빼도 포커스 표식은 남는다.
+   [왜 ink-deep이 아니라 ink-mid인가] 테두리를 뺀 자리를 채움이 이어받아야 한다. ink-deep은
+   사이드바 바탕과 ΔL 0.035(대비 1.02:1)뿐이라 테두리가 사라지면 호버가 통째로 안 보였다
+   (실측). 활성이 배경 채널을 비웠으므로 이 한 단은 활성을 침범하지 않는다. */
 .side-bar-theater-header:hover,
 .side-bar-theater-header:focus-visible {
-  background: var(--ink-deep);
-  border-color: var(--surface-rim);
+  background: var(--ink-mid);
   color: var(--text-secondary);
   outline: none;
 }
@@ -5664,10 +5675,19 @@ body[data-side-bar-animating="true"] .canvas-operation {
   background: var(--brass-glow);
 }
 
+/* 활성 헤더는 배경 채움을 호버에게 완전히 넘긴다. 위치(활성)와 순간(호버)이 같은 채널을
+   공유하는 한 어느 쪽을 올려도 다른 쪽이 뭉개지므로, 활성은 스파인·배지·이름 명도로만
+   말한다. 활성 행은 aria-disabled라 눌리지 않으므로 호버 피드백이 없는 편이 정직하다. */
 .side-bar-theater-header.is-active {
   color: var(--text-secondary);
   border-color: transparent;
-  background: var(--ink-deep);
+  background: transparent;
+}
+
+/* 이름만 최고 명도로 올린다 — 행 전체를 올리면 chevron·+·⋯ 컨트롤까지 함께 밝아져
+   활성 Theater의 컨트롤이 다른 Theater보다 눈에 띄는 역전이 생긴다. */
+.side-bar-theater-header.is-active .side-bar-theater-name {
+  color: var(--text-primary);
 }
 
 .side-bar-theater-anchor {
@@ -5683,6 +5703,19 @@ body[data-side-bar-animating="true"] .canvas-operation {
   font-family: var(--font-mono);
   font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring);
+}
+
+/* 활성 Theater의 이니셜 배지는 brass로 채워 반전한다. 배지는 좌측 정렬선 위에 있어 목록을
+   훑는 눈이 가장 먼저 닿는 자리이고, 스파인과 달리 헤더 행 안에서 읽히므로 둘이 같은 사실을
+   서로 다른 거리에서 말한다. 채움 위 글자는 brass 전용 텍스트 티어를 쓴다 — 라이트에서
+   자기 채움 위 AA를 보장하는 유일한 값이다. 대기 tick은 배지 바깥 모서리에 떠 있어 가려지지
+   않는다. */
+.side-bar-theater-header.is-active .side-bar-theater-anchor {
+  background: var(--brass);
+  color: var(--text-on-brass);
 }
 
 .side-bar-ghost-theater-row {
@@ -6366,7 +6399,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 @media (prefers-reduced-motion: reduce) {
   .side-bar-group-header,
-  .side-bar-theater-header {
+  .side-bar-theater-header,
+  .side-bar-theater-anchor {
     transition: none;
   }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1934,6 +1934,53 @@ describe("Instrument core design contract", () => {
     expect(sidebar).toMatch(/side-bar-theater-anchor[\s\S]{0,400}side-bar-status-axis-live-tick/);
   });
 
+  it("pins the active Theater marker to channels the hover state does not use", () => {
+    const components = source("styles/components.css");
+    // 위치(어느 Theater가 열려 있나)와 순간(커서가 어디 있나)은 서로 다른 채널을 쓴다. 한때
+    // 둘 다 행 배경 채움이었고 값까지 같아(4테마 전부 ΔL 0.000) 호버한 비활성 Theater가
+    // 활성보다 강했다 — 호버에만 rim 테두리가 더 붙었기 때문이다.
+    const activeSection = components.match(/\.side-bar-theater-section--active \{[^}]*\}/)?.[0] ?? "";
+    const headerHover = components.match(/\.side-bar-theater-header:hover,\n\.side-bar-theater-header:focus-visible \{[^}]*\}/)?.[0] ?? "";
+    const activeHeader = components.match(/\.side-bar-theater-header\.is-active \{[^}]*\}/)?.[0] ?? "";
+    const activeAnchor = components.match(/\.side-bar-theater-header\.is-active \.side-bar-theater-anchor \{[^}]*\}/)?.[0] ?? "";
+    const activeName = components.match(/\.side-bar-theater-header\.is-active \.side-bar-theater-name \{[^}]*\}/)?.[0] ?? "";
+
+    // 활성은 구역 왼쪽 2px brass 스파인이 나른다. 헤더가 아니라 구역에 붙으므로 헤더가 스크롤
+    // 밖으로 밀려나도 아래 칩들의 소속이 유지된다.
+    expect(activeSection).toContain("linear-gradient(var(--brass), var(--brass))");
+    expect(activeSection).toContain("2px calc(100% - 8px)");
+    // 옛 상하 rim은 목록의 다른 구분선과 같은 무게라 활성 신호로 읽히지 않았다 — 되살아나면
+    // 스파인과 두 겹으로 말하게 된다.
+    expect(activeSection).not.toContain("border-top");
+    expect(activeSection).not.toContain("border-bottom");
+    // 스파인은 배경 레이어로 그린다: 이 섹션의 ::before/::after는 드래그 drop 표시가 점유한다.
+    expect(components).not.toMatch(/\.side-bar-theater-section--active::(before|after)/);
+
+    // 호버는 배경 채움 하나만 쓴다. 테두리가 돌아오면 다시 활성보다 강해진다.
+    expect(headerHover).toContain("background: var(--ink-mid);");
+    expect(headerHover).not.toContain("border-color");
+    // focus-visible은 자기 brass 테두리를 따로 진다 — 호버에서 테두리를 뺀 것이 포커스 표식을
+    // 지우면 안 된다.
+    expect(components).toMatch(/\.side-bar-theater-header:focus-visible \{[^}]*border-color: color-mix\(in oklch, var\(--brass\) 55%/);
+
+    // 활성 헤더는 배경 채널을 호버에게 완전히 넘긴다.
+    expect(activeHeader).toContain("background: transparent;");
+    expect(activeHeader).not.toContain("var(--ink-deep)");
+
+    // 가까이서는 배지 반전이, 멀리서는 스파인이 같은 사실을 말한다. 채움 위 글자는 라이트에서
+    // AA를 보장하는 brass 전용 텍스트 티어여야 한다.
+    expect(activeAnchor).toContain("background: var(--brass);");
+    expect(activeAnchor).toContain("color: var(--text-on-brass);");
+
+    // 이름만 최고 명도로 올린다 — 행 전체를 올리면 활성 Theater의 행 컨트롤이 다른 Theater의
+    // 것보다 밝아지는 역전이 생긴다.
+    expect(activeName).toContain("color: var(--text-primary);");
+
+    // 배지가 색 전환을 지므로 reduced-motion에서 함께 멎어야 한다.
+    const reducedMotion = components.match(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*$/)?.[0] ?? "";
+    expect(reducedMotion).toMatch(/\.side-bar-theater-anchor \{\s*transition: none;/);
+  });
+
   it("pins the selectable Right Rail panel behavior contract", () => {
     const rail = source("styles/rail.css");
     const rightRail = source("rail/right-rail.tsx");


### PR DESCRIPTION
## Summary

- 사이드바에서 활성 Theater와 호버가 **같은 채널(행 배경 채움)을 같은 값으로** 쓰고 있었습니다. 4개 테마 전부 실측 ΔL 0.000이었고, 호버에만 rim 테두리가 더 붙어 **커서를 얹은 비활성 Theater가 실제 활성보다 강했습니다.**
- 활성 표식을 호버가 쓰지 않는 채널로 옮겼습니다: 구역 왼쪽 2px brass 스파인(섹션 의사요소는 드래그 drop 표시가 이미 점유하므로 배경 레이어로 그림), 이니셜 배지 brass 반전(`--text-on-brass`), 이름만 최고 명도로 승격(행 컨트롤은 그대로).
- 배경 채널은 호버가 전부 가져가고 rim 테두리를 뺐습니다. 테두리를 뺀 자리를 채움이 이어받도록 호버 채움을 `--ink-deep`(바탕 대비 1.02:1) → `--ink-mid` 한 단 올렸습니다. 목록의 다른 구분선과 같은 무게였던 섹션 상하 rim은 퇴역했습니다.

### 실측 (격리 콘솔, 4테마)

| | 변경 전 | 변경 후 |
|---|---|---|
| 활성 헤더 배경 ΔL | +0.035 ~ +0.048 (whites −0.015) | **0.000** (배경 채널 비움) |
| 호버 배경 ΔL | +0.035 ~ +0.048 | +0.069 ~ +0.130 (whites −0.039) |
| 호버 테두리 alpha | 0.22 ~ 1.00 | **0.00** |
| 활성 스파인 대비 | 없음 | 10.64 / 9.62 / 9.04 / 4.33 |
| 활성 배지 글자 대비 | 비활성과 동일 | 10.64 / 9.62 / 9.04 / **4.65** (AA) |
| 활성 이름 대비 | 5.97 ~ 7.38 | 15.65 ~ 17.43 |

## Test Plan

- [x] `vitest run tests/instrument-design-contract.test.ts tests/operations-side-bar-status-axis.test.tsx tests/operations-side-bar-inactive-theater.test.tsx tests/theaters.test.ts` — 129 passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — exit 0
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공, 서빙 번들 해시 대조 확인
- [x] 격리 콘솔 헤드리스 실측: 4테마 활성/호버/비활성 계산색 + 스크린샷
- [x] 활성 Theater 접힘 상태에서 스파인 유지 확인, chevron 포커스 링 정상