### PR TITLE
feat(fleet-console): rest repository controls on the soft graphite grammar

### DIFF
--- a/.changelog.d/repository-soft-graphite.md
+++ b/.changelog.d/repository-soft-graphite.md
@@ -1,0 +1,12 @@
+---
+branch: repository-soft-graphite
+---
+
+### fleet-console
+
+#### Changed
+
+- Repository panel adopts the Soft Graphite control grammar: primary verbs, toggles, and row actions now rest on a visible fill-and-border body instead of appearing as bare text until hover.
+  ko: 저장소 패널이 소프트 그래파이트 컨트롤 문법을 입습니다. 주 동사·토글·행 액션이 hover 전까지 맨글자로 서 있던 대신, 쉬는 상태에서도 채움과 테두리의 몸을 갖습니다.
+- Repository inputs float above the surface instead of sinking into darker wells, selections paint as rounded location-tinted fills instead of side spines, file status letters become tinted chips, ref badges soften into capsules, and list rows gain rounded hover with taller commit rows.
+  ko: 저장소 입력 상자가 표면보다 어두운 우물로 파이는 대신 표면 위로 떠오르고, 선택은 측면 스파인 대신 라운드 위치색 필로 칠해지며, 파일 상태 글자는 틴트 칩이 되고, ref 뱃지는 캡슐로 부드러워지고, 목록 행은 라운드 hover와 더 높은 커밋 행을 얻습니다.

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -397,7 +397,9 @@
   --duration-base: 220ms;
   --duration-slow: 360ms;
 
-  /* 상호작용 컨트롤의 상태 recipe(Quiet Controls C′) — rest는 각 소비처의 중립 면이 맡고,
+  /* 상호작용 컨트롤의 상태 recipe(Quiet Controls C′) — rest는 침묵이 아니라 낮은 목소리다:
+     동사·컨트롤은 쉬는 상태에서도 극저대비 rest 채널(--control-rest + 헤어라인)로 자기 몸을
+     알린다. 완전 투명 rest는 2026-09-01 저장소 실측(주 동사 4종의 시각 신호 0개)으로 기각됐다.
      focus는 입력 수단의 별도 외곽 링이다. "지속" 상태는 accent가 아니라 세 문장으로 갈린다:
      배타 선택 = 극저대비 중립 워시(--control-wash) + 잉크 대비 + 2px brass 다텀 한 점,
      독립 ON = 잉크(--control-tint-* 저채도 워시), 불리언 ON = 워시 + brass 글리프.
@@ -406,9 +408,16 @@
      hover는 기존 brass 예고를 유지한다. 열림(aria-expanded·is-open)과 필드 focus-within은
      지속이 아니라 순간이므로 --control-open-rim이 진다. 선택이 brass를 다텀 한 점으로만
      소비하므로 "brass = 위치·포커스·호버" 채널 계약은 좁아진다. 워시 리터럴은 각 테마
-     블록이 자기 잉크 위에서 재조율한다 — 다크는 화이트 워시, 라이트는 잉크 워시로 극이 뒤집힌다. */
+     블록이 자기 잉크 위에서 재조율한다 — 다크는 화이트 워시, 라이트는 잉크 워시로 극이 뒤집힌다.
+     rest 사다리는 wash 사다리와 겹치지 않는다: rest(5%) < wash-selected(7%) — 쉬는 몸이
+     선택된 면보다 무거워지면 두 상태가 뒤집혀 읽힌다. field는 입력 필드의 면이다 — 원료 잉크
+     우물(ink-abyss 알파)로 표면보다 어둡게 파는 문법은 같은 실측으로 퇴역했고, 필드는 표면
+     위로 반 칸 떠오른다(라이트는 종이보다 밝은 쪽). */
   --control-hover-fill: color-mix(in oklab, var(--brass) 8%, transparent);
   --control-hover-rim: color-mix(in oklab, var(--brass) 42%, var(--surface-rim));
+  --control-rest: oklch(96% 0.01 90 / 5%);
+  --control-rest-hover: oklch(96% 0.01 90 / 9%);
+  --control-field: oklch(96% 0.01 90 / 4.5%);
   --control-wash: oklch(96% 0.01 90 / 7%);
   --control-wash-hover: oklch(96% 0.01 90 / 4%);
   --control-tint-fill: color-mix(in oklab, var(--brass) 9%, transparent);
@@ -538,6 +547,9 @@
   --hairline-strong: oklch(48% 0.03 248);
 
   /* Quiet Controls 워시 — pearl(hue 88) 화이트를 얹어 감청 위에서도 워시가 차갑게 식지 않는다. */
+  --control-rest: oklch(96% 0.012 88 / 5.5%);
+  --control-rest-hover: oklch(96% 0.012 88 / 9.5%);
+  --control-field: oklch(96% 0.012 88 / 5%);
   --control-wash: oklch(96% 0.012 88 / 8%);
   --control-wash-hover: oklch(96% 0.012 88 / 4.5%);
 
@@ -651,6 +663,9 @@
   --hairline-strong: oklch(45% 0.005 252);
 
   /* Quiet Controls 워시 — 무채 화이트 한 겹. 선택마저 무채가 되고 구리색은 다텀·focus·글리프에만 남는다. */
+  --control-rest: oklch(95% 0.003 250 / 5%);
+  --control-rest-hover: oklch(95% 0.003 250 / 9%);
+  --control-field: oklch(95% 0.003 250 / 4.5%);
   --control-wash: oklch(95% 0.003 250 / 7%);
   --control-wash-hover: oklch(95% 0.003 250 / 4%);
 
