### PR TITLE
refactor(fleet-console): retire the sidebar card header and inline operation filter

### DIFF
--- a/.changelog.d/sidebar-head-filter-retire.md
+++ b/.changelog.d/sidebar-head-filter-retire.md
@@ -1,0 +1,8 @@
+---
+branch: sidebar-head-filter-retire
+---
+
+### fleet-console
+#### Removed
+- Retire the sidebar card header and its inline operation filter: the Theater label, the Theater count, and the header new-Theater button are gone, and the list starts at the group/status switch. New Theater stays available from the row at the bottom of the list and from the command band.
+  ko: 사이드바 카드 헤더와 인라인 Operation 필터를 걷습니다. Theater 라벨·개수·헤더의 새 Theater 버튼이 사라지고 목록은 그룹/상태 전환에서 시작합니다. 새 Theater는 목록 맨 아래 행과 커맨드 밴드에서 그대로 열 수 있습니다.

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -174,8 +174,6 @@ export const canvasEn = {
   "sidebar.chip.closeArmed": "Close?",
 
   // ── sidebar 헤더/필터 (전면 해도 개편 P2) ────────────────────────────────
-  "sidebar.filter.placeholder": "Filter operations…",
-  "sidebar.filter.aria": "Filter operations by title",
 
   // ── rail ────────────────────────────────────────────────────────────────
   "pane.caption.expand": "Expand",
@@ -367,8 +365,6 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "sidebar.chip.closeTitle": "Operation 닫기",
   "sidebar.chip.closeArmed": "닫을까요?",
 
-  "sidebar.filter.placeholder": "Operation 필터…",
-  "sidebar.filter.aria": "Operation 제목으로 필터",
 
   "pane.caption.expand": "확대",
   "pane.caption.close": "페인 닫기",

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -362,7 +362,6 @@ export function OperationsSideBar({
   const [activeContextMenu, setActiveContextMenu] = useState<ActiveContextMenu | null>(null);
   const [newMenu, setNewMenu] = useState<NewMenuState | null>(null);
   const [browserOpen, setBrowserOpen] = useState(false);
-  const [operationFilter, setOperationFilter] = useState("");
   // 우클릭 가드는 다음 우클릭에서만 돈다. 마지막 Theater를 잊는 동안 이미 열린 상자는
   // 목록이 비워져도 그대로 남으므로, 그 전환에서 걷는다.
   useEffect(() => {
@@ -385,14 +384,7 @@ export function OperationsSideBar({
     previousCollapsedRef.current = collapsed;
   }, [collapsed]);
 
-  // 인라인 필터는 가리기만 진다 — 이동·점프는 ⌘K 팔레트의 일이다(역할 분리). 제목 부분
-  // 일치·전 Theater 대상이며, 표시 엔트리 구축에만 관여하고 활동 추적·드래그 등 상태 로직은
-  // 계속 전체 목록을 본다. 세션 상태다 — 새 페이지 로드는 필터 없이 시작한다.
-  const normalizedOperationFilter = operationFilter.trim().toLowerCase();
-  const filterVisibleOperations = normalizedOperationFilter === ""
-    ? operations
-    : operations.filter((operation) => operation.title.toLowerCase().includes(normalizedOperationFilter));
-  const activeOperations = filterVisibleOperations.filter((operation) => operation.theaterId === activeTheaterId);
+  const activeOperations = operations.filter((operation) => operation.theaterId === activeTheaterId);
   const activeGroups = groups.filter((group) => group.theaterId === activeTheaterId);
   const minimizedSet = new Set(minimized);
   const collapsedGroupSet = new Set(collapsedGroups);
@@ -513,12 +505,6 @@ export function OperationsSideBar({
       setSideBarCollapsed(false);
       return false;
     }
-    // 인라인 필터가 대상 칩을 숨기고 있으면 필터를 걷는다 — 칩이 마운트되지 않으면
-    // 팔레트에서 온 이름 변경·그룹 배정 액션이 조용히 증발한다(적대 리뷰 확정).
-    if (normalizedOperationFilter !== "" && !operation.title.toLowerCase().includes(normalizedOperationFilter)) {
-      setOperationFilter("");
-      return false;
-    }
     if (collapsedTheaters.includes(operation.theaterId)) {
       setTheaterCollapsed(operation.theaterId, false);
       return false;
@@ -540,7 +526,7 @@ export function OperationsSideBar({
       return false;
     }
     return false;
-  }), [activeTheaterId, collapsed, collapsedGroupSet, collapsedTheaters, idleArrivalIds, normalizedOperationFilter, operationRuntime, operations, statusAxis]);
+  }), [activeTheaterId, collapsed, collapsedGroupSet, collapsedTheaters, idleArrivalIds, operationRuntime, operations, statusAxis]);
 
   useEffect(() => {
     if (armedCloseId === null) return;
@@ -937,38 +923,6 @@ export function OperationsSideBar({
     >
       {!collapsed && theaterError ? <p className="side-bar-theater-error">{theaterError}</p> : null}
 
-      {/* 헤더 행 — 카드가 자기 이름·수량·도구를 갖는 자기 완결 계기 문법(전면 해도 개편 P2).
-          War Room의 TriageSideBar에는 두지 않는다: 그쪽은 Theater 목록이 아니라 STATUS 큐다. */}
-      {!collapsed ? (
-        <div className="side-bar-head">
-          <span className="side-bar-head-label">Theaters</span>
-          <span className="side-bar-head-count">{theaters.length}</span>
-          <button
-            type="button"
-            className="side-bar-head-tool"
-            onClick={openTheaterBrowser}
-            disabled={addingTheater}
-            aria-label={t("sidebar.theater.newTheater")}
-            title={t("sidebar.theater.newTheater")}
-          >
-            <PlusIcon />
-          </button>
-        </div>
-      ) : null}
-      {!collapsed && theaters.length > 0 ? (
-        <div className="side-bar-filter">
-          <input
-            type="search"
-            className="side-bar-filter-input"
-            value={operationFilter}
-            placeholder={t("sidebar.filter.placeholder")}
-            aria-label={t("sidebar.filter.aria")}
-            onChange={(event) => setOperationFilter(event.currentTarget.value)}
-            onKeyDown={(event) => { if (event.key === "Escape" && operationFilter !== "") { event.stopPropagation(); setOperationFilter(""); } }}
-          />
-        </div>
-      ) : null}
-
       {/* 축은 목록 전체를 다시 쓰는 하나짜리 세션 스위치다 — Theater 행에 두면 배치가 국소라고
           말하면서 효과는 전역이라 읽는 사람이 스코프를 오해한다. 목록 위 고정 스트립에
           한 번만 서고, 눌림이 아니라 낱말로 현재 축을 말한다. Theater가 없으면 정리할
@@ -1021,7 +975,7 @@ export function OperationsSideBar({
             const theaterCanvas = getTheaterCanvasSnapshot(theater.id);
             const inactiveEntries = buildTheaterEntries({
               theaterId: theater.id,
-              operations: filterVisibleOperations,
+              operations,
               operationOrder: theaterCanvas.operationOrder,
               minimizedSet: new Set(theaterCanvas.minimized),
               // 비활성 Theater의 칩은 캔버스에 없으므로 활성(brass/aria-current) 표시 대상이 아니다(Codex P3).

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5461,106 +5461,18 @@ body[data-side-bar-animating="true"] .canvas-operation {
   line-height: 1.45;
 }
 
-/* ── 카드 헤더 + 인라인 필터 (전면 해도 개편 P2) ───────────────────────────
-   부유 카드가 자기 이름·수량·도구를 갖는 자기 완결 계기 문법. 필터는 가리기 전용이고
-   이동은 ⌘K가 진다 — 두 필터가 같은 열에서 역할을 다투지 않게 placeholder가 구분한다. */
-.side-bar-head {
-  display: flex;
-  align-items: center;
-  flex: none;
-  gap: 6px;
-  padding: var(--space-2) var(--space-3) 2px;
-}
-
-.side-bar-head-label {
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--t-2xs);
-  font-weight: var(--weight-bold);
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.side-bar-head-count {
-  /* 수량은 정적 메타데이터다 — brass는 위치/포커스 채널이라 휴지 숫자에 쓸 수 없다. */
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--t-2xs);
-  font-weight: var(--weight-bold);
-  font-variant-numeric: tabular-nums;
-}
-
-.side-bar-head-tool {
-  display: grid;
-  place-items: center;
-  flex: none;
-  width: 20px;
-  height: 20px;
-  margin-left: auto;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: var(--radius-xs);
-  background: none;
-  color: var(--text-tertiary);
-  cursor: pointer;
-}
-
-.side-bar-head-tool svg {
-  width: 12px;
-  height: 12px;
-  display: block;
-}
-
-.side-bar-head-tool:hover:not(:disabled),
-.side-bar-head-tool:focus-visible {
-  border-color: var(--control-hover-rim);
-  background: var(--control-hover-fill);
-  color: var(--text-primary);
-  outline: none;
-}
-
-.side-bar-head-tool:disabled {
-  opacity: var(--control-disabled-opacity);
-  cursor: not-allowed;
-}
-
-.side-bar-filter {
-  flex: none;
-  padding: 2px var(--space-2) var(--space-1);
-}
-
-.side-bar-filter-input {
-  width: 100%;
-  height: 24px;
-  padding: 0 var(--space-2);
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xs);
-  background: color-mix(in oklch, var(--ink-abyss) 55%, transparent);
-  color: var(--text-primary);
-  font-family: var(--font-mono);
-  font-size: var(--t-xs);
-}
-
-.side-bar-filter-input::placeholder {
-  color: var(--text-tertiary);
-}
-
-.side-bar-filter-input:focus-visible {
-  border-color: var(--control-open-rim);
-  outline: none;
-}
-
-
 /* 축 스트립은 스크롤 목록 바깥에 고정된 하나짜리 뷰 스위치다 — 커맨드 밴드의
    .command-band-mode-switch와 같은 세그먼트 문법을 사이드바 폭에 맞춰 좁힌 것이고,
-   새 어휘가 아니다. 눌림은 Quiet Controls C′의 워시+다텀이 말하고 상자는 없다. */
+   새 어휘가 아니다. 눌림은 Quiet Controls C′의 워시+다텀이 말하고 상자는 없다.
+   카드의 첫 요소이므로 위 여백은 이 스트립이 진다 — 좌우보다 한 단 넓게 잡아야
+   세그먼트 워시가 카드 상단 라운드에 붙지 않는다. */
 .operations-side-bar-axis {
   position: relative;
   display: flex;
   flex: none;
   align-items: center;
   gap: var(--space-1);
-  margin: var(--space-1) var(--space-1) 2px;
+  margin: var(--space-2) var(--space-1) 2px;
 }
 
 .operations-side-bar-axis-seg {


### PR DESCRIPTION
## Summary
- 사이드바 부유 카드의 헤더 행(`THEATERS` 라벨 · Theater 개수 · `+` 새 Theater 버튼)을 제거했습니다. 새 Theater는 목록 맨 아래 유령 행과 커맨드 밴드의 "Add Theater…"로 그대로 열립니다.
- 인라인 Operation 필터 입력을 제거하고, 그에 딸린 `operationFilter` 상태 · 파생 표시 목록 · 팔레트 액션의 필터 해제 분기 · 전용 CSS · i18n 문자열까지 함께 걷었습니다. Operation 검색·이동은 계속 ⌘K 팔레트가 집니다.
- 헤더가 물러나면서 그룹/상태 축 스트립이 카드의 첫 요소가 되므로, 카드 상단 여백을 축 스트립이 지도록 `--space-1` → `--space-2`로 올려 세그먼트 워시가 카드 상단 라운드에 붙지 않게 했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 196 files / 2360 tests passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — pass
- [x] `pnpm --filter @dotobokuri/fleet-console build` — pass
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty` — OK (6 entries)
- [x] 격리 Console 헤드리스 실측(Theater 1개): `.side-bar-head` / `.side-bar-filter` 부재, 카드 상단 → 축 스트립 간격 9px, 스크린샷으로 상단 마감 확인
- [x] Theater 0개 상태 실측: 축 스트립 없음, 카드 상단 → "새 Theater" 행 간격 7px