### PR TITLE
feat(fleet-console): make chat work status toggle its sheet

### DIFF
--- a/.changelog.d/chat-work-ledge.md
+++ b/.changelog.d/chat-work-ledge.md
@@ -4,5 +4,5 @@ branch: chat-work-ledge
 
 ### fleet-console
 #### Changed
-- Background work in the chat view now lives on a ledge above the composer: a labelled Show/Hide button reveals the job list as a sheet over the conversation, and Escape or a click on the conversation hides it again. The ledge replaces the composer glyph and the side-by-side work pane.
-  ko: 채팅 뷰의 백그라운드 작업이 입력창 위 선반에 자리합니다. 보기/접기 버튼이 작업 목록을 대화 위 시트로 띄우고, Esc나 대화 클릭으로 다시 접습니다. 선반이 입력창 글리프와 나란히 서던 작업 면을 대신합니다.
+- Background work in the chat view now lives on a ledge above the composer: the spinner and status text highlight together and toggle the job list as a sheet over the conversation, while Escape or a click on the conversation hides it again. The ledge replaces the composer glyph and the side-by-side work pane.
+  ko: 채팅 뷰의 백그라운드 작업이 입력창 위 선반에 자리합니다. 스피너와 상태 문구 전체가 함께 강조되며 작업 목록을 대화 위 시트로 여닫고, Esc나 대화 클릭으로 다시 접습니다. 선반이 입력창 글리프와 나란히 서던 작업 면을 대신합니다.

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2682,19 +2682,22 @@ describe("Instrument core design contract", () => {
     expect(ledgeBlock).not.toContain("position: absolute");
     expect(chatView0).toContain('className={`agent-chat-ledge${running ? "" : " is-rest"}`}');
     expect(chatView0).toContain("{hasJobs ? (");
-    // 컴포저 글리프는 없다 — 글리프의 카운트는 선반의 말이 되고 "연다"는 동사는 문의 라벨이 됐다.
+    // 컴포저 글리프는 없다 — 글리프의 카운트는 선반의 말이 되고 그 상태 전체가 여닫는 표면이다.
     expect(chatComposer0).not.toContain("agent-chat-composer-work");
     expect(chat).not.toContain(".agent-chat-composer-work");
-    // 문은 컨트롤로 보여야 한다 — 투명 rest는 헤더로 읽혔다(2026-09-02 실측). Quiet Controls
-    // 레시피 그대로: rest 몸, brass 예고, 열림은 --control-open-rim, 라벨은 동사(Show/Hide).
+    // 별도 보기/접기 동사와 화살표는 없다. 스피너·상태·작업 이름을 담은 한 버튼이 rest에서는
+    // 선반의 문장으로 머물다가 hover/focus에 brass로 하이라이트되고, 열림은 rim으로 남는다.
     const ledgeToggleBlock = chat.match(/^\.agent-chat-ledge-toggle \{[^}]*\}/m)?.[0] ?? "";
-    expect(ledgeToggleBlock).toContain("background: var(--control-rest);");
-    expect(ledgeToggleBlock).not.toContain("background: transparent");
+    expect(ledgeToggleBlock).toContain("background: transparent;");
+    expect(ledgeToggleBlock).toContain("border: 1px solid transparent;");
+    expect(chat).toMatch(/^\.agent-chat-ledge-toggle:hover \{[^}]*background: var\(--control-rest-hover\);[^}]*color: var\(--brass-ink\);/m);
     expect(chat).toMatch(/^\.agent-chat-ledge-toggle\[aria-expanded="true"\] \{[^}]*border-color: var\(--control-open-rim\);/m);
