### PR TITLE
fix(fleet-console): bridge bundled Hangul fonts into Session Analyst artifacts

### DIFF
--- a/.changelog.d/analyst-artifact-cjk-fonts.md
+++ b/.changelog.d/analyst-artifact-cjk-fonts.md
@@ -1,0 +1,8 @@
+---
+branch: analyst-artifact-cjk-fonts
+---
+
+### fleet-console
+#### Fixed
+- Render Hangul inside Session Analyst artifacts with the bundled Console fonts (Pretendard for prose, the coding font for labels and code) instead of the OS fallback.
+  ko: 세션 분석가 아티팩트 안의 한글을 OS 폴백 대신 번들된 콘솔 서체(본문은 Pretendard, 라벨·코드는 코딩 서체)로 렌더합니다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -767,6 +767,9 @@ importers:
       node-pty:
         specifier: ^1.0.0
         version: 1.1.0
+      pretendard:
+        specifier: ^1.3.9
+        version: 1.3.9
       react:
         specifier: ^19.2.3
         version: 19.2.7

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
@@ -46,6 +46,11 @@ export type ArtifactThemeColors = {
   /** 콘솔 번들 @font-face에서 읽은 same-origin 서체 경로 — 문서가 콘솔 서체를 잇는다. */
   readonly sansFont?: string;
   readonly monoFont?: string;
+  /** 한글 폴백 서체의 same-origin @font-face 시트 경로. 서브셋 92장짜리 변수 폰트(Pretendard)는
+      파일 하나로 못 잇고, 코딩 서체(Nanum Gothic Coding)는 굵기별 파일이 갈리므로 시트 단위로
+      넘긴다 — 서버가 sans에는 "Pretendard Variable", mono에는 "Nanum Gothic Coding"을 세운다. */
+  readonly sansCjkSheets?: readonly string[];
+  readonly monoCjkSheets?: readonly string[];
 };
 
 const ARTIFACT_OPTIONAL_PARAMS = ["card", "inset", "hairline", "hairlineStrong", "accent", "muted", "faint", "positive", "warn", "critical", "focus", "sansFont", "monoFont"] as const;
@@ -56,6 +61,8 @@ export function analysisArtifactUrl(artifactId: string, theme: ConsoleTheme, col
     const value = colors[key];
     if (value) query.set(key, value);
   }
+  for (const sheet of colors.sansCjkSheets ?? []) query.append("sansCjkSheet", sheet);
+  for (const sheet of colors.monoCjkSheets ?? []) query.append("monoCjkSheet", sheet);
   return `/plugins/terminal/analysis/artifacts/${encodeURIComponent(artifactId)}?${query.toString()}`;
 }
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-panel.tsx
@@ -2,6 +2,11 @@ import type { ConsoleTheme, OperationRenderContext } from "@fleet-console/sdk/pl
 import { React } from "@fleet-console/sdk/plugin/browser";
 import type { AnalysisArtifact } from "./analysis-types.js";
 
+// 한글 폴백 서체의 @font-face 시트 — ?url이라 같은 Vite 번들이 처리한 시트의 경로만 받고, 여기서
+// 로드하지는 않는다(콘솔 본체는 core main.tsx가 이미 싣는다). 아티팩트 문서가 이 경로를 링크한다.
+import nanumGothicCodingBoldSheetUrl from "@fontsource/nanum-gothic-coding/korean-700.css?url";
+import nanumGothicCodingRegularSheetUrl from "@fontsource/nanum-gothic-coding/korean-400.css?url";
+import pretendardSheetUrl from "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css?url";
 import { analysisArtifactUrl, clearAnalysisArtifacts, type ArtifactThemeColors } from "./analysis-api.js";
 import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
 import { getT } from "../i18n/index.js";
