### PR TITLE
feat(fleet-console): replace the resident mode tray with segment hover dials

### DIFF
--- a/.changelog.d/helm-dial.md
+++ b/.changelog.d/helm-dial.md
@@ -1,0 +1,8 @@
+---
+branch: helm-dial
+---
+
+### fleet-console
+#### Changed
+- Canvas mode tools now open as a hover dial under each mode word instead of sitting beside the switch, so the centered mode switch no longer shifts when modes change, picking a tool from another mode enters that mode in one click, and any tool state left off its default stays visible as a compact badge next to the switch.
+  ko: 캔버스 모드 도구가 스위치 옆 상주 대신 각 모드 낱말 아래 hover 다이얼로 열립니다. 중앙의 모드 스위치가 모드 전환에도 더 이상 밀리지 않고, 다른 모드의 도구를 고르면 한 번의 클릭으로 그 모드에 진입하며, 기본값을 벗어난 도구 상태는 스위치 곁 축약 배지로 계속 보입니다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type FocusEvent, type ReactElement } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type FocusEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactElement } from "react";
 import { Link } from "react-router-dom";
 
 import { SegmentedThumb } from "@fleet-console/sdk/react/browser";
@@ -50,11 +50,39 @@ const TACTICAL_LAYOUTS: readonly {
   { id: "rows", titleKey: "chrome.commandBand.tacticalRows", Icon: FormationRowsIcon },
 ];
 
+const MODE_TOOLS_LABEL_KEY: Readonly<Record<CanvasMode, CoreMessageKey>> = {
+  cruise: "chrome.commandBand.cruiseTools",
+  tactical: "chrome.commandBand.tacticalTools",
+  warRoom: "chrome.commandBand.warRoomTools",
+};
+
+// Helm Dial은 hover가 실재하는 입력에서만 문이 된다 — 터치·coarse 포인터는 상주 트레이를
+// 유지한다(등가 경로 없는 접기 금지). React에서 갈라 렌더하는 이유: 트레이와 다이얼을 CSS로만
+// 갈라 이중 마운트하면 [data-war-room-tool] 투어 앵커가 문서에 두 벌 생겨, 화면 안내가
+// 보이지 않는 사본을 짚는다.
+const FINE_POINTER_QUERY = "(hover: hover) and (pointer: fine)";
+
+function useFinePointer(): boolean {
+  const [finePointer, setFinePointer] = useState(
+    () => typeof window !== "undefined" && typeof window.matchMedia === "function" && window.matchMedia(FINE_POINTER_QUERY).matches,
+  );
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia(FINE_POINTER_QUERY);
+    const sync = () => setFinePointer(query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+  return finePointer;
+}
+
 export function CommandBand({ operationsViewVisible: requestedOperationsViewVisible }: CommandBandProps) {
   const t = useT();
   const state = useConsoleState();
   const updateProgress = useUpdateProgress();
   const viewMode = useViewMode();
+  const finePointer = useFinePointer();
   const operationsViewVisible = requestedOperationsViewVisible && viewMode.effective !== "mobile";
   // 패널 접기 토글은 밴드에서 퇴역했다(Periscope 문법) — 접기는 각 패널의 자기 컨트롤이,
   // 접힌 뒤의 복귀는 화면 엣지 독(brass 필라멘트 + 호버 픽)이 진다. ⌘B·⌘⌥B는 의미 불변이며
@@ -78,6 +106,106 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       return;
     }
     if (formationView) clearFormationView();
+  };
+  // Helm Dial — 캡슐 도구 클릭은 "그 모드로 진입 + 도구 적용"이 한 제스처다. 도구가 제 모드의
+  // 낱말 아래에서만 나오므로 어느 모드의 손잡이인지가 소속으로 명시되고, 무경고 모드 이탈의
+  // 전제였던 "소속 없는 도구 줄"(2026-08 격자 클릭 사고)은 존재하지 않는다. 모드 전이의
+  // 소유권은 여전히 이 클러스터 하나다.
+  const enterCruiseThen = (action: () => void) => {
+    if (canvasMode !== "cruise") selectCanvasMode("cruise");
+    action();
+  };
+  const enterWarRoomThen = (action: () => void) => {
+    if (canvasMode !== "warRoom") enterTriage(focusedTriageOperationId(document.activeElement));
+    action();
+  };
+  // 같은 레이아웃 재클릭은 무시한다 — selectFormationLayout은 동일 레이아웃에서 모드를 꺼버리는데,
+  // 모드 이탈 권한은 Cruise 세그먼트만 갖는다. War Room에서 내려올 때 formation이 이미 그
+  // 레이아웃으로 서 있으면 triage 해제만으로 목적지에 닿았으므로 역시 부르지 않는다(토글-오프 함정).
+  const selectTacticalLayout = (layout: FormationLayout) => {
+    if (triageActive) setTriageActive(false);
+    if (!formationView || formationLayout !== layout) selectFormationLayout(layout);
+  };
+  // Esc는 캡슐에서 낱말로 되돌아오는 계단이다 — 포커스가 세그먼트로 돌아가면 focus-within이
+  // 유지되어 캡슐은 열린 채 남고, Tab 이탈이 문을 닫는다.
+  const handleDialEscape = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Escape") return;
+    const seg = event.currentTarget.querySelector<HTMLButtonElement>(".command-band-mode-seg");
+    const active = document.activeElement;
+    if (seg === null || !(active instanceof Node) || !event.currentTarget.contains(active) || active === seg) return;
+    event.stopPropagation();
+    seg.focus();
+  };
+  // 트레이(coarse)와 다이얼(fine)은 같은 도구 정의를 쓴다 — 두 벌이 되는 순간 드리프트가
+  // 시작된다. data-war-room-tool은 화면 안내가 짚는 자리이므로 활성 모드에서만 부착한다:
+  // 캡슐이 세 모드 모두 상시 마운트되어도 "War Room에서 항상 + War Room에서만"이라는 투어
+  // 활성화 계약이 그대로 성립한다.
+  //
+  // 도구도 세그먼트처럼 mousedown을 preventDefault한다 — 클릭이 도구에 포커스를 남기면
+  // focus-within이 캡슐을 계속 열어 두고, 열린 채 남은 캡슐이 이웃 캡슐의 클릭 지점을 덮는다
+  // (실입력 검증에서 SK 클릭이 tactical 도구에 착지한 사고). 키보드 포커스(Tab)는 그대로다.
+  const suppressToolFocus = (event: { preventDefault(): void }) => event.preventDefault();
+  const modeTools = (mode: CanvasMode): ReactElement => {
+    if (mode === "cruise") {
+      return (<>
+        <button type="button" className="command-band-mode-tool" onMouseDown={suppressToolFocus} onClick={() => enterCruiseThen(() => animateViewportTo({ x: 0, y: 0, zoom: 1 }))} disabled={state.activeTheaterId === null} aria-label={t("chrome.commandBand.resetCanvasView")} title={t("chrome.commandBand.resetCanvasView")}><ResetViewIcon /></button>
+        <button type="button" className="command-band-mode-tool" onMouseDown={suppressToolFocus} onClick={() => enterCruiseThen(fitAllOperations)} disabled={state.activeTheaterId === null || !state.operationsHydrated} aria-label={t("chrome.commandBand.fitAllPanels")} title={t("chrome.commandBand.fitAllPanels")}><FitAllIcon /></button>
+        <button
+          type="button"
+          className="command-band-mode-tool"
+          data-cruise-tool="station-keeping"
+          aria-pressed={stationKeeping}
+          disabled={state.activeTheaterId === null || !state.operationsHydrated}
+          aria-label={t("chrome.commandBand.stationKeeping")}
+          title={t("chrome.commandBand.stationKeeping")}
+          onMouseDown={suppressToolFocus}
+          onClick={() => enterCruiseThen(() => setStationKeeping(!stationKeeping))}
+        ><StationKeepingIcon /></button>
+      </>);
+    }
+    if (mode === "tactical") {
+      return (<>
+        {TACTICAL_LAYOUTS.map((layout) => (
+          <button
+            key={layout.id}
+            type="button"
+            className="command-band-mode-tool"
+            onMouseDown={suppressToolFocus}
+            onClick={() => selectTacticalLayout(layout.id)}
+            disabled={state.activeTheaterId === null}
+            // 눌림은 "지금 활성"만 말한다 — Cruise에서 열어본 캡슐이 기억된 레이아웃을
+            // 눌림으로 칠하면 아직 서 있지 않은 formation을 서 있다고 말하게 된다.
+            aria-pressed={canvasMode === "tactical" && formationLayout === layout.id}
+            aria-label={t(layout.titleKey)}
+            title={t(layout.titleKey)}
+          ><layout.Icon /></button>
+        ))}
+      </>);
+    }
+    return (<>
+      <button
+        type="button"
+        className="command-band-mode-tool"
+        {...(canvasMode === "warRoom" ? { "data-war-room-tool": "spotlight" } : {})}
+        aria-pressed={triageSpotlightEnabled}
+        disabled={state.theaters.length === 0}
+        aria-label={t("canvas.triage.spotlightTitle")}
+        title={t("canvas.triage.spotlightTitle")}
+        onMouseDown={suppressToolFocus}
+        onClick={() => enterWarRoomThen(() => setTriageSpotlightEnabled(!triageSpotlightEnabled))}
+      ><SpotlightIcon /></button>
+      <button
+        type="button"
+        className="command-band-mode-tool is-valued"
+        {...(canvasMode === "warRoom" ? { "data-war-room-tool": "density" } : {})}
+        aria-pressed={triageDeckZoomLive !== 1.0}
+        disabled={state.theaters.length === 0}
+        aria-label={t("canvas.triage.densityChipTitle")}
+        title={t("canvas.triage.densityChipTitle")}
+        onMouseDown={suppressToolFocus}
+        onClick={() => enterWarRoomThen(cycleTriageDeckZoomPreset)}
+      ><DensityIcon /><span>{triageDeckZoomLive.toFixed(1)}×</span></button>
+    </>);
   };
   const environmentTriggerRef = useRef<HTMLButtonElement>(null);
   const environmentPopoverRef = useRef<HTMLDivElement>(null);