@@ -818,7 +833,12 @@
   --hairline-strong: oklch(76% 0.014 100);
 
   /* Quiet Controls 워시 — 종이 위 잉크 극. 다크의 화이트 워시를 그대로 반전하면 백지 위
-     백워시라 지각 불가이므로, 라이트만 어두운 잉크를 낮은 알파로 얹는다. */
+     백워시라 지각 불가이므로, 라이트만 어두운 잉크를 낮은 알파로 얹는다.
+     rest도 같은 극 — field만은 알파 워시가 아니라 종이보다 밝은 실색이다: 어두운 잉크 워시를
+     입력 필드에 깔면 라이트에서 필드가 "파인 우물"로 되돌아간다(다크 우물 퇴역과 같은 이유). */
+  --control-rest: oklch(30% 0.015 95 / 4.5%);
+  --control-rest-hover: oklch(30% 0.015 95 / 7.5%);
+  --control-field: oklch(99.3% 0.003 95);
   --control-wash: oklch(30% 0.015 95 / 6.5%);
   --control-wash-hover: oklch(30% 0.015 95 / 3.5%);
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -507,12 +507,17 @@ describe("Instrument core design contract", () => {
   it("keeps the interaction control recipe theme-owned", () => {
     const theme = source("styles/theme.css");
     const root = theme.match(/^:root \{[\s\S]*?^\}/m)?.[0] ?? "";
-    // Quiet Controls C′: 지속 상태는 accent가 아니라 세 문장으로 갈린다 — 배타 선택 =
-    // 극저대비 워시(wash) + 잉크 대비 + 2px brass 다텀, 독립 ON = 잉크(tint),
+    // Quiet Controls C′: rest는 침묵이 아니라 낮은 목소리다(2026-09-01 저장소 실측 재가) —
+    // 동사·컨트롤은 rest 채널(--control-rest)로 쉬는 몸을 알리고, 입력 필드는 우물 대신
+    // --control-field로 표면 위에 떠오른다. 지속 상태는 accent가 아니라 세 문장으로 갈린다 —
+    // 배타 선택 = 극저대비 워시(wash) + 잉크 대비 + 2px brass 다텀, 독립 ON = 잉크(tint),
     // 불리언 ON = 워시 + brass 글리프. 열림·focus-within은 open-rim이 진다.
     for (const token of [
       "--control-hover-fill",
       "--control-hover-rim",
+      "--control-rest",
+      "--control-rest-hover",
+      "--control-field",
       "--control-wash",
       "--control-wash-hover",
       "--control-tint-fill",
@@ -530,6 +535,8 @@ describe("Instrument core design contract", () => {
     for (const name of ["maritime", "carbon", "whites"]) {
       const blocks = theme.match(new RegExp(`^:root\\[data-theme="${name}"\\] \\{[\\s\\S]*?\\n\\}`, "gm")) ?? [];
       expect(blocks.some((block) => block.includes("--control-wash:") && block.includes("--control-wash-hover:"))).toBe(true);
+      // rest·field도 같은 극성 재조율 대상이다 — 라이트의 field는 잉크 워시가 아니라 종이보다 밝은 실색.
+      expect(blocks.some((block) => block.includes("--control-rest:") && block.includes("--control-field:"))).toBe(true);
     }
     // 옛 selected recipe(테두리+채움+brass 글자 동시 발화)와 융기(thumb) recipe는 퇴역했다 — 부활 금지.
     expect(theme).not.toContain("--control-selected-fill");

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -163,7 +163,7 @@ interface GraphGutterProps {
 
 const LANE_WIDTH = 14;
 // .history-commit-row의 고정 높이(diff.css)와 반드시 일치해야 행 간 레인 선이 이음새 없이 연결된다
-export const ROW_HEIGHT = 28;
+export const ROW_HEIGHT = 30;
 const NODE_R = 3.5;
 const HEAD_RING_R = 5.5;
 const STROKE_WIDTH = 2;

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1995,7 +1995,10 @@
 .repository-staging-bulk:disabled { opacity: 0.4; cursor: default; }
 .repository-staging-rows { padding: 2px 0 8px; }
 .repository-staging-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; margin: 0 4px; padding: 0; border-radius: var(--radius-xs); transition: background 0.1s; }
-.repository-staging-row:hover { background: color-mix(in oklch, var(--ink-fog) 9%, transparent); }
+/* 스테이징 행은 .repository-file-row와 같은 요소에 서므로(staging-view.tsx), 선택(.is-cur)을
+   제외하지 않으면 같은 특이도의 후순위 hover가 brass 선택 필을 잉크로 덮는다 — 행 액션을
+   쓰는 순간 선택 표시가 사라지는 회귀(Codex P2 재현 확인). */
+.repository-staging-row:hover:not(.is-cur) { background: color-mix(in oklch, var(--ink-fog) 9%, transparent); }
 .repository-staging-row-main {
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr) auto;

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -92,11 +92,13 @@
   flex: 1;
 }
 
+/* 입력 필드는 우물이 아니다 — 원료 잉크 알파로 표면보다 어둡게 파는 문법은 2026-09-01
+   소프트 그래파이트 재가로 퇴역했다. 필드는 --control-field로 표면 위에 반 칸 떠오른다. */
 .repository-filter-input,
 .history-filter-input {
   flex: 1;
   min-width: 0;
-  background: color-mix(in oklch, var(--ink-abyss) 35%, transparent);
+  background: var(--control-field);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
   color: var(--text-secondary);
@@ -141,12 +143,14 @@
   background: color-mix(in oklch, var(--surface-band) 55%, transparent);
 }
 
+/* 메타 라벨은 계기판 어휘(mono·uppercase·광폭 자간)를 걷고 본문 서체의 낮은 목소리로 선다 —
+   2026-09-01 소프트 그래파이트 재가. 데이터(sha·시각·경로)만 mono로 남는다. */
 .repository-toolbar-label {
   flex: 1;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-size: var(--t-xs);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.02em;
   color: var(--text-tertiary);
 }
 
@@ -291,11 +295,10 @@
 
 .repository-section-name {
   flex: 1;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-size: var(--t-xs);
   font-weight: var(--weight-medium);
-  letter-spacing: 0.13em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--text-secondary);
 }
 
@@ -324,16 +327,20 @@
 }
 
 /* ── 파일 행 (리스트뷰 + 트리 리프 공유) ── */
+/* 라운드 행 문법(소프트 그래파이트) — 행의 hover·선택 면은 좌우 4px 인셋의 라운드 필이다.
+   스파인 대신 면이 말하고, 선택 면은 위치 채널(brass)의 저알파 워시를 입는다. */
 .repository-file-row {
   display: grid;
-  grid-template-columns: 16px 1fr auto;
+  grid-template-columns: 18px 1fr auto;
   align-items: center;
   gap: 0 8px;
-  width: 100%;
+  width: calc(100% - 8px);
   min-width: 0;
-  padding: 5px 12px;
+  margin: 0 4px;
+  padding: 6px 10px;
   background: none;
   border: none;
+  border-radius: var(--radius-xs);
   cursor: pointer;
   text-align: left;
   transition: background 0.1s;
@@ -343,15 +350,22 @@
   background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
 }
 
-/* 선택은 중립 잉크 워시와 brass 스파인으로 표시해 위치만 brass가 말하게 한다. */
+/* 선택 = 위치 채널의 저알파 라운드 필 — 2026-09-01 소프트 그래파이트 재가로 스파인 문법 퇴역. */
 .repository-file-row.is-cur {
-  background: color-mix(in oklch, var(--ink-fog) 12%, transparent);
-  box-shadow: inset 2px 0 0 var(--brass);
+  background: color-mix(in oklab, var(--brass) 10%, transparent);
 }
 
+/* 상태 글리프는 맨글자가 아니라 칩이다 — currentColor 틴트 한 겹이 글자 색과 같은 신호
+   채널에서 흐르므로 상태별 규칙을 늘리지 않고도 M/A/D/U가 스캔 단위로 읽힌다. */
 .repository-status-glyph {
+  display: inline-grid;
+  place-items: center;
+  width: 17px;
+  height: 17px;
+  border-radius: calc(var(--radius-xs) - 2px);
+  background: color-mix(in oklab, currentColor 14%, transparent);
   font-family: var(--font-mono);
-  font-size: var(--t-xs);
+  font-size: var(--t-2xs);
   font-weight: var(--weight-bold);
   text-align: center;
 }
@@ -416,10 +430,12 @@
   grid-template-columns: 12px 15px 1fr;
   align-items: center;
   gap: 0 6px;
-  width: 100%;
-  padding: 4px 12px;
+  width: calc(100% - 8px);
+  margin: 0 4px;
+  padding: 4px 10px;
   background: none;
   border: none;
+  border-radius: var(--radius-xs);
   cursor: pointer;
   text-align: left;
   transition: background 0.1s;
@@ -469,18 +485,20 @@
 }
 
 /* ── 기타 공통 ── */
+/* rest = 낮은 목소리(2-cue): 워시 한 겹 + 헤어라인이 쉬는 상태에서도 몸을 알린다. */
 .repository-refresh-btn {
-  background: none;
+  background: var(--control-rest);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
   cursor: pointer;
   font-size: var(--t-xs);
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   padding: 3px 8px;
 }
 
 .repository-refresh-btn:hover {
-  color: var(--text-secondary);
+  background: var(--control-rest-hover);
+  color: var(--text-primary);
 }
 
 /* 잘림은 "조용한 메모"가 아니라 상태다 — File Explorer(.fexp-truncated-badge)와 같은 warn 처리를
@@ -779,8 +797,8 @@
   padding: 3px 8px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  background: none;
-  color: var(--text-tertiary);
+  background: var(--control-rest);
+  color: var(--text-secondary);
   cursor: pointer;
   font-family: var(--font-mono);
   font-size: var(--t-2xs);
@@ -788,7 +806,8 @@
 
 .history-order-toggle:hover {
   border-color: color-mix(in oklch, var(--brass) 40%, var(--surface-rim));
-  color: var(--text-secondary);
+  background: var(--control-rest-hover);
+  color: var(--text-primary);
 }
 
 .history-order-toggle:focus-visible {
@@ -814,10 +833,13 @@
 
 .history-commit-row {
   position: relative;
-  width: 100%;
+  /* 라운드 행 문법 — 좌우 4px 인셋. 전 행이 같은 만큼 밀리므로 그래프 레인의 세로 연속성은 유지된다. */
+  width: calc(100% - 8px);
   min-width: 0;
-  /* 높이는 graph-gutter의 ROW_HEIGHT(28px)와 동기 — 어긋나면 레인 선이 행 사이에서 끊긴다 */
-  height: 28px;
+  margin: 0 4px;
+  border-radius: var(--radius-xs);
+  /* 높이는 graph-gutter의 ROW_HEIGHT(30px)와 동기 — 어긋나면 레인 선이 행 사이에서 끊긴다 */
+  height: 30px;
   color: inherit;
   transition: background 0.1s;
 }
@@ -844,8 +866,7 @@
 }
 
 .history-commit-row.is-selected {
-  background: color-mix(in oklch, var(--ink-fog) 12%, transparent);
-  box-shadow: inset 2px 0 0 var(--brass);
+  background: color-mix(in oklab, var(--brass) 10%, transparent);
 }
 
 /* 현재 체크아웃 브랜치에서 도달 불가능한 커밋은 본문만 강등 — 그래프/배지는 유지.
@@ -877,24 +898,27 @@
   display: none;
 }
 
-/* Fork 문법의 ref 뱃지 — 알약이 아니라 아이콘 칸과 라벨 칸이 구분선으로 나뉜 라운드 사각이고,
-   라벨은 볼드 sans로 훑어 읽힌다. 색조는 --badge-tone 하나로만 흐르며 테두리·아이콘·바탕이 그 톤을 공유한다.
-   기본 톤은 중성이고, 종류가 고정된 축(체크아웃 위치=brass, 태그=plum)만 아래 규칙이 덮어쓴다.
-   나머지 브랜치·원격·워크트리는 커밋 행이 자기 레인 색을 인라인으로 주입한다 —
-   장식적 구분 채도는 그래프 레인과 같은 --id-* 정체성 봉투에서만 오고, 상태 신호 채널을 침범하지 않는다. */
+/* Fork 문법의 ref 뱃지 — 아이콘 칸과 라벨 칸이 구분선으로 나뉜 캡슐. 색조는 --badge-tone
+   하나로만 흐르며 테두리·아이콘·바탕이 그 톤을 공유한다. 기본 톤은 중성이고, 종류가 고정된
+   축(체크아웃 위치=brass, 태그=plum)만 아래 규칙이 덮어쓴다. 나머지 브랜치·원격·워크트리는
+   커밋 행이 자기 레인 색을 인라인으로 주입한다 — 장식적 구분 채도는 그래프 레인과 같은
+   --id-* 정체성 봉투에서만 오고, 상태 신호 채널을 침범하지 않는다.
+   [독트린 예외 기록] radius-pill은 "도트·비콘·상태 캡슐 전용"이며 ref 뱃지는 상태 캡슐 축에
+   선다 — 2026-09-01 소프트 그래파이트 재가로 고알파 사각(82%/22%/bold)에서 저알파 캡슐
+   (45%/14%/medium)로 낮췄다: 뱃지가 커밋 제목보다 큰 목소리를 내지 않게 하는 감쇠다. */
 .history-badge {
   --badge-tone: var(--ink-fog);
   display: inline-flex;
   align-items: stretch;
   flex: none;
   overflow: hidden;
-  border: 1px solid color-mix(in oklch, var(--badge-tone) 82%, transparent);
-  border-radius: var(--radius-xs);
-  background: color-mix(in oklch, var(--badge-tone) 22%, transparent);
+  border: 1px solid color-mix(in oklch, var(--badge-tone) 45%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--badge-tone) 14%, transparent);
   color: var(--text-primary);
   font-family: var(--font-body);
   font-size: var(--t-xs);
-  font-weight: var(--weight-bold);
+  font-weight: var(--weight-medium);
   letter-spacing: 0.01em;
   line-height: 1.5;
 }
@@ -902,8 +926,8 @@
 .history-badge-mark {
   display: inline-flex;
   align-items: center;
-  padding: 0 3px;
-  border-right: 1px solid color-mix(in oklch, var(--badge-tone) 65%, transparent);
+  padding: 0 3px 0 5px;
+  border-right: 1px solid color-mix(in oklch, var(--badge-tone) 40%, transparent);
   color: color-mix(in oklch, var(--badge-tone) 88%, var(--text-primary));
 }
 
@@ -912,7 +936,7 @@
 }
 
 .history-badge-label {
-  padding: 0 5px;
+  padding: 0 7px 0 5px;
 }
 
 .history-badge-icon {
@@ -1052,7 +1076,7 @@
   height: 22px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  background: transparent;
+  background: var(--control-rest);
   color: var(--text-tertiary);
   cursor: pointer;
   font-size: var(--t-sm);
@@ -1136,8 +1160,8 @@
 .history-divider { touch-action: none; }
 .history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr) auto minmax(0, auto) 7ch auto; gap: 0 7px; }
 /* gutter는 DOM 최후미이나 col 1에 놓이므로 grid-row를 고정하지 않으면 auto-placement가 커서를 되돌리지 못해
-   유령 2행 트랙(0px 28px)을 만든다 → 텍스트는 0px 트랙 상단, 노드는 28px 트랙 중앙으로 반 행 어긋난다.
-   grid-row: 1로 전 셀을 단일 28px 트랙에 묶어 노드와 커밋 텍스트를 정렬한다. 본문 마커는 조건부 셀이라
+   유령 2행 트랙(0px 30px)을 만든다 → 텍스트는 0px 트랙 상단, 노드는 30px 트랙 중앙으로 반 행 어긋난다.
+   grid-row: 1로 전 셀을 단일 30px 트랙에 묶어 노드와 커밋 텍스트를 정렬한다. 본문 마커는 조건부 셀이라
    나머지 셀도 열을 명시해야 마커가 없는 행에서 뒤 셀들이 한 칸씩 당겨지지 않는다. */
 .history-graph-gutter { grid-column: 1; grid-row: 1; }
 /* Fork 문법 — refs 뱃지가 제목 앞(그래프 뒤)에서 커밋의 정체를 먼저 알린다.
@@ -1165,21 +1189,21 @@
 .history-author time { margin-left: auto; }
 .history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: color-mix(in oklch, var(--ink-fog) 24%, var(--ink-veil)); color: var(--text-secondary); font-family: var(--font-mono); font-size: var(--t-2xs); font-weight: var(--weight-bold); }
 .history-inspector-ids, .history-ref-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
-.history-sha-copy, .history-parent { border-radius: var(--radius-xs); background: none; cursor: pointer; font-family: var(--font-mono); font-size: var(--t-xs); padding: 3px 8px; }
+.history-sha-copy, .history-parent { border-radius: var(--radius-xs); background: var(--control-rest); cursor: pointer; font-family: var(--font-mono); font-size: var(--t-xs); padding: 3px 8px; }
 .history-sha-copy { border: 1px solid var(--surface-rim); color: var(--text-secondary); }.history-sha-copy span { color: var(--text-tertiary); margin-left: 7px; }.history-sha-copy.is-copied { border-color: var(--positive); color: var(--positive-ink); }
 .history-parent { border: 1px solid var(--surface-rim); color: var(--text-secondary); }
 /* min-width/열 minmax가 없으면 섹션의 자동 최소 크기가 min-content(가장 긴 경로)로 굳어
    grid 트랙을 무시하고 옆 diff 열 위로 넘친다 — 폭 조절이 화면에 반영되지 않는 원인. */
 .history-commit-files { display: grid; grid-template-rows: auto minmax(0, 1fr); grid-template-columns: minmax(0, 1fr); min-width: 0; min-height: 0; overflow: hidden; }