@@ -282,9 +287,14 @@ function getArtifactColors(): ArtifactThemeColors {
  * 콘솔 번들의 @font-face에서 본문·모노 서체의 same-origin 자산 경로를 읽는다.
  * 아티팩트 iframe은 콘솔의 @font-face를 상속하지 않으므로, 문서가 같은 파일을 스스로
  * 선언해야 콘솔 서체를 잇는다. 변수 폰트는 서브셋별 규칙이 여럿이라 라틴 서브셋
- * (U+0000 범위를 쥔 규칙)을 고른다 — 한글은 콘솔과 동일하게 시스템 폴백이 진다.
+ * (U+0000 범위를 쥔 규칙)을 고른다.
+ *
+ * 한글은 파일 하나로 못 잇는다 — Pretendard는 unicode-range로 쪼갠 서브셋 92장이고 Nanum
+ * Gothic Coding은 굵기별 파일이다. 그래서 라틴처럼 woff2 경로가 아니라, Vite가 같은 번들에서
+ * 처리해 내놓은 @font-face **시트**의 경로를 넘긴다. 문서가 그 시트를 링크하면 브라우저가
+ * 화면에 실제로 등장한 한글 서브셋만 내려받는다(콘솔 본체와 같은 동작).
  */
-function consoleFontSources(): Pick<ArtifactThemeColors, "sansFont" | "monoFont"> {
+function consoleFontSources(): Pick<ArtifactThemeColors, "sansFont" | "monoFont" | "sansCjkSheets" | "monoCjkSheets"> {
   try {
     let sans: string | undefined;
     let mono: string | undefined;
@@ -315,10 +325,29 @@ function consoleFontSources(): Pick<ArtifactThemeColors, "sansFont" | "monoFont"
       }
       if (sans && mono) break;
     }
-    return { ...(sans ? { sansFont: sans } : {}), ...(mono ? { monoFont: mono } : {}) };
+    const sansCjkSheets = sameOriginSheetPaths([pretendardSheetUrl]);
+    const monoCjkSheets = sameOriginSheetPaths([nanumGothicCodingRegularSheetUrl, nanumGothicCodingBoldSheetUrl]);
+    return {
+      ...(sans ? { sansFont: sans } : {}),
+      ...(mono ? { monoFont: mono } : {}),
+      ...(sansCjkSheets.length ? { sansCjkSheets } : {}),
+      ...(monoCjkSheets.length ? { monoCjkSheets } : {}),
+    };
   } catch {
     return {};
   }
+}
+
+/* 번들이 준 시트 URL을 same-origin 경로로 정규화한다. 개발 서버·베이스 경로에 따라 절대 URL일
+   수 있고, 다른 origin이면 아티팩트의 오프라인 계약(자기 origin 밖을 부르지 않음) 위반이라 버린다. */
+function sameOriginSheetPaths(urls: readonly string[]): readonly string[] {
+  const paths: string[] = [];
+  for (const raw of urls) {
+    const url = new URL(raw, window.location.href);
+    if (url.origin !== window.location.origin || !url.pathname.endsWith(".css")) continue;
+    paths.push(url.pathname);
+  }
+  return paths;
 }
 
 function ArtifactTime({ createdAt, language }: { readonly createdAt: number; readonly language: ConsoleLocale }) {

--- a/runtime/fleet-plugins/terminal/client/shared/assets.d.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/assets.d.ts
@@ -1,1 +1,7 @@
 declare module "*.css";
+
+// Vite의 ?url 자산 import — 처리된 파일의 same-origin 경로를 돌려준다(아티팩트 서체 시트 브리지).
+declare module "*.css?url" {
+  const url: string;
+  export default url;
+}

--- a/runtime/fleet-plugins/terminal/package.json
+++ b/runtime/fleet-plugins/terminal/package.json
@@ -35,6 +35,7 @@
     "@xterm/addon-webgl": "0.20.0-beta.298",
     "@xterm/xterm": "6.1.0-beta.302",
     "node-pty": "^1.0.0",
+    "pretendard": "^1.3.9",
     "react": "^19.2.3",
     "ws": "^8.18.0"
   },

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -61,9 +61,14 @@ const ARTIFACT_META_CSP = `<meta http-equiv="Content-Security-Policy" content="$
 
 describe("Session Analyst server contract", () => {
   it("serializes all Console theme coordinates into artifact URLs", () => {
-    const url = new URL(analysisArtifactUrl("artifact/id", "carbon", { ground: "#101820", foreground: "#f2f4f7", card: "#18212b", inset: "#0c1014", hairline: "#35404d", hairlineStrong: "#4a5764", accent: "#65d1ff", muted: "#96a0ad", faint: "#7d8894", positive: "#5fd39a", warn: "#e5c07b", critical: "#f2777a", focus: "#d9a441", sansFont: "/console/assets/manrope-latin.woff2", monoFont: "/console/assets/jetbrains-latin.woff2" }), "http://fleet.invalid");
+    const url = new URL(analysisArtifactUrl("artifact/id", "carbon", { ground: "#101820", foreground: "#f2f4f7", card: "#18212b", inset: "#0c1014", hairline: "#35404d", hairlineStrong: "#4a5764", accent: "#65d1ff", muted: "#96a0ad", faint: "#7d8894", positive: "#5fd39a", warn: "#e5c07b", critical: "#f2777a", focus: "#d9a441", sansFont: "/console/assets/manrope-latin.woff2", monoFont: "/console/assets/jetbrains-latin.woff2", sansCjkSheets: ["/console/assets/pretendard.css"], monoCjkSheets: ["/console/assets/korean-400.css", "/console/assets/korean-700.css"] }), "http://fleet.invalid");
 
     expect(url.pathname).toBe("/plugins/terminal/analysis/artifacts/artifact%2Fid");
+    // 한글 시트는 굵기별로 여러 장이라 같은 키를 반복한다 — 서버는 getAll로 읽는다.
+    expect(url.searchParams.getAll("sansCjkSheet")).toEqual(["/console/assets/pretendard.css"]);
+    expect(url.searchParams.getAll("monoCjkSheet")).toEqual(["/console/assets/korean-400.css", "/console/assets/korean-700.css"]);
+    url.searchParams.delete("sansCjkSheet");
+    url.searchParams.delete("monoCjkSheet");
     expect(Object.fromEntries(url.searchParams)).toEqual({
       theme: "carbon",
       ground: "#101820",
@@ -866,6 +871,77 @@ describe("Session Analyst server contract", () => {
     expect(response.body).not.toContain("injected-surface");
     expect(response.body).not.toContain("javascript:alert");
     expect(document.documentElement.hasAttribute("onload")).toBe(false);
+  });
+
+  it("links same-origin Hangul fallback sheets and seats their faces behind the Latin bridge", async () => {
+    const router = createRouterHarness(true);
+    const transcriptPath = join(await mkdtemp(join(tmpdir(), "analysis-artifact-fonts-")), "session.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    let emit: ((event: { type: "artifact"; artifact: { id: string; title: string; html: string; createdAt: string } }) => void) | undefined;
+    router.setProviderSession({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath });
+    registerAnalysis(router, {
+      createSession: ((options: { onEvent: typeof emit }) => {
+        emit = options.onEvent;
+        return { start: async () => undefined, send: async () => undefined, dispose: async () => undefined };
+      }) as never,
+    });
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", START_SELECTION);
+    emit?.({ type: "artifact", artifact: { id: "fonts", title: "Fonts", html: "<p>한글</p>", createdAt: new Date(0).toISOString() } });
+    const query = new URLSearchParams({ theme: "carbon", ground: "#101820", foreground: "#f2f4f7", sansFont: "/console/assets/manrope-latin.woff2", monoFont: "/console/assets/jetbrains-latin.woff2" });
+    query.append("sansCjkSheet", "/console/assets/pretendardvariable-dynamic-subset-DIMR61Pu.css");
+    query.append("monoCjkSheet", "/console/assets/korean-400-BaAbCdEf.css");
+    query.append("monoCjkSheet", "/console/assets/korean-700-BaAbCdEf.css");
+    // 같은 경로의 중복은 한 번만, origin 밖·상위 경로·프로토콜 상대·비-CSS는 전부 버린다.
+    query.append("monoCjkSheet", "/console/assets/korean-700-BaAbCdEf.css");
+    query.append("monoCjkSheet", "https://fonts.example/evil.css");
+    query.append("monoCjkSheet", "/console/assets/../secret.css");
+    query.append("monoCjkSheet", "//fonts.example/evil.css");
+    query.append("monoCjkSheet", "/console/assets/evil.js");
+    query.append("sansCjkSheet", '/console/assets/x.css"><script>globalThis.sheetInjected=true</script><link href="');
+
+    const response = await router.call("GET", `/api/v1/plugins/terminal/analysis/artifacts/fonts?${query.toString()}`);
+
+    expect(response.status).toBe(200);
+    const document = new DOMParser().parseFromString(response.body, "text/html");
+    const links = Array.from(document.head.querySelectorAll('link[rel="stylesheet"]')).map((link) => link.getAttribute("href"));
+    expect(links).toEqual([
+      "/console/assets/pretendardvariable-dynamic-subset-DIMR61Pu.css",
+      "/console/assets/korean-400-BaAbCdEf.css",
+      "/console/assets/korean-700-BaAbCdEf.css",
+    ]);
+    const style = document.head.querySelector("style")?.textContent ?? "";
+    expect(style).toContain('--fleet-sans:"Fleet Console Sans","Pretendard Variable",ui-sans-serif');
+    expect(style).toContain('--fleet-mono:"Fleet Console Mono","Nanum Gothic Coding",ui-monospace');
+    expect(response.body).not.toContain("fonts.example");
+    expect(response.body).not.toContain("secret.css");
+    expect(response.body).not.toContain("evil.js");
+    expect(response.body).not.toContain("sheetInjected");
+  });
+
+  it("keeps the system Hangul fallback when no sheet is bridged", async () => {
+    const router = createRouterHarness(true);
+    const transcriptPath = join(await mkdtemp(join(tmpdir(), "analysis-artifact-fonts-")), "session.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    let emit: ((event: { type: "artifact"; artifact: { id: string; title: string; html: string; createdAt: string } }) => void) | undefined;
+    router.setProviderSession({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath });
+    registerAnalysis(router, {
+      createSession: ((options: { onEvent: typeof emit }) => {
+        emit = options.onEvent;
+        return { start: async () => undefined, send: async () => undefined, dispose: async () => undefined };
+      }) as never,
+    });
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", START_SELECTION);
+    emit?.({ type: "artifact", artifact: { id: "plain", title: "Plain", html: "<p>plain</p>", createdAt: new Date(0).toISOString() } });
+
+    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/plain?theme=carbon&ground=%23101820&foreground=%23f2f4f7");
+
+    const document = new DOMParser().parseFromString(response.body, "text/html");
+    expect(document.head.querySelector('link[rel="stylesheet"]')).toBeNull();
+    const style = document.head.querySelector("style")?.textContent ?? "";
+    expect(style).toContain('--fleet-sans:ui-sans-serif');
+    expect(style).toContain('--fleet-mono:ui-monospace');
+    expect(style).not.toContain("Pretendard");
+    expect(style).not.toContain("Nanum");
   });
 
   it("host-gates artifact documents and returns 404 for unknown ids", async () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -191,8 +191,10 @@ function artifactDocument(html: string, requestUrl: string | undefined): string 
   const focus = safeArtifactColor(query.get("focus"), accent);
   const sansFont = safeArtifactFontPath(query.get("sansFont"));
   const monoFont = safeArtifactFontPath(query.get("monoFont"));
+  const sansCjkSheets = safeArtifactSheetPaths(query.getAll("sansCjkSheet"));
+  const monoCjkSheets = safeArtifactSheetPaths(query.getAll("monoCjkSheet"));
   const canvasStyle = `background-color:${ground}!important;background-image:none!important;color:${foreground}!important;min-height:100%!important;color-scheme:${ANALYSIS_ARTIFACT_LIGHT_THEMES.has(theme) ? "light" : "dark"}!important;`;
-  const baseHead = `${ANALYSIS_ARTIFACT_META_CSP}${artifactBaseStylesheet({ ground, card, inset, foreground, muted, faint, hairline, hairlineStrong, accent, positive, warn, critical, focus, sansFont, monoFont })}`;
+  const baseHead = `${ANALYSIS_ARTIFACT_META_CSP}${artifactBaseStylesheet({ ground, card, inset, foreground, muted, faint, hairline, hairlineStrong, accent, positive, warn, critical, focus, sansFont, monoFont, sansCjkSheets, monoCjkSheets })}`;
   const documentTags = findArtifactDocumentTags(html);
   if (documentTags) {
     const htmlTag = withArtifactAttribute(withArtifactAttribute(documentTags.htmlTag.source, "data-theme", theme), "style", canvasStyle, ARTIFACT_CANVAS_STYLE_PROPERTIES);
@@ -300,9 +302,10 @@ const ARTIFACT_BASE_RULES = [
  * 모델은 그 위에서 위계와 구조만 결정하면 되게 한다. 이 시트는 문서 맨 앞(<html> 직후)에
  * 들어가므로 모델이 뒤에서 같은 선택자로 덮을 수 있다 — 바닥이지 감옥이 아니다.
  *
- * 폰트는 시스템 스택만 쓴다. iframe은 Console의 @font-face를 상속하지 않고, 외부 폰트
+ * 폰트는 콘솔 자기 자산만 잇는다. iframe은 Console의 @font-face를 상속하지 않고, 외부 폰트
  * 호스트를 부르는 것은 아티팩트의 격리 계약(프로세스 메모리 전용·바깥으로 신호 없음)을
- * 깨기 때문이다.
+ * 깨기 때문이다. 라틴은 woff2 한 장을 @font-face로 직접 세우고, 한글은 서브셋이 여럿이라
+ * 콘솔 번들의 @font-face 시트를 same-origin으로 링크한다 — 어느 쪽도 자기 origin 밖은 없다.
  */
 function artifactBaseStylesheet(tokens: {
   readonly ground: string;
@@ -320,16 +323,23 @@ function artifactBaseStylesheet(tokens: {
   readonly focus: string;
   readonly sansFont?: string;
   readonly monoFont?: string;
+  readonly sansCjkSheets?: readonly string[];
+  readonly monoCjkSheets?: readonly string[];
 }): string {
   // 콘솔 자기 자산의 same-origin 서체 — 외부 신호 0. 응답 헤더의 sandbox가 문서를 opaque
   // origin으로 만들므로 폰트 fetch는 CORS 경로를 탄다(정적 서버가 woff2에 ACAO를 싣는 이유).
   // 내려받은 사본에서는 상대 경로가 죽고 폴백 스택이 선다 — 오프라인 계약은 그대로다.
   const sansFace = tokens.sansFont ? `@font-face{font-family:"Fleet Console Sans";src:url("${tokens.sansFont}") format("woff2");font-weight:100 999;font-style:normal;font-display:swap}` : "";
   const monoFace = tokens.monoFont ? `@font-face{font-family:"Fleet Console Mono";src:url("${tokens.monoFont}") format("woff2");font-weight:100 999;font-style:normal;font-display:swap}` : "";
-  const sansStack = `${tokens.sansFont ? `"Fleet Console Sans",` : ""}ui-sans-serif,system-ui,-apple-system,"Segoe UI","Apple SD Gothic Neo","Malgun Gothic",Roboto,sans-serif`;
-  const monoStack = `${tokens.monoFont ? `"Fleet Console Mono",` : ""}ui-monospace,"SF Mono",Menlo,Consolas,"D2Coding",monospace`;
+  // 한글 폴백 — 클라이언트가 넘긴 시트가 세우는 서체 이름은 역할별로 고정이다(sans=Pretendard
+  // Variable, mono=Nanum Gothic Coding). 이름까지 파라미터로 받으면 스택 문자열에 임의 값이
+  // 실리므로 경로만 받고 이름은 여기서 잠근다. 시트가 없으면 시스템 CJK 폴백이 그대로 선다.
+  const cjkSheets = [...(tokens.sansCjkSheets ?? []), ...(tokens.monoCjkSheets ?? [])];
+  const cjkLinks = cjkSheets.map((href) => `<link rel="stylesheet" href="${href}">`).join("");
+  const sansStack = `${tokens.sansFont ? `"Fleet Console Sans",` : ""}${tokens.sansCjkSheets?.length ? `"Pretendard Variable",` : ""}ui-sans-serif,system-ui,-apple-system,"Segoe UI","Apple SD Gothic Neo","Malgun Gothic",Roboto,sans-serif`;
+  const monoStack = `${tokens.monoFont ? `"Fleet Console Mono",` : ""}${tokens.monoCjkSheets?.length ? `"Nanum Gothic Coding",` : ""}ui-monospace,"SF Mono",Menlo,Consolas,"D2Coding",monospace`;
   const root = `:root{--fleet-canvas:${tokens.ground};--fleet-surface:${tokens.card};--fleet-card:${tokens.card};--fleet-inset:${tokens.inset};--fleet-ink:${tokens.foreground};--fleet-muted:${tokens.muted};--fleet-faint:${tokens.faint};--fleet-hairline:${tokens.hairline};--fleet-hairline-strong:${tokens.hairlineStrong};--fleet-accent:${tokens.accent};--fleet-positive:${tokens.positive};--fleet-warn:${tokens.warn};--fleet-critical:${tokens.critical};--fleet-focus:${tokens.focus};--fleet-sans:${sansStack};--fleet-mono:${monoStack}}`;
-  return `<style>${sansFace}${monoFace}${root}${ARTIFACT_BASE_RULES}</style>`;
+  return `${cjkLinks}<style>${sansFace}${monoFace}${root}${ARTIFACT_BASE_RULES}</style>`;
 }
 
 /**
@@ -342,6 +352,22 @@ const SAFE_ARTIFACT_FONT_PATH = /^\/[A-Za-z0-9_\-./]{1,200}\.woff2$/;
 function safeArtifactFontPath(value: string | null): string | undefined {
   if (!value || !SAFE_ARTIFACT_FONT_PATH.test(value) || value.includes("..") || value.includes("//")) return undefined;
   return value;
+}
+
+/* 한글 폴백 시트도 같은 계약이다 — same-origin 상대 경로의 .css만, 중복 없이, 상한까지. 시트는
+   @font-face 외의 규칙도 실을 수 있지만 콘솔이 내놓은 자기 자산만 가리킬 수 있으므로(스킴·호스트
+   거부) 문서에 낯선 규칙이 들어올 경로는 없다. 상한은 sans 1장 + mono 굵기 2장에 여유 하나다. */
+const SAFE_ARTIFACT_SHEET_PATH = /^\/[A-Za-z0-9_\-./]{1,200}\.css$/;
+const MAX_ARTIFACT_CJK_SHEETS = 4;
+
+function safeArtifactSheetPaths(values: readonly string[]): readonly string[] {
+  const safe: string[] = [];
+  for (const value of values) {
+    if (!SAFE_ARTIFACT_SHEET_PATH.test(value) || value.includes("..") || value.includes("//") || safe.includes(value)) continue;
+    safe.push(value);
+    if (safe.length >= MAX_ARTIFACT_CJK_SHEETS) break;
+  }
+  return safe;
 }
 
 type HtmlStartTag = { readonly start: number; readonly end: number; readonly source: string };


### PR DESCRIPTION
## Summary
- 세션 분석가 아티팩트 iframe은 Manrope·JetBrains Mono의 라틴 woff2 한 장씩만 same-origin @font-face로 이었고, 한글은 시스템 스택("Apple SD Gothic Neo")으로 계약돼 있었습니다. #986으로 분석가 패널의 한글은 번들 서체가 됐지만 아티팩트 안 한글은 여전히 OS 폰트였습니다.
- 한글은 파일 한 장으로 못 잇습니다(Pretendard = unicode-range 서브셋 92장, Nanum Gothic Coding = 굵기별 파일). 그래서 같은 Vite 번들이 처리한 @font-face **시트**를 `?url` 자산으로 방출하고, 클라이언트가 그 same-origin 경로를 `sansCjkSheet`/`monoCjkSheet` 파라미터로 넘기며, 서버가 `<link rel="stylesheet">`로 문서 앞에 잇고 스택에 `"Pretendard Variable"`(sans)·`"Nanum Gothic Coding"`(mono)을 라틴 브리지 뒤에 세웁니다. 브라우저는 화면에 실제로 나온 한글 서브셋만 내려받습니다(콘솔 본체와 같은 동작).
- 서버 검증은 woff2 브리지와 같은 계약입니다: same-origin 상대 경로의 `.css`만, 스킴·호스트·`..`·`//` 거부, 중복 제거, 상한 4장. 서체 이름은 파라미터로 받지 않고 서버가 잠급니다. 시트가 없으면 이전과 같은 시스템 한글 스택이 섭니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`: `pretendardvariable-dynamic-subset-*.css`·`korean-400-*.css`·`korean-700-*.css`가 해시된 `/console/assets/...woff2` url()로 방출됨
- [x] terminal `pnpm typecheck` 0건 · fleet-console `pnpm typecheck` 통과 · `analysis-routes.test.ts` 44건 통과(신규 2건: 시트 링크·서체 착석·적대 파라미터 거부 / 시트 부재 시 시스템 스택 유지)
- [x] 격리 콘솔(워크트리 dist)에서 실제 모델(Sonnet)로 아티팩트 발행 후 실측: iframe src에 시트 3장 포함, 아티팩트 문서에 `<link>` 3개와 `--fleet-sans:"Fleet Console Sans","Pretendard Variable",…`/`--fleet-mono:"Fleet Console Mono","Nanum Gothic Coding",…` 확인, HAR에서 opaque origin(`Origin: null`)의 iframe이 Pretendard 서브셋 7장과 Nanum 400 woff2를 CORS(ACAO *)로 200 수신, 스크린샷에서 본문 한글=Pretendard·키커/KPI 라벨 한글=Nanum Gothic Coding
- [x] `node scripts/compile-changelog-fragments.mjs --check` OK