@@ -183,8 +311,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
 
   // 좌·우 클러스터의 실측 콘텐츠 폭이 중앙 여백 하한의 원료이고, 맵 컨트롤의 자연 폭이 중앙
   // 소요 폭이다. 사이드바 폭이 아니라 클러스터 폭이 하한을 정하므로 viewport 미디어쿼리로는
-  // 판정할 수 없다. 자식 끝을 재는 이유: 칩 폭 변화(연결 상태 라벨·폰트 로드)와 모드 트레이의
-  // 모드별 폭 변동이 모두 하한·소요 폭을 움직인다. offsetParent 좌표계는 밴드와 동일하다.
+  // 판정할 수 없다. 자식 끝을 재는 이유: 칩 폭 변화(연결 상태 라벨·폰트 로드)와 coarse 포인터
+  // 상주 트레이의 모드별 폭 변동이 모두 하한·소요 폭을 움직인다. fine 포인터에서는 다이얼·에코가
+  // 절대 배치라 소요 폭이 스위치 상수로 고정된다 — 모드 전환이 더는 중앙을 밀지 않는다.
+  // offsetParent 좌표계는 밴드와 동일하다.
   useLayoutEffect(() => {
     const band = commandBandRef.current;
     if (!band || typeof ResizeObserver === "undefined") return;
@@ -195,10 +325,13 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       setLeftContentEnd(bandLeft === null ? 0 : Math.max(0, ...Array.from(bandLeft.children, (child) => (child instanceof HTMLElement ? child.offsetLeft + child.offsetWidth : 0))));
       const bandRight = bandRightRef.current;
       setRightContentWidth(bandRight === null ? 0 : Math.max(0, ...Array.from(bandRight.children, (child) => (child instanceof HTMLElement ? width - child.offsetLeft : 0))));
-      // scrollWidth를 읽는다 — 중앙 트랙이 소요 폭보다 좁게 눌린 프레임에서도 자연 폭을
-      // 돌려주므로, 눌린 값이 판정에 되먹임되어 접힘/복귀가 진동하는 일이 없다.
+      // 플로우 자식의 범위로 잰다 — 자식이 flex:none이라 중앙 트랙이 좁게 눌린 프레임에서도
+      // 자연 폭을 돌려주고(눌린 값이 판정에 되먹임되어 접힘/복귀가 진동하지 않음), 다이얼·에코
+      // 같은 절대 배치 자손의 오버플로는 배제한다. scrollWidth는 그 오버플로까지 세어(스위치의
+      // scrollable overflow가 전파됨) 에코 배지 등장이 is-center-flow 판정을 흔든다 — 실측으로
+      // 213→247 부풂을 확인하고 물렸다.
       const mapControls = mapControlsRef.current;
-      setCenterContentWidth(mapControls === null ? 0 : mapControls.scrollWidth);
+      setCenterContentWidth(mapControls === null ? 0 : Math.max(0, ...Array.from(mapControls.children, (child) => (child instanceof HTMLElement ? child.offsetLeft - mapControls.offsetLeft + child.offsetWidth : 0))));
     };
     measure();
     const observer = new ResizeObserver(measure);
@@ -212,7 +345,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
     const bandRight = bandRightRef.current;
     if (bandRight) for (const child of bandRight.children) observer.observe(child);
     return () => observer.disconnect();
-  }, [operationsViewVisible, state.channel, state.connection, canvasMode, fullscreen.isFullscreen]);
+  }, [operationsViewVisible, state.channel, state.connection, canvasMode, fullscreen.isFullscreen, finePointer]);
 
   useEffect(() => {
     if (state.channel === "local") return;
@@ -316,80 +449,50 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       <div className="command-band-center">
         <div ref={mapControlsRef} className="command-band-map-controls">
         {operationsViewVisible ? <div className="command-band-mode-switch" role="group" aria-label={t("chrome.commandBand.canvasMode")}>
-          <SegmentedThumb />
+          <SegmentedThumb activeSelector=".command-band-mode-cell.is-active" />
           {CANVAS_MODES.map((mode) => (
-            <button
+            <div
               key={mode.id}
-              type="button"
-              className="command-band-mode-seg"
+              className={`command-band-mode-cell${canvasMode === mode.id ? " is-active" : ""}`}
               data-canvas-mode={mode.id}
-              disabled={mode.id === "tactical" ? state.activeTheaterId === null : state.theaters.length === 0}
-              aria-pressed={canvasMode === mode.id}
-              aria-label={t(mode.titleKey)}
-              title={t(mode.titleKey)}
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() => selectCanvasMode(mode.id)}
+              onKeyDown={handleDialEscape}
             >
-              {mode.label}
-            </button>
+              <button
+                type="button"
+                className="command-band-mode-seg"
+                data-canvas-mode={mode.id}
+                disabled={mode.id === "tactical" ? state.activeTheaterId === null : state.theaters.length === 0}
+                aria-pressed={canvasMode === mode.id}
+                aria-label={t(mode.titleKey)}
+                title={t(mode.titleKey)}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => selectCanvasMode(mode.id)}
+              >
+                {mode.label}
+              </button>
+              {/* Helm Dial — 캡슐은 닫혀도 DOM에 존속한다: display:none이면 투어 앵커 판정과
+                  focus-within 키보드 개방이 함께 죽는다. 절대 배치라 중앙 소요 폭(scrollWidth)에는
+                  들지 않는다(포지셔닝된 자손의 오버플로는 조상 측정으로 전파되지 않음을 실측 확인). */}
+              {finePointer ? <div className="command-band-mode-dial" role="group" aria-label={t(MODE_TOOLS_LABEL_KEY[mode.id])}>
+                <span className="command-band-mode-dial-label" aria-hidden="true">{mode.label}</span>
+                {modeTools(mode.id)}
+              </div> : null}
+            </div>
           ))}
+          {/* 이탈-상태 에코 — 기본값을 벗어난 도구 상태만 축약 배지로 남는다(평시 침묵). 다이얼이
+              hover 뒤로 접은 상태 가시성을 여기서 되갚는다. coarse 포인터는 트레이가 이미 말한다.
+              스위치 직우는 검색의 안정 앵커 자리(#983)라, 랙은 스위치 좌측에 절대 배치로 걸린다. */}
+          {finePointer && (stationKeeping || triageDeckZoomLive !== 1.0) ? <div className="command-band-mode-echo-rack">
+            {stationKeeping ? <span className="command-band-mode-echo" role="img" aria-label={t("chrome.commandBand.stationKeeping")} title={t("chrome.commandBand.stationKeeping")}><StationKeepingIcon /></span> : null}
+            {triageDeckZoomLive !== 1.0 ? <span className="command-band-mode-echo" role="img" aria-label={t("canvas.triage.densityChipTitle")} title={t("canvas.triage.densityChipTitle")}>{triageDeckZoomLive.toFixed(1)}×</span> : null}
+          </div> : null}
         </div> : null}
         <button type="button" className="command-band-button command-band-search" onClick={toggleOperationSearch} aria-label={t("chrome.commandBand.searchSessions")} title={t("chrome.commandBand.searchSessionsTitle")}>
           <SearchIcon />
         </button>