-.history-files-title { display: flex; gap: 8px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .1em; text-transform: uppercase; }.history-files-stats { margin-left: auto; letter-spacing: 0; }.history-files-title i { color: var(--positive-ink); font-style: normal; }.history-files-title em { color: var(--coral-ink); font-style: normal; }.history-files-view-toggle { margin-left: 0; }
+.history-files-title { display: flex; gap: 8px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-body); font-size: var(--t-xs); font-weight: var(--weight-medium); letter-spacing: .02em; }.history-files-stats { margin-left: auto; letter-spacing: 0; }.history-files-title i { color: var(--positive-ink); font-style: normal; }.history-files-title em { color: var(--coral-ink); font-style: normal; }.history-files-view-toggle { margin-left: 0; }
 .history-files-scroll { min-height: 0; overflow: auto; }.history-commit-files .repository-file-row { padding-left: 14px; }
 .history-changes-tab { min-height: 0; overflow: hidden; }.history-changes-columns { display: grid; min-height: 0; height: 100%; }.history-changes-columns > .history-commit-files { border-right: 1px solid var(--surface-rim); }
-.history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 24px; height: 24px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: none; color: var(--text-tertiary); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
+.history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-xs); }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 24px; height: 24px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--control-rest); color: var(--text-tertiary); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
 .history-inspector-empty { padding: 16px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-sm); }.history-inspector-error { color: var(--coral-ink); }
 /* 진행형 축소 — 컨테이너(패널·트리 리사이즈)가 좁아질수록 작성자 → 시간 → sha → 뱃지 순으로 양보한다.
    숨긴 셀은 grid item에서 빠지므로 그 자리의 트랙까지 함께 걷어내야 한다(7ch 같은 고정 트랙은 비어도 폭을 잡는다).
    제목은 어느 폭에서도 한 줄을 유지한다(기본 규칙의 nowrap+ellipsis): 행 높이는 그래프 gutter의
-   ROW_HEIGHT(28px)와 가상 스크롤 기하에 묶여 있어 줄바꿈이 레인 선과 스크롤 위치를 함께 깨뜨린다. */
+   ROW_HEIGHT(30px)와 가상 스크롤 기하에 묶여 있어 줄바꿈이 레인 선과 스크롤 위치를 함께 깨뜨린다. */
 @container (max-width: 760px) {
   .history-commit-author { display: none; }
   .history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr) auto 7ch auto; }
