### PR TITLE
fix(fleet-console): steady fast shell activity

### DIFF
--- a/.changelog.d/chat-fast-shell-continuity.md
+++ b/.changelog.d/chat-fast-shell-continuity.md
@@ -1,0 +1,8 @@
+---
+branch: chat-fast-shell-continuity
+---
+
+### fleet-console
+#### Fixed
+- Keep fast Shell activity legible as one continuous running-to-complete row in Chat Mode.
+  ko: 채팅 모드에서 빠른 Shell 작업이 실행부터 완료까지 하나의 연속된 행으로 읽히도록 개선했습니다.

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-events.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-events.ts
@@ -538,6 +538,10 @@ export interface AgentChatTurnItem {
   readonly detail?: string;
   readonly id?: string;
   readonly state?: AgentChatStepState;
+  /** 라이브 화면에서 이 스텝이 처음 열린 수신 시각. 빠른 Shell의 시각 수명에만 쓰며 저널 계약은 아니다. */
+  readonly startedAt?: number;
+  /** 라이브 결과가 돌아온 수신 시각. 시작 시각과 함께 있을 때만 짧은 완료 이음매를 만든다. */
+  readonly settledAt?: number;
   readonly result?: string;
   readonly outside?: boolean;
   readonly change?: AgentChatChange;
@@ -966,7 +970,15 @@ export function reduceAgentChatLog(state: AgentChatLogState, event: AgentChatClo
       });
     case "tool-start":
       // 이름만 아는 스텝을 먼저 세운다. 뒤따르는 완성 tool 이벤트가 같은 id로 좌표를 채운다.
-      return appendItem(wakeLastTurn(state, now), { type: "tool", name: event.name, detail: "", id: event.id, state: "running" });
+      // 시작 시각은 라이브 수신 시각이 있을 때만 남긴다 — 재생에는 running 표면도 인지 바닥도 없다.
+      return appendItem(wakeLastTurn(state, now), {
+        type: "tool",
+        name: event.name,
+        detail: "",
+        id: event.id,
+        state: "running",
+        ...(now !== undefined && !state.replaying ? { startedAt: now } : {}),
+      });
     case "tool": {
       // 재생 구간의 스텝은 이미 끝난 일이다 — 결과 줄이 뒤따르면 ok/fail로 다시 옮겨 붙는다.
       const initial: AgentChatStepState = state.replaying ? "done" : "running";
@@ -976,13 +988,18 @@ export function reduceAgentChatLog(state: AgentChatLogState, event: AgentChatClo
         detail: event.detail,
         state: initial,
         ...(event.id !== undefined ? { id: event.id } : {}),
+        ...(initial === "running" && now !== undefined ? { startedAt: now } : {}),
         ...(event.outside === true ? { outside: true } : {}),
         ...(event.change ? { change: event.change } : {}),
       };
       // tool-start가 이미 세운 스텝이면 새 줄을 만들지 않고 그 자리를 채운다.
       const woken = wakeLastTurn(state, now);
       const merged = event.id !== undefined
-        ? mergeItemById(woken, event.id, (item) => ({ ...filled, state: item.state ?? initial }))
+        ? mergeItemById(woken, event.id, (item) => ({
+          ...filled,
+          state: item.state ?? initial,
+          ...(item.startedAt !== undefined ? { startedAt: item.startedAt } : {}),
+        }))
         : null;
       return merged ?? appendItem(woken, filled);
     }