-    expect(chatView0).toContain('{t(open ? "terminal.chat.ledgeHide" : "terminal.chat.ledgeShow")}');
-    // 화살표는 시트의 이동 방향이다 — 열리면 돌아서 아래를 가리킨다(열린 채 아래를 가리키던
-    // 옛 ⌄는 "더 펼침"으로 읽혔다).
-    expect(chat).toContain('.agent-chat-ledge-toggle[aria-expanded="true"] svg { transform: rotate(180deg); }');
+    expect(chatView0).toContain('className="agent-chat-ledge-toggle"');
+    expect(chatView0).not.toContain('{t(open ? "terminal.chat.ledgeHide" : "terminal.chat.ledgeShow")}');
+    expect(chatView0).not.toContain('<svg viewBox="0 0 16 16"');
+    expect(chatView0).toContain('className="agent-chat-strip-orbit"');
+    expect(chatView0).toContain('className="agent-chat-strip-count"');
+    expect(chatView0).toContain('className="agent-chat-ledge-name"');
     // 도는 중이면 aurora 오브(공용 키프레임). reduced-motion이 오브와 시트의 상승을 멈춘다.
     const stripOrbitBlock = chat.match(/^\.agent-chat-strip-orbit \{[^}]*\}/m)?.[0] ?? "";
     expect(stripOrbitBlock).toContain("animation: agent-chat-orbit 0.9s linear infinite;");

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -260,7 +260,7 @@ export function AgentChatView({
     setOpenJobId(id);
     setWorkOpen(true);
   }, []);