@@ -1220,8 +1244,10 @@
 /* 브랜치는 정체의 일부라 이름 옆에 붙인다 — margin-left:auto로 밀면 넓은 레일에서 이름과의 연관이 끊긴다.
    brass는 location 채널이므로 "어느 체크아웃인가"를 칠하는 데 쓴다. */
 .repository-identity span { min-width: 0; overflow: hidden; color: var(--brass-ink); flex: 0 1 auto; font-family: var(--font-mono); font-size: var(--t-2xs); text-overflow: ellipsis; white-space: nowrap; }
-.repository-sync-button { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; padding: 4px 7px; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; color: var(--text-tertiary); cursor: pointer; flex: none; font: inherit; font-size: var(--t-sm); }
-.repository-sync-button:hover:not(:disabled) { border-color: var(--surface-rim); background: color-mix(in oklch, var(--ink-fog) 9%, transparent); color: var(--text-primary); }
+/* 패널의 주 동사(가져오기·Pull·Push·Stash) — 완전 투명 rest는 "시각 신호 0개"로 실측 기각됐다.
+   rest부터 워시+헤어라인의 2-cue로 서고, hover는 한 단 무거워질 뿐 문법이 바뀌지 않는다. */
+.repository-sync-button { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; padding: 4px 10px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--control-rest); color: var(--text-secondary); cursor: pointer; flex: none; font: inherit; font-size: var(--t-sm); }
+.repository-sync-button:hover:not(:disabled) { border-color: var(--surface-rim-strong); background: var(--control-rest-hover); color: var(--text-primary); }
 .repository-sync-button:disabled { cursor: default; opacity: .7; }
 /* 아이콘은 ↻와 ✓를 같은 자리에 겹쳐 두는 13px 슬롯이다 — 글리프를 교체하면 버튼 폭이 흔들려
    옆의 라벨이 밀린다. 회전은 계속 슬롯 자체에 걸어 두 글리프가 같은 축을 돈다. */