-        {operationsViewVisible && canvasMode === "cruise" ? <div className="command-band-mode-tray" role="group" aria-label={t("chrome.commandBand.cruiseTools")}>
+        {operationsViewVisible && !finePointer ? <div className="command-band-mode-tray" role="group" aria-label={t(MODE_TOOLS_LABEL_KEY[canvasMode])}>
           <span className="command-band-mode-tray-divider" aria-hidden="true" />
-          <button type="button" className="command-band-mode-tool" onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })} disabled={state.activeTheaterId === null} aria-label={t("chrome.commandBand.resetCanvasView")} title={t("chrome.commandBand.resetCanvasView")}><ResetViewIcon /></button>
-          <button type="button" className="command-band-mode-tool" onClick={fitAllOperations} disabled={state.activeTheaterId === null || !state.operationsHydrated} aria-label={t("chrome.commandBand.fitAllPanels")} title={t("chrome.commandBand.fitAllPanels")}><FitAllIcon /></button>
-          <button
-            type="button"
-            className="command-band-mode-tool"
-            data-cruise-tool="station-keeping"
-            aria-pressed={stationKeeping}
-            disabled={state.activeTheaterId === null || !state.operationsHydrated}
-            aria-label={t("chrome.commandBand.stationKeeping")}
-            title={t("chrome.commandBand.stationKeeping")}
-            onClick={() => setStationKeeping(!stationKeeping)}
-          ><StationKeepingIcon /></button>
-        </div> : null}
-        {operationsViewVisible && canvasMode === "warRoom" ? <div className="command-band-mode-tray" role="group" aria-label={t("chrome.commandBand.warRoomTools")}>
-          <span className="command-band-mode-tray-divider" aria-hidden="true" />
-          {/* data-war-room-tool은 화면 안내가 짚는 자리다 — 라벨이나 트레이 순서가 바뀌어도
-              앵커가 조용히 사라지지 않도록 의미 속성으로 표시한다. */}
-          <button
-            type="button"
-            className="command-band-mode-tool"
-            data-war-room-tool="spotlight"
-            aria-pressed={triageSpotlightEnabled}
-            aria-label={t("canvas.triage.spotlightTitle")}
-            title={t("canvas.triage.spotlightTitle")}
-            onClick={() => setTriageSpotlightEnabled(!triageSpotlightEnabled)}
-          ><SpotlightIcon /></button>
-          <button
-            type="button"
-            className="command-band-mode-tool is-valued"
-            data-war-room-tool="density"
-            aria-pressed={triageDeckZoomLive !== 1.0}
-            aria-label={t("canvas.triage.densityChipTitle")}
-            title={t("canvas.triage.densityChipTitle")}
-            onClick={cycleTriageDeckZoomPreset}
-          ><DensityIcon /><span>{triageDeckZoomLive.toFixed(1)}×</span></button>
-        </div> : null}
-        {operationsViewVisible && canvasMode === "tactical" ? <div className="command-band-mode-tray" role="group" aria-label={t("chrome.commandBand.tacticalTools")}>
-          <span className="command-band-mode-tray-divider" aria-hidden="true" />
-          {TACTICAL_LAYOUTS.map((layout) => (
-            <button
-              key={layout.id}
-              type="button"
-              className="command-band-mode-tool"
-              // 이미 켜진 레이아웃을 다시 누르면 selectFormationLayout이 모드를 꺼버린다 —
-              // 모드 이탈은 Cruise 세그먼트만 소유하므로 같은 레이아웃 클릭은 무시한다.
-              onClick={() => { if (formationLayout !== layout.id) selectFormationLayout(layout.id); }}
-              aria-pressed={formationLayout === layout.id}
-              aria-label={t(layout.titleKey)}
-              title={t(layout.titleKey)}
-            ><layout.Icon /></button>
-          ))}
+          {modeTools(canvasMode)}
         </div> : null}
         </div>
       </div>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -115,9 +115,11 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
     if (formationView) clearFormationView();
   };
   // 클릭은 포커스를 남기지 않는 문법(preventDefault) 탓에, 키보드로 들어간 캡슐 포커스가 다른