@@ -1011,6 +1028,7 @@ export function reduceAgentChatLog(state: AgentChatLogState, event: AgentChatClo
       const merged = mergeItemById(state, event.id, (item) => ({
         ...item,
         state: event.ok ? "ok" : "fail",
+        ...(now !== undefined && !state.replaying ? { settledAt: now } : {}),
         ...(event.summary.length > 0 ? { result: event.summary } : {}),
       }));
       // 짝을 못 찾은 결과는 버린다 — 좌표 없는 결말은 원장에 세울 자리가 없다.

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-events.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-events.ts
@@ -977,7 +977,7 @@ export function reduceAgentChatLog(state: AgentChatLogState, event: AgentChatClo
         detail: "",
         id: event.id,
         state: "running",
-        ...(now !== undefined && !state.replaying ? { startedAt: now } : {}),
+        ...(now !== undefined && !state.replaying && agentChatToolFamily(event.name) === "run" ? { startedAt: now } : {}),
       });
     case "tool": {
       // 재생 구간의 스텝은 이미 끝난 일이다 — 결과 줄이 뒤따르면 ok/fail로 다시 옮겨 붙는다.
@@ -988,7 +988,7 @@ export function reduceAgentChatLog(state: AgentChatLogState, event: AgentChatClo
         detail: event.detail,
         state: initial,
         ...(event.id !== undefined ? { id: event.id } : {}),
-        ...(initial === "running" && now !== undefined ? { startedAt: now } : {}),
+        ...(initial === "running" && now !== undefined && agentChatToolFamily(event.name) === "run" ? { startedAt: now } : {}),
         ...(event.outside === true ? { outside: true } : {}),
         ...(event.change ? { change: event.change } : {}),
       };

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -869,9 +869,7 @@ function Ledger({
   );
   // continuityItem은 마지막 Shell 하나다. 앞서 끝난 작업은 그대로 남기고, 그 항목만 평소 집계에서
   // 빼 같은 자리에 전용 상태 행으로 세운다 — 원장 전체가 700ms 동안 사라지면 연속성이 아니다.
-  const ledgerItems = continuityItem?.id !== undefined
-    ? items.filter((item) => item.id !== continuityItem.id)
-    : items;
+  const ledgerItems = continuityItem !== null ? items.slice(0, -1) : items;
   const segments = segmentAgentChatLedger(ledgerItems, hasJob);
   if (segments.length === 0 && !pending && continuityItem === null) return null;
   return (
@@ -950,24 +948,28 @@ const FAST_SHELL_COMPLETION_MS = 220;
  * 개입하지 않아 과거 로그를 다시 열 때마다 애니메이션이 되살아나지 않는다.
  */
 function useFastShellContinuity(turn: AgentChatTurn): AgentChatTurnItem | null {
-  const candidate = [...turn.items].reverse().find((item) => (
-    item.type === "tool"
-    && agentChatToolFamily(item.name) === "run"
-    && item.startedAt !== undefined
-    && (item.state === "running" || (
-      item.settledAt !== undefined
-      && item.settledAt - item.startedAt < FAST_SHELL_PERCEPTION_MS
+  // 원장의 시간은 꼬리에서 앞으로 흐르지 않는다. 마지막 항목이 다른 활동이면 앞의 빠른 Shell을
+  // 아래로 옮겨 다시 살리지 않는다 — 이음매는 오직 지금 화면에서 바뀌는 마지막 개체의 것이다.
+  const tail = turn.items.at(-1);
+  const candidate = tail?.type === "tool"
+    && agentChatToolFamily(tail.name) === "run"
+    && tail.startedAt !== undefined
+    && (tail.state === "running" || (
+      tail.settledAt !== undefined
+      && tail.settledAt - tail.startedAt < FAST_SHELL_PERCEPTION_MS
     ))
-  ));
+    ? tail
+    : undefined;
   const perceptionAt = candidate?.startedAt !== undefined ? candidate.startedAt + FAST_SHELL_PERCEPTION_MS : 0;
   const deadline = perceptionAt + FAST_SHELL_COMPLETION_MS;
-  const [now, setNow] = React.useState(() => Date.now());
+  const [, rerender] = React.useState(0);
+  const now = Date.now();
   React.useEffect(() => {
     if (candidate === undefined || candidate.state === "running" || now >= deadline) return;
     const next = now < perceptionAt ? perceptionAt : deadline;
-    const timer = window.setTimeout(() => setNow(Date.now()), Math.max(0, next - Date.now()));
+    const timer = window.setTimeout(() => rerender((value) => value + 1), Math.max(0, next - Date.now()));
     return () => window.clearTimeout(timer);
-  }, [candidate?.id, candidate?.state, deadline, now, perceptionAt]);
+  }, [candidate?.id, candidate?.state, deadline, now < perceptionAt]);
   if (candidate === undefined) return null;
   if (candidate.state === "running") return candidate;
   if (now >= deadline) return null;

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-view.tsx
@@ -664,6 +664,8 @@ function ChatTurn({
   const t = getT(language);
   const view = splitAgentChatTurn(turn);
   const working = turn.state === "working";
+  const continuityItem = useFastShellContinuity(turn);
+  const holdingContinuity = continuityItem !== null;
   // 이 턴이 낳은 잡 중 아직 도는 것. 접힘 줄이 이 수를 말하지 않으면, 접힘이 "다 끝났다"를
   // 뜻하게 되고 그것이 이 표면을 만든 이유인 거짓말이다.
   const stillRunning = turn.items.reduce((count, item) => {
@@ -721,13 +723,28 @@ function ChatTurn({
                   onOpenJob={onOpenJob}
                   onAnswer={onAnswer}
                   working
+                  continuityItem={continuityItem}
                   pending={view.streamingText === null
+                    && continuityItem === null
                     && !view.ledger.some((item) => item.state === "running")
                     // 답을 기다리는 동안에는 아무도 생각하지 않는다 — 카드 아래에서 링이 계속 돌면
                     // 화면이 두 사실을 동시에 말하고, 사용자는 자기 차례인지 알 수 없다.
                     && !view.awaiting}
                 />
               </>
+            ) : holdingContinuity ? (
+              // 빠른 Shell이 턴과 함께 닫혀도 라이브 줄을 새 접힘으로 바꾸지 않는다. 같은 줄이 같은
+              // 자리에서 완료로 변한 뒤 물러난다 — 명령과 Answer는 이미 도착했고, 늦추는 것은 이
+              // 시각 개체 하나뿐이다.
+              <Ledger
+                operationId={operationId}
+                items={view.ledger}
+                language={language}
+                jobsByToolUse={jobsByToolUse}
+                onOpenJob={onOpenJob}
+                onAnswer={onAnswer}
+                continuityItem={continuityItem}
+              />
             ) : hasSettledWork ? (
               <WorkFold
                 durationMs={turn.durationMs}
@@ -831,6 +848,7 @@ function Ledger({
   onAnswer,
   working = false,
   pending = false,
+  continuityItem = null,
 }: {
   readonly operationId: string;
   readonly items: readonly AgentChatTurnItem[];
@@ -842,16 +860,22 @@ function Ledger({
   readonly working?: boolean;
   /** 라이브 줄의 꼬리에 "생각 중…"을 붙인다 — 도구도 글자도 없는 구간의 유일한 신호다. */
   readonly pending?: boolean;
+  readonly continuityItem?: AgentChatTurnItem | null;
 }) {
   const t = getT(language);
   const hasJob = React.useCallback(
     (item: AgentChatTurnItem) => item.id !== undefined && jobsByToolUse.has(item.id),
     [jobsByToolUse],
   );
-  const segments = segmentAgentChatLedger(items, hasJob);
-  if (segments.length === 0 && !pending) return null;
+  // continuityItem은 마지막 Shell 하나다. 앞서 끝난 작업은 그대로 남기고, 그 항목만 평소 집계에서
+  // 빼 같은 자리에 전용 상태 행으로 세운다 — 원장 전체가 700ms 동안 사라지면 연속성이 아니다.
+  const ledgerItems = continuityItem?.id !== undefined
+    ? items.filter((item) => item.id !== continuityItem.id)
+    : items;
+  const segments = segmentAgentChatLedger(ledgerItems, hasJob);
+  if (segments.length === 0 && !pending && continuityItem === null) return null;
   return (
-    <div className="agent-chat-ledger">
+    <div className={`agent-chat-ledger${continuityItem !== null ? " is-continuity" : ""}`}>
       {segments.map((segment, index) => {
         // 도는 턴의 마지막 구간만 라이브다 — 그 구간의 꼬리 한 줄이 "지금 무엇을 하는가"를 진다.
         const live = working && index === segments.length - 1;
@@ -897,6 +921,7 @@ function Ledger({
           </div>
         );
       })}
+      {continuityItem !== null ? <ContinuityTally item={continuityItem} language={language} /> : null}
       {/* 첫 도구가 나가기 전의 첫 공백 — 세울 구간이 없으므로 빈 집계에 꼬리만 단다. */}
       {pending && segments.length === 0
         ? <Tally groups={[]} folded={[]} language={language} live tails={[]} thinking />
@@ -916,6 +941,70 @@ function Ledger({
  * 도는 스텝 사이에 끼는데, 거기서 멈추면 앞의 스텝이 자기 행을 되찾는다. 앵커는 태어난 자리를
  * 지키는 물건이므로 걷지 않고 지나가기만 한다 — 그래서 반환은 위치가 아니라 조각의 집합이다.
  */
+const FAST_SHELL_PERCEPTION_MS = 480;
+const FAST_SHELL_COMPLETION_MS = 220;
+
+/**
+ * 빠른 Shell의 마지막 상태를 잠시 같은 자리에 붙든다. 서버 상태와 Answer는 그대로 앞서가고,
+ * 여기서 늦추는 것은 live Tally 하나뿐이다. 시작·결과 시각이 없는 재생 턴이나 다른 도구에는
+ * 개입하지 않아 과거 로그를 다시 열 때마다 애니메이션이 되살아나지 않는다.
+ */
+function useFastShellContinuity(turn: AgentChatTurn): AgentChatTurnItem | null {
+  const candidate = [...turn.items].reverse().find((item) => (
+    item.type === "tool"
+    && agentChatToolFamily(item.name) === "run"
+    && item.startedAt !== undefined
+    && (item.state === "running" || (
+      item.settledAt !== undefined
+      && item.settledAt - item.startedAt < FAST_SHELL_PERCEPTION_MS
+    ))
+  ));
+  const perceptionAt = candidate?.startedAt !== undefined ? candidate.startedAt + FAST_SHELL_PERCEPTION_MS : 0;
+  const deadline = perceptionAt + FAST_SHELL_COMPLETION_MS;
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    if (candidate === undefined || candidate.state === "running" || now >= deadline) return;
+    const next = now < perceptionAt ? perceptionAt : deadline;
+    const timer = window.setTimeout(() => setNow(Date.now()), Math.max(0, next - Date.now()));
+    return () => window.clearTimeout(timer);
+  }, [candidate?.id, candidate?.state, deadline, now, perceptionAt]);
+  if (candidate === undefined) return null;
+  if (candidate.state === "running") return candidate;
+  if (now >= deadline) return null;
+  // 결과가 먼저 돌아와도 480ms까지는 running 모습 그대로다. 그 뒤 같은 줄이 완료형으로 변한다.
+  return now < perceptionAt ? { ...candidate, state: "running" } : candidate;
+}
+
+/** 같은 live Tally가 결과를 받은 뒤 완료형으로 변한 모습. 새 행이나 toast를 만들지 않는다. */
+function ContinuityTally({
+  item,
+  language,
+}: {
+  readonly item: AgentChatTurnItem;
+  readonly language: "en" | "ko";
+}) {
+  const running = item.state === "running";
+  const failed = item.state === "fail";
+  const elapsed = item.startedAt !== undefined && item.settledAt !== undefined
+    ? formatDuration(Math.max(0, item.settledAt - item.startedAt))
+    : null;
+  const verb = running ? runningVerb(item.name ?? "", language) : pastVerb(item.name ?? "", language);
+  return (
+    <div className={`agent-chat-tally is-continuity is-${item.state ?? "done"}`} role="status" aria-atomic="true">
+      {running
+        ? <span className="agent-chat-step-orbit" aria-hidden="true" />
+        : <span className="agent-chat-continuity-mark" aria-hidden="true">{failed ? "✕" : "✓"}</span>}
+      <span className={`agent-chat-tally-text${running ? " agent-chat-live-text" : ""}`}>
+        <span className="agent-chat-tally-clause">
+          <span className="agent-chat-tally-glyph" aria-hidden="true"><AgentGlyph name="run" /></span>
+          <span>{`${verb}${item.detail ? ` ${item.detail}` : ""}`}</span>
+        </span>
+      </span>
+      {!running && elapsed !== null ? <span className="agent-chat-continuity-elapsed">{elapsed}</span> : null}
+    </div>
+  );
+}
+
 function runningTails(parts: readonly AgentChatLedgerPart[]): ReadonlySet<AgentChatLedgerPart> {
   const hoisted = new Set<AgentChatLedgerPart>();
   for (let at = parts.length - 1; at >= 0; at -= 1) {

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx
@@ -543,6 +543,101 @@ describe("chat ledger — family glyphs on the tally clauses", () => {
  * 예전에는 도는 턴의 집계 줄이 무조건 링을 달고, 그 아래 생각 상자가 링을 하나 더 달았다
  * (실측: 링 2개, 애니메이션 6개가 동시에).
  */
+describe("chat ledger — fast Shell continuity", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_180);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function fastShellTurn(state: "working" | "done" = "done"): AgentChatLogState {
+    return {
+      ...stateWith([]),
+      turns: [{
+        dispatch: { text: "go" },
+        items: [{
+          type: "tool",
+          name: "Bash",
+          detail: "pwd",
+          id: "t1",
+          state: "ok",
+          startedAt: 1_100,
+          settledAt: 1_180,
+        }],
+        state,
+        toolCount: 1,
+        draft: "",
+        ...(state === "done" ? { answer: "Done." } : {}),
+      }],
+    };
+  }
+
+  it("keeps the running Shell in the same row before its result arrives", () => {
+    logState = {
+      ...fastShellTurn("working"),
+      turns: [{
+        ...fastShellTurn("working").turns[0]!,
+        items: [{ type: "tool", name: "Bash", detail: "pwd", id: "t1", state: "running", startedAt: 1_100 }],
+      }],
+    };
+    mount("running");
+    const row = container?.querySelector(".agent-chat-tally.is-continuity");
+    expect(row?.querySelector(".agent-chat-step-orbit")).not.toBeNull();
+    expect(row?.textContent).toContain("Running pwd");
+    expect(container?.querySelectorAll(".agent-chat-step-orbit")).toHaveLength(1);
+  });
+
+  it("keeps one Shell row in place until it morphs from running to completed", () => {
+    logState = fastShellTurn();
+    mount();
+
+    let row = container?.querySelector(".agent-chat-tally.is-continuity");
+    expect(row, container?.innerHTML).not.toBeNull();
+    expect(row?.querySelector(".agent-chat-step-orbit")).not.toBeNull();
+    expect(row?.textContent).toContain("Running pwd");
+    expect(container?.querySelector(".agent-chat-fold")).toBeNull();
+    // 인지 바닥은 모델의 다음 말까지 막는 지연이 아니다 — Answer는 도착 즉시 읽힌다.
+    expect(container?.querySelector(".agent-chat-answer-body")?.textContent).toContain("Done.");
+
+    act(() => { vi.advanceTimersByTime(400); });
+    row = container?.querySelector(".agent-chat-tally.is-continuity");
+    expect(row?.querySelector(".agent-chat-step-orbit")).toBeNull();
+    expect(row?.querySelector(".agent-chat-continuity-mark")?.textContent).toBe("✓");
+    expect(row?.textContent).toContain("Ran pwd");
+    expect(row?.textContent).toContain("80ms");
+
+    act(() => { vi.advanceTimersByTime(220); });
+    expect(container?.querySelector(".agent-chat-tally.is-continuity")).toBeNull();
+    expect(container?.querySelector(".agent-chat-fold")).not.toBeNull();
+  });
+
+  it("does not hold a slow Shell or another fast tool", () => {
+    logState = fastShellTurn();
+    logState = {
+      ...logState,
+      turns: [{
+        ...logState.turns[0]!,
+        items: [{ type: "tool", name: "Bash", detail: "sleep 1", state: "ok", startedAt: 100, settledAt: 1_180 }],
+      }],
+    };
+    mount();
+    expect(container?.querySelector(".agent-chat-tally.is-continuity")).toBeNull();
+
+    logState = {
+      ...logState,
+      turns: [{
+        ...logState.turns[0]!,
+        items: [{ type: "tool", name: "Read", detail: "a.md", state: "ok", startedAt: 1_100, settledAt: 1_180 }],
+      }],
+    };
+    render();
+    expect(container?.querySelector(".agent-chat-tally.is-continuity")).toBeNull();
+  });
+});
+
 describe("chat ledger — one live line", () => {
   function workingWith(items: readonly unknown[], draft = ""): AgentChatLogState {
     return {

--- a/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
+++ b/runtime/fleet-plugins/terminal/client/agent/chat/chat.css
@@ -481,6 +481,32 @@
   color: var(--text-secondary);
 }
 
+/* 빠른 Shell은 이 한 줄을 재사용해 running → completed로 변한다. 새 완료 행으로 바꾸지 않고
+   마크만 같은 폭에서 교체해 텍스트의 좌표를 지킨다. 상태색은 마크만 진다. */
+.agent-chat-tally.is-continuity {
+  width: 100%;
+  color: var(--text-secondary);
+  transition: background-color var(--duration-fast), color var(--duration-fast);
+}
+
+.agent-chat-continuity-mark {
+  width: 9px;
+  flex: none;
+  text-align: center;
+  color: var(--positive);
+}
+
+.agent-chat-tally.is-continuity.is-fail .agent-chat-continuity-mark {
+  color: var(--coral);
+}
+
+.agent-chat-continuity-elapsed {
+  margin-left: auto;
+  flex: none;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
 /* 좌→우 명도 물결.
    [doctrine] 진행은 이미 링(aurora)이 말한다. 이 물결은 같은 사실을 두 번 말하는 것이 아니라
    "이 줄이 아직 자라고 있다"를 말하므로 색 채널을 하나도 빌리지 않는다 — 신호(aurora)도,

--- a/runtime/fleet-plugins/terminal/tests/agent-chat-log-reducer.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-chat-log-reducer.test.ts
@@ -289,6 +289,42 @@ describe("chat log steps", () => {
     expect(state.turns.at(-1)?.items.at(-1)).toMatchObject({ state: "ok", result: "File created" });
   });
 
+  it("keeps live tool timing on the same step through completion", () => {
+    let state = fold([
+      { kind: "replay-start" },
+      { kind: "replay-end", turns: 0 },
+      { kind: "dispatch", text: "go" },
+      { kind: "turn-start", receivedAt: 1_000 },
+      { kind: "tool-start", id: "t1", name: "Bash", receivedAt: 1_100 },
+      { kind: "tool", name: "Bash", detail: "pwd", id: "t1", receivedAt: 1_120 },
+    ]);
+    expect(state.turns.at(-1)?.items.at(-1)).toMatchObject({
+      id: "t1",
+      state: "running",
+      startedAt: 1_100,
+    });
+
+    state = fold([{ kind: "tool-result", id: "t1", ok: true, summary: "", receivedAt: 1_180 }], state);
+    expect(state.turns.at(-1)?.items.at(-1)).toMatchObject({
+      id: "t1",
+      state: "ok",
+      startedAt: 1_100,
+      settledAt: 1_180,
+    });
+  });
+
+  it("does not attach live timing to replayed tools", () => {
+    const state = fold([
+      { kind: "replay-start" },
+      { kind: "turn-start", receivedAt: 1_000 },
+      { kind: "tool", name: "Bash", detail: "pwd", id: "t1", receivedAt: 1_100 },
+      { kind: "tool-result", id: "t1", ok: true, summary: "", receivedAt: 1_180 },
+      { kind: "replay-end", turns: 1 },
+    ]);
+    expect(state.turns.at(-1)?.items.at(-1)).not.toHaveProperty("startedAt");
+    expect(state.turns.at(-1)?.items.at(-1)).not.toHaveProperty("settledAt");
+  });
+
   it("settles a still-running step when the turn closes without its result", () => {
     const state = fold([
       { kind: "replay-start" },


### PR DESCRIPTION
## Summary
- Keep fast Shell activity on one stable Chat Mode row instead of flashing between live and settled markup.
- Hold very fast Shell runs in the running state for a 480 ms perception floor, then show completion for 220 ms before settling into the existing work fold.
- Limit live timing metadata to Shell activity and keep replayed history static.

## Test Plan
- [x] `corepack pnpm exec vitest run runtime/fleet-plugins/terminal/tests/agent-chat-log-reducer.test.ts runtime/fleet-plugins/terminal/client/agent/chat/chat-work-surface.test.tsx`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Isolated browser verification with live Chat Mode Bash commands and replay reload