@@ -1241,7 +1267,7 @@
 /* 숨김-마운트 래퍼가 높이 문맥을 끊으면 history-root의 height:100%가 내용 높이로 풀려 내부 스크롤이 죽는다 */
 .repository-source-fill { height: 100%; min-width: 0; min-height: 0; }
 .repository-discovery { display: flex; align-items: center; gap: 8px; flex: none; padding: 6px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
-.repository-discovery-depth { display: inline-flex; align-items: center; gap: 3px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); letter-spacing: .1em; text-transform: uppercase; }
+.repository-discovery-depth { display: inline-flex; align-items: center; gap: 3px; color: var(--text-tertiary); font-family: var(--font-body); font-size: var(--t-2xs); font-weight: var(--weight-medium); letter-spacing: .04em; }
 .repository-depth-step { border: 0; background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: var(--t-sm); padding: 0 3px; }
 .repository-depth-step:hover:not(:disabled) { color: var(--text-primary); }
 .repository-depth-step:disabled { opacity: .4; cursor: default; }
@@ -1249,7 +1275,7 @@
 .repository-scan-count { margin-left: auto; min-width: 0; overflow: hidden; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); text-overflow: ellipsis; white-space: nowrap; }
 .repository-ref-list { padding: var(--space-2); display: grid; gap: 2px; }
 .repository-ref-group { display: grid; gap: 2px; }
-.repository-ref-group-label { padding: 8px 10px 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); font-weight: var(--weight-regular); letter-spacing: .18em; text-transform: uppercase; }
+.repository-ref-group-label { padding: 8px 10px 2px; color: var(--text-tertiary); font-family: var(--font-body); font-size: var(--t-2xs); font-weight: var(--weight-medium); letter-spacing: .04em; }
 .repository-ref-row { display: flex; align-items: center; gap: 9px; width: 100%; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); cursor: pointer; font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit; text-align: left; padding: 7px 10px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
 .repository-ref-row:hover { background: color-mix(in oklch, var(--ink-fog) 9%, transparent); color: var(--text-primary); }
 .repository-ref-row:disabled { cursor: default; }
@@ -1329,9 +1355,10 @@
   border: 0;
   background: transparent;
   color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--t-2xs);
