### PR TITLE
feat(fleet-console): launch into the chat view from the right-click menu

### DIFF
--- a/.changelog.d/launch-menu-start-surface.md
+++ b/.changelog.d/launch-menu-start-surface.md
@@ -1,0 +1,8 @@
+---
+branch: launch-menu-start-surface
+---
+
+### fleet-console
+#### Added
+- Launch a Claude Operation straight into the chat view from the right-click menu. Each model row carries a start-surface mark you can click, or reach with the Left arrow, and the menu remembers the surface for the next time it opens. Rows whose launch kind cannot start a chat carry no mark, and the menu keeps its own choice rather than following Quick Launch.
+  ko: 우클릭 메뉴에서 Claude Operation을 채팅뷰로 곧장 실행합니다. 모델 행마다 시작 표면 표식이 서고, 눌러서 또는 왼쪽 방향키로 바꿉니다. 메뉴는 그 표면을 다음에 열릴 때까지 기억하며, 채팅으로 시작할 수 없는 실행 종류의 행에는 표식이 서지 않습니다. 이 기억은 Quick Launch와 따로 삽니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
-import type { OperationCatalogPlugin, OperationLaunchKind, OperationLaunchVariantRow } from "@fleet-console/sdk/operations";
+import type { OperationCatalogPlugin, OperationLaunchKind, OperationLaunchVariantRow, OperationLaunchView } from "@fleet-console/sdk/operations";
 
 import { FEATURE_TOUR_BOUNDARY_ATTRIBUTE, FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
 import { getGlobalSettingsStoreState, isSavingGlobalSettingsField, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { useT } from "../i18n/index.js";
+import { readLaunchStartSurface, supportsChatStart, withStartSurface, writeLaunchStartSurface } from "../launch-start-surface.js";
 import { resolveLaunchKindAnnotation } from "../launch-kind-annotations.js";
 import { EffortGaugeGlyph, EffortTrack, effortLadderPosition, gatedEffortNames } from "../components/effort-track.js";
 import { appendSeenFeatureTour, EFFORT_CONFIRM_TIP_SEEN_KEY } from "../components/feature-tour.js";
 import { launchProviderFromGroupId, launchProviderGlyph } from "../components/launch-provider-glyphs.js";
+import { ChatBubbleIcon, TerminalViewIcon } from "../components/start-view-glyphs.js";
 
 interface CanvasContextMenuProps {
   // 캔버스(<main>) 기준 화면 좌표. 메뉴를 이 지점에 띄운다.
@@ -82,6 +84,10 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const [openEffortRow, setOpenEffortRow] = useState<string | null>(null);
   // 행마다 고른 강도. 트랙은 값만 정하고 실행은 모델 행이 일으키므로, 그 사이를 이 상태가 잇는다.
   const [rowEfforts, setRowEfforts] = useState<Readonly<Record<string, string | null>>>({});
+  // 이 메뉴가 여는 표면. 강도와 달리 **행마다가 아니라 메뉴 하나에 하나**다 — 세 행의 표식이
+  // 함께 뒤집히는 것이 곧 "이건 한 값"이라는 설명이 된다. 열 때 기억에서 씨앗을 받고, 바꾸면
+  // 즉시 되쓴다(다음에 열릴 메뉴가 이어받는 값이 곧 요구사항의 "기본값"이다).
+  const [startSurface, setStartSurface] = useState<OperationLaunchView>(readLaunchStartSurface);
   const [effortPosition, setEffortPosition] = useState<{
     readonly id: string;
     readonly left: number;
@@ -351,6 +357,57 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   // Shell은 더 이상 Operation이 아니라 확대 표면이므로 실행 카탈로그에 아예 없다.
   const launchCatalog = catalog.filter((plugin) => plugin.kinds.length > 0);
 
+  // 표면을 뒤집는다. 기억은 즉시 되쓴다 — 발사까지 미루면 메뉴를 닫은 사용자가 자기가 바꾼 값을
+  // 잃고, 다음에 열리는 메뉴가 옛 표면으로 되돌아간다.
+  const toggleStartSurface = useCallback(() => {
+    setStartSurface((previous) => {
+      const next = previous === "chat" ? "terminal" : "chat";
+      writeLaunchStartSurface(next);
+      return next;
+    });
+  }, []);
+
+  /**
+   * 행 앞에 서는 표면 표식이자, 그 표면을 뒤집는 자리.
+   *
+   * 버튼 안의 span이라 초점 대상이 아니다 — 강도 손잡이와 같은 구조이고 같은 이유다: 행 자체가
+   * 실행 버튼이라 그 안에 두 번째 버튼을 중첩할 수 없다. 키보드 경로는 행에서의 ArrowLeft이고,
+   * 오른쪽 끝의 ArrowRight(강도 트랙)와 좌우로 마주 선다.
+   *
+   * 채팅을 선언하지 않은 종류에는 서지 않는다. 못 여는 표면을 고를 수 있는 척하는 표식은
+   * 그 자체가 결함이고, 그 판정은 카탈로그가 이미 싣고 온 `launchViews`가 소유한다.
+   *
+   * **모델 행에만 선다.** 이 목록의 왼쪽 홈통은 표식 한 자리이고(아래 CSS 계약), 실행 종류 행은
+   * 그 자리를 자기 아이콘에 이미 내주었다 — 둘을 함께 세우면 글자 열이 갈린다. 지금 채팅을
+   * 선언하는 종류는 모두 모델 밴드로 펼쳐지므로 실제 카탈로그에 빈 곳은 없다. 변형 없이 채팅을
+   * 선언하는 종류가 생기는 날, 그 행에 표식을 세울 자리를 먼저 정하는 것이 이 규칙을 넓히는 값이다.
+   */
+  const renderStartSurfaceMark = (kind: OperationLaunchKind) => {
+    if (!supportsChatStart(kind)) return null;
+    const chat = startSurface === "chat";
+    return (
+      <span
+        className="operation-launch-surface-mark"
+        data-launch-start-surface={startSurface}
+        title={t(chat ? "launchVariants.startView.switchToTerminal" : "launchVariants.startView.switchToChat")}
+        onClick={(event) => {
+          // 표식은 실행이 아니라 표면을 바꾼다. 행 버튼까지 함께 발화하면 좌표를 고치려던
+          // 클릭이 그대로 출격이 된다(강도 손잡이가 같은 규율을 쓴다).
+          event.preventDefault();
+          event.stopPropagation();
+          toggleStartSurface();
+        }}
+      >
+        {chat ? <ChatBubbleIcon /> : <TerminalViewIcon />}
+        {/* 표면 이름은 시각적으로만 접어 행의 접근 이름에 남긴다 — 아이콘만으로는 스크린리더가
+            이 행이 무엇으로 열리는지 말하지 못한다(종류 설명이 쓰는 --quiet와 같은 기법). */}
+        <span className="operation-launch-surface-mark-name">
+          {t(chat ? "launchVariants.startView.chat" : "launchVariants.startView.terminal")}
+        </span>
+      </span>
+    );
+  };
+
   // 모델 행은 자기 행 키만 들고 다닌다(강도 상자·고른 단이 그 키에 매달린다). 실행은 여전히
   // 실행 종류가 일으키므로, 키에서 그 종류로 되돌아오는 길을 카탈로그 한 번 훑어 만들어 둔다.
   const variantRows = useMemo(() => {
@@ -407,6 +464,15 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         event.preventDefault();
         moveFocus(null, 0, "last");
         return;
+      case "ArrowLeft": {
+        // 왼쪽은 행 앞의 표면 표식과 마주 본다(오른쪽은 강도 트랙). 표식이 실제로 선 행에서만
+        // 듣는다 — 판정을 여기서 다시 세우지 않고 DOM에 이미 선 표식을 묻는 이유는, 포인터와
+        // 키보드가 같은 조건에서 같은 값을 바꾸도록 착지를 하나로 두기 위해서다.
+        if (!target.closest<HTMLElement>(MENU_ITEM_SELECTOR)?.querySelector(".operation-launch-surface-mark")) return;
+        event.preventDefault();
+        toggleStartSurface();
+        return;
+      }
       case "ArrowRight": {
         // 모델 행에서만 오른쪽이 열 것을 가진다 — 그 행의 강도 트랙이다.
         const entry = target.closest<HTMLElement>(".operation-launch-variant-entry");
@@ -644,8 +710,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                                 // 열렸는지는 aria-controls가 가리킨다.
                                 aria-expanded={rowHasEffort ? effortOpen : undefined}
                                 aria-controls={effortOpen ? EFFORT_POPUP_ID : undefined}
-                                onClick={() => onLaunchKind(plugin.id, kind, chosenChip?.launch ?? row.launch)}
+                                onClick={() => onLaunchKind(plugin.id, kind, withStartSurface(chosenChip?.launch ?? row.launch, kind, startSurface))}
                               >
+                                {renderStartSurfaceMark(kind)}
                                 <span className="operation-launch-variant-row-label">{row.label}</span>
                                 {row.starred ? <span className="operation-launch-variant-star" aria-hidden="true">★</span> : null}
                                 {/* 강도 손잡이. 지금 실린 강도를 되비치는 표식이면서, 트랙을 여는 자리이기도 하다 —
@@ -752,7 +819,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                 // 같은 노브를 다시 눌러 실행한 순간에만 팁을 졸업시킨다. 선택·피처 투어 건너뛰기는
                 // 제스처를 익힌 증거가 아니다.
                 if (!effortConfirmTipSeen) void persistEffortConfirmTipSeen();
-                onLaunchKind(effortTarget.pluginId, effortTarget.kind, chip.launch);
+                // 트랙에서 확정하는 실행도 같은 표면으로 나간다 — 두 발사 경로가 다른 표면을 쓰면
+                // 같은 행이 어떻게 눌렸는지에 따라 다른 곳에서 태어난다.
+                onLaunchKind(effortTarget.pluginId, effortTarget.kind, withStartSurface(chip.launch, effortTarget.kind, startSurface));
               }}
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -21,6 +21,7 @@ import { getIdleArrivalIds, subscribeIdleArrival } from "../operation-marks.js";
 import { OperationNameMark } from "./operation-name-mark.js";
 import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph, type LaunchProviderGlyphId } from "./launch-provider-glyphs.js";
 import { EffortTrack, gatedEffortNames, resolveRowEffort } from "./effort-track.js";
+import { ChatBubbleIcon, TerminalViewIcon } from "./start-view-glyphs.js";
 import { ComposerAttachControl, ComposerBar, ComposerChip, ComposerField, ComposerInput, ComposerRestStrip, ComposerSubmitButton, renderUltracodeHighlight, syncComposerHighlight } from "./composer-blocks.js";
 
 // 카드 폭은 팔레트(920px)보다 좁다 — 팔레트는 결과 목록을 담고, 여기는 한 문단을 담는다.
@@ -1967,40 +1968,6 @@ function EffortCommandIcon() {
       <path d="M2.5 8h11" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
       <circle cx="5" cy="8" r="1.4" fill="currentColor" />
       <circle cx="11" cy="8" r="2.1" fill="none" stroke="currentColor" strokeWidth="1.5" />
-    </svg>
-  );
-}
-
-/**
- * 채팅 표식의 말풍선 — 한 제품에서 채팅을 가리키는 그림은 하나여야 한다. 커맨드 아이콘
- * 격자(16)에 맞춰, 꼬리는 왼쪽 아래로, 몸통은 둥근 모서리 하나로 읽히게 그린다.
- */
-function ChatBubbleIcon() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path
-        d="M5.1 12.5h-.3a2.4 2.4 0 0 1-2.4-2.4V6.1a2.4 2.4 0 0 1 2.4-2.4h6.4a2.4 2.4 0 0 1 2.4 2.4v4a2.4 2.4 0 0 1-2.4 2.4H7.7l-2.6 2.1z"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-/** 터미널 시작. 셸 프롬프트의 갈매기 하나 — 채팅 말풍선과 같은 격자·같은 굵기로 마주 세운다. */
-function TerminalViewIcon() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path
-        d="M4 5.2 7 8l-3 2.8M8.6 11.2h3.6"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
     </svg>
   );
 }

--- a/runtime/fleet-console/core/client/src/components/start-view-glyphs.tsx
+++ b/runtime/fleet-console/core/client/src/components/start-view-glyphs.tsx
@@ -1,0 +1,41 @@
+/**
+ * Operation이 태어날 표면을 가리키는 두 그림.
+ *
+ * 한 모듈에 사는 이유는 그림 하나가 두 벌 생기지 않게 하기 위해서다 — 같은 뜻을 두 표면이
+ * 조금씩 다른 선으로 그리면, 사용자는 Quick Launch에서 배운 말풍선을 런치 메뉴에서 다시
+ * 배워야 한다. 실행 종류 어휘를 `agent-cli-launch-kinds.ts` 하나가 소유하는 것과 같은 규율이다.
+ *
+ * 둘은 같은 16 격자·같은 1.4 굵기 위에 마주 선다. 한쪽만 고치면 나란히 섰을 때 무게가
+ * 어긋나므로, 굵기와 격자는 언제나 함께 움직인다.
+ */
+
+/** 채팅 시작. 꼬리는 왼쪽 아래로, 몸통은 둥근 모서리 하나로 읽히게 그린다. */
+export function ChatBubbleIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path
+        d="M5.1 12.5h-.3a2.4 2.4 0 0 1-2.4-2.4V6.1a2.4 2.4 0 0 1 2.4-2.4h6.4a2.4 2.4 0 0 1 2.4 2.4v4a2.4 2.4 0 0 1-2.4 2.4H7.7l-2.6 2.1z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/** 터미널 시작. 셸 프롬프트의 갈매기 하나 — 채팅 말풍선과 같은 격자·같은 굵기로 마주 세운다. */
+export function TerminalViewIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path
+        d="M4 5.2 7 8l-3 2.8M8.6 11.2h3.6"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -82,6 +82,10 @@ export const commonEn = {
   "launchVariants.effort.apexToggle": "Show {tiers}",
   "launchVariants.effort.apexCollapse": "Hide {tiers}",
   "launchVariants.effort.confirmTip": "Press the knob again to launch.",
+  "launchVariants.startView.terminal": "Terminal view",
+  "launchVariants.startView.chat": "Chat view",
+  "launchVariants.startView.switchToChat": "Start in chat view (Left arrow)",
+  "launchVariants.startView.switchToTerminal": "Start in terminal view (Left arrow)",
 } as const;
 
 export const commonKo: Record<keyof typeof commonEn, string> = {
@@ -167,4 +171,8 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchVariants.effort.apexToggle": "{tiers} 펼치기",
   "launchVariants.effort.apexCollapse": "{tiers} 접기",
   "launchVariants.effort.confirmTip": "노브를 다시 누르면 실행됩니다.",
+  "launchVariants.startView.terminal": "터미널뷰",
+  "launchVariants.startView.chat": "채팅뷰",
+  "launchVariants.startView.switchToChat": "채팅뷰로 시작 (왼쪽 방향키)",
+  "launchVariants.startView.switchToTerminal": "터미널뷰로 시작 (왼쪽 방향키)",
 };

--- a/runtime/fleet-console/core/client/src/launch-start-surface.ts
+++ b/runtime/fleet-console/core/client/src/launch-start-surface.ts
@@ -1,0 +1,62 @@
+/**
+ * 우클릭 런치 메뉴가 여는 시작 표면 — 터미널이냐 채팅이냐.
+ *
+ * **Quick Launch의 `view`와 일부러 갈라 둔 값이다.** 두 입구는 같은 것을 실행하지만 서로 다른
+ * 습관에 속한다: 컴포저는 문장을 먼저 쓰고 보내는 자리라 대화가 기본이 되기 쉽고, 메뉴는
+ * 캔버스 위 좌표를 찍어 띄우는 자리다. 한쪽에서의 한 번이 다른 쪽 기본을 바꾸면, 사용자는
+ * 자기가 건드리지 않은 문이 바뀐 것을 발사한 뒤에야 알게 된다. 그래서 기억은 둘이고,
+ * 어긋남은 각 표면이 **자기 표식을 상시 세워** 갚는다(숨은 모드 금지).
+ *
+ * 값은 메뉴 하나에 하나다 — 모델 행마다 따로 두지 않는다. 행마다 다른 표면을 기억하면 같은
+ * 메뉴 안에서 어떤 행은 터미널, 어떤 행은 채팅으로 열려 "이 메뉴를 누르면 무엇이 나오는가"를
+ * 행 단위로 다시 확인해야 한다. 하나의 값이라 세 행의 표식이 함께 뒤집히고, 그 동시성이 곧
+ * 계약의 설명이 된다.
+ *
+ * 서버 durable state가 아니라 localStorage인 이유는 `quick-launch-preferences.ts`와 같다 —
+ * 이것은 이 브라우저의 습관이지 Console이 소유한 작전 상태가 아니다.
+ */
+
+import type { OperationLaunchView } from "@fleet-console/sdk/operations";
+
+const STORAGE_KEY = "fleet-console.launchMenu.startSurface";
+
+/** 기억이 없거나 읽을 수 없을 때의 표면. 기본은 기억이 아니라 계약이 정한다. */
+export const DEFAULT_LAUNCH_START_SURFACE: OperationLaunchView = "terminal";
+
+export function readLaunchStartSurface(): OperationLaunchView {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "chat" ? "chat" : DEFAULT_LAUNCH_START_SURFACE;
+  } catch {
+    // 스토리지 차단(사생활 보호 모드)은 "기억 없음"과 같은 상태다.
+    return DEFAULT_LAUNCH_START_SURFACE;
+  }
+}
+
+export function writeLaunchStartSurface(surface: OperationLaunchView): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, surface);
+  } catch {
+    // 기억에 실패해도 이번 실행 자체는 막지 않는다.
+  }
+}
+
+/** 이 실행 종류가 채팅으로 태어날 수 있는가. 선언이 없으면 터미널뿐이라는 뜻이다. */
+export function supportsChatStart(kind: { readonly launchViews?: readonly OperationLaunchView[] }): boolean {
+  return kind.launchViews?.includes("chat") === true;
+}
+
+/**
+ * 발사 변형에 시작 표면을 싣는다.
+ *
+ * 채팅일 때만, 그리고 그 종류가 채팅을 선언했을 때만 싣는다. 모르는 값을 실어 보내면 서버가
+ * 409(`chat_unsupported`)로 되돌려 주는데, 그 왕복은 사용자가 고른 좌표를 잃는 길일 뿐이다 —
+ * 여기서 터미널로 접는 편이 정직하다(플러그인 런치 어댑터가 같은 규율을 쓴다).
+ */
+export function withStartSurface(
+  launch: Readonly<Record<string, string>> | undefined,
+  kind: { readonly launchViews?: readonly OperationLaunchView[] },
+  surface: OperationLaunchView,
+): Readonly<Record<string, string>> | undefined {
+  if (surface !== "chat" || !supportsChatStart(kind)) return launch;
+  return { ...(launch ?? {}), viewMode: "chat" };
+}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8793,6 +8793,57 @@ body[data-side-bar-animating="true"] .canvas-operation {
   padding-left: calc(var(--space-2) + 14px + var(--space-2) - var(--space-1));
 }
 
+/* 시작 표면 표식 — 이 행이 무엇으로 태어나는지 상시 말하고, 누르면 그 표면을 뒤집는다.
+   값은 메뉴 하나에 하나이므로 한 번 뒤집으면 밴드의 모든 행이 함께 바뀐다.
+
+   새 홈통을 열지 않는다. 위 규칙이 모델 행을 들여쓴 것은 왼쪽 홈통이 표식 자리이기 때문이고,
+   표식이 실제로 서면 그 자리를 채우므로 들여쓰기를 되돌린다 — 둘을 함께 두면 모델 이름만 한 칸
+   더 밀려 같은 메뉴 안에서 글자 열이 셋으로 갈린다. 폭은 그 홈통과 같은 14px여야 라벨의 x가
+   표식 유무와 무관하게 한 자리에 남는다.
+
+   [doctrine] 채널은 `--apex`다. 채팅 시작은 신호(상태)도 위치도 아닌 "기본 밖의 선택"이며,
+   Quick Launch의 `.quick-launch-card.is-chat-start`가 같은 이유로 이미 같은 채널을 쓴다. */
+.operation-launch-surface-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex: none;
+  color: var(--text-tertiary);
+  transition: color var(--duration-fast) var(--ease-spring);
+}
+
+.operation-launch-surface-mark svg {
+  width: 13px;
+  height: 13px;
+}
+
+.operation-launch-surface-mark[data-launch-start-surface="chat"] {
+  color: var(--apex);
+}
+
+.operation-launch-surface-mark:hover {
+  color: var(--text-primary);
+}
+
+.canvas-context-menu .operation-launch-variant-row:has(.operation-launch-surface-mark) {
+  padding-left: calc(var(--space-2) - var(--space-1));
+}
+
+/* 표면 이름은 시각적으로만 접어 행의 접근 이름에 남긴다 — 아이콘 하나로는 보조기술이 이 행이
+   어디서 태어나는지 말하지 못한다. 종류 설명의 --quiet와 같은 기법이다. */
+.operation-launch-surface-mark-name {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 /* 라벨이 남는 폭을 전부 먹고 ★·꺾쇠는 그 뒤에 붙는다. 정렬을 표식 쪽 margin-left:auto로 만들면
    표식이 둘일 때 여백이 그 사이에서 나뉘어 ★가 행 한가운데 뜬다. */
 .operation-launch-variant-row-label,

--- a/runtime/fleet-console/tests/canvas-context-menu-start-surface.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-start-surface.test.tsx
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OperationCatalogPlugin } from "@fleet-console/sdk/operations";
+
+import { CanvasContextMenu } from "../core/client/src/canvas/canvas-context-menu.js";
+import { EFFORT_CONFIRM_TIP_SEEN_KEY } from "../core/client/src/components/feature-tour.js";
+import { hydrateGlobalSettings } from "../core/client/src/global-settings-store.js";
+import { readLaunchStartSurface, withStartSurface } from "../core/client/src/launch-start-surface.js";
+import type { GlobalSettingsState } from "../core/client/src/types.js";
+
+const SETTINGS: GlobalSettingsState = {
+  consolePortMode: "dynamic",
+  consoleStaticPort: null,
+  remoteAccess: { enabled: false, publicEndpointEnabled: false, listenAddress: "", advertisedHost: "", listenPort: { mode: "auto", value: 49152 }, advertisedPort: { mode: "auto", value: 49153 }, acknowledgment: null },
+  language: "auto",
+  seenFeatureTours: [],
+  theme: "instrument",
+  uiFont: { source: "builtin", id: "manrope", size: 14 },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  hydrateGlobalSettings(SETTINGS);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  window.localStorage.clear();
+  hydrateGlobalSettings(SETTINGS);
+});
+
+describe("launch menu start surface", () => {
+  it("stands a mark only on rows whose kind declares a chat start", () => {
+    renderMenu();
+
+    expect(surfaceMark("fable")).not.toBeNull();
+    expect(surfaceMark("opus")).not.toBeNull();
+    // Codex는 launchViews를 선언하지 않는다 — 못 여는 표면을 고를 수 있는 척하면 안 된다.
+    expect(surfaceMark("gpt")).toBeNull();
+  });
+
+  it("opens on the terminal surface until something says otherwise", () => {
+    renderMenu();
+
+    expect(surfaceMark("fable")!.dataset.launchStartSurface).toBe("terminal");
+    expect(surfaceMark("opus")!.dataset.launchStartSurface).toBe("terminal");
+  });
+
+  // 값은 메뉴 하나에 하나다. 세 행이 함께 뒤집히는 것이 곧 그 계약의 설명이므로, 한 행만 바뀌는
+  // 회귀는 사용자에게 "행마다 다른 표면"이라는 없는 규칙을 가르친다.
+  it("flips every chat-capable row from one mark, and launches nothing", () => {
+    const onLaunchKind = vi.fn();
+    renderMenu(onLaunchKind);
+
+    act(() => surfaceMark("fable")!.click());
+
+    expect(surfaceMark("fable")!.dataset.launchStartSurface).toBe("chat");
+    expect(surfaceMark("opus")!.dataset.launchStartSurface).toBe("chat");
+    expect(onLaunchKind).not.toHaveBeenCalled();
+  });
+
+  it("carries viewMode only while the menu is armed for chat", () => {
+    const onLaunchKind = vi.fn();
+    renderMenu(onLaunchKind);
+
+    act(() => row("fable").click());
+    expect(onLaunchKind.mock.calls[0]![2]).toEqual({ model: "fable" });
+
+    act(() => surfaceMark("fable")!.click());
+    act(() => row("fable").click());
+    expect(onLaunchKind.mock.calls[1]![2]).toEqual({ model: "fable", viewMode: "chat" });
+  });
+
+  // 같은 행이 어떻게 눌렸는지에 따라 다른 곳에서 태어나면 안 된다 — 트랙에서 확정하는 실행도
+  // 같은 표면으로 나간다.
+  it("keeps the effort-track launch on the same surface", () => {
+    const onLaunchKind = vi.fn();
+    // 트랙 확정 팁은 졸업 기록을 서버에 되쓴다 — 이 시험이 보려는 것은 표면이므로 이미 본 것으로 둔다.
+    hydrateGlobalSettings({ ...SETTINGS, seenFeatureTours: [EFFORT_CONFIRM_TIP_SEEN_KEY] });
+    renderMenu(onLaunchKind);
+
+    act(() => surfaceMark("fable")!.click());
+    act(() => row("fable").parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+    act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+
+    const track = document.querySelector<HTMLElement>(".effort-track");
+    if (!track) throw new Error("Missing the effort track");
+    act(() => track.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
+    act(() => track.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+
+    const launch = onLaunchKind.mock.calls.at(-1)![2] as Record<string, string>;
+    expect(launch).toEqual({ model: "fable", effort: "max", viewMode: "chat" });
+  });
+
+  it("hands the choice to the next menu that opens", () => {
+    renderMenu();
+    act(() => surfaceMark("fable")!.click());
+
+    expect(readLaunchStartSurface()).toBe("chat");
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    renderMenu();
+
+    expect(surfaceMark("fable")!.dataset.launchStartSurface).toBe("chat");
+  });
+
+  // 왼쪽은 표면, 오른쪽은 강도. 포인터와 키보드가 같은 조건에서 같은 값을 바꾼다.
+  it("answers the left arrow on a row that carries the mark", () => {
+    renderMenu();
+
+    act(() => row("fable").dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true })));
+
+    expect(surfaceMark("fable")!.dataset.launchStartSurface).toBe("chat");
+  });
+
+  it("stays silent on the left arrow where no mark stands", () => {
+    renderMenu();
+
+    act(() => row("gpt").dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true })));
+
+    expect(surfaceMark("fable")!.dataset.launchStartSurface).toBe("terminal");
+    expect(readLaunchStartSurface()).toBe("terminal");
+  });
+});
+
+describe("withStartSurface", () => {
+  it("refuses to arm a kind that never declared a chat start", () => {
+    expect(withStartSurface({ model: "gpt" }, { }, "chat")).toEqual({ model: "gpt" });
+    expect(withStartSurface({ model: "gpt" }, { launchViews: ["terminal"] }, "chat")).toEqual({ model: "gpt" });
+  });
+
+  it("leaves a terminal launch untouched", () => {
+    const launch = { model: "fable" };
+    expect(withStartSurface(launch, { launchViews: ["terminal", "chat"] }, "terminal")).toBe(launch);
+  });
+});
+
+function renderMenu(onLaunchKind = vi.fn()): void {
+  act(() => root.render(
+    <CanvasContextMenu
+      anchor={{ x: 200, y: 120 }}
+      viewportBounds={{ width: 1116, height: 856 }}
+      catalog={CATALOG}
+      canLaunch
+      renderKindIcon={() => null}
+      onLaunchKind={onLaunchKind}
+      onClose={vi.fn()}
+    />,
+  ));
+}
+
+function row(rowId: string): HTMLElement {
+  const element = document.querySelector<HTMLElement>(`[data-launch-variant-row="${rowId}"]`);
+  if (!element) throw new Error(`Missing the row for ${rowId}`);
+  return element;
+}
+
+function surfaceMark(rowId: string): HTMLElement | null {
+  return row(rowId).querySelector<HTMLElement>(".operation-launch-surface-mark");
+}
+
+function effortHandle(rowId: string): HTMLElement {
+  const handle = row(rowId).closest<HTMLElement>(".operation-launch-variant-entry")
+    ?.querySelector<HTMLElement>(".operation-launch-variant-effort-handle");
+  if (!handle) throw new Error(`Missing the effort handle for ${rowId}`);
+  return handle;
+}
+
+/** 채팅을 선언한 종류와 선언하지 않은 종류가 한 메뉴에 함께 선다 — 표식의 경계가 이 픽스처다. */
+const CATALOG: readonly OperationCatalogPlugin[] = [{
+  id: "terminal",
+  title: "Terminal",
+  kinds: [
+    {
+      id: "claude",
+      type: "agent",
+      title: "Claude",
+      launchViews: ["terminal", "chat"],
+      variants: [{
+        id: "native",
+        label: "Claude",
+        rows: [
+          {
+            id: "fable",
+            label: "Fable",
+            launch: { model: "fable" },
+            chips: [
+              { id: "high", label: "HIGH", launch: { model: "fable", effort: "high" } },
+              { id: "max", label: "MAX", launch: { model: "fable", effort: "max" } },
+            ],
+          },
+          {
+            id: "opus",
+            label: "Opus",
+            launch: { model: "opus" },
+            chips: [
+              { id: "high", label: "HIGH", launch: { model: "opus", effort: "high" } },
+            ],
+          },
+        ],
+      }],
+    },
+    {
+      id: "codex",
+      type: "agent",
+      title: "Codex",
+      variants: [{
+        id: "native",
+        label: "Codex",
+        rows: [{
+          id: "gpt",
+          label: "GPT",
+          launch: { model: "gpt" },
+          chips: [{ id: "high", label: "HIGH", launch: { model: "gpt", effort: "high" } }],
+        }],
+      }],
+    },
+  ],
+}];