-  // 컴포저의 백그라운드 작업 글리프가 여는 문 — 특정 잡을 고르지 않고 목록(작업 면)을 연다.
+  // 선반의 작업 상태가 여는 면 — 특정 잡을 고르지 않고 목록(작업 면)을 연다.
   const openWork = React.useCallback(() => {
     setOpenJobId(null);
     setWorkOpen(true);
@@ -327,7 +327,7 @@ export function AgentChatView({
 
   // 열리거나 목록·상세가 갈아 끼워지면 보이는 내용의 첫 컨트롤로 초점을 보낸다. 시트는 DOM에서
   // 선반보다 앞에 있고, 뷰를 바꾼 버튼은 그 순간 사라진다 — 이 좌표를 듣지 않으면 Tab은 컴포저로
-  // 건너뛰고 Esc도 패널 밖 body에서 시작한다. 접을 때는 언제나 선반의 문으로 돌아간다.
+  // 건너뛰고 Esc도 패널 밖 body에서 시작한다. 접을 때는 언제나 선반의 상태 버튼으로 돌아간다.
   React.useEffect(() => {
     if (!workOpen) return;
     workSheetRef.current?.querySelector<HTMLElement>("button:not(:disabled)")?.focus();
@@ -474,9 +474,8 @@ export function AgentChatView({
         ) : null}
         </div>
 
-        {/* 선반 — 잡이 하나라도 태어난 세션에 서는 한 줄. 무엇이 도는지 말로 말하고, 상태 옆
-            문은 자기 동사(Show/Hide)를 단다. 시트가 열려도 이 줄은 같은 자리에 그대로다:
-            들어온 문이 나가는 문이고, 그 문은 옮겨 다니지 않는다. */}
+        {/* 선반 — 잡이 하나라도 태어난 세션에 서는 한 줄. 스피너와 상태 문구가 한 덩어리의
+            버튼으로 시트를 여닫는다. 시트가 열려도 같은 자리에서 같은 상태를 계속 말한다. */}
         {hasJobs ? (
           <WorkLedge
             jobs={state.jobs}
@@ -1601,12 +1600,12 @@ function StageDots({ stages }: { readonly stages: readonly AgentChatJob["stages"
 }
 
 /**
- * 선반 — 컴포저 위에 서는 한 줄. 잡이 하나라도 있는 동안 무엇이 도는지 말로 말하고, 상태 옆 문이
- * 시트를 연다. 문의 라벨은 그것이 할 동사(Show/Hide)이고 화살표는 시트가 움직일 방향이다 — 열려
- * 있을 때 아래를 가리키던 화살표가 "더 펼침"으로 읽혀 접는 문을 못 찾던 자리다.
+ * 선반 — 컴포저 위에 서는 한 줄. 잡이 하나라도 있으면 스피너와 상태 문구가 한 덩어리의 버튼으로
+ * 시트를 연다. 따로 붙인 보기/접기 동사는 상태를 두 번 읽게 하므로 두지 않고, 같은 상태를 다시
+ * 누르면 시트가 접힌다.
  *
- * 색 규칙은 스트립 시절 그대로다: 도는 개수는 aurora(상태), 정착만 남은 개수는 중립 잉크. 문은
- * Quiet Controls의 rest 몸(--control-rest)을 입는다 — 투명한 rest는 헤더로 읽혔다.
+ * 색 규칙은 스트립 시절 그대로다: 도는 개수는 aurora(상태), 정착만 남은 개수는 중립 잉크.
+ * brass는 버튼 전체의 hover/focus 예고에만 쓴다.
  */
 function WorkLedge({
   jobs,
@@ -1629,15 +1628,6 @@ function WorkLedge({
   const running = openJobs.length > 0;
   return (
     <div className={`agent-chat-ledge${running ? "" : " is-rest"}`}>
-      {running
-        ? <span className="agent-chat-strip-orbit" aria-hidden="true" />
-        : <span className="agent-chat-strip-dot" aria-hidden="true" />}
-      <span className="agent-chat-strip-count">
-        {running ? t("terminal.chat.stripRunning", { count: openJobs.length }) : settledLabel(jobs.length, t)}
-      </span>
-      {/* 문은 오른쪽 캔버스 모서리에서 물러난다 — 기본 패널 기하에서는 미니맵이 그 모서리를
-          덮는다. 상태 바로 뒤에 두면 어떤 지도 상태에서도 실제 포인터가 닿고, 문과 상태도 한
-          문장으로 읽힌다. */}
       <button
         type="button"
         ref={toggleRef}
@@ -1647,14 +1637,16 @@ function WorkLedge({
         aria-label={t(open ? "terminal.chat.ledgeHideAria" : "terminal.chat.ledgeShowAria")}
         onClick={onToggle}
       >
-        <span>{t(open ? "terminal.chat.ledgeHide" : "terminal.chat.ledgeShow")}</span>
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-          <path d="M4 10l4-4 4 4" />
-        </svg>
+        {running
+          ? <span className="agent-chat-strip-orbit" aria-hidden="true" />
+          : <span className="agent-chat-strip-dot" aria-hidden="true" />}
+        <span className="agent-chat-strip-count">
+          {running ? t("terminal.chat.stripRunning", { count: openJobs.length }) : settledLabel(jobs.length, t)}
+        </span>
+        {/* 도는 것이 있으면 그 이름을 잇는다 — 개수만으로는 무엇이 도는지 모른다. 정착만 남았을
+            때는 개수가 곧 내용이다. */}
+        {running ? <span className="agent-chat-ledge-name">· {openJobs[0]?.title}</span> : null}
       </button>
-      {/* 도는 것이 있으면 그 이름을 잇는다 — 개수만으로는 무엇이 도는지 모른다. 정착만 남았을
-          때는 개수가 곧 내용이다. */}
-      {running ? <span className="agent-chat-ledge-name">· {openJobs[0]?.title}</span> : null}
     </div>
   );
 }
@@ -1663,8 +1655,8 @@ function WorkLedge({
  * 시트 — 잡 목록과 잡 하나의 상세. 둘은 같은 자리에서 갈아 끼워진다.
  *
  * 대화 옆 컬럼도 아래 서랍도 아니다. 선반 바로 위에서 대화의 아래쪽을 덮으며 떠오르고, 접으면
- * 로그와 컴포저는 처음 그 자리다. 접는 문은 이 안에 없다: 선반의 문이 Hide로 바뀌어 같은 자리에
- * 서 있고, Esc와 대화 위 클릭이 그 문을 대신한다.
+ * 로그와 컴포저는 처음 그 자리다. 접는 문은 이 안에 없다: 선반의 같은 상태 버튼을 다시 누르거나
+ * Esc와 대화 위를 누르면 접힌다.
  */
 function WorkSheet({
   id,

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -1634,7 +1634,6 @@ function WorkLedge({
         className="agent-chat-ledge-toggle"
         aria-expanded={open}
         aria-controls={controlsId}
-        aria-label={t(open ? "terminal.chat.ledgeHideAria" : "terminal.chat.ledgeShowAria")}
         onClick={onToggle}
       >
         {running

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
@@ -92,8 +92,8 @@ function mount(activity: "idle" | "running" = "idle"): void {
   render(activity);
 }
 
-// 백그라운드 작업의 문 — 컴포저 위 선반의 Show/Hide 버튼. 컴포저 글리프와 떠 있던 스트립을 대신한다.
-function door(): HTMLButtonElement | null {
+// 백그라운드 작업의 상태 버튼 — 스피너와 관련 문구 전체가 작업 면을 여닫는다.
+function statusToggle(): HTMLButtonElement | null {
   return container?.querySelector<HTMLButtonElement>(".agent-chat-ledge-toggle") ?? null;
 }
 
@@ -109,7 +109,7 @@ function logVisible(): boolean {
 describe("chat work surface", () => {
   it("stays out of the way until the session has background work", () => {
     mount();
-    expect(door()).toBeNull();
+    expect(statusToggle()).toBeNull();
     expect(workPane()).toBeNull();
     expect(logVisible()).toBe(true);
   });
@@ -119,16 +119,21 @@ describe("chat work surface", () => {
     // 아니라 대화 옆에서 동시에 돈다 — 시트는 대화의 아래쪽을 덮을 뿐, 로그는 그대로 서 있다.
     logState = stateWith([job()]);
     mount();
-    const toggle = door();
+    const toggle = statusToggle();
     expect(toggle).not.toBeNull();
-    expect(toggle?.textContent).toBe("Show");
+    expect(toggle?.querySelector(".agent-chat-strip-orbit")).not.toBeNull();
+    expect(toggle?.textContent).toContain("1 running");
+    expect(toggle?.textContent).toContain("two-step");
+    expect(toggle?.textContent).not.toContain("Show");
+    expect(toggle?.textContent).not.toContain("Hide");
     act(() => { toggle?.click(); });
 
     expect(workPane()).not.toBeNull();
     expect(logVisible()).toBe(true);
-    // 문은 같은 자리에 남아 자기 동사를 바꾼다 — 들어온 문이 나가는 문이다.
-    expect(door()?.textContent).toBe("Hide");
-    expect(door()?.getAttribute("aria-expanded")).toBe("true");
+    expect(statusToggle()?.getAttribute("aria-expanded")).toBe("true");
+    act(() => { statusToggle()?.click(); });
+    expect(workPane()).toBeNull();
+    expect(statusToggle()?.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("keeps a door to the work surface after the last job settles", () => {
@@ -141,7 +146,7 @@ describe("chat work surface", () => {
     expect(ledge?.querySelector(".agent-chat-strip-dot")).not.toBeNull();
     expect(ledge?.querySelector(".agent-chat-strip-orbit")).toBeNull();
     expect(ledge?.querySelector(".agent-chat-strip-count")?.textContent).toBe("1 job");
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     expect(workPane()).not.toBeNull();
   });
 
@@ -150,35 +155,37 @@ describe("chat work surface", () => {
     // 잡과 함께 물러나므로, 그때 시트가 남으면 문 없는 시트가 열린 채 굳는다.
     logState = stateWith([job()]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     expect(workPane()).not.toBeNull();
 
     logState = stateWith([]);
     render();
 
-    expect(door()).toBeNull();
+    expect(statusToggle()).toBeNull();
     expect(workPane()).toBeNull();
     expect(logVisible()).toBe(true);
   });
 });
 
 describe("chat work surface — panel controls", () => {
-  it("moves focus into the opened sheet, then hides on Escape and returns focus to the door", () => {
-    // 시트는 DOM에서 문보다 앞에 있으므로 문에 초점을 둔 채 열면 다음 Tab이 컴포저로 건너뛴다.
-    // 보이는 첫 작업으로 초점을 보내고, Esc로 접으면 같은 자리의 문으로 돌아온다.
+  it("moves focus into the opened sheet, then hides on Escape and returns focus to the status", () => {
+    // 시트는 DOM에서 선반보다 앞에 있으므로 상태에 초점을 둔 채 열면 다음 Tab이 컴포저로 건너뛴다.
+    // 보이는 첫 작업으로 초점을 보내고, Esc로 접으면 같은 자리의 상태 버튼으로 돌아온다.
     logState = stateWith([job()]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     expect(workPane()).not.toBeNull();
-    expect(door()?.getAttribute("aria-controls")).toBe(workPane()?.id);
+    expect(statusToggle()?.getAttribute("aria-controls")).toBe(workPane()?.id);
     const firstJob = workPane()?.querySelector<HTMLButtonElement>(".agent-chat-job");
     expect(document.activeElement).toBe(firstJob);
 
     act(() => { firstJob?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })); });
     expect(workPane()).toBeNull();
-    expect(door()?.getAttribute("aria-expanded")).toBe("false");
-    expect(door()?.textContent).toBe("Show");
-    expect(document.activeElement).toBe(door());
+    expect(statusToggle()?.getAttribute("aria-expanded")).toBe("false");
+    expect(statusToggle()?.textContent).toContain("1 running");
+    expect(statusToggle()?.textContent).not.toContain("Show");
+    expect(statusToggle()?.textContent).not.toContain("Hide");
+    expect(document.activeElement).toBe(statusToggle());
   });
 
   it("keeps focus inside the sheet when list and detail replace each other", () => {
@@ -186,7 +193,7 @@ describe("chat work surface — panel controls", () => {
     // 초점을 이어야 Esc가 계속 이 패널에 귀속되고, Tab도 보이는 내용 안에서 시작한다.
     logState = stateWith([job()]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     const jobButton = workPane()?.querySelector<HTMLButtonElement>(".agent-chat-job");
 
     act(() => { jobButton?.click(); });
@@ -206,7 +213,7 @@ describe("chat work surface — panel controls", () => {
     // 오지 않아 시트는 그대로 남는다 — capture 단계에서는 이 위계를 뒤집는다.
     logState = stateWith([job()]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     const input = container?.querySelector<HTMLTextAreaElement>(".agent-chat-composer-input");
     input?.addEventListener("keydown", (event) => {
       if (event.key === "Escape") {
@@ -226,7 +233,7 @@ describe("chat work surface — panel controls", () => {
     // 조합 중 Esc는 입력기 소유다. 컴포저와 같은 경계로 시트도 듣지 않는다.
     logState = stateWith([job()]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     const input = container?.querySelector<HTMLTextAreaElement>(".agent-chat-composer-input");
     const escape = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true, isComposing: true });
 
@@ -241,7 +248,7 @@ describe("chat work surface — panel controls", () => {
     // Esc까지 먼저 삼켜 이 시트를 접고, 열린 시트가 여럿이면 전부 함께 접힌다.
     logState = stateWith([job()]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     const outside = document.createElement("button");
     document.body.append(outside);
     const escape = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
@@ -257,7 +264,7 @@ describe("chat work surface — panel controls", () => {
     // 시트가 덮지 않은 대화 위를 누르면 물러난다 — 콘솔의 팝오버와 같은 문법이다.
     logState = stateWith([job()]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     expect(workPane()).not.toBeNull();
 
     act(() => { container?.querySelector(".agent-chat-log")?.dispatchEvent(new Event("pointerdown", { bubbles: true })); });
@@ -269,7 +276,7 @@ describe("chat work surface — panel controls", () => {
     // 작업 면이 열리는 순간 그 오른쪽 위로 넘어가 접기 컨트롤을 덮는다(실측으로 겪은 자리다).
     logState = stateWith([job()]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     expect(container?.querySelector(".agent-view-chip-row")).toBeNull();
     // 컴포저는 대화 면의 것이다 — 문맥 미터도 그 컨트롤 행에 실려 함께 남는다.
     const composer = container?.querySelector(".agent-chat-composer");
@@ -315,7 +322,7 @@ describe("chat work surface — stage identities", () => {
       }],
     })]);
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     act(() => { container?.querySelector<HTMLButtonElement>(".agent-chat-sheet .agent-chat-job")?.click(); });
 
     const cells = [...(container?.querySelectorAll<HTMLElement>(".agent-chat-stage-row .is-model") ?? [])];
@@ -336,7 +343,7 @@ describe("chat work surface — job detail timing", () => {
     const closed = { id: "b1", kind: "shell" as const, title: "loop", open: false, status: "stopped" as const, stages: [], ends: 1 };
     logState = { ...stateWith([closed]), jobs: [closed] };
     mount();
-    act(() => { door()?.click(); });
+    act(() => { statusToggle()?.click(); });
     act(() => { container?.querySelector<HTMLButtonElement>(".agent-chat-sheet .agent-chat-job")?.click(); });
     await act(async () => { await Promise.resolve(); });
     const first = detailCalls.length;

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
@@ -124,6 +124,7 @@ describe("chat work surface", () => {
     expect(toggle?.querySelector(".agent-chat-strip-orbit")).not.toBeNull();
     expect(toggle?.textContent).toContain("1 running");
     expect(toggle?.textContent).toContain("two-step");
+    expect(toggle?.getAttribute("aria-label")).toBeNull();
     expect(toggle?.textContent).not.toContain("Show");
     expect(toggle?.textContent).not.toContain("Hide");
     act(() => { toggle?.click(); });

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -2610,21 +2610,21 @@
   color: var(--text-tertiary);
 }
 
-/* 문. 라벨이 동사(Show/Hide)이고 화살표가 시트의 이동 방향이다 — 열리면 180° 돌아 아래를
-   가리킨다. Quiet Controls 레시피 그대로: rest 몸·brass 예고·열림은 --control-open-rim.
-   [doctrine] 투명 rest 금지 — 컨트롤이 헤더로 읽히던 것이 이 표면의 결함이었다. */
+/* 상태 버튼. 별도 동사와 화살표를 붙이지 않고 스피너·상태·이름 전체가 한 번에 반응한다.
+   rest에서는 선반의 한 줄로 머물고, hover/focus에만 brass로 클릭 가능성을 예고한다. */
 .agent-chat-ledge-toggle {
   appearance: none;
-  flex: none;
+  min-width: 0;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-2);
   height: 24px;
-  padding: 0 6px 0 9px;
+  margin: 0;
+  padding: 0 6px;
   border-radius: var(--radius-xs);
-  border: 1px solid var(--hairline);
-  background: var(--control-rest);
-  color: var(--text-secondary);
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
   font: inherit;
   cursor: pointer;
   transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
@@ -2639,7 +2639,6 @@
 .agent-chat-ledge-toggle[aria-expanded="true"] {
   background: var(--control-wash);
   border-color: var(--control-open-rim);
-  color: var(--text-primary);
 }
 
 .agent-chat-ledge-toggle:focus-visible {
@@ -2647,14 +2646,14 @@
   outline-offset: 2px;
 }
 
-.agent-chat-ledge-toggle svg {
-  width: 14px;
-  height: 14px;
-  flex: none;
-  transition: transform var(--duration-fast);
+.agent-chat-ledge-toggle:hover .agent-chat-strip-count,
+.agent-chat-ledge-toggle:hover .agent-chat-ledge-name {
+  color: inherit;
 }
 
-.agent-chat-ledge-toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
+.agent-chat-ledge-toggle[aria-expanded="true"] .agent-chat-ledge-name {
+  color: var(--text-secondary);
+}
 
 /* 시트 — 로그의 좌표계(.agent-chat-body) 바닥에 붙어 대화의 아래 62%를 덮는다. 절대배치인
    이유가 이 표면의 요점이다: 열어도 로그와 컴포저가 움직이지 않는다. Follow 칩(z 3)보다 위층. */


### PR DESCRIPTION
## Summary
- remove the separate Show/Hide control from the chat work ledge
- make the spinner, status count, and job title one hover-highlighted toggle target
- preserve sheet focus, Escape, and accessibility behavior and amend the pending release note

## Test Plan
- [x] `corepack pnpm exec vitest run runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx runtime/fleet-console/tests/instrument-design-contract.test.ts`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] Browser E2E: hover highlight, click/re-click toggle, Enter, Escape focus return

Changelog-Amend: chat-work-ledge.md