-  letter-spacing: .14em;
+  font-family: var(--font-body);
+  font-size: var(--t-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: .02em;
   cursor: pointer;
   text-align: left;
 }
@@ -1362,10 +1389,12 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  width: 100%;
-  min-height: 26px;
-  padding: 4px 10px 4px 18px;
+  width: calc(100% - 8px);
+  min-height: 28px;
+  margin: 0 4px;
+  padding: 4px 8px 4px 14px;
   border: 0;
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -1398,9 +1427,8 @@
 }
 
 .repository-ws-tree-row.is-active {
-  background: color-mix(in oklch, var(--brass) 7%, transparent);
+  background: color-mix(in oklab, var(--brass) 10%, transparent);
   color: var(--text-primary);
-  box-shadow: inset 2px 0 0 var(--brass);
 }
 
 .repository-ws-tree-row.is-current {
@@ -1547,9 +1575,10 @@
 .repository-ws-ref-subhead {
   padding: 4px 10px 2px 20px;
   color: var(--text-tertiary);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-size: var(--t-2xs);
-  letter-spacing: .12em;
+  font-weight: var(--weight-medium);
+  letter-spacing: .04em;
 }
 
 .repository-ws-tree-error {
@@ -1684,8 +1713,8 @@
 }
 
 /* ── Compare 뷰 ── */
-.repository-compare-swap { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; padding: 0; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: none; color: var(--text-tertiary); cursor: pointer; flex: none; font-size: var(--t-sm); }
-.repository-compare-swap:hover:not(:disabled) { color: var(--text-secondary); }
+.repository-compare-swap { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; padding: 0; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--control-rest); color: var(--text-tertiary); cursor: pointer; flex: none; font-size: var(--t-sm); }
+.repository-compare-swap:hover:not(:disabled) { background: var(--control-rest-hover); color: var(--text-secondary); }
 .repository-compare-meta { flex: none; padding: 5px 10px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--t-2xs); }
 .repository-compare-meta span { color: var(--text-secondary); }
 
@@ -1714,7 +1743,7 @@
 .history-commit-row:focus-within .history-row-compare { display: inline-flex; }
 .history-row-compare:hover,
 .history-row-compare:focus-visible { border-color: var(--aurora); background: color-mix(in oklch, var(--aurora) 12%, var(--ink-mid)); color: var(--text-primary); outline: none; }
-.history-commit-row.is-picked { background: color-mix(in oklch, var(--aurora) 9%, transparent); box-shadow: inset 2px 0 0 var(--aurora); }
+.history-commit-row.is-picked { background: color-mix(in oklch, var(--aurora) 12%, transparent); }
 .history-commit-row.is-picked .history-commit-sha { color: var(--aurora); }
 .repository-pin-chip { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 42%, transparent); border-radius: var(--radius-xs); color: var(--aurora); cursor: pointer; }
 .repository-pin-chip:hover { background: color-mix(in oklch, var(--aurora) 10%, transparent); color: var(--text-primary); }
@@ -1938,9 +1967,10 @@
   align-items: center;
   gap: 6px;
   padding: 6px 10px;
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--font-body);
   font-size: var(--t-xs);
-  letter-spacing: 0.08em;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.02em;
   color: var(--text-tertiary);
   border-bottom: 1px solid var(--hairline);
   position: sticky;
@@ -1964,14 +1994,15 @@
 }
 .repository-staging-bulk:disabled { opacity: 0.4; cursor: default; }
 .repository-staging-rows { padding: 2px 0 8px; }
-.repository-staging-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; padding: 0; }
+.repository-staging-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; margin: 0 4px; padding: 0; border-radius: var(--radius-xs); transition: background 0.1s; }
+.repository-staging-row:hover { background: color-mix(in oklch, var(--ink-fog) 9%, transparent); }
 .repository-staging-row-main {
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) auto;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
   align-items: center;
   gap: 7px;
   min-width: 0;
-  padding: 3px 4px 3px 10px;
+  padding: 4px 4px 4px 8px;
   border: none;
   background: transparent;
   color: inherit;
@@ -1987,7 +2018,7 @@
   font-size: var(--t-xs);
   line-height: 1;
   color: var(--text-secondary);
-  background: var(--ink-mid);
+  background: var(--control-rest);
   border: 1px solid var(--hairline);
   border-radius: var(--radius-xs);
   padding: 2px 6px;
@@ -2017,7 +2048,7 @@
   font: inherit;
   font-size: var(--t-sm);
   color: var(--text-primary);
-  background: color-mix(in oklch, var(--ink-abyss) 35%, transparent);
+  background: var(--control-field);
   border: 1px solid var(--hairline-strong);
   padding: 6px 10px;
   resize: none;
@@ -2259,8 +2290,8 @@
   padding: 5px 8px;
   border: 1px solid var(--hairline);
   border-radius: var(--radius-xs);