-  // 셀 클릭 뒤에도 살아남아 그 캡슐을 focus-within으로 계속 열어 둔다 — 스위치 클릭이 소비되는
-  // 순간 다이얼 안의 포커스만 내보낸다. 다이얼 밖 포커스(예: War Room 무대 지명의 근거가 되는
-  // 패널 포커스)는 건드리지 않는다.
+  // 셀 클릭 뒤에도 살아남아 그 캡슐을 focus-within으로 계속 열어 둔다 — 포인터 mousedown이
+  // 소비되는 순간 다이얼 안의 포커스만 내보낸다. mousedown 경로에만 거는 이유: Enter/Space
+  // 활성화는 click만 만들므로, 키보드 사용자가 방금 조작한 도구의 포커스(가시적 위치)는
+  // 보존된다. 다이얼 밖 포커스(예: War Room 무대 지명의 근거가 되는 패널 포커스)도 건드리지
+  // 않는다.
   const releaseDialFocus = () => {
     const active = document.activeElement;
     if (active instanceof HTMLElement && active.closest(".command-band-mode-dial") !== null) active.blur();
@@ -127,12 +129,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   // 전제였던 "소속 없는 도구 줄"(2026-08 격자 클릭 사고)은 존재하지 않는다. 모드 전이의
   // 소유권은 여전히 이 클러스터 하나다.
   const enterCruiseThen = (action: () => void) => {
-    releaseDialFocus();
     if (canvasMode !== "cruise") selectCanvasMode("cruise");
     action();
   };
   const enterWarRoomThen = (action: () => void) => {
-    releaseDialFocus();
     if (canvasMode !== "warRoom") enterTriage(focusedTriageOperationId(document.activeElement));
     action();
   };
@@ -140,7 +140,6 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   // 모드 이탈 권한은 Cruise 세그먼트만 갖는다. War Room에서 내려올 때 formation이 이미 그
   // 레이아웃으로 서 있으면 triage 해제만으로 목적지에 닿았으므로 역시 부르지 않는다(토글-오프 함정).
   const selectTacticalLayout = (layout: FormationLayout) => {
-    releaseDialFocus();
     if (triageActive) setTriageActive(false);
     if (!formationView || formationLayout !== layout) selectFormationLayout(layout);
   };
@@ -162,7 +161,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   // 도구도 세그먼트처럼 mousedown을 preventDefault한다 — 클릭이 도구에 포커스를 남기면
   // focus-within이 캡슐을 계속 열어 두고, 열린 채 남은 캡슐이 이웃 캡슐의 클릭 지점을 덮는다
   // (실입력 검증에서 SK 클릭이 tactical 도구에 착지한 사고). 키보드 포커스(Tab)는 그대로다.
-  const suppressToolFocus = (event: { preventDefault(): void }) => event.preventDefault();
+  const suppressToolFocus = (event: { preventDefault(): void }) => {
+    event.preventDefault();
+    releaseDialFocus();
+  };
   const modeTools = (mode: CanvasMode): ReactElement => {
     if (mode === "cruise") {
       return (<>
@@ -357,7 +359,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       // 동안 스위치가 움직이지 않는다는 계약은 그대로다.
       const mapControls = mapControlsRef.current;
       const echoRack = echoRackRef.current;
-      const echoReserve = echoRack === null ? 0 : ECHO_RACK_GAP_PX + echoRack.offsetWidth;
+      // fit 판정은 소요 폭을 좌우 대칭으로 나눠 앉히므로, 스위치 오른쪽으로만 뻗는 랙의
+      // 한쪽 돌출을 가리려면 예약을 두 배로 넣어야 한다 — 한 배만 넣으면 경계 폭에서 랙
+      // 절반이 여전히 우측 굴터를 침범한다.
+      const echoReserve = echoRack === null ? 0 : 2 * (ECHO_RACK_GAP_PX + echoRack.offsetWidth);
       setCenterContentWidth(mapControls === null ? 0 : echoReserve + Math.max(0, ...Array.from(mapControls.children, (child) => (child instanceof HTMLElement ? child.offsetLeft - mapControls.offsetLeft + child.offsetWidth : 0))));
     };
     measure();
@@ -496,8 +501,8 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
                 aria-pressed={canvasMode === mode.id}
                 aria-label={t(mode.titleKey)}
                 title={t(mode.titleKey)}
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => { releaseDialFocus(); selectCanvasMode(mode.id); }}
+                onMouseDown={(event) => { event.preventDefault(); releaseDialFocus(); }}
+                onClick={() => selectCanvasMode(mode.id)}
               >
                 {mode.label}
               </button>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -62,6 +62,10 @@ const MODE_TOOLS_LABEL_KEY: Readonly<Record<CanvasMode, CoreMessageKey>> = {
 // 보이지 않는 사본을 짚는다.
 const FINE_POINTER_QUERY = "(hover: hover) and (pointer: fine)";
 
+// layout.css .command-band-mode-echo-rack의 right: calc(100% + 10px)와 같은 값 — 에코 랙의
+// fit 예약 폭(간격+랙 폭) 계산에 쓴다. CSS와 함께 움직여야 한다.
+const ECHO_RACK_GAP_PX = 10;
+
 function useFinePointer(): boolean {
   const [finePointer, setFinePointer] = useState(
     () => typeof window !== "undefined" && typeof window.matchMedia === "function" && window.matchMedia(FINE_POINTER_QUERY).matches,
@@ -93,6 +97,9 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const triageSpotlightEnabled = useTriageSpotlightEnabled();
   const stationKeeping = useStationKeeping();
   const triageDeckZoomLive = useTriageDeckZoomLive();
+  // 라이브 줌 수치가 아니라 "이탈 여부"만 measure effect를 다시 돌린다 — 핀치 중 매 프레임
+  // 관찰자를 재구성하지 않기 위해서다. 배지 텍스트 폭 변화는 tabular-nums로 상수다.
+  const densityEchoVisible = triageDeckZoomLive !== 1.0;
   const canvasMode: CanvasMode = triageActive ? "warRoom" : formationView ? "tactical" : "cruise";
   const selectCanvasMode = (mode: CanvasMode) => {
     if (mode === canvasMode) return;
@@ -211,6 +218,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const environmentPopoverRef = useRef<HTMLDivElement>(null);
   const commandBandRef = useRef<HTMLElement>(null);
   const mapControlsRef = useRef<HTMLDivElement>(null);
+  const echoRackRef = useRef<HTMLDivElement>(null);
   const bandLeftRef = useRef<HTMLDivElement>(null);
   const bandRightRef = useRef<HTMLDivElement>(null);
   const edgeRevealRef = useRef<HTMLButtonElement>(null);
@@ -326,12 +334,20 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       const bandRight = bandRightRef.current;
       setRightContentWidth(bandRight === null ? 0 : Math.max(0, ...Array.from(bandRight.children, (child) => (child instanceof HTMLElement ? width - child.offsetLeft : 0))));
       // 플로우 자식의 범위로 잰다 — 자식이 flex:none이라 중앙 트랙이 좁게 눌린 프레임에서도
-      // 자연 폭을 돌려주고(눌린 값이 판정에 되먹임되어 접힘/복귀가 진동하지 않음), 다이얼·에코
+      // 자연 폭을 돌려주고(눌린 값이 판정에 되먹임되어 접힘/복귀가 진동하지 않음), 다이얼
       // 같은 절대 배치 자손의 오버플로는 배제한다. scrollWidth는 그 오버플로까지 세어(스위치의
-      // scrollable overflow가 전파됨) 에코 배지 등장이 is-center-flow 판정을 흔든다 — 실측으로
+      // scrollable overflow가 전파됨) 에코 배지 등장이 스위치를 다시 밀게 한다 — 실측으로
       // 213→247 부풂을 확인하고 물렸다.
+      //
+      // 에코 랙만은 fit 판정에 다시 예약한다: 랙은 중앙 배치 폭(플로우)에 들지 않아 스위치를
+      // 밀지 않지만, 스위치 우측 굴터 공간을 실제로 점유하므로 예약 없이는 경계 폭에서 우측
+      // 클러스터 위로 겹친다(브라우저 크롬은 모바일 전환이 선행하지만, 데스크톱 셸의 OS 컨트롤
+      // 예약이 우측 폭을 키우면 도달한다). 배지가 있을 때 폴백이 조금 일찍 올 뿐, 중앙에 있는
+      // 동안 스위치가 움직이지 않는다는 계약은 그대로다.
       const mapControls = mapControlsRef.current;
-      setCenterContentWidth(mapControls === null ? 0 : Math.max(0, ...Array.from(mapControls.children, (child) => (child instanceof HTMLElement ? child.offsetLeft - mapControls.offsetLeft + child.offsetWidth : 0))));
+      const echoRack = echoRackRef.current;
+      const echoReserve = echoRack === null ? 0 : ECHO_RACK_GAP_PX + echoRack.offsetWidth;
+      setCenterContentWidth(mapControls === null ? 0 : echoReserve + Math.max(0, ...Array.from(mapControls.children, (child) => (child instanceof HTMLElement ? child.offsetLeft - mapControls.offsetLeft + child.offsetWidth : 0))));
     };
     measure();
     const observer = new ResizeObserver(measure);
@@ -344,8 +360,12 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
     if (bandLeft) for (const child of bandLeft.children) observer.observe(child);
     const bandRight = bandRightRef.current;
     if (bandRight) for (const child of bandRight.children) observer.observe(child);
+    // 에코 랙은 mapControls 크기를 바꾸지 않는 절대 배치라 RO가 등장을 못 듣는다 — 마운트는
+    // 아래 deps의 배지 조건이, 폭 변화(폰트 로드)는 직접 관찰이 measure를 다시 부른다.
+    const echoRack = echoRackRef.current;
+    if (echoRack) observer.observe(echoRack);
     return () => observer.disconnect();
-  }, [operationsViewVisible, state.channel, state.connection, canvasMode, fullscreen.isFullscreen, finePointer]);
+  }, [operationsViewVisible, state.channel, state.connection, canvasMode, fullscreen.isFullscreen, finePointer, stationKeeping, densityEchoVisible]);
 
   useEffect(() => {
     if (state.channel === "local") return;
@@ -482,9 +502,9 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           {/* 이탈-상태 에코 — 기본값을 벗어난 도구 상태만 축약 배지로 남는다(평시 침묵). 다이얼이
               hover 뒤로 접은 상태 가시성을 여기서 되갚는다. coarse 포인터는 트레이가 이미 말한다.
               스위치 직우는 검색의 안정 앵커 자리(#983)라, 랙은 스위치 좌측에 절대 배치로 걸린다. */}
-          {finePointer && (stationKeeping || triageDeckZoomLive !== 1.0) ? <div className="command-band-mode-echo-rack">
+          {finePointer && (stationKeeping || densityEchoVisible) ? <div ref={echoRackRef} className="command-band-mode-echo-rack">
             {stationKeeping ? <span className="command-band-mode-echo" role="img" aria-label={t("chrome.commandBand.stationKeeping")} title={t("chrome.commandBand.stationKeeping")}><StationKeepingIcon /></span> : null}
-            {triageDeckZoomLive !== 1.0 ? <span className="command-band-mode-echo" role="img" aria-label={t("canvas.triage.densityChipTitle")} title={t("canvas.triage.densityChipTitle")}>{triageDeckZoomLive.toFixed(1)}×</span> : null}
+            {densityEchoVisible ? <span className="command-band-mode-echo" role="img" aria-label={t("canvas.triage.densityChipTitle")} title={t("canvas.triage.densityChipTitle")}>{triageDeckZoomLive.toFixed(1)}×</span> : null}
           </div> : null}
         </div> : null}
         <button type="button" className="command-band-button command-band-search" onClick={toggleOperationSearch} aria-label={t("chrome.commandBand.searchSessions")} title={t("chrome.commandBand.searchSessionsTitle")}>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -114,15 +114,25 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
     }
     if (formationView) clearFormationView();
   };
+  // 클릭은 포커스를 남기지 않는 문법(preventDefault) 탓에, 키보드로 들어간 캡슐 포커스가 다른
+  // 셀 클릭 뒤에도 살아남아 그 캡슐을 focus-within으로 계속 열어 둔다 — 스위치 클릭이 소비되는
+  // 순간 다이얼 안의 포커스만 내보낸다. 다이얼 밖 포커스(예: War Room 무대 지명의 근거가 되는
+  // 패널 포커스)는 건드리지 않는다.
+  const releaseDialFocus = () => {
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && active.closest(".command-band-mode-dial") !== null) active.blur();
+  };
   // Helm Dial — 캡슐 도구 클릭은 "그 모드로 진입 + 도구 적용"이 한 제스처다. 도구가 제 모드의
   // 낱말 아래에서만 나오므로 어느 모드의 손잡이인지가 소속으로 명시되고, 무경고 모드 이탈의
   // 전제였던 "소속 없는 도구 줄"(2026-08 격자 클릭 사고)은 존재하지 않는다. 모드 전이의
   // 소유권은 여전히 이 클러스터 하나다.
   const enterCruiseThen = (action: () => void) => {
+    releaseDialFocus();
     if (canvasMode !== "cruise") selectCanvasMode("cruise");
     action();
   };
   const enterWarRoomThen = (action: () => void) => {
+    releaseDialFocus();
     if (canvasMode !== "warRoom") enterTriage(focusedTriageOperationId(document.activeElement));
     action();
   };
