### PR TITLE
fix(fleet-console): give the mono font token a bundled Hangul fallback

### DIFF
--- a/.changelog.d/analyst-mono-cjk-fallback.md
+++ b/.changelog.d/analyst-mono-cjk-fallback.md
@@ -1,0 +1,8 @@
+---
+branch: analyst-mono-cjk-fallback
+---
+
+### fleet-console
+#### Fixed
+- Render Hangul in monospace UI text (Session Analyst caption, chips, and status lines) with the bundled coding font instead of the OS fallback.
+  ko: 고정폭 UI 텍스트(세션 분석가 캡션·칩·상태 줄)의 한글을 OS 폴백 대신 번들 코딩 서체로 렌더합니다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@fontsource-variable/source-code-pro':
         specifier: ^5.2.7
         version: 5.2.7
+      '@fontsource/nanum-gothic-coding':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@types/node':
         specifier: ^24.10.0
         version: 24.12.2

--- a/runtime/fleet-console/core/client/src/main.tsx
+++ b/runtime/fleet-console/core/client/src/main.tsx
@@ -14,6 +14,11 @@ import "@fontsource-variable/fraunces/standard-italic.css";
 import "@fontsource-variable/manrope";
 // Pretendard dynamic subset: 한글 폴백 서체 — 브라우저가 unicode-range로 필요한 subset woff2만 내려받는다.
 import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
+// Nanum Gothic Coding: --font-mono의 한글 폴백. JetBrains Mono·ui-monospace·SF Mono·Menlo 어느 것도 한글
+// 글리프가 없어 이 서체가 없으면 mono 표면(캡션·칩·펄스)의 한글만 OS 비례폭 고딕으로 새어 나간다.
+// 터미널 플러그인이 같은 서체를 xterm용으로 싣지만, 토큰의 폴백은 토큰을 정의하는 코어가 소유한다.
+import "@fontsource/nanum-gothic-coding/korean-400.css";
+import "@fontsource/nanum-gothic-coding/korean-700.css";
 import "@fontsource-variable/jetbrains-mono";
 import "@fontsource-variable/cascadia-code";
 import "@fontsource-variable/fira-code";

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -340,7 +340,9 @@
      OS 폴백의 얇은 스템 대신 번들 서체로 렌더되어 라틴과 굵기·폭이 정합된다. */
   --font-display: "Fraunces Variable", "Fraunces", "Pretendard Variable", ui-serif, Georgia, "Times New Roman", serif;
   --font-body: "Manrope Variable", "Manrope", "Pretendard Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  --font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  /* mono의 한글 폴백은 Nanum Gothic Coding — 터미널·채팅 로그와 같은 서체라 캡션·칩·펄스의 한글이
+     본문 로그와 한 몸으로 읽힌다. Pretendard가 아닌 이유: 비례폭이라 mono 라틴과 폭 리듬이 갈린다. */
+  --font-mono: "JetBrains Mono Variable", "JetBrains Mono", "Nanum Gothic Coding", ui-monospace, "SF Mono", Menlo, monospace;
   --font-body-size: 14px;
 
   /* 크기도 굵기와 같은 이유로 사다리 하나만 쓴다 — 굵기를 3티어로 묶어 놓고 크기를 raw px로

--- a/runtime/fleet-console/package.json
+++ b/runtime/fleet-console/package.json
@@ -94,6 +94,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/manrope": "^5.2.8",
     "@fontsource-variable/source-code-pro": "^5.2.7",
+    "@fontsource/nanum-gothic-coding": "^5.3.0",
     "@types/node": "^24.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary
- 세션 분석가의 캡션·모드 칩·펄스·영수증 등 `--font-mono`를 쓰는 표면에서 한글만 OS 비례폭 고딕으로 새어 나가던 문제를 고칩니다. 코어 `--font-mono` 토큰에 번들 서체 Nanum Gothic Coding을 한글 폴백으로 넣고, core `main.tsx`에서 한글 400/700 서브셋을 로드합니다.
- 채팅뷰는 터미널 글꼴 설정 경로가 이미 같은 폴백을 얹고 있어 정상이었고, 그래서 분석가만 시스템 폰트처럼 보였습니다. 토큰의 폴백은 토큰을 정의하는 코어가 소유하도록 두었습니다(터미널 플러그인의 xterm용 로드는 그대로).
- 분석가 아티팩트 iframe은 별도의 same-origin 서체 브리지(라틴 전용, CJK는 시스템 스택으로 계약)라 이 PR 범위 밖입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` 통과
- [x] vitest: instrument-design-contract · ui-font-document · desktop-theme · console-settings (139) + terminal chat-font-authority · terminal-font (17) 통과
- [x] 격리 콘솔(워크트리 dist) 헤드리스 실측: `document.fonts`에 Nanum Gothic Coding 400/700 loaded, 분석가 캡션 "분석가 · 준비됨"·"초기화"·"대화/아티팩트"가 코딩 서체로 렌더(스크린샷 확인), 같은 한글 런 폭이 시스템 폰트 195px 대비 토큰 242px
- [x] `node scripts/compile-changelog-fragments.mjs --check` OK