-  /* 입력 재질은 커밋 상자와 같은 결 — 원료 잉크 단독 배경은 디자인 계약이 금지한다. */
-  background: color-mix(in oklch, var(--ink-abyss) 35%, transparent);
+  /* 입력 재질은 커밋 상자와 같은 결 — 필드 채널 하나를 함께 소비한다. */
+  background: var(--control-field);
   color: var(--text-primary);
   font-size: var(--t-sm);
 }

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -152,29 +152,68 @@ describe("Repository signal mixing", () => {
 });
 
 describe("Repository design grammar", () => {
-  it("reserves brass for location while selections use neutral ink", () => {
+  // 2026-09-01 소프트 그래파이트 재가 — 선택은 스파인이 아니라 위치 채널(brass)의 저알파
+  // 라운드 필이다. 스파인(inset 2px) 문법은 이 패널에서 퇴역했고, 필의 알파는 10%로 통일해
+  // 선택 면이 hover(잉크 9%)보다 한 단 무거우면서도 신호 채널을 침범하지 않게 한다.
+  it("paints selection as a low-alpha brass fill without spines", () => {
     expect(blockOf(".repository-ref-row.is-current")).toContain("var(--text-primary)");
     expect(blockOf(".repository-ref-row.is-current")).not.toContain("var(--brass)");
     expect(blockOf(".repository-ref-row.is-current:hover")).not.toContain("var(--brass)");
     expect(blockOf(".repository-ref-row.is-current .repository-ref-sub")).toContain("var(--brass-ink)");
 
     const selectedFile = blockOf(".repository-file-row.is-cur");
-    expect(selectedFile).toContain("color-mix(in oklch, var(--ink-fog) 12%, transparent)");
-    expect(selectedFile).toContain("inset 2px 0 0 var(--brass)");
+    expect(selectedFile).toContain("var(--brass) 10%");
+    expect(selectedFile).not.toContain("inset 2px 0 0");
     expect(blockOf(".repository-file-row.is-cur .repository-file-fn")).toContain("var(--text-primary)");
 
     const selectedCommit = blockOf(".history-commit-row.is-selected");
-    expect(selectedCommit).toContain("var(--ink-fog) 12%");
-    expect(selectedCommit).not.toContain("var(--brass) 14%");
+    expect(selectedCommit).toContain("var(--brass) 10%");
+    expect(selectedCommit).not.toContain("inset 2px 0 0");
 
-    // 워크스페이스 트리의 활성(중앙 뷰) 행 — brass 스파인 + 옅은 wash + 1차 텍스트.
     const activeTreeRow = blockOf(".repository-ws-tree-row.is-active");
     expect(activeTreeRow).toContain("var(--text-primary)");
-    expect(activeTreeRow).toContain("var(--brass) 7%");
-    expect(activeTreeRow).toContain("inset 2px 0 0 var(--brass)");
+    expect(activeTreeRow).toContain("var(--brass) 10%");
+    expect(activeTreeRow).not.toContain("inset 2px 0 0");
 
     expect(blockOf(".history-badge--tag")).not.toContain("var(--brass)");
     expect(blockOf(".history-badge--head")).toContain("var(--brass)");
+  });
+
+  // 라운드 행 문법 — 행은 좌우 4px 인셋 위에서 라운드 필로 hover·선택을 말한다. 커밋 행은
+  // 전 행이 같은 만큼 밀려야 그래프 레인의 세로 연속성이 유지되고, 높이는 ROW_HEIGHT와 동기다.
+  it("keeps rows on the rounded inset grammar with the graph row height in sync", () => {
+    for (const selector of [".repository-file-row", ".repository-folder-row", ".repository-ws-tree-row", ".history-commit-row"]) {
+      const body = blockOf(selector);
+      expect(body, selector).toContain("border-radius: var(--radius-xs)");
+      expect(body, selector).toContain("margin: 0 4px");
+      expect(body, selector).toContain("calc(100% - 8px)");
+    }
+    expect(blockOf(".history-commit-row")).toContain("height: 30px");
+  });
+
+  // rest는 침묵이 아니라 낮은 목소리다 — 주 동사와 보조 컨트롤은 쉬는 상태에서도
+  // rest 채널 + 헤어라인의 2-cue로 몸을 알리고, 입력 필드는 우물 대신 field 채널로 떠오른다.
+  it("gives every verb, control, and input a resting body", () => {
+    const verb = blockOf(".repository-sync-button");
+    expect(verb).toContain("background: var(--control-rest)");
+    expect(verb).toContain("border: 1px solid var(--surface-rim)");
+    expect(verb).not.toContain("background: transparent");
+    for (const selector of [".history-order-toggle", ".repository-refresh-btn", ".repository-reload-state", ".repository-compare-swap", ".repository-stage-action"]) {
+      expect(blockOf(selector), selector).toContain("var(--control-rest)");
+    }
+    for (const selector of [".repository-filter-input", ".repository-stash-popover-input"]) {
+      expect(blockOf(selector), selector).toContain("var(--control-field)");
+    }
+    expect(blocksOf(".repository-commit-subject").concat(blocksOf(".repository-commit-body")).some((body) => body.includes("var(--control-field)"))).toBe(true);
+    expect(css).not.toContain("var(--ink-abyss) 35%");
+  });
+
+  // 상태 글리프는 맨글자가 아니라 칩이다 — currentColor 틴트라 상태별 규칙 없이 신호 채널을 따른다.
+  it("wraps status glyphs in currentColor-tinted chips", () => {
+    const glyph = blockOf(".repository-status-glyph");
+    expect(glyph).toContain("currentColor 14%");
+    expect(glyph).toContain("width: 17px");
+    expect(glyph).toContain("height: 17px");
   });
 
   it("uses core surface tokens for panel material", () => {
@@ -195,7 +234,7 @@ describe("Repository design grammar", () => {
     for (const body of detailPanes) expect(body).toContain("var(--surface-glass) 70%");
 
     for (const selector of [".repository-filter-input", ".history-filter-input"]) {
-      expect(blockOf(selector), selector).toContain("var(--ink-abyss) 35%");
+      expect(blockOf(selector), selector).toContain("var(--control-field)");
     }
     // 뷰 토글은 상자 없는 세그먼트다(Quiet Controls C′) — 선택은 워시+다텀이 말하고 그룹 경계는 간격이 진다.
     expect(blockOf(".repository-view-toggle")).not.toContain("background");
@@ -241,7 +280,9 @@ describe("Repository design grammar", () => {
   // 2026-08-05 재가 — in-history compare 앵커와 수동 Sync 표면화의 신호 채널 문법.
   // pin/pick은 상태이므로 aurora(신호), 실패는 coral, 성공 요약은 positive — brass는 위치/포커스 전용으로 남는다.
   it("keeps the anchor-compare and sync surfaces on the signal channel, never brass", () => {
-    expect(blockOf(".history-commit-row.is-picked")).toContain("inset 2px 0 0 var(--aurora)");
+    const picked = blockOf(".history-commit-row.is-picked");
+    expect(picked).toContain("var(--aurora) 12%");
+    expect(picked).not.toContain("var(--brass)");
     expect(blockOf(".history-row-compare")).toContain("var(--aurora)");
     expect(blockOf(".history-row-compare")).not.toContain("var(--brass)");
     expect(blockOf(".repository-sync-toast.is-error")).toContain("var(--coral)");
@@ -283,7 +324,7 @@ describe("Repository design grammar", () => {
     expect(sectionHead).toContain("border: 0");
     expect(sectionHead).toContain("background: transparent");
     expect(sectionHead).toContain("color: var(--text-tertiary)");
-    expect(sectionHead).toContain("font-family: var(--font-mono)");
+    expect(sectionHead).toContain("font-family: var(--font-body)");
     expect(sectionHead).toContain("cursor: pointer");
     expect(sectionHead).toContain("text-align: left");
 
@@ -312,23 +353,24 @@ describe("Repository design grammar", () => {
     expect(css).not.toMatch(/\.repository-scan-depth\b/);
   });
 
-  // 2026-08-07 재가 — Fork 문법의 ref 뱃지. 색조는 --badge-tone 한 채널로만 흐르고, 종류가 고정된 축만
-  // CSS가 소유한다(체크아웃 위치=brass, 태그=plum). 나머지는 커밋 행이 자기 레인 색을 주입한다.
+  // 2026-08-07 재가, 2026-09-01 소프트 그래파이트 재조율 — Fork 문법의 ref 뱃지. 색조는
+  // --badge-tone 한 채널로만 흐르고, 종류가 고정된 축만 CSS가 소유한다(체크아웃 위치=brass,
+  // 태그=plum). 고알파 사각(82%/22%/bold)은 저알파 캡슐(45%/14%/medium)로 낮아졌다 —
+  // 뱃지가 커밋 제목보다 큰 목소리를 내지 않게 하는 감쇠이며, radius-pill 소비는 규칙 옆
+  // 독트린 주석에 기록된 상태 캡슐 축의 예외다.
   it("routes every ref badge color through one tone channel, with location on brass", () => {
     const badge = blockOf(".history-badge");
     expect(badge).toContain("--badge-tone:");
     for (const property of ["border", "background", "border-right"]) {
       expect(blocksOf(".history-badge").concat(blocksOf(".history-badge-mark")).some((body) => body.includes(`${property}:`) && body.includes("var(--badge-tone)")), property).toBe(true);
     }
-    // 알약이 아니라 라운드 사각 + 볼드 sans — Fork가 뱃지를 라벨이 아닌 표식으로 읽히게 하는 축.
-    expect(badge).not.toContain("border-radius: var(--radius-pill)");
-    expect(badge).toContain("border-radius: var(--radius-xs)");
+    expect(badge).toContain("border-radius: var(--radius-pill)");
     expect(badge).toContain("font-family: var(--font-body)");
     expect(badge).toContain("font-size: var(--t-xs)");
-    expect(badge).toContain("font-weight: var(--weight-bold)");
-    expect(badge).toContain("var(--badge-tone) 82%");
-    expect(badge).toContain("var(--badge-tone) 22%");
-    expect(blockOf(".history-badge-mark")).toContain("var(--badge-tone) 65%");
+    expect(badge).toContain("font-weight: var(--weight-medium)");
+    expect(badge).toContain("var(--badge-tone) 45%");
+    expect(badge).toContain("var(--badge-tone) 14%");
+    expect(blockOf(".history-badge-mark")).toContain("var(--badge-tone) 40%");
     expect(blockOf(".history-badge-remote-mark")).toContain("var(--badge-tone)");
 
     for (const selector of [".history-badge--head", ".history-badge.is-current"]) {


### PR DESCRIPTION
## Summary
- 2026-09-01 실측 제안(저장소 패널 재설계안, A안 소프트 그래파이트) 재가에 따른 P1+P3 인도입니다. 격리 콘솔 실측에서 주 동사 4종(가져오기·Pull·Push·Stash)의 rest가 배경·테두리 완전 투명으로 확인된 "어포던스 기근"을 전역 채널로 해소합니다.
- **P1 — 전역 rest 채널**: Quiet Controls recipe에 `--control-rest` / `--control-rest-hover` / `--control-field`를 신설(4테마 극성 재조율, 라이트 field는 종이보다 밝은 실색). 저장소의 동사·보조 컨트롤이 rest부터 워시+헤어라인 2-cue로 서고, 입력 상자는 ink-abyss 우물 대신 표면 위로 떠오릅니다.
- **P3 — 워크벤치 문법**: 행 hover·선택이 좌우 4px 인셋의 라운드 필(선택 = brass 10% 위치 틴트, 스파인 퇴역)로 바뀌고, M/A/D/U 상태 글자는 currentColor 틴트 칩, ref 뱃지는 저알파 캡슐, 메타 라벨은 mono-uppercase에서 본문 서체로, 커밋 행은 그래프 거터와 동기로 ROW_HEIGHT 30이 됩니다.
- 계약 테스트 동반 개정: instrument 계약이 새 컨트롤 채널의 테마별 재조율을 고정하고, 저장소 design-grammar가 라운드 인셋 행·resting body·칩 문법을 고정합니다.
- 잉크 스케일 전역 리프트(P2)는 재가된 도입 경로대로 별도 4테마 값 표 제안으로 후속합니다. 액센트(brass 유지 vs 인디고)는 미확정 결정 포인트라 본 PR은 전부 `--brass` 토큰 소비로 액센트-중립입니다.

## Test Plan
- [x] `@fleet-plugins/repository` vitest 41파일 445테스트 green + typecheck clean
- [x] `fleet-console` instrument-design-contract 98테스트 green
- [x] `node scripts/compile-changelog-fragments.mjs --check` OK
- [x] 워크트리 빌드로 격리 콘솔 기동, 시드 저장소(브랜치 6·워크트리·태그·스태시·변경 3파일)로 Instrument·Carbon·Maritime·Whites 4테마 실측 스크린샷 확인 — 동사 rest 몸·라운드 선택 필·상태 칩·캡슐 뱃지·입력 리프트, 그래프 레인 연속성(ROW_HEIGHT 30) 정상