### PR TITLE
feat(fleet-console): remember rail panel width per tool

### DIFF
--- a/.changelog.d/rail-pane-width.md
+++ b/.changelog.d/rail-pane-width.md
@@ -1,0 +1,14 @@
+---
+branch: rail-pane-width
+---
+
+### fleet-console
+#### Changed
+- Remember Activity Rail panel width per tool, so widening one panel no longer widens every other panel, and a tool you have never resized keeps opening at the width its own panel declares.
+  ko: Activity Rail 패널 폭을 도구별로 기억합니다. 한 패널을 넓혀도 나머지 패널이 함께 넓어지지 않고, 한 번도 조절하지 않은 도구는 계속 그 패널이 선언한 폭으로 열립니다.
+- Open Settings wide enough for its theme grid to stand in two columns by default.
+  ko: 설정 패널이 기본 상태에서 테마 격자를 2열로 세울 만큼 넓게 열립니다.
+
+#### Fixed
+- Reset only the active panel's width when you double-click the rail resize handle, leaving every other tool's remembered width in place.
+  ko: 레일 크기 조절 손잡이를 더블클릭하면 지금 열린 패널의 폭만 초기화하고, 다른 도구가 기억한 폭은 그대로 둡니다.

--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -13,6 +13,7 @@ import { PaneBody, usePaneContext } from "./pane-body.js";
 import { PaneCaption } from "./pane-caption.js";
 import { PaneDivider } from "./pane-divider.js";
 import { clampPrimaryWidth, MIN_PANE_PX, type PaneSplitLimits } from "./pane-geometry.js";
+import { resolvePaneDefaultWidth } from "../rail/pane-width.js";
 import { setPaneWidth, usePaneWidths } from "./pane-width-store.js";
 import { usePaneIndex, type HostPaneContext, type RailEntryBinding } from "./pane-registry.js";
 import { closePane, focusPane, openPane, replacePaneParams, resetSurfacePanes, useFocusedPaneId, useRailPanes } from "./pane-store.js";