@@ -130,6 +140,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   // 모드 이탈 권한은 Cruise 세그먼트만 갖는다. War Room에서 내려올 때 formation이 이미 그
   // 레이아웃으로 서 있으면 triage 해제만으로 목적지에 닿았으므로 역시 부르지 않는다(토글-오프 함정).
   const selectTacticalLayout = (layout: FormationLayout) => {
+    releaseDialFocus();
     if (triageActive) setTriageActive(false);
     if (!formationView || formationLayout !== layout) selectFormationLayout(layout);
   };
@@ -486,7 +497,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
                 aria-label={t(mode.titleKey)}
                 title={t(mode.titleKey)}
                 onMouseDown={(event) => event.preventDefault()}
-                onClick={() => selectCanvasMode(mode.id)}
+                onClick={() => { releaseDialFocus(); selectCanvasMode(mode.id); }}
               >
                 {mode.label}
               </button>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { SegmentedThumb } from "@fleet-console/sdk/react/browser";
 
 import { fetchConsoleEnvironment } from "../api.js";
-import { animateViewportTo, clearFormationView, fitAllOperations, selectFormationLayout, setStationKeeping, toggleFormationView, useFormationLayout, useFormationView, useStationKeeping, type FormationLayout } from "../canvas/canvas-store.js";
+import { animateViewportTo, clearFormationView, fitAllOperations, getFormationLayout, getFormationView, getLoadedTheaterId, loadForTheater, selectFormationLayout, setStationKeeping, toggleFormationView, useFormationLayout, useFormationView, useStationKeeping, type FormationLayout } from "../canvas/canvas-store.js";
 import { enterTriage, focusedTriageOperationId, setTriageActive, setTriageSpotlightEnabled, useTriageActive, useTriageDeckZoomLive, useTriageSpotlightEnabled } from "../canvas/triage-store.js";
 import { cycleTriageDeckZoomPreset } from "../canvas/triage-watch-deck.js";
 import { commandBandCenterFits, commandBandCenterGutter } from "./command-band-guards.js";
@@ -12,7 +12,7 @@ import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
 import { ViewModeToggle } from "./view-mode-toggle.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { useUpdateProgress } from "../update-progress-store.js";
-import { toggleOperationSearch } from "../store.js";
+import { getState, toggleOperationSearch } from "../store.js";
 import type { ConsoleEnvironmentDiagnostics } from "../types.js";
 import { useT, type CoreMessageKey } from "../i18n/index.js";
 import { useViewMode } from "../view-mode-store.js";
@@ -139,9 +139,20 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   // 같은 레이아웃 재클릭은 무시한다 — selectFormationLayout은 동일 레이아웃에서 모드를 꺼버리는데,
   // 모드 이탈 권한은 Cruise 세그먼트만 갖는다. War Room에서 내려올 때 formation이 이미 그
   // 레이아웃으로 서 있으면 triage 해제만으로 목적지에 닿았으므로 역시 부르지 않는다(토글-오프 함정).
+  // 판정은 렌더 시점 값이 아니라 라이브 게터로 한다 — 아래 이탈 경로가 로드를 앞당긴 뒤에는
+  // 렌더 값이 이전 Theater의 것이라 토글-오프 함정을 다시 연다.
   const selectTacticalLayout = (layout: FormationLayout) => {
-    if (triageActive) setTriageActive(false);
-    if (!formationView || formationLayout !== layout) selectFormationLayout(layout);
+    if (triageActive) {
+      setTriageActive(false);
+      // War Room 이탈은 활성 Theater를 마지막 무대 Theater로 복귀시킬 수 있는데(triage-store),
+      // canvas-store의 formation 상태는 passive effect의 loadForTheater가 돌 때까지 이전
+      // Theater를 가리킨다. 그 창에서 formation을 쓰면 표기가 옛 Theater에 남고 복귀 Theater는
+      // Cruise로 착지한다 — 로드를 동기로 앞당겨 복귀 Theater의 상태 위에서 진입한다(effect의
+      // 같은 id 재로드는 수렴한다).
+      const returnTheaterId = getState().activeTheaterId;
+      if (returnTheaterId !== null && returnTheaterId !== getLoadedTheaterId()) loadForTheater(returnTheaterId);
+    }
+    if (!getFormationView() || getFormationLayout() !== layout) selectFormationLayout(layout);
   };
   // Esc는 캡슐에서 낱말로 되돌아오는 계단이다 — 포커스가 세그먼트로 돌아가면 focus-within이
   // 유지되어 캡슐은 열린 채 남고, Tab 이탈이 문을 닫는다.

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -622,7 +622,10 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 /* Cruise / Tactical / War Room — 캔버스 모드는 이 세그먼트 스위치 하나만 소유한다.
-   모드 전용 도구는 오른쪽 트레이에 붙으므로, 다른 모드의 도구는 애초에 존재하지 않는다.
+   Helm Dial(2026-09 재가): 모드 전용 도구는 상주 트레이 대신 제 낱말 아래 캡슐로 내려온다
+   (fine 포인터). 캡슐·에코는 절대 배치라 중앙 소요 폭(scrollWidth)에 들지 않는다 — 스위치는
+   모드가 바뀌어도 움직이지 않는다(트레이 시절 실측: War Room 전환마다 5.5px 밀림). coarse
+   포인터는 hover가 없으므로 상주 트레이 문법을 유지한다.
    C′ 문법: 상자를 걷고 워시+다텀이 선택을 말한다 — 그룹 경계는 간격이 진다. */
 .command-band-mode-switch {
   position: relative;
@@ -630,6 +633,23 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   flex: none;
   align-items: center;
   gap: var(--space-1);
+}
+
+.command-band-mode-cell {
+  position: relative;
+  display: flex;
+}
+
+/* 낱말→캡슐 사이 공극은 열림 동안 셀의 히트 영역으로 잇는다 — 포인터가 7px 협곡을 건너는
+   동안 hover가 끊겨 캡슐이 닫히면 문이 아니라 함정이다. */
+.command-band-mode-cell:hover::before,
+.command-band-mode-cell:focus-within::before {
+  position: absolute;
+  top: 100%;
+  right: -6px;
+  left: -6px;
+  height: 9px;
+  content: "";
 }
 
 /* 24px 높이의 좁은 세그먼트는 다텀도 한 치수 좁게 선다. */
@@ -703,6 +723,126 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   }
 }
 