### PR DESCRIPTION
## Summary
- 우클릭 런치 메뉴가 채팅뷰로 곧장 실행할 수 있게 됐습니다. 카탈로그는 이미 `launchViews`를 싣고 있었고 플러그인·서버도 `viewMode` 런치 변형을 받고 있었는데, 메뉴만 둘 다 읽지 않아 모든 우클릭이 터미널로 떨어졌습니다.
- 채팅을 선언한 실행 종류의 모델 행에 시작 표면 표식이 섭니다. 목록의 기존 왼쪽 홈통(종류 행 아이콘 자리)에 들어서므로 **메뉴 높이는 그대로**입니다(실측 264 × 140.5px 유지). 표식을 누르거나 행에서 `ArrowLeft`(오른쪽 `ArrowRight`=강도 트랙과 좌우 대칭)로 뒤집습니다.
- 표면은 **행마다가 아니라 메뉴 하나에 하나**입니다. 한 번 뒤집으면 밴드의 모든 행이 함께 바뀌고, 그 동시성이 곧 계약의 설명이 됩니다. 채팅으로 시작할 수 없는 종류의 행에는 표식이 서지 않습니다.
- 기억은 이 브라우저에 남되 **Quick Launch의 `view`와 의도적으로 분리**했습니다. 한쪽 입구에서의 한 번이 다른 쪽 기본을 조용히 바꾸지 않습니다.
- 채팅·터미널 글리프를 공유 모듈로 옮겼습니다 — 한 제품이 채팅을 가리키는 그림은 하나여야 합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm vitest run` — 197 파일 / 2373건 통과 (신규 `canvas-context-menu-start-surface.test.tsx` 10건 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] 격리 Console(`FLEET_CONSOLE_DATA_DIR`) 헤드리스 실측:
  - 메뉴 264 × 140.5px 유지 — 기준선과 동일(높이 증가 0px)
  - 표식 x=513(밴드 공급자 글리프와 동일 열) · 라벨 x=535(캡션과 동일 열) · 폭 14px — 표식 유무·터미널↔채팅 전환 모두에서 라벨 x 불변
  - 표식 색: 터미널 `oklch(0.64 0.012 245)`(`--text-tertiary`) → 채팅 `oklch(0.75 0.13 295)`(`--apex`, "기본 밖의 선택" 채널)
  - 클릭 한 번에 세 행이 함께 `chat`으로 전환
  - 런치 요청 본문에 `"viewMode":"chat"` 실림 → Operation이 **채팅뷰로 바로 태어남**(PTY·전환 인터스티셜 없음)
  - 새로고침 뒤에도 `chat` 유지, `fleet-console.quickLaunch.selection`은 `null`로 불변(분리 확인)