@@ -166,7 +167,7 @@ export const RailSurface = memo(function RailSurface({
   const primaryWidth = clampPrimaryWidth(
     paneWidths[primary?.id ?? ""]
       ?? (soloWidthRef.current > 0 ? soloWidthRef.current : undefined)
-      ?? primary?.defaultWidth
+      ?? (primary === null ? undefined : resolvePaneDefaultWidth(primary))
       ?? MIN_PANE_PX,
     limits,
   );
@@ -178,7 +179,7 @@ export const RailSurface = memo(function RailSurface({
   // **서 있는 detail이 없을 때는 값을 건드리지 않는다.** 아직 한 본문 안에서 두 열을 그리는
   // 플러그인이 같은 창구로 폭을 요구하고 있어서, 0을 써 버리면 그 요구를 덮는다.
   const desiredExtra = standing.reduce(
-    (sum, { descriptor }) => sum + (paneWidths[descriptor.id] ?? descriptor.defaultWidth ?? MIN_PANE_PX),
+    (sum, { descriptor }) => sum + (paneWidths[descriptor.id] ?? resolvePaneDefaultWidth(descriptor)),
     0,
   );
   useEffect(() => {
@@ -375,7 +376,7 @@ function PaneHost({
     focused,
     // 폭은 표면이 정한다. 본문은 컨테이너 쿼리로 스스로 열화하므로, 측정값을 렌더마다 흘리면
     // 컨텍스트가 매번 새로 만들어져 본문이 다시 그려진다.
-    width: width ?? descriptor.defaultWidth ?? 0,
+    width: width ?? (descriptor.defaultWidth ?? (descriptor.widthClass === undefined ? 0 : resolvePaneDefaultWidth(descriptor))),
     theaterId,
     api,
     lifecycle: HOST_CAPABILITIES.lifecycle,

--- a/runtime/fleet-console/core/client/src/rail/pane-width.ts
+++ b/runtime/fleet-console/core/client/src/rail/pane-width.ts
@@ -83,6 +83,21 @@ function drop(key: string): void {
   try { localStorage.removeItem(key); } catch { /* ignore */ }
 }
 
+/** 저장된 지도. 키가 없거나 읽을 수 없으면 `null` — 부르는 쪽은 둘을 똑같이 "없음"으로 다룬다. */
+function readWidthMap(): Record<string, number> | null {
+  const raw = localStorage.getItem(PREFS_PANEL_WIDTHS);
+  if (raw === null) return null;
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return null; }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const widths: Record<string, number> = {};
+  for (const [id, value] of Object.entries(parsed)) {
+    const px = sanitize(value);
+    if (id !== "" && px !== null) widths[id] = px;
+  }
+  return widths;
+}
+
 /**
  * 저장된 도구별 폭을 읽는다. 단일 폭 시절의 값은 여기서 **1회** 승계된다.
  *
@@ -94,16 +109,11 @@ function drop(key: string): void {
  */
 export function readStoredPanelWidths(activePanelId: string | null): StoredPanelWidths {
   try {
-    const raw = localStorage.getItem(PREFS_PANEL_WIDTHS);
-    if (raw !== null) {
-      const parsed: unknown = JSON.parse(raw);
-      const widths: Record<string, number> = {};
-      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
-        for (const [id, value] of Object.entries(parsed)) {
-          const px = sanitize(value);
-          if (id !== "" && px !== null) widths[id] = px;
-        }
-      }
+    // 읽을 수 없는 지도는 **없는 것으로 친다.** 여기서 통째로 포기하면 함께 남아 있던 멀쩡한
+    // 단일 폭이 영원히 가려지고, 깨진 지도 자체도 걷히지 않는다(v1.79.0의 마이그레이션이
+    // 깨진 지도를 만나면 그대로 두었으므로 둘이 공존하는 상태가 실제로 존재한다).
+    const widths = readWidthMap();
+    if (widths !== null) {
       // 옛 단일 키가 함께 남아 있으면 걷는다 — 도구별 지도가 있는 한 그 값은 주인이 없다.
       drop(LEGACY_PREFS_CARD_WIDTH);
       drop(LEGACY_PREFS_PANEL_WIDTH);
@@ -114,7 +124,11 @@ export function readStoredPanelWidths(activePanelId: string | null): StoredPanel
       ?? sanitize(Number(localStorage.getItem(LEGACY_PREFS_PANEL_WIDTH)));
     drop(LEGACY_PREFS_CARD_WIDTH);
     drop(LEGACY_PREFS_PANEL_WIDTH);
-    if (legacy === null || activePanelId === null) return {};
+    if (legacy === null || activePanelId === null) {
+      // 승계할 값이 없어도 읽을 수 없던 지도는 걷는다 — 남겨 두면 다음 로드도 같은 자리에서 막힌다.
+      drop(PREFS_PANEL_WIDTHS);
+      return {};
+    }
     const migrated = { [activePanelId]: legacy };
     write(migrated);
     return migrated;

--- a/runtime/fleet-console/core/client/src/rail/pane-width.ts
+++ b/runtime/fleet-console/core/client/src/rail/pane-width.ts
@@ -1,0 +1,141 @@
+import type { PaneDescriptor, PaneWidthClass } from "@fleet-console/sdk/pane";
+
+/**
+ * 레일 카드 폭의 단일 출처 — 등급표, 기본값 해석, 그리고 도구별 기억.
+ *
+ * 폭을 한 모듈이 소유하는 이유는 두 번 데었기 때문이다.
+ *
+ * **하나.** 폭의 기억은 한때 패널별이었다(#373). 레일이 다중 Pin 스택이 되면서 두 패널이 한
+ * 카드에 동시에 상주하게 되자 "패널마다 다른 폭"이 성립하지 않아 카드 단일 값으로 접혔다
+ * (#963). 그 전제는 독점 슬롯 회귀(#968)로 사라졌지만 기제는 남아, 한 도구를 넓히면 나머지
+ * 다섯이 함께 넓어지고 그 상태가 재부팅을 넘어 살아남았다. 폭의 소유자는 다시 도구다.
+ *
+ * **둘.** 페인이 자기 폭을 픽셀로 발명하면 그 픽셀이 자기 컨테이너 브레이크포인트와 어긋나도
+ * 아무도 잡지 못한다 — 설정 페인은 `defaultWidth: 360`을 선언했는데 자기 테마 격자가 2열이
+ * 되는 문턱은 420이어서, 기본 상태에서 그 격자가 한 번도 2열로 서지 못했다. 그래서 새 페인은
+ * 픽셀이 아니라 **등급**을 말하고, 픽셀은 여기서만 해석한다. 등급표가 브레이크포인트를
+ * 넘는지는 `tests/instrument-design-contract.test.ts`가 지킨다.
+ */
+
+/** 카드가 이보다 좁아지지 않는다. 아래 등급은 전부 이 바닥 위에 있어야 한다. */
+export const MIN_PANEL_WIDTH = 240;
+
+/** 폭에 대해 아무 말도 하지 않은 페인의 몫. */
+export const DEFAULT_PANEL_WIDTH = 312;
+
+/**
+ * 등급 → px. 페인이 픽셀을 발명하는 대신 고르는 어휘다.
+ *
+ * - `narrow` — 폭이 판독을 거의 바꾸지 않는 목록(스킬 계열). 실측상 336px 위로는 내용이 더
+ *   펴지지 않는다.
+ * - `standard` — 계량기·행 카드가 한 줄에 서는 폭(사용 한도·원장 계열). 실측 무릎 368px 위.
+ * - `wide` — 안에서 2열 격자가 서야 하는 본문(설정 계열). 코어 CSS의 설정 페인 컨테이너
+ *   문턱(420px)을 반드시 넘는다.
+ */
+export const PANE_WIDTH_CLASS_PX: Readonly<Record<PaneWidthClass, number>> = {
+  narrow: 328,
+  standard: 392,
+  wide: 440,
+};
+
+/**
+ * 카드 폭과 페인 컨테이너 폭의 차(px).
+ *
+ * `@container` 질의는 카드가 아니라 페인 요소의 폭으로 판정한다. 등급표가 브레이크포인트를
+ * "겨우" 넘으면 이 차이만큼 판정이 뒤집히므로, 계약 테스트는 이 여유를 얹고 비교한다.
+ *
+ * 값은 실측이다 — 카드 440px에서 `.settings-pane`의 폭은 428px이었다(테두리·패딩 몫).
+ */
+export const PANE_CONTAINER_INSET_ALLOWANCE = 12;
+
+/** 페인이 선언한 폭 — 픽셀이 먼저고, 없으면 등급, 그것도 없으면 호스트 기본값. */
+export function resolvePaneDefaultWidth(pane: Pick<PaneDescriptor, "defaultWidth" | "widthClass"> | null | undefined): number {
+  if (pane === null || pane === undefined) return DEFAULT_PANEL_WIDTH;
+  if (pane.defaultWidth !== undefined && Number.isFinite(pane.defaultWidth)) return Math.round(pane.defaultWidth);
+  if (pane.widthClass !== undefined) return PANE_WIDTH_CLASS_PX[pane.widthClass];
+  return DEFAULT_PANEL_WIDTH;
+}
+
+/* ── 도구별 기억 ───────────────────────────────────────────────────────────── */
+
+/** 도구 id → 사용자가 조절한 폭(px). 조절하지 않은 도구는 여기 없다. */
+export type StoredPanelWidths = Readonly<Record<string, number>>;
+
+const PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
+/** #963~#968의 카드 단일 폭. 마지막 활성 도구에게 상속시키고 걷는다. */
+const LEGACY_PREFS_CARD_WIDTH = "fleet-console.rail.cardWidth";
+/** #373 이전의 단일 폭. 같은 방식으로 상속시킨다. */
+const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
+
+function sanitize(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < MIN_PANEL_WIDTH) return null;
+  return Math.round(value);
+}
+
+function write(widths: StoredPanelWidths): void {
+  try {
+    if (Object.keys(widths).length === 0) localStorage.removeItem(PREFS_PANEL_WIDTHS);
+    else localStorage.setItem(PREFS_PANEL_WIDTHS, JSON.stringify(widths));
+  } catch { /* ignore */ }
+}
+
+function drop(key: string): void {
+  try { localStorage.removeItem(key); } catch { /* ignore */ }
+}
+
+/**
+ * 저장된 도구별 폭을 읽는다. 단일 폭 시절의 값은 여기서 **1회** 승계된다.
+ *
+ * 승계는 마지막으로 열려 있던 도구에게만 간다. 그 값은 사용자가 그 도구를 보면서 정한
+ * 폭이었고, 화면에 없던 다섯 도구가 그 폭을 물려받을 근거는 처음부터 없었다 — 그 근거 없는
+ * 상속이 바로 이번에 걷어내는 결함이다. 열려 있던 도구가 없으면 그 값은 주인이 없으므로 버린다.
+ *
+ * 승계한 뒤에는 옛 키를 지운다. 남겨 두면 다음 로드가 같은 상속을 다시 심는다.
+ */
+export function readStoredPanelWidths(activePanelId: string | null): StoredPanelWidths {
+  try {
+    const raw = localStorage.getItem(PREFS_PANEL_WIDTHS);
+    if (raw !== null) {
+      const parsed: unknown = JSON.parse(raw);
+      const widths: Record<string, number> = {};
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        for (const [id, value] of Object.entries(parsed)) {
+          const px = sanitize(value);
+          if (id !== "" && px !== null) widths[id] = px;
+        }
+      }
+      // 옛 단일 키가 함께 남아 있으면 걷는다 — 도구별 지도가 있는 한 그 값은 주인이 없다.
+      drop(LEGACY_PREFS_CARD_WIDTH);
+      drop(LEGACY_PREFS_PANEL_WIDTH);
+      return widths;
+    }
+
+    const legacy = sanitize(Number(localStorage.getItem(LEGACY_PREFS_CARD_WIDTH)))
+      ?? sanitize(Number(localStorage.getItem(LEGACY_PREFS_PANEL_WIDTH)));
+    drop(LEGACY_PREFS_CARD_WIDTH);
+    drop(LEGACY_PREFS_PANEL_WIDTH);
+    if (legacy === null || activePanelId === null) return {};
+    const migrated = { [activePanelId]: legacy };
+    write(migrated);
+    return migrated;
+  } catch { return {}; }
+}
+
+/** 한 도구의 폭을 기록한다. 다른 도구의 기억은 건드리지 않는다. */
+export function saveStoredPanelWidth(current: StoredPanelWidths, panelId: string, width: number): StoredPanelWidths {
+  const px = sanitize(Math.round(width));
+  if (px === null) return current;
+  if (current[panelId] === px) return current;
+  const next = { ...current, [panelId]: px };
+  write(next);
+  return next;
+}
+
+/** 한 도구의 기억만 지운다 — 그 도구는 다음부터 자기 선언 기본값으로 열린다. */
+export function clearStoredPanelWidth(current: StoredPanelWidths, panelId: string): StoredPanelWidths {
+  if (!(panelId in current)) return current;
+  const next = { ...current };
+  delete next[panelId];
+  write(next);
+  return next;
+}

--- a/runtime/fleet-console/core/client/src/rail/pane-width.ts
+++ b/runtime/fleet-console/core/client/src/rail/pane-width.ts
@@ -83,7 +83,15 @@ function drop(key: string): void {
   try { localStorage.removeItem(key); } catch { /* ignore */ }
 }
 
-/** 저장된 지도. 키가 없거나 읽을 수 없으면 `null` — 부르는 쪽은 둘을 똑같이 "없음"으로 다룬다. */
+/**
+ * 저장된 지도. 쓸 수 있는 항목을 하나도 내놓지 못하면 `null` — 부르는 쪽은 그것을 "없음"과
+ * 똑같이 다룬다.
+ *
+ * 경계가 "읽을 수 있는가"가 아니라 "무엇이라도 말하는가"인 이유는, 권위의 근거가 형식이 아니라
+ * 내용이기 때문이다. 항목이 하나도 안 남는 지도는 아무것도 말하지 않으므로, 그것을 권위로 받아
+ * 함께 남아 있던 멀쩡한 단일 폭을 버릴 근거가 없다. 항목이 하나라도 살아남으면 그 지도는 정보를
+ * 담고 있고, 그때는 승계로 되돌아가지 않는다.
+ */
 function readWidthMap(): Record<string, number> | null {
   const raw = localStorage.getItem(PREFS_PANEL_WIDTHS);
   if (raw === null) return null;
@@ -95,7 +103,7 @@ function readWidthMap(): Record<string, number> | null {
     const px = sanitize(value);
     if (id !== "" && px !== null) widths[id] = px;
   }
-  return widths;
+  return Object.keys(widths).length === 0 ? null : widths;
 }
 
 /**

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -18,6 +18,14 @@ import { useSideBarState } from "../sidebar/operations-side-bar-store.js";
 import type { ConnectionState } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
 import { closeRailPanel, reportRailOccupiedPx, requestRailPanelExtraWidth, toggleRailPanel, useRailActivePanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelExtraWidth } from "./rail-store.js";
+import {
+  MIN_PANEL_WIDTH,
+  clearStoredPanelWidth,
+  readStoredPanelWidths,
+  resolvePaneDefaultWidth,
+  saveStoredPanelWidth,
+  type StoredPanelWidths,
+} from "./pane-width.js";
 import { GearGlyph, SETTINGS_RAIL_ENTRY_ID } from "../settings/settings-entry.js";
 import { useRailEntries, type RailEntryBinding } from "../pane/pane-registry.js";
 import { RailSurface } from "../pane/rail-surface.js";
@@ -30,65 +38,17 @@ interface RightRailProps {
 
 /** rail 컨텍스트마다 새 능력 객체를 만들면 패널 본문이 매 렌더 재마운트된다. */
 const STABLE_RAIL_SURFACES = createHostCapabilities().surfaces;
-const MIN_PANEL_WIDTH = 240;
-const DEFAULT_PANEL_WIDTH = 312;
 /** 아이콘 열 폭 — rail.css .right-rail-icons와 한 값. */
 const RAIL_ICON_STRIP_WIDTH = 44;
-/* 카드 폭은 패널별이 아니라 카드 단일 값이다 — 어느 패널이 상주하든 카드는 한 폭을 기억한다.
-   구 패널별 기억(panelWidths)은 첫 로드에 최댓값으로 승격해 카드 폭으로 흡수한다(1회성). */
-const PREFS_CARD_WIDTH = "fleet-console.rail.cardWidth";
-const LEGACY_PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
-const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
-
-function readStoredCardWidth(): number | null {
-  try {
-    const raw = localStorage.getItem(PREFS_CARD_WIDTH);
-    if (raw !== null) {
-      const parsed = Number(raw);
-      return Number.isFinite(parsed) && parsed >= MIN_PANEL_WIDTH ? Math.round(parsed) : null;
-    }
-    // 1회성 마이그레이션: 패널별 기억·단일 레거시 키의 최댓값을 카드 폭으로 승격한다.
-    const candidates: number[] = [];
-    const legacyWidths = localStorage.getItem(LEGACY_PREFS_PANEL_WIDTHS);
-    if (legacyWidths !== null) {
-      const parsed: unknown = JSON.parse(legacyWidths);
-      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
-        for (const value of Object.values(parsed)) {
-          if (typeof value === "number" && Number.isFinite(value) && value >= MIN_PANEL_WIDTH) candidates.push(Math.round(value));
-        }
-      }
-    }
-    const legacySingle = Number(localStorage.getItem(LEGACY_PREFS_PANEL_WIDTH));
-    if (Number.isFinite(legacySingle) && legacySingle >= MIN_PANEL_WIDTH) candidates.push(Math.round(legacySingle));
-    if (candidates.length === 0) return null;
-    const migrated = Math.max(...candidates);
-    try {
-      localStorage.setItem(PREFS_CARD_WIDTH, String(migrated));
-      localStorage.removeItem(LEGACY_PREFS_PANEL_WIDTHS);
-      localStorage.removeItem(LEGACY_PREFS_PANEL_WIDTH);
-    } catch { /* best-effort migration */ }
-    return migrated;
-  } catch { return null; }
-}
-
-function saveStoredCardWidth(width: number): void {
-  try { localStorage.setItem(PREFS_CARD_WIDTH, String(Math.round(width))); } catch { /* ignore */ }
-}
-
-function clearStoredCardWidth(): void {
-  try { localStorage.removeItem(PREFS_CARD_WIDTH); } catch { /* ignore */ }
-}
-
 /** 엔트리의 대표 페인 — 폭 기본값 등 표면 차원의 힌트를 primary가 말한다(pane 계약). */
-function primaryPaneOf(binding: RailEntryBinding) {
+function primaryPaneOf(binding: RailEntryBinding | null) {
+  if (binding === null) return null;
   return binding.panes.find((pane) => pane.role === "primary") ?? binding.panes[0] ?? null;
 }
 
-function defaultCardWidthFor(bindings: readonly RailEntryBinding[]): number {
-  return bindings.reduce(
-    (max, binding) => Math.max(max, Math.round(primaryPaneOf(binding)?.defaultWidth ?? DEFAULT_PANEL_WIDTH)),
-    MIN_PANEL_WIDTH,
-  );
+/** 이 도구가 손대지 않은 상태에서 서는 폭 — 대표 페인이 선언한 픽셀 또는 등급. */
+function declaredWidthOf(binding: RailEntryBinding | null): number {
+  return Math.max(MIN_PANEL_WIDTH, resolvePaneDefaultWidth(primaryPaneOf(binding)));
 }
 
 export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps) {
@@ -148,23 +108,28 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   const widthBudget = Math.floor(viewportWidth - 148 - sideBarOccupiedPx);
   const maxPanelWidth = Math.max(MIN_PANEL_WIDTH, widthBudget - extraWidth);
 
+  // 폭은 카드가 아니라 도구가 기억한다. 조절한 도구만 자기 값을 갖고, 손대지 않은 도구는
+  // 계속 자기 선언값으로 열린다 — 그래야 페인이 기본값을 고쳤을 때 그 개선이 사용자에게 닿는다.
+  const [storedWidths, setStoredWidths] = useState<StoredPanelWidths>(() => readStoredPanelWidths(activePanelId));
+  const storedWidthsRef = useRef(storedWidths);
+  storedWidthsRef.current = storedWidths;
+
   // 저장 폭은 클램프 없이 desired로 보존한다 — init에서 클램프한 값을 desired로 심으면
   // 큰 화면에서 저장한 폭이 좁은 창 로드 한 번에 소실되어, 창을 다시 넓혀도 복원되지
   // 않는다(Codex 리뷰 확정 — 구 폭 기억 effect의 restore-on-expansion 계약 승계).
-  const [initialWidths] = useState(() => {
-    const stored = readStoredCardWidth();
-    const fallback = defaultCardWidthFor(activeBinding !== null ? [activeBinding] : paneEntries);
-    const desired = Math.max(MIN_PANEL_WIDTH, stored ?? fallback);
-    return { desired, rendered: Math.min(maxPanelWidth, desired) };
-  });
-  const [cardWidth, setCardWidthState] = useState(initialWidths.rendered);
-  const desiredWidthRef = useRef(initialWidths.desired);
-  const cardWidthRef = useRef(initialWidths.rendered);
+  const desiredWidth = activeBinding === null
+    ? declaredWidthOf(null)
+    : Math.max(MIN_PANEL_WIDTH, storedWidths[activeBinding.entry.id] ?? declaredWidthOf(activeBinding));
+  const [cardWidth, setCardWidthState] = useState(() => Math.min(maxPanelWidth, desiredWidth));
+  const cardWidthRef = useRef(cardWidth);
   const [isDragging, setIsDragging] = useState(false);
   const extraWidthRef = useRef(extraWidth);
   extraWidthRef.current = extraWidth;
   const sideBarOccupiedRef = useRef(sideBarOccupiedPx);
   sideBarOccupiedRef.current = sideBarOccupiedPx;
+  // 조절은 언제나 **화면에 선 도구**의 몫이다 — 핸들러는 안정 참조로 두고 대상만 ref로 읽는다.
+  const activePaneIdRef = useRef<string | null>(null);
+  activePaneIdRef.current = activeBinding?.entry.id ?? null;
 
   useLayoutEffect(() => {
     const onResize = () => {
@@ -176,13 +141,15 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   }, []);
 
   // 뷰포트 클램프 — 좁아지면 즉시 줄이고, 다시 넓어지면 기억한 폭으로 복귀한다(기존 계약 유지).
+  // 같은 effect가 도구 전환도 받는다: desired는 활성 도구가 정하므로 도구가 바뀌면 그 도구의
+  // 폭으로 카드가 다시 선다. 드래그 중에는 포인터가 폭의 주인이라 desired를 보지 않는다.
   useLayoutEffect(() => {
-    const desiredWidth = isDragging ? cardWidthRef.current : desiredWidthRef.current;
-    const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxPanelWidth, desiredWidth));
+    const target = isDragging ? cardWidthRef.current : desiredWidth;
+    const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxPanelWidth, target));
     if (next === cardWidthRef.current) return;
     cardWidthRef.current = next;
     setCardWidthState(next);
-  }, [isDragging, maxPanelWidth]);
+  }, [isDragging, maxPanelWidth, desiredWidth]);
 
   useLayoutEffect(() => {
     if (previousRailChromeExpandedRef.current && !railChromeExpanded) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-rail-toggle");
@@ -218,9 +185,9 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
     const onUp = () => {
       document.removeEventListener("pointermove", onMove);
       document.removeEventListener("pointerup", onUp);
-      desiredWidthRef.current = cardWidthRef.current;
       setIsDragging(false);
-      saveStoredCardWidth(desiredWidthRef.current);
+      const panelId = activePaneIdRef.current;
+      if (panelId !== null) setStoredWidths(saveStoredPanelWidth(storedWidthsRef.current, panelId, cardWidthRef.current));
     };
 
     document.addEventListener("pointermove", onMove);
@@ -251,22 +218,19 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
 
     event.preventDefault();
     next = Math.max(MIN_PANEL_WIDTH, Math.min(currentMaxWidth, Math.round(next)));
-    desiredWidthRef.current = next;
     cardWidthRef.current = next;
     setCardWidthState(next);
-    saveStoredCardWidth(desiredWidthRef.current);
+    const panelId = activePaneIdRef.current;
+    if (panelId !== null) setStoredWidths(saveStoredPanelWidth(storedWidthsRef.current, panelId, next));
   }, []);
 
-  // 메뉴의 "패널 폭 초기화" — 기억을 지우고 활성 패널의 선언 기본값으로 되돌린다.
+  // 가장자리 더블클릭의 "패널 폭 초기화" — 그 도구의 기억만 지운다. 폭은 그 뒤 클램프
+  // effect가 선언 기본값에서 다시 세운다(기억을 지우는 것이 곧 되돌리는 것이다).
   const handleResetCardWidth = useCallback(() => {
-    clearStoredCardWidth();
-    const currentMaxWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidthRef.current - sideBarOccupiedRef.current));
-    const next = Math.max(MIN_PANEL_WIDTH, Math.min(currentMaxWidth, defaultCardWidthFor(activeBinding !== null ? [activeBinding] : paneEntries)));
-    desiredWidthRef.current = next;
-    cardWidthRef.current = next;
-    setCardWidthState(next);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activePanelId, paneEntries.length]);
+    const panelId = activePaneIdRef.current;
+    if (panelId === null) return;
+    setStoredWidths(clearStoredPanelWidth(storedWidthsRef.current, panelId));
+  }, []);
 
   const baseCtx: RailPanelContext = useMemo(() => ({
     theaterId,

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -172,6 +172,10 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
     e.preventDefault();
     const startX = e.clientX;
     const startWidth = cardWidthRef.current;
+    // 끌기의 주인은 손잡이를 잡은 그 도구다 — 시작점의 다른 값들과 함께 여기서 고정한다.
+    // 제스처가 지속되는 동안 플러그인의 `panels.open`이나 라우트 변경이 다른 패널을 세울 수
+    // 있고, 놓는 순간의 활성 도구를 읽으면 끌던 폭이 도착한 도구의 기억으로 샌다.
+    const dragPanelId = activePaneIdRef.current;
     setIsDragging(true);
 
     const onMove = (ev: PointerEvent) => {
@@ -186,8 +190,7 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
       document.removeEventListener("pointermove", onMove);
       document.removeEventListener("pointerup", onUp);
       setIsDragging(false);
-      const panelId = activePaneIdRef.current;
-      if (panelId !== null) setStoredWidths(saveStoredPanelWidth(storedWidthsRef.current, panelId, cardWidthRef.current));
+      if (dragPanelId !== null) setStoredWidths(saveStoredPanelWidth(storedWidthsRef.current, dragPanelId, cardWidthRef.current));
     };
 
     document.addEventListener("pointermove", onMove);

--- a/runtime/fleet-console/core/client/src/settings/settings-pane.tsx
+++ b/runtime/fleet-console/core/client/src/settings/settings-pane.tsx
@@ -122,8 +122,10 @@ export const settingsPanes: readonly PaneDescriptor[] = [
     id: SETTINGS_PANE_ID,
     role: "primary",
     mounts: ["rail"],
-    // 칩 폭과 카드 행이 함께 서는 최소선. 옛 페이지 폭의 전제는 컨테이너 쿼리가 대신 받는다.
-    defaultWidth: 360,
+    // 안에서 테마 격자가 2열로 서야 하는 본문이다. 픽셀을 직접 고르던 시절의 360은 자기
+    // 컨테이너 문턱(components.css의 `@container (max-width: 420px)`) 아래여서, 기본 상태의
+    // 설정 페인이 그 격자를 한 번도 2열로 세우지 못했다. 등급이 그 어긋남을 대신 막는다.
+    widthClass: "wide",
     title: () => (locale: ConsoleLocale) => getT(locale)("settings.title"),
     render: (ctx) => <SettingsPaneBody ctx={ctx} />,
     search: settingsSearchProvider,

--- a/runtime/fleet-console/sdk/pane/types.ts
+++ b/runtime/fleet-console/sdk/pane/types.ts
@@ -108,6 +108,21 @@ export interface PaneDescriptor {
    */
   readonly defaultWidth?: number;
   /**
+   * 처음 설 때의 폭을 픽셀 대신 **등급**으로 말한다. 호스트가 등급 → px를 해석한다.
+   *
+   * 픽셀을 직접 고르면 그 값이 자기 본문의 `@container` 문턱과 어긋나도 아무도 잡지 못한다 —
+   * 설정 페인이 360을 선언했는데 테마 격자가 2열이 되는 문턱은 420이어서, 기본 상태에서 그
+   * 격자가 한 번도 2열로 서지 못한 일이 실제로 있었다. 등급은 그 어긋남을 구조적으로 막는다:
+   * 픽셀표와 브레이크포인트가 호스트 한 곳에 함께 있고, 계약 테스트가 둘의 관계를 지킨다.
+   *
+   * - `narrow` — 폭이 판독을 거의 바꾸지 않는 목록.
+   * - `standard` — 계량기·행 카드가 한 줄에 서야 하는 본문.
+   * - `wide` — 안에서 2열 격자가 서야 하는 본문.
+   *
+   * `defaultWidth`를 함께 선언하면 픽셀이 이긴다. 새 페인은 등급만 쓰는 것이 좋다.
+   */
+  readonly widthClass?: PaneWidthClass;
+  /**
    * 닫아도 본문을 살려 둔다.
    *
    * 계약의 기본은 닫기=언마운트다. 그런데 콘솔에는 그러면 안 되는 본문이 있다 — PTY와
@@ -129,6 +144,11 @@ export interface PaneDescriptor {
    */
   readonly search?: PaneSearchProvider;
 }
+
+/**
+ * 페인이 처음 설 때 원하는 폭의 등급. px 해석은 호스트가 소유한다.
+ */
+export type PaneWidthClass = "narrow" | "standard" | "wide";
 
 export type PaneRole = "primary" | "detail" | "aside";
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -5,6 +5,14 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
+import {
+  DEFAULT_PANEL_WIDTH,
+  MIN_PANEL_WIDTH,
+  PANE_CONTAINER_INSET_ALLOWANCE,
+  PANE_WIDTH_CLASS_PX,
+  resolvePaneDefaultWidth,
+} from "../core/client/src/rail/pane-width.js";
+
 const CONSOLE_ROOT = new URL("../", import.meta.url);
 const CLIENT_ROOT = new URL("../core/client/src/", import.meta.url);
 const PRODUCT_SOURCE_ROOTS = [
@@ -4394,5 +4402,70 @@ describe("War Room deck panel grammar", () => {
     expect(sidebar.indexOf('className="triage-side-bar-dormant-shelf"')).toBeGreaterThan(
       sidebar.indexOf('className="triage-side-bar-minimized-shelf"'),
     );
+  });
+});
+
+/* 폭 등급은 픽셀 발명을 막으려고 도입됐다 — 그 약속을 지키는 자리가 여기다.
+   설정 페인이 `defaultWidth: 360`을 선언하던 시절, 자기 테마 격자가 2열이 되는 문턱은 420이라
+   기본 상태에서 그 격자가 한 번도 2열로 서지 못했다. 등급표와 브레이크포인트가 서로를 모르면
+   그 어긋남은 또 난다. 아래 계약이 둘을 한 자리에서 맞춰 본다. */
+describe("Pane width class contract", () => {
+  const components = source("styles/components.css");
+  const settingsPane = source("settings/settings-pane.tsx");
+
+  /**
+   * 설정 페인의 **테마 격자**를 1열로 접는 컨테이너 문턱들.
+   *
+   * 페인 안의 모든 문턱을 재지 않는 이유는, 그중 일부는 레일 폭에서 접히는 것이 정상이기
+   * 때문이다(폰트 브라우저의 2단은 640px 문턱이라 레일 카드가 어떤 등급으로도 못 넘는다).
+   * 기본 폭이 반드시 넘어야 하는 것은 그 페인이 **처음 보여 주는 것**의 문턱이고, 설정에서는
+   * 테마 격자가 그것이다 — 실제로 어긋났던 자리도 여기다.
+   */
+  function themeGridCollapseBreakpoints(): number[] {
+    const found: number[] = [];
+    const pattern = /@container\s*\(max-width:\s*(\d+)px\)\s*\{/g;
+    for (let match = pattern.exec(components); match !== null; match = pattern.exec(components)) {
+      // 블록 끝까지 훑어 이 절이 테마 격자를 겨냥하는지 본다(중첩 규칙 포함).
+      let depth = 1;
+      let index = match.index + match[0].length;
+      while (index < components.length && depth > 0) {
+        const ch = components[index];
+        if (ch === "{") depth += 1;
+        else if (ch === "}") depth -= 1;
+        index += 1;
+      }
+      const block = components.slice(match.index, index);
+      if (block.includes(".settings-pane .theme-grid")) found.push(Number(match[1]));
+    }
+    return found;
+  }
+
+  it("keeps the settings pane on the width class instead of an invented pixel", () => {
+    // 픽셀을 되살리면 브레이크포인트와 다시 어긋날 수 있다 — 이 페인은 등급으로만 말한다.
+    expect(settingsPane).toContain('widthClass: "wide",');
+    expect(settingsPane).not.toMatch(/defaultWidth:\s*\d+/);
+  });
+
+  it("clears the settings theme-grid collapse breakpoint with the wide class", () => {
+    const breakpoints = themeGridCollapseBreakpoints();
+    // 문턱이 사라지면 이 계약은 아무것도 지키지 않는다 — 존재부터 확인한다.
+    expect(breakpoints.length).toBeGreaterThan(0);
+    for (const breakpoint of breakpoints) {
+      // 카드 폭에서 페인 컨테이너 폭까지의 인셋만큼 여유를 얹고 비교한다.
+      expect(PANE_WIDTH_CLASS_PX.wide).toBeGreaterThan(breakpoint + PANE_CONTAINER_INSET_ALLOWANCE);
+    }
+  });
+
+  it("keeps the class ladder ordered and above the card floor", () => {
+    expect(PANE_WIDTH_CLASS_PX.narrow).toBeGreaterThan(MIN_PANEL_WIDTH);
+    expect(PANE_WIDTH_CLASS_PX.standard).toBeGreaterThan(PANE_WIDTH_CLASS_PX.narrow);
+    expect(PANE_WIDTH_CLASS_PX.wide).toBeGreaterThan(PANE_WIDTH_CLASS_PX.standard);
+  });
+
+  it("lets a declared pixel win over the class and falls back to the host default", () => {
+    expect(resolvePaneDefaultWidth({ defaultWidth: 392, widthClass: "wide" })).toBe(392);
+    expect(resolvePaneDefaultWidth({ widthClass: "narrow" })).toBe(PANE_WIDTH_CLASS_PX.narrow);
+    expect(resolvePaneDefaultWidth({})).toBe(DEFAULT_PANEL_WIDTH);
+    expect(resolvePaneDefaultWidth(null)).toBe(DEFAULT_PANEL_WIDTH);
   });
 });

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -432,6 +432,42 @@ describe("Right Rail card width", () => {
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("360px");
   });
 
+  it("treats a malformed map as absent so the retired card width still lands", () => {
+    // v1.79.0의 마이그레이션은 깨진 지도를 만나면 아무것도 못 하고 그대로 뒀다 — 그 뒤 사용자가
+    // 폭을 조절했다면 깨진 지도와 멀쩡한 카드 폭이 함께 남는다. 깨진 지도가 그 값을 영원히
+    // 가리면 안 되고, 그 지도 자체도 걷혀야 한다.
+    window.localStorage.setItem("fleet-console.rail.panelWidths", "{oops");
+    window.localStorage.setItem("fleet-console.rail.cardWidth", "500");
+    renderRail();
+
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("500px");
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths")!)).toEqual({ repository: 500 });
+    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBeNull();
+  });
+
+  it("saves a drag under the panel that owned the handle, not the one that arrived mid-drag", () => {
+    // 드래그는 수백 ms 이상 지속되는 제스처다. 그 사이 플러그인의 `panels.open`이나 라우트
+    // 변경이 다른 패널을 세울 수 있고, 그때 끌던 폭이 도착한 패널의 기억으로 새면 안 된다.
+    renderRail();
+    const handle = container.querySelector<HTMLElement>(".right-rail-resize-handle");
+    act(() => {
+      handle!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true, clientX: 800 }));
+    });
+    act(() => {
+      document.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: 760 }));
+    });
+    // 끄는 도중 다른 패널이 선다.
+    act(() => openRailPanel("codex"));
+    act(() => {
+      document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, clientX: 760 }));
+    });
+
+    const stored = JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths") ?? "{}");
+    expect(stored).toEqual({ repository: 400 });
+    // 도착한 패널은 자기 선언값 그대로다.
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("420px");
+  });
+
   it("keyboard resize persists the width under the active panel's key", () => {
     renderRail();
     const handle = container.querySelector<HTMLElement>(".right-rail-resize-handle");

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -372,29 +372,74 @@ describe("Right Rail card width", () => {
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("420px");
   });
 
-  it("migrates the legacy per-panel width map to one card width (max) and drops the legacy keys", () => {
+  it("opens every untouched panel at its own declared width", () => {
+    // 기억이 없는 도구는 언제나 자기 선언값으로 선다 — 이웃의 폭도, 전체 최댓값도 아니다.
+    renderRail();
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("360px");
+    act(() => openRailPanel("codex"));
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("420px");
+    act(() => openRailPanel("repository"));
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("360px");
+  });
+
+  it("keeps a resized panel's width off every other panel", () => {
+    // 이번 개편의 계약 그 자체 — 한 도구를 넓혀도 나머지는 자기 선언값 그대로 열린다.
+    renderRail();
+    const handle = container.querySelector<HTMLElement>(".right-rail-resize-handle");
+    act(() => {
+      handle!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", shiftKey: true, bubbles: true }));
+    });
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("424px");
+
+    act(() => openRailPanel("codex"));
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("420px");
+
+    act(() => openRailPanel("repository"));
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("424px");
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths")!)).toEqual({ repository: 424 });
+  });
+
+  it("restores the per-panel width map and drops the retired single-width keys", () => {
     window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ repository: 380, codex: 452 }));
+    window.localStorage.setItem("fleet-console.rail.cardWidth", "900");
     renderRail();
 
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("380px");
+    act(() => openRailPanel("codex"));
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("452px");
-    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBe("452");
-    expect(window.localStorage.getItem("fleet-console.rail.panelWidths")).toBeNull();
+    // 도구별 지도가 있으면 카드 단일 값은 주인이 없다 — 남겨 두면 다음 로드가 되심는다.
+    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBeNull();
+  });
+
+  it("hands the retired card width to the last active panel only", () => {
+    // 그 폭은 사용자가 그 도구를 보면서 정한 값이다. 화면에 없던 도구가 물려받을 근거는 없다.
+    window.localStorage.setItem("fleet-console.rail.activePanelId", "codex");
+    window.localStorage.setItem("fleet-console.rail.cardWidth", "500");
+    act(() => openRailPanel("codex"));
+    renderRail();
+
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("500px");
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths")!)).toEqual({ codex: 500 });
+    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBeNull();
+
+    act(() => openRailPanel("repository"));
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("360px");
   });
 
   it("falls back without crashing for a corrupted stored width", () => {
-    window.localStorage.setItem("fleet-console.rail.cardWidth", "not-a-number");
+    window.localStorage.setItem("fleet-console.rail.panelWidths", "not-json");
     renderRail();
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("360px");
   });
 
-  it("keyboard resize persists the card width under the card key", () => {
+  it("keyboard resize persists the width under the active panel's key", () => {
     renderRail();
     const handle = container.querySelector<HTMLElement>(".right-rail-resize-handle");
     expect(handle?.getAttribute("aria-valuenow")).toBe("360");
     act(() => {
       handle!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
     });
-    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBe("376");
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths")!)).toEqual({ repository: 376 });
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("376px");
   });
 
@@ -411,12 +456,12 @@ describe("Right Rail card width", () => {
   it("keeps an over-viewport stored width as the desired target and restores it when the window widens", () => {
     // 좁은 창 로드에서 렌더 폭만 클램프하고 저장 폭은 desired로 남긴다 — init 클램프를
     // desired로 심으면 큰 화면에서 저장한 폭이 재로드 한 번에 소실된다(Codex 리뷰 계약).
-    window.localStorage.setItem("fleet-console.rail.cardWidth", "900");
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ repository: 900 }));
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
     renderRail();
     // 1200 − 148 − 304 = 748로 클램프되어 렌더.
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("748px");
-    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBe("900");
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths")!)).toEqual({ repository: 900 });
 
     act(() => {
       Object.defineProperty(window, "innerWidth", { configurable: true, value: 1600 });
@@ -494,8 +539,8 @@ describe("Right Rail settings gear", () => {
     expect(document.activeElement).toBe(gearButton());
   });
 
-  it("resets the card width to the active panel's default on a divider double-click", () => {
-    window.localStorage.setItem("fleet-console.rail.cardWidth", "500");
+  it("resets only the active panel's width on a divider double-click", () => {
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ repository: 500, codex: 452 }));
     renderRail();
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("500px");
 
@@ -503,8 +548,9 @@ describe("Right Rail settings gear", () => {
     const handle = container.querySelector<HTMLElement>(".right-rail-resize-handle");
     act(() => handle!.dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
 
-    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBeNull();
     expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("360px");
+    // 이웃의 기억은 남는다 — 초기화는 지금 선 도구의 몫이다.
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths")!)).toEqual({ codex: 452 });
   });
 
   it("leaves no portaled rail menu behind", () => {

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -445,6 +445,32 @@ describe("Right Rail card width", () => {
     expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBeNull();
   });
 
+  it("treats a map with no usable entry as absent so the retired card width still lands", () => {
+    // 문법은 멀쩡한데 쓸 수 있는 항목이 하나도 없는 지도는 아무것도 말하지 않는다 — 그것을
+    // 권위로 받으면 함께 남은 멀쩡한 단일 폭을 근거 없이 버린다. v1.79.0의 리더는 후보를 하나도
+    // 못 찾으면 removeItem 앞에서 조기 반환해 그 지도를 남겼으므로, 이 공존도 실제로 존재한다.
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ repository: "oops" }));
+    window.localStorage.setItem("fleet-console.rail.cardWidth", "500");
+    renderRail();
+
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("500px");
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths")!)).toEqual({ repository: 500 });
+    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBeNull();
+  });
+
+  it("keeps a partly valid map authoritative instead of falling back", () => {
+    // 항목 하나라도 쓸 수 있으면 그 지도는 정보를 담고 있다 — 그때는 승계로 되돌아가지 않는다.
+    // "쓸 수 있는 항목이 하나라도 있는가"가 경계이고, 이 경계는 더 밀리지 않는다.
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ repository: 480, codex: "oops" }));
+    window.localStorage.setItem("fleet-console.rail.cardWidth", "500");
+    renderRail();
+
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("480px");
+    act(() => openRailPanel("codex"));
+    expect(railRoot().style.getPropertyValue("--right-rail-panel-width")).toBe("420px");
+    expect(window.localStorage.getItem("fleet-console.rail.cardWidth")).toBeNull();
+  });
+
   it("saves a drag under the panel that owned the handle, not the one that arrived mid-drag", () => {
     // 드래그는 수백 ms 이상 지속되는 제스처다. 그 사이 플러그인의 `panels.open`이나 라우트
     // 변경이 다른 패널을 세울 수 있고, 그때 끌던 폭이 도착한 패널의 기억으로 새면 안 된다.


### PR DESCRIPTION
## Summary

- **폭 기억의 단위를 카드에서 도구로 되돌립니다.** 저장 키가 `fleet-console.rail.cardWidth` 단일 값에서 `fleet-console.rail.panelWidths`(도구 id → px) 지도로 돌아갑니다. 한 도구를 넓혀도 나머지는 자기 선언 폭으로 열리고, 한 번도 조절하지 않은 도구는 계속 선언값을 따라 페인이 기본값을 고치면 그 개선이 사용자에게 닿습니다. 퇴역한 단일 값은 **마지막 활성 도구에게만** 승계한 뒤 키를 걷습니다 — 그 폭은 화면에 서 있던 도구의 것이었고 나머지 다섯이 물려받을 근거는 없었습니다.
- **설정 페인 기본 폭을 교정합니다.** 선언값 360은 자기 컨테이너 문턱(`components.css`의 `@container (max-width: 420px)`) 아래여서 기본 상태에서 테마 격자가 2열로 선 적이 없었습니다. 등급 `wide`(440)로 바꿔 기본 상태에서 2열이 섭니다.
- **페인 폭 등급 어휘를 도입합니다.** SDK가 `widthClass: "narrow" | "standard" | "wide"`를 말하고 px는 호스트(`rail/pane-width.ts`)가 해석합니다. 계약 테스트가 등급표와 설정 테마 격자 문턱의 관계를 지켜, 설정 360 같은 어긋남이 다시 나올 수 없습니다.

이 결함은 버그로 태어나지 않았습니다. 단일 카드 폭은 레일이 다중 Pin 스택이던 시절(#963) 두 패널이 한 카드에 상주하므로 타당했고, 독점 슬롯 회귀(#968)로 그 전제가 사라졌는데 기제만 남았습니다.

## Test Plan

- [x] `pnpm test` — 워크스페이스 전체 그린 (fleet-console 2370 passed / 24 skipped 포함)
- [x] `pnpm typecheck` — 전체 그린
- [x] `pnpm build` — 전체 그린
- [x] 회귀 테스트 추가 (`tests/right-rail.test.tsx`): 손대지 않은 도구는 자기 선언 폭으로 개방 · 한 도구 조절이 다른 도구로 전염되지 않음 · 단일 폭은 마지막 활성 도구에만 승계 · 도구별 지도 복원 · 초기화는 활성 도구만
- [x] 폭 등급 계약 (`tests/instrument-design-contract.test.ts`): 설정은 등급으로만 선언 · `wide`가 테마 격자 문턱 + 컨테이너 인셋을 넘음 · 등급 사다리 순서 · 픽셀 우선 해석
- [x] 격리 Console 헤드리스 실측 (창 1280px, 번들 해시 대조): 신규 프로필에서 설정 440 / Codex 420 / 파일 360 / 스킬 360 / 원장 392 / 사용 한도 392 로 각자 개방 · 사용 한도를 584로 조절해도 나머지 다섯은 선언 폭 유지, 저장은 `{"quota":584}` 하나 · 재부팅 후 지속 · 더블클릭 초기화는 그 도구만 392로 복귀 · v1.79.0 상태(`cardWidth=612`, active=quota) 시드 후 `{"quota":612}`로만 승계되고 나머지는 선언 폭 · 설정 440에서 테마 격자 `177px 177px`(2열) 확인