### PR TITLE
feat(ai-gateway): add OpenCode Go Muse Spark 1.3

### DIFF
--- a/.changelog.d/opencode-muse-spark-1-3.md
+++ b/.changelog.d/opencode-muse-spark-1-3.md
@@ -1,0 +1,13 @@
+---
+branch: opencode-muse-spark-1-3
+---
+
+### fleet-console
+#### Changed
+- Offer Muse-Spark-1.3-Contributor in the Fleet Console OpenCode Go model loadout instead of Muse-Spark-1.2-Contributor, preserving its 1M context window and supported reasoning-effort rungs.
+  ko: Fleet Console의 OpenCode Go 모델 선별에서 Muse-Spark-1.2-Contributor 대신 Muse-Spark-1.3-Contributor를 제공하며, 1M 컨텍스트 창과 지원하는 추론 강도 단을 유지합니다.
+
+### fleet-cli
+#### Changed
+- Offer Muse-Spark-1.3-Contributor in the fleet gateway OpenCode Go model picker instead of Muse-Spark-1.2-Contributor, preserving its 1M context window and supported reasoning-effort rungs.
+  ko: fleet gateway의 OpenCode Go 모델 선택기에서 Muse-Spark-1.2-Contributor 대신 Muse-Spark-1.3-Contributor를 제공하며, 1M 컨텍스트 창과 지원하는 추론 강도 단을 유지합니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-09-03T00:00:00Z",
+  "updatedAt": "2026-09-03T12:58:55Z",
   "providers": {
     "antigravity": {
       "name": "Antigravity",
@@ -783,7 +783,7 @@
     "opencode": {
       "name": "OpenCode",
       "defaultModel": "minimax-m3",
-      "source": "live GET https://opencode.ai/zen/go/v1/models + per-model wire probes on /messages, /responses, /chat/completions (2026-08-03); contextWindow cross-checked against models.dev api.json opencode-go entries and oh-my-pi packages/catalog/src/models.json (2026-08-03, both agree). Excluded: mimo-v2-pro/mimo-v2-omni (upstream server_error), hy3-preview (listed but Router.ModelNotFound); superseded generations removed 2026-08-08 \u2014 the catalog keeps each lineup's current generation only; ox-alpha-free and muse-spark-1.2-contributor added 2026-08-21 from the same live list, each wire chosen by a streaming probe on that date (ox-alpha-free frames natively on /chat/completions and returns reasoning_content deltas; muse-spark-1.2-contributor frames natively on /responses and echoes its own reasoning block) and each effort ladder taken from the upstream's own rejection message (ox-alpha-free: low/high/max; muse-spark-1.2-contributor: none/minimal/low/medium/high/xhigh, so max is refused); their contextWindow comes from models.dev api.json opencode-go entries (2026-08-21). muse-spark-1.2-contributor's Responses backend accepts only tool_choice auto: named function choices, required, and none are refused with a 400 (2026-08-21), so a caller that forces a tool cannot use it",
+      "source": "live GET https://opencode.ai/zen/go/v1/models + per-model wire probes on /messages, /responses, /chat/completions (2026-08-03); contextWindow cross-checked against models.dev api.json opencode-go entries and oh-my-pi packages/catalog/src/models.json (2026-08-03, both agree). Excluded: mimo-v2-pro/mimo-v2-omni (upstream server_error), hy3-preview (listed but Router.ModelNotFound); superseded generations removed 2026-08-08 \u2014 the catalog keeps each lineup's current generation only; ox-alpha-free and muse-spark-1.2-contributor added 2026-08-21 from the same live list, each wire chosen by a streaming probe on that date (ox-alpha-free frames natively on /chat/completions and returns reasoning_content deltas; muse-spark-1.2-contributor frames natively on /responses and echoes its own reasoning block) and each effort ladder taken from the upstream's own rejection message (ox-alpha-free: low/high/max; muse-spark-1.2-contributor: none/minimal/low/medium/high/xhigh, so max is refused); their contextWindow comes from models.dev api.json opencode-go entries (2026-08-21). muse-spark-1.2-contributor's Responses backend accepts only tool_choice auto: named function choices, required, and none are refused with a 400 (2026-08-21), so a caller that forces a tool cannot use it. muse-spark-1.3-contributor replaced 1.2 as the current generation on 2026-09-03 from the live list; /responses was the only working wire in three endpoint probes, none and max were refused while minimal/low/medium/high/xhigh succeeded, and only tool_choice auto was accepted. Its 1048576 contextWindow comes from the models.dev opencode-go entry (2026-09-03)",
       "models": [
         {
           "modelId": "minimax-m3",
@@ -832,8 +832,8 @@
           "benchmarkKey": "grok-4.5"
         },
         {
-          "modelId": "muse-spark-1.2-contributor",
-          "name": "Muse-Spark-1.2-Contributor",
+          "modelId": "muse-spark-1.3-contributor",
+          "name": "Muse-Spark-1.3-Contributor",
           "capabilityClass": "flagship",
           "wire": "responses",
           "contextWindow": 1048576,

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -1100,14 +1100,14 @@ describe("model catalog", () => {
         .toMatchObject({ cursorMaxMode: true });
     }
     expect(KIMI_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual(["k3", "k3-256k"]);
-    // OpenCode Go의 서비스 가능 전 모델(2026-08-03 라이브 프로브, 08-21 두 모델 추가).
+    // OpenCode Go의 서비스 가능 전 모델(2026-08-03 라이브 프로브, 09-03 Muse 1.3 세대교체).
     // wire 미선언 = Anthropic passthrough, 그 외에는 선언된 네이티브 wire의 번역 경로를 탄다.
     expect(OPENCODE_SUBSCRIPTION_MODELS.map((model) => [model.upstreamId, model.wire ?? "anthropic"])).toEqual([
       ["minimax-m3", "anthropic"],
       ["qwen3.8-max", "anthropic"],
       ["gpt-5.6-luna", "responses"],
       ["grok-4.5", "responses"],
-      ["muse-spark-1.2-contributor", "responses"],
+      ["muse-spark-1.3-contributor", "responses"],
       ["deepseek-v4-flash", "chat-completions"],
       ["deepseek-v4-pro", "chat-completions"],
       ["glm-5.2", "chat-completions"],
@@ -1129,7 +1129,7 @@ describe("model catalog", () => {
       ])).toEqual([
       ["gpt-5.6-luna", ["low", "medium", "high", "xhigh", "max"]],
       ["grok-4.5", ["low", "medium", "high"]],
-      ["muse-spark-1.2-contributor", ["low", "medium", "high", "xhigh"]],
+      ["muse-spark-1.3-contributor", ["low", "medium", "high", "xhigh"]],
       ["ox-alpha-free", ["low", "high", "max"]],
     ]);
   });

--- a/packages/core-ai-gateway/tests/router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/router/routes.test.ts
@@ -2420,7 +2420,8 @@ describe("route surface", () => {
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
     expect(ids).toContain("claude-gateway--opencode--minimax-m3[1m]");
     expect(ids).toContain("claude-gateway--opencode--ox-alpha-free[1m]");
-    expect(ids).toContain("claude-gateway--opencode--muse-spark-1.2-contributor[1m]");
+    expect(ids).toContain("claude-gateway--opencode--muse-spark-1.3-contributor[1m]");
+    expect(ids).not.toContain("claude-gateway--opencode--muse-spark-1.2-contributor[1m]");
     expect(list.data).toContainEqual(expect.objectContaining({
       id: "claude-gateway--cursor--grok-4.5",
       display_name: "Cursor-Grok-4.5",

--- a/packages/core-ai-gateway/tests/settings/index.test.ts
+++ b/packages/core-ai-gateway/tests/settings/index.test.ts
@@ -241,7 +241,11 @@ describe("ai-gateway settings", () => {
   it("drops models that left the catalog", () => {
     expect(normalizeAiGatewaySettings({
       version: 1,
-      models: [{ id: "opencode--qwen3.7-max" }, { id: "kimi--k3", efforts: ["max"] }],
+      models: [
+        { id: "opencode--qwen3.7-max" },
+        { id: "opencode--muse-spark-1.2-contributor" },
+        { id: "kimi--k3", efforts: ["max"] },
+      ],
     })).toEqual({ version: 1, models: [{ id: "kimi--k3", efforts: ["max"] }] });
   });
 


### PR DESCRIPTION
## Summary
- replace the superseded OpenCode Go Muse Spark 1.2 Contributor catalog entry with Muse Spark 1.3 Contributor
- preserve the live-probed Responses wire, 1M context window, supported reasoning-effort rungs, and auto-only tool choice contract
- remove stale 1.2 selections and advertise only the current 1.3 model in Claude Code discovery

## Test Plan
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console test`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`