### PR TITLE
fix(ai-gateway): normalize Gemini tuple tool schemas

### DIFF
--- a/.changelog.d/antigravity-gemini-schema-fix.md
+++ b/.changelog.d/antigravity-gemini-schema-fix.md
@@ -1,0 +1,8 @@
+---
+branch: antigravity-gemini-schema-fix
+---
+
+### fleet-cli
+#### Fixed
+- Accept tuple-shaped tool schemas when using Antigravity Gemini models.
+  ko: Antigravity Gemini 모델 사용 시 튜플 형태의 도구 스키마를 허용합니다.

--- a/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
+++ b/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
@@ -190,7 +190,10 @@ function geminiOpenValueApproximation(depth = 2): Record<string, unknown> {
 function sanitizeGeminiItems(value: unknown): Record<string, unknown> {
   if (!isRecord(value)) return geminiOpenValueApproximation();
   const schema = sanitizeGeminiSchema(value);
-  return Object.keys(schema).length === 0 ? geminiOpenValueApproximation() : schema;
+  const hasStructure = typeof schema.type === "string"
+    || isRecord(schema.properties)
+    || Array.isArray(schema.anyOf);
+  return hasStructure ? schema : geminiOpenValueApproximation();
 }
 
 function schemaAlternatives(schema: Record<string, unknown>): Record<string, unknown>[] {

--- a/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
+++ b/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
@@ -172,6 +172,48 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function geminiOpenValueApproximation(depth = 2): Record<string, unknown> {
+  const alternatives: Record<string, unknown>[] = [
+    // `nullable` carries the otherwise unrepresentable JSON null branch.
+    { type: "string", nullable: true },
+    { type: "number" },
+    { type: "boolean" },
+    { type: "object", properties: {} },
+  ];
+  if (depth > 0) alternatives.push({
+    type: "array",
+    items: geminiOpenValueApproximation(depth - 1),
+  });
+  return { anyOf: alternatives };
+}
+
+function sanitizeGeminiItems(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) return geminiOpenValueApproximation();
+  const schema = sanitizeGeminiSchema(value);
+  return Object.keys(schema).length === 0 ? geminiOpenValueApproximation() : schema;
+}
+
+function schemaAlternatives(schema: Record<string, unknown>): Record<string, unknown>[] {
+  if (Object.keys(schema).length === 1 && Array.isArray(schema.anyOf)) {
+    return schema.anyOf.filter(isRecord);
+  }
+  return [schema];
+}
+
+function geminiTupleItems(
+  items: readonly unknown[],
+  options: { readonly additional?: unknown; readonly allowsAdditional: boolean },
+): Record<string, unknown> {
+  const alternatives = items.flatMap((item) => schemaAlternatives(sanitizeGeminiItems(item)));
+  if (options.allowsAdditional) {
+    alternatives.push(...schemaAlternatives(sanitizeGeminiItems(options.additional)));
+  }
+  const distinct = [...new Map(alternatives.map((schema) => [JSON.stringify(schema), schema])).values()];
+  if (distinct.length === 0) return geminiOpenValueApproximation();
+  if (distinct.length === 1) return distinct[0]!;
+  return { anyOf: distinct };
+}
+
 export function sanitizeGeminiSchema(value: unknown): Record<string, unknown> {
   if (!isRecord(value)) return { type: "object", properties: {} };
   const out: Record<string, unknown> = {};
@@ -188,7 +230,23 @@ export function sanitizeGeminiSchema(value: unknown): Record<string, unknown> {
         break;
       }
       case "items":
-        out.items = sanitizeGeminiSchema(raw);
+        // Gemini requires one concrete schema here. JSON Schema tuples arrive either as the
+        // draft-07 array form or as 2020-12 `prefixItems` plus an unconstrained `{}` tail.
+        // Passing that empty tail produces `properties[...].items.items: missing field` and
+        // rejects every tool in the request, so lower the positional schemas into one union.
+        if (Array.isArray(raw)) {
+          out.items = geminiTupleItems(raw, {
+            additional: value.additionalItems,
+            allowsAdditional: value.additionalItems !== false,
+          });
+        } else if (Array.isArray(value.prefixItems)) {
+          out.items = geminiTupleItems(value.prefixItems, {
+            additional: raw,
+            allowsAdditional: raw !== false,
+          });
+        } else {
+          out.items = sanitizeGeminiItems(raw);
+        }
         break;
       case "anyOf":
         if (Array.isArray(raw)) out.anyOf = raw.map((entry) => sanitizeGeminiSchema(entry));
@@ -234,6 +292,14 @@ export function sanitizeGeminiSchema(value: unknown): Record<string, unknown> {
   // An object with no declared type reads as untyped upstream and is refused;
   // every tool parameter document is an object at its root.
   if (out.type === undefined && out.properties !== undefined) out.type = "object";
+  // Unlike JSON Schema, Gemini does not interpret a missing `items` as an unconstrained
+  // element. Supply a concrete schema even when a client used only `prefixItems` or left
+  // the array open-ended.
+  if (out.type === "array" && out.items === undefined) {
+    out.items = Array.isArray(value.prefixItems)
+      ? geminiTupleItems(value.prefixItems, { allowsAdditional: true })
+      : geminiOpenValueApproximation();
+  }
   // The mirror case: a declared object with no property map. A client spells a free-form
   // payload that way — Grok Build's `use_tool.tool_input` carries whatever schema the MCP
   // tool on the other side declares, so it cannot enumerate fields. Gemini refuses the

--- a/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
+++ b/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
@@ -300,6 +300,18 @@ export function sanitizeGeminiSchema(value: unknown): Record<string, unknown> {
       ? geminiTupleItems(value.prefixItems, { allowsAdditional: true })
       : geminiOpenValueApproximation();
   }
+  // A homogeneous schema cannot express tuple length on its own. Preserve the positional
+  // ceiling when the source explicitly closed its tail, without weakening a smaller limit.
+  const tuple = Array.isArray(value.items)
+    ? value.items
+    : Array.isArray(value.prefixItems) ? value.prefixItems : undefined;
+  const closedTuple = Array.isArray(value.items)
+    ? value.additionalItems === false
+    : tuple !== undefined && value.items === false;
+  if (closedTuple && tuple) {
+    const explicitMax = typeof out.maxItems === "number" ? out.maxItems : undefined;
+    out.maxItems = explicitMax === undefined ? tuple.length : Math.min(explicitMax, tuple.length);
+  }
   // The mirror case: a declared object with no property map. A client spells a free-form
   // payload that way — Grok Build's `use_tool.tool_input` carries whatever schema the MCP
   // tool on the other side declares, so it cannot enumerate fields. Gemini refuses the

--- a/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
+++ b/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
@@ -194,13 +194,10 @@ function sanitizeGeminiItems(value: unknown): Record<string, unknown> {
 }
 
 function schemaAlternatives(schema: Record<string, unknown>): Record<string, unknown>[] {
-  if (Object.keys(schema).length !== 1 || !Array.isArray(schema.anyOf)) return [schema];
-  return schema.anyOf.flatMap((entry) => {
-    if (!isRecord(entry) || Object.keys(entry).length === 0) {
-      return schemaAlternatives(geminiOpenValueApproximation());
-    }
-    return [entry];
-  });
+  if (Object.keys(schema).length === 1 && Array.isArray(schema.anyOf)) {
+    return schema.anyOf.filter(isRecord);
+  }
+  return [schema];
 }
 
 function geminiTupleItems(
@@ -252,7 +249,9 @@ export function sanitizeGeminiSchema(value: unknown): Record<string, unknown> {
         }
         break;
       case "anyOf":
-        if (Array.isArray(raw)) out.anyOf = raw.map((entry) => sanitizeGeminiSchema(entry));
+        if (Array.isArray(raw)) {
+          out.anyOf = raw.flatMap((entry) => schemaAlternatives(sanitizeGeminiItems(entry)));
+        }
         break;
       case "format": {
         const type = typeof value.type === "string" ? value.type : "";

--- a/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
+++ b/packages/core-ai-gateway/src/upstream/antigravity/generate-content/wire.ts
@@ -194,10 +194,13 @@ function sanitizeGeminiItems(value: unknown): Record<string, unknown> {
 }
 
 function schemaAlternatives(schema: Record<string, unknown>): Record<string, unknown>[] {
-  if (Object.keys(schema).length === 1 && Array.isArray(schema.anyOf)) {
-    return schema.anyOf.filter(isRecord);
-  }
-  return [schema];
+  if (Object.keys(schema).length !== 1 || !Array.isArray(schema.anyOf)) return [schema];
+  return schema.anyOf.flatMap((entry) => {
+    if (!isRecord(entry) || Object.keys(entry).length === 0) {
+      return schemaAlternatives(geminiOpenValueApproximation());
+    }
+    return [entry];
+  });
 }
 
 function geminiTupleItems(

--- a/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
@@ -546,6 +546,21 @@ describe("antigravity request wire", () => {
       items: { anyOf: [{ type: "string" }, { type: "integer" }] },
       maxItems: 1,
     });
+    expect(sanitizeGeminiSchema({
+      type: "array",
+      prefixItems: [{ anyOf: [{ type: "string" }, {}, { $ref: "#/$defs/value" }] }],
+      items: false,
+    })).toMatchObject({
+      type: "array",
+      items: {
+        anyOf: expect.arrayContaining([
+          { type: "string" },
+          { type: "string", nullable: true },
+          expect.objectContaining({ type: "array" }),
+        ]),
+      },
+      maxItems: 1,
+    });
     expect(sanitizeGeminiSchema({ type: "array" })).toMatchObject({
       type: "array",
       items: {

--- a/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
@@ -550,7 +550,11 @@ describe("antigravity request wire", () => {
       type: "array",
       prefixItems: [{
         description: "value",
-        anyOf: [{ type: "string" }, {}, { $ref: "#/$defs/value" }],
+        anyOf: [
+          { type: "string" },
+          {},
+          { description: "referenced", $ref: "#/$defs/value" },
+        ],
       }],
       items: false,
     })).toMatchObject({

--- a/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
@@ -548,7 +548,10 @@ describe("antigravity request wire", () => {
     });
     expect(sanitizeGeminiSchema({
       type: "array",
-      prefixItems: [{ anyOf: [{ type: "string" }, {}, { $ref: "#/$defs/value" }] }],
+      prefixItems: [{
+        description: "value",
+        anyOf: [{ type: "string" }, {}, { $ref: "#/$defs/value" }],
+      }],
       items: false,
     })).toMatchObject({
       type: "array",

--- a/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
@@ -468,6 +468,84 @@ describe("antigravity request wire", () => {
     });
   });
 
+  it("lowers tuple arrays into the homogeneous item schema Gemini requires", () => {
+    // ToolSearch's `where` is a tuple array. Dropping JSON Schema 2020-12's
+    // `prefixItems` leaves its inner array with an empty `items`, so Gemini rejects the turn.
+    const schema = sanitizeGeminiSchema({
+      type: "object",
+      properties: {
+        query: {
+          type: "object",
+          properties: {
+            where: {
+              type: "array",
+              items: {
+                type: "array",
+                prefixItems: [
+                  { type: "string" },
+                  { type: "string", enum: ["eq", "ne"] },
+                  {},
+                ],
+                items: {},
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(schema).toMatchObject({
+      type: "object",
+      properties: {
+        query: {
+          properties: {
+            where: {
+              type: "array",
+              items: {
+                type: "array",
+                items: { anyOf: expect.any(Array) },
+              },
+            },
+          },
+        },
+      },
+    });
+    const inner = ((schema.properties as Record<string, unknown>).query as Record<string, unknown>)
+      .properties as Record<string, Record<string, unknown>>;
+    const alternatives = ((inner.where.items as Record<string, unknown>).items as Record<string, unknown>)
+      .anyOf as Record<string, unknown>[];
+    expect(alternatives).toContainEqual({ type: "string", enum: ["eq", "ne"] });
+    expect(alternatives).toContainEqual({ type: "string", nullable: true });
+    expect(alternatives).toContainEqual(expect.objectContaining({ type: "array" }));
+
+    // A concrete 2020-12 tail is part of the homogeneous approximation too; dropping either
+    // side would incorrectly erase valid positional or additional values.
+    expect(sanitizeGeminiSchema({
+      type: "array",
+      prefixItems: [{ type: "integer" }],
+      items: { type: "string" },
+    })).toEqual({
+      type: "array",
+      items: { anyOf: [{ type: "integer" }, { type: "string" }] },
+    });
+    expect(sanitizeGeminiSchema({
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "integer" }],
+      items: false,
+    })).toEqual({
+      type: "array",
+      items: { anyOf: [{ type: "string" }, { type: "integer" }] },
+    });
+    expect(sanitizeGeminiSchema({ type: "array" })).toMatchObject({
+      type: "array",
+      items: {
+        anyOf: expect.arrayContaining([
+          { type: "string", nullable: true },
+          expect.objectContaining({ type: "array" }),
+        ]),
+      },
+    });
+  });
+
   it("rewrites a tool name the wire cannot carry and restores it on the way back", () => {
     const codec = createToolNameCodec();
     const long = `mcp__${"server".repeat(12)}__create_issue`;

--- a/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/antigravity.test.ts
@@ -534,6 +534,17 @@ describe("antigravity request wire", () => {
     })).toEqual({
       type: "array",
       items: { anyOf: [{ type: "string" }, { type: "integer" }] },
+      maxItems: 2,
+    });
+    expect(sanitizeGeminiSchema({
+      type: "array",
+      items: [{ type: "string" }, { type: "integer" }],
+      additionalItems: false,
+      maxItems: 1,
+    })).toEqual({
+      type: "array",
+      items: { anyOf: [{ type: "string" }, { type: "integer" }] },
+      maxItems: 1,
     });
     expect(sanitizeGeminiSchema({ type: "array" })).toMatchObject({
       type: "array",


### PR DESCRIPTION
## Summary
- lower draft-07 and JSON Schema 2020-12 tuple arrays into homogeneous item unions accepted by Antigravity Gemini
- preserve positional schemas and additional-item tails while replacing unconstrained empty item schemas with a concrete Gemini-compatible approximation
- add regression coverage for the ToolSearch `query.where` schema that previously caused a request-level 400

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] live Antigravity Gemini 3.7 Flash call with the affected tuple schema reached `response.completed`