+/* Helm Dial 캡슐 — 밴드에 앵커된 떠 있는 면이므로 환경 팝오버·시스템 메뉴와 같은 strong
+   계열 유리를 쓴다. 닫힘 = 투명+무포인터이되 DOM에 존속한다: display:none이면 투어 앵커
+   판정과 focus-within 키보드 개방이 함께 죽는다. 여는 문은 셋뿐이다 — hover(의도 지연),
+   focus-within(즉시), 투어 하이라이트(즉시). */
+.command-band-mode-dial {
+  --dial-align-x: -50%;
+  position: absolute;
+  z-index: 45;
+  top: calc(100% + 7px);
+  left: 50%;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 5px;
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-md);
+  background:
+    var(--glass-sheen),
+    linear-gradient(var(--glass-tint-strong), var(--glass-tint-strong)),
+    var(--glass-underlay);
+  -webkit-backdrop-filter: var(--glass-backdrop-strong);
+  backdrop-filter: var(--glass-backdrop-strong);
+  box-shadow: inset 0 1px 0 var(--glass-rim), inset 0 -1px 0 var(--glass-bevel), var(--glass-lift);
+  /* visibility가 히트 판정을 가시성과 동기한다 — pointer-events만으로는 :hover 즉시 auto가
+     되어, 의도 지연 동안 아직 투명한 캡슐이 이웃 캡슐의 클릭을 먹는다(실입력 실측: 대각선
+     마우스 경로가 스친 이웃 셀의 보이지 않는 캡슐이 SK 클릭을 삼킴). 닫힘 시에는 페이드가
+     끝나는 200ms 뒤에 숨겨 급단절을 피한다. */
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(var(--dial-align-x), -4px);
+  /* 기본 60ms는 닫힘 관용(이탈 후 잠깐의 되돌아옴을 용서), 열림 지연은 아래 hover 규칙이 진다. */
+  transition: opacity var(--duration-fast) ease 60ms, transform var(--duration-fast) var(--ease-spring) 60ms, visibility 0s linear 200ms;
+}
+
+/* 첫/끝 셀의 캡슐은 클러스터 안쪽으로 정렬한다 — 스위치 밖 돌출을 줄여 중앙 근방을 지킨다. */
+.command-band-mode-cell[data-canvas-mode="cruise"] > .command-band-mode-dial {
+  --dial-align-x: 0%;
+  left: 0;
+}
+
+.command-band-mode-cell[data-canvas-mode="warRoom"] > .command-band-mode-dial {
+  --dial-align-x: 0%;
+  right: 0;
+  left: auto;
+}
+
+/* hover 의도 지연 — 모드 전환 클릭길 위에서 캡슐이 어른거리지 않게 한 박자 늦게 연다.
+   visibility도 같은 지연을 타므로 지연 창 동안에는 히트 대상도 아니다. */
+.command-band-mode-cell:hover > .command-band-mode-dial {
+  transition-delay: 160ms, 160ms, 160ms;
+}
+
+.command-band-mode-cell:hover > .command-band-mode-dial,
+.command-band-mode-cell:focus-within > .command-band-mode-dial,
+.command-band-mode-dial:has(.is-feature-tour-anchor) {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(var(--dial-align-x), 0);
+}
+
+/* 키보드 진입과 화면 안내 하이라이트는 의도 확인이 필요 없다 — 즉시 연다. Tab 흐름:
+   세그먼트에 포커스가 앉는 순간 focus-within이 캡슐을 보이게 하므로, 닫힘 상태의
+   visibility:hidden이 도구를 Tab에서 숨겨도 다음 Tab이 자연히 캡슐 안으로 들어간다. */
+.command-band-mode-cell:focus-within > .command-band-mode-dial,
+.command-band-mode-dial:has(.is-feature-tour-anchor) {
+  transition-delay: 0ms, 0ms, 0ms;
+}
+
+.command-band-mode-dial-label {
+  padding: 0 6px 0 5px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  font-weight: var(--weight-bold);
+}
+
+/* 이탈-상태 에코 — 기본값을 벗어난 도구 상태만 스위치 곁에 남는다(평시 침묵). 면은 불리언 ON
+   문법(워시+brass 글리프)의 잔향이다. 플로우 밖 절대 배치: 등장·퇴장이 중앙 소요 폭에
+   되먹이면 스위치가 다시 밀린다. */
+/* 스위치 직우는 검색 버튼의 안정 앵커 자리다(#983) — 랙은 반대쪽(좌측)에 건다. 좌측 돌출도
+   중앙 소요 폭 측정(플로우 자식 범위)에는 들지 않아 스위치는 움직이지 않는다. */
+.command-band-mode-echo-rack {
+  position: absolute;
+  top: 50%;
+  right: calc(100% + 10px);
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  transform: translateY(-50%);
+}
+
+.command-band-mode-echo {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 4px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: var(--radius-pill);
+  background: var(--control-wash);
+  color: var(--brass-ink);
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  font-weight: var(--weight-bold);
+  font-variant-numeric: tabular-nums;
+}
+
+.command-band-mode-echo svg {
+  display: block;
+  width: 12px;
+  height: 12px;
+}
+
+/* coarse 포인터 상주 트레이 — hover 없는 입력의 등가 경로. 활성 모드의 도구만 마운트한다. */
 .command-band-mode-tray {
   display: flex;
   flex: none;
@@ -832,6 +972,7 @@ html[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-le
   .operations-side-bar,
   .right-rail,
   .command-band-map-controls,
+  .command-band-mode-dial,
   .command-band-left {
     transition: none !important;
   }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2234,7 +2234,10 @@ describe("Instrument core design contract", () => {
     expect(commandBand.match(/className="command-band-mode-tool/g)?.length).toBe(commandBand.match(/onMouseDown=\{suppressToolFocus\}/g)?.length);
     // 이탈-상태 에코 — 다이얼이 hover 뒤로 접은 상태 가시성은 기본값 이탈 배지가 되갚는다
     // (평시 침묵). 배지가 플로우에 들면 등장·퇴장이 중앙을 다시 민다.
-    expect(commandBand).toContain("{finePointer && (stationKeeping || triageDeckZoomLive !== 1.0) ? <div className=\"command-band-mode-echo-rack\">");
+    expect(commandBand).toContain("{finePointer && (stationKeeping || densityEchoVisible) ? <div ref={echoRackRef} className=\"command-band-mode-echo-rack\">");
+    // 에코 랙은 중앙 배치 폭에는 들지 않되(스위치 부동) fit 판정에는 예약된다 — 예약이 없으면
+    // 데스크톱 셸의 OS 컨트롤 예약 폭에서 배지가 우측 클러스터 위로 겹친다(Codex P2).
+    expect(commandBand).toContain("const echoReserve = echoRack === null ? 0 : ECHO_RACK_GAP_PX + echoRack.offsetWidth;");
     // 같은 레이아웃 재클릭은 무시한다 — selectFormationLayout은 동일 레이아웃에서 모드를 끄는데,
     // 모드 이탈 권한은 Cruise 세그먼트만 갖는다. War Room에서 내려올 때 formation이 이미 그
     // 레이아웃이면 triage 해제만으로 목적지에 닿았으므로 역시 부르지 않는다(토글-오프 함정).

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2230,19 +2230,22 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain('<span className="command-band-mode-tray-divider" aria-hidden="true" />');
     // 도구도 세그먼트처럼 mousedown을 preventDefault한다 — 클릭이 포커스를 남기면 focus-within이
     // 캡슐을 계속 열어 두고, 열린 채 남은 캡슐이 이웃 캡슐의 클릭 지점을 덮는다(실입력 실측 사고).
-    expect(commandBand).toContain("const suppressToolFocus = (event: { preventDefault(): void }) => event.preventDefault();");
+    expect(commandBand).toContain("const suppressToolFocus = (event: { preventDefault(): void }) => {");
     expect(commandBand.match(/className="command-band-mode-tool/g)?.length).toBe(commandBand.match(/onMouseDown=\{suppressToolFocus\}/g)?.length);
     // 같은 문법의 반대면: preventDefault는 이전 포커스를 보존하므로, 키보드로 들어간 캡슐
-    // 포커스가 다른 셀 클릭 뒤에도 그 캡슐을 열어 둔다 — 스위치 클릭이 다이얼 안 포커스만
-    // 내보낸다(다이얼 밖 포커스는 War Room 무대 지명의 근거라 건드리지 않는다).
+    // 포커스가 다른 셀 클릭 뒤에도 그 캡슐을 열어 둔다 — 포인터 mousedown만 다이얼 안 포커스를
+    // 내보낸다. click 경로에 걸면 Enter/Space 활성화가 방금 조작한 도구의 키보드 위치까지
+    // 파괴한다(다이얼 밖 포커스는 War Room 무대 지명의 근거라 건드리지 않는다).
     expect(commandBand).toContain("const releaseDialFocus = () => {");
-    expect(commandBand).toContain('onClick={() => { releaseDialFocus(); selectCanvasMode(mode.id); }}');
+    expect(commandBand).toContain("onMouseDown={(event) => { event.preventDefault(); releaseDialFocus(); }}");
+    expect(commandBand).not.toMatch(/onClick=\{[^}]*releaseDialFocus/);
     // 이탈-상태 에코 — 다이얼이 hover 뒤로 접은 상태 가시성은 기본값 이탈 배지가 되갚는다
     // (평시 침묵). 배지가 플로우에 들면 등장·퇴장이 중앙을 다시 민다.
     expect(commandBand).toContain("{finePointer && (stationKeeping || densityEchoVisible) ? <div ref={echoRackRef} className=\"command-band-mode-echo-rack\">");
     // 에코 랙은 중앙 배치 폭에는 들지 않되(스위치 부동) fit 판정에는 예약된다 — 예약이 없으면
-    // 데스크톱 셸의 OS 컨트롤 예약 폭에서 배지가 우측 클러스터 위로 겹친다(Codex P2).
-    expect(commandBand).toContain("const echoReserve = echoRack === null ? 0 : ECHO_RACK_GAP_PX + echoRack.offsetWidth;");
+    // 데스크톱 셸의 OS 컨트롤 예약 폭에서 배지가 우측 클러스터 위로 겹친다(Codex P2). 대칭
+    // 판정식이 한쪽 돌출을 가리려면 예약은 두 배다.
+    expect(commandBand).toContain("const echoReserve = echoRack === null ? 0 : 2 * (ECHO_RACK_GAP_PX + echoRack.offsetWidth);");
     // 같은 레이아웃 재클릭은 무시한다 — selectFormationLayout은 동일 레이아웃에서 모드를 끄는데,
     // 모드 이탈 권한은 Cruise 세그먼트만 갖는다. War Room에서 내려올 때 formation이 이미 그
     // 레이아웃이면 triage 해제만으로 목적지에 닿았으므로 역시 부르지 않는다(토글-오프 함정).

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2249,7 +2249,10 @@ describe("Instrument core design contract", () => {
     // 같은 레이아웃 재클릭은 무시한다 — selectFormationLayout은 동일 레이아웃에서 모드를 끄는데,
     // 모드 이탈 권한은 Cruise 세그먼트만 갖는다. War Room에서 내려올 때 formation이 이미 그
     // 레이아웃이면 triage 해제만으로 목적지에 닿았으므로 역시 부르지 않는다(토글-오프 함정).
-    expect(commandBand).toContain("if (!formationView || formationLayout !== layout) selectFormationLayout(layout);");
+    expect(commandBand).toContain("if (!getFormationView() || getFormationLayout() !== layout) selectFormationLayout(layout);");
+    // War Room 이탈이 활성 Theater를 복귀시키는 창에서 formation을 쓰면 표기가 옛 Theater에
+    // 남는다(canvas-store는 passive 로드까지 이전 Theater를 가리킨다) — 로드를 동기로 앞당긴다.
+    expect(commandBand).toContain("if (returnTheaterId !== null && returnTheaterId !== getLoadedTheaterId()) loadForTheater(returnTheaterId);");
     // 눌림은 "지금 활성"만 말한다 — 비활성 모드 캡슐에서 기억된 레이아웃을 눌림으로 칠하지 않는다.
     expect(commandBand).toContain('aria-pressed={canvasMode === "tactical" && formationLayout === layout.id}');
     // Tactical은 Theater별 상태라 활성 Theater로, War Room은 전역 모드라 등록된 Theater 존재로 게이트한다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2232,6 +2232,11 @@ describe("Instrument core design contract", () => {
     // 캡슐을 계속 열어 두고, 열린 채 남은 캡슐이 이웃 캡슐의 클릭 지점을 덮는다(실입력 실측 사고).
     expect(commandBand).toContain("const suppressToolFocus = (event: { preventDefault(): void }) => event.preventDefault();");
     expect(commandBand.match(/className="command-band-mode-tool/g)?.length).toBe(commandBand.match(/onMouseDown=\{suppressToolFocus\}/g)?.length);
+    // 같은 문법의 반대면: preventDefault는 이전 포커스를 보존하므로, 키보드로 들어간 캡슐
+    // 포커스가 다른 셀 클릭 뒤에도 그 캡슐을 열어 둔다 — 스위치 클릭이 다이얼 안 포커스만
+    // 내보낸다(다이얼 밖 포커스는 War Room 무대 지명의 근거라 건드리지 않는다).
+    expect(commandBand).toContain("const releaseDialFocus = () => {");
+    expect(commandBand).toContain('onClick={() => { releaseDialFocus(); selectCanvasMode(mode.id); }}');
     // 이탈-상태 에코 — 다이얼이 hover 뒤로 접은 상태 가시성은 기본값 이탈 배지가 되갚는다
     // (평시 침묵). 배지가 플로우에 들면 등장·퇴장이 중앙을 다시 민다.
     expect(commandBand).toContain("{finePointer && (stationKeeping || densityEchoVisible) ? <div ref={echoRackRef} className=\"command-band-mode-echo-rack\">");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2196,9 +2196,11 @@ describe("Instrument core design contract", () => {
     expect(commandBand).not.toContain("command-band-dock-divider");
     expect(commandBand).toContain('aria-label={t("chrome.commandBand.resetCanvasView")}');
     expect(commandBand).toContain("<ResetViewIcon />");
-    expect(commandBand).toContain("onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })}");
-    // 캔버스 모드는 세그먼트 스위치 하나가 단독으로 소유한다 — 모드별 도구를 밴드에 상시
-    // 늘어놓으면 다른 모드의 도구를 눌러 무경고로 모드를 이탈시킬 수 있다(2026-08 격자 클릭 사고).
+    expect(commandBand).toContain("onClick={() => enterCruiseThen(() => animateViewportTo({ x: 0, y: 0, zoom: 1 }))}");
+    // 캔버스 모드는 세그먼트 스위치 하나가 단독으로 소유한다. Helm Dial(2026-09 재가): 모드
+    // 전용 도구는 상주 트레이 대신 제 낱말 아래 캡슐로 내려온다 — 소속 없는 도구 줄이 만들던
+    // 무경고 모드 이탈(2026-08 격자 클릭 사고)은 소속 낱말이 해소하고, 캡슐 도구 클릭은
+    // "그 모드로 진입 + 도구 적용"으로 명시적이다.
     expect(commandBand).toContain('className="command-band-mode-switch" role="group" aria-label={t("chrome.commandBand.canvasMode")}');
     // 모드는 낱말로, 모드 전용 도구는 아이콘으로 말한다 — 세그먼트에 아이콘을 더하면 클러스터가
     // 375px까지 벌어져 1280px 밴드에서 중앙 브레드크럼이 사라진다(2026-08 실측).
@@ -2208,20 +2210,37 @@ describe("Instrument core design contract", () => {
     expect(commandBand).not.toMatch(/<mode\.Icon \/>/);
     expect(commandBand).toContain('const canvasMode: CanvasMode = triageActive ? "warRoom" : formationView ? "tactical" : "cruise";');
     expect(commandBand).toContain('aria-pressed={canvasMode === mode.id}');
-    // 트레이는 활성 모드의 도구만 마운트한다 — 비활성 모드 도구는 disabled가 아니라 부재다.
-    // 검색이 중앙 상주가 되며 트레이는 Operations 뷰 게이트를 각자 지닌다(모드 스위치와 동일).
-    expect(commandBand).toContain('{operationsViewVisible && canvasMode === "cruise" ? <div className="command-band-mode-tray"');
-    expect(commandBand).toContain('{operationsViewVisible && canvasMode === "tactical" ? <div className="command-band-mode-tray"');
-    expect(commandBand).toContain('{operationsViewVisible && canvasMode === "warRoom" ? <div className="command-band-mode-tray"');
-    expect(commandBand).toContain("onClick={cycleTriageDeckZoomPreset}");
-    expect(commandBand).toContain("onClick={() => setTriageSpotlightEnabled(!triageSpotlightEnabled)}");
+    // 다이얼은 hover가 실재하는 입력에서만 문이 된다 — coarse 포인터는 상주 트레이 유지
+    // (등가 경로 없는 접기 금지). React에서 갈라 렌더해 투어 앵커가 문서에 한 벌만 존재한다.
+    // 검색이 중앙 상주가 되며(#983) 트레이는 Operations 뷰 게이트를 함께 지닌다.
+    expect(commandBand).toContain('const FINE_POINTER_QUERY = "(hover: hover) and (pointer: fine)";');
+    expect(commandBand).toContain('{finePointer ? <div className="command-band-mode-dial" role="group"');
+    expect(commandBand).toContain('{operationsViewVisible && !finePointer ? <div className="command-band-mode-tray"');
+    // SegmentedThumb는 셀 좌표계를 탄다 — 셀이 position:relative를 갖는 순간 세그먼트의
+    // offsetLeft는 셀 기준이 되어 스위치 좌표로 쓸 수 없다.
+    expect(commandBand).toContain('<SegmentedThumb activeSelector=".command-band-mode-cell.is-active" />');
+    // 캡슐은 닫혀도 DOM에 존속한다(투어 앵커 판정 + focus-within 키보드 개방). 투어 활성화
+    // 계약("War Room에서 항상 + War Room에서만")은 앵커 속성을 활성 모드에서만 부착해 지킨다.
+    expect(commandBand).toContain('{...(canvasMode === "warRoom" ? { "data-war-room-tool": "spotlight" } : {})}');
+    expect(commandBand).toContain('{...(canvasMode === "warRoom" ? { "data-war-room-tool": "density" } : {})}');
+    expect(commandBand).toContain("onClick={() => enterWarRoomThen(cycleTriageDeckZoomPreset)}");
+    expect(commandBand).toContain("onClick={() => enterWarRoomThen(() => setTriageSpotlightEnabled(!triageSpotlightEnabled))}");
     // 값은 남기되 낱말은 두지 않는다 — 아이콘 + 배율 수치.
     expect(commandBand).toContain("<DensityIcon /><span>{triageDeckZoomLive.toFixed(1)}×</span>");
     expect(commandBand).toContain('<span className="command-band-mode-tray-divider" aria-hidden="true" />');
+    // 도구도 세그먼트처럼 mousedown을 preventDefault한다 — 클릭이 포커스를 남기면 focus-within이
+    // 캡슐을 계속 열어 두고, 열린 채 남은 캡슐이 이웃 캡슐의 클릭 지점을 덮는다(실입력 실측 사고).
+    expect(commandBand).toContain("const suppressToolFocus = (event: { preventDefault(): void }) => event.preventDefault();");
+    expect(commandBand.match(/className="command-band-mode-tool/g)?.length).toBe(commandBand.match(/onMouseDown=\{suppressToolFocus\}/g)?.length);
+    // 이탈-상태 에코 — 다이얼이 hover 뒤로 접은 상태 가시성은 기본값 이탈 배지가 되갚는다
+    // (평시 침묵). 배지가 플로우에 들면 등장·퇴장이 중앙을 다시 민다.
+    expect(commandBand).toContain("{finePointer && (stationKeeping || triageDeckZoomLive !== 1.0) ? <div className=\"command-band-mode-echo-rack\">");
     // 같은 레이아웃 재클릭은 무시한다 — selectFormationLayout은 동일 레이아웃에서 모드를 끄는데,
-    // 모드 이탈 권한은 Cruise 세그먼트만 갖는다.
-    expect(commandBand).toContain("onClick={() => { if (formationLayout !== layout.id) selectFormationLayout(layout.id); }}");
-    expect(commandBand).toContain("aria-pressed={formationLayout === layout.id}");
+    // 모드 이탈 권한은 Cruise 세그먼트만 갖는다. War Room에서 내려올 때 formation이 이미 그
+    // 레이아웃이면 triage 해제만으로 목적지에 닿았으므로 역시 부르지 않는다(토글-오프 함정).
+    expect(commandBand).toContain("if (!formationView || formationLayout !== layout) selectFormationLayout(layout);");
+    // 눌림은 "지금 활성"만 말한다 — 비활성 모드 캡슐에서 기억된 레이아웃을 눌림으로 칠하지 않는다.
+    expect(commandBand).toContain('aria-pressed={canvasMode === "tactical" && formationLayout === layout.id}');
     // Tactical은 Theater별 상태라 활성 Theater로, War Room은 전역 모드라 등록된 Theater 존재로 게이트한다.
     expect(commandBand).toContain('disabled={mode.id === "tactical" ? state.activeTheaterId === null : state.theaters.length === 0}');
     // 모드 이름은 번역하지 않는 제품 고유 명칭이다 — 로케일 메시지에 이름을 넣으면 두 벌이 생긴다.
@@ -2241,7 +2260,20 @@ describe("Instrument core design contract", () => {
     expect(components).not.toContain(".side-bar-theater-add-btn {");
     expect(layout).toContain(".command-band-mode-switch {");
     expect(layout).toContain(".command-band-mode-seg {");
+    expect(layout).toContain(".command-band-mode-cell {");
     expect(layout).toContain(".command-band-mode-tray-divider {");
+    // Helm Dial 캡슐 — strong 계열 유리(환경 팝오버와 같은 재질), 절대 배치, 세 개의 문
+    // (hover 의도 지연 · focus-within 즉시 · 투어 하이라이트 즉시).
+    expect(layout).toContain(".command-band-mode-dial {");
+    expect(layout).toMatch(/\.command-band-mode-dial \{[^}]*backdrop-filter: var\(--glass-backdrop-strong\);/);
+    // visibility가 히트 판정을 가시성과 동기한다 — pointer-events만으로는 의도 지연 동안
+    // 투명 캡슐이 이웃 캡슐의 클릭을 먹는다(실입력 실측 사고).
+    expect(layout).toMatch(/\.command-band-mode-dial \{[^}]*visibility: hidden;/);
+    expect(layout).toMatch(/\.command-band-mode-dial \{[^}]*visibility 0s linear 200ms;/);
+    expect(layout).toContain('.command-band-mode-dial:has(.is-feature-tour-anchor)');
+    expect(layout).toContain(".command-band-mode-cell:focus-within > .command-band-mode-dial,");
+    // 에코 배지는 플로우 밖 절대 배치다 — 플로우에 들면 등장·퇴장이 중앙 소요 폭에 되먹인다.
+    expect(layout).toMatch(/\.command-band-mode-echo-rack \{\s*position: absolute;/);
     // 맵 컨트롤 클러스터는 컨테이너 플로우 배치다 — 개별 절대 위치 + 매직 오프셋(구 116px)은
     // 버튼 추가 시 겹침으로 깨지므로(선별 처리 아이콘 덮임 사고) 다시 도입하지 않는다.
     expect(layout).toContain(".command-band-map-controls {");
@@ -2503,6 +2535,7 @@ describe("Instrument core design contract", () => {
     expect(reducedMotionBlock).toContain(".operations-side-bar,");
     expect(reducedMotionBlock).toContain(".right-rail,");
     expect(reducedMotionBlock).toContain(".command-band-map-controls,");
+    expect(reducedMotionBlock).toContain(".command-band-mode-dial,");
     expect(reducedMotionBlock).toContain(".command-band-left {");
     expect(reducedMotionBlock).toContain("transition: none !important;");
   });


### PR DESCRIPTION
## Summary
- 커맨드 밴드 모드 전용 도구를 상주 트레이에서 걷어, 각 모드 낱말 아래 hover 다이얼 캡슐(160ms 의도 지연 · focus-within · 투어 하이라이트가 여는 세 개의 문)로 옮깁니다. 모드 스위치가 중앙 트랙의 단독 승객이 되어 실측된 −48.5px 중앙 편향과 모드 전환 시 5.5px 밀림이 모두 0이 되고, 중앙 유지 폭 여유가 약 100px 넓어집니다(실측 780px까지 중앙 유지).
- 캡슐 도구 클릭은 "그 모드로 진입 + 적용" 한 제스처입니다(Cruise에서 Tactical 열 배치 = 1클릭, 격자 플래시 없음). War Room에서 내려올 때 `selectFormationLayout`의 동일 레이아웃 토글-오프 경로를 우회합니다. 기본값을 벗어난 도구 상태(Station Keeping ON, 덱 밀도 ≠ 1.0×)는 스위치 곁 축약 에코 배지로 상시 가시성을 유지합니다.
- coarse 포인터는 상주 트레이를 유지하고(등가 경로 없는 접기 금지), `data-war-room-tool` 투어 앵커는 활성 모드에서만 부착해 "War Room에서 항상 + War Room에서만" 활성화 계약을 캡슐 상시 마운트 아래에서도 지킵니다. 실입력 검증이 잡은 두 결함 — 클릭 포커스가 캡슐을 이웃 위에 열어두는 문제, 의도 지연 중 투명 캡슐이 클릭을 먹는 문제 — 를 mousedown preventDefault와 visibility 지연 동기화로 봉합했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `vitest run tests/instrument-design-contract.test.ts tests/feature-tour.test.ts tests/connection-ui-contract.test.ts tests/feature-tour-serialization.test.tsx tests/canvas-store.test.ts tests/i18n.test.ts tests/operations-boot-minimization.integration.test.ts tests/theme-notice.test.ts tests/fullscreen-command-band.test.ts` — 283 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build` + 격리 콘솔 실브라우저 검증: 3모드 전환 스위치 x 부동(533.4 상수) · 소요 폭 213 상수 · hover/실클릭 다이얼 · 교차 모드 1클릭 진입+적용 · 에코 배지 등장/소멸 · War Room 투어 발화+캡슐 강제 개방 · focus/Esc 키보드 경로 · 780px 중앙 유지·760px 모바일 전환 · 페이지 에러 0