### PR TITLE
feat(fleet-console): stop Cruise wheel zoom-out at the fleet map

### DIFF
--- a/.changelog.d/cruise-zoom-floor.md
+++ b/.changelog.d/cruise-zoom-floor.md
@@ -1,0 +1,8 @@
+---
+branch: cruise-zoom-floor
+---
+
+### fleet-console
+#### Changed
+- Zooming the Cruise canvas out now stops at the fleet map. Once every Operation has collapsed into a dot, further wheel-out only dimmed the sea while the map itself stood unchanged, so the bottom of the zoom range was impossible to feel; the wheel now holds at that altitude, and zooming back in still leaves from where it stopped.
+  ko: Cruise 캔버스 축소가 함대 지도에서 멈춥니다. 모든 Operation이 점으로 잦아든 뒤의 추가 축소는 지도를 그대로 둔 채 바다만 옅게 만들어 축소의 끝을 손으로 알 수 없었는데, 이제 휠이 그 고도에서 멈추고 확대는 그 자리에서 그대로 돌아갑니다.

--- a/runtime/fleet-console/core/client/src/canvas/fleet-map-layout.ts
+++ b/runtime/fleet-console/core/client/src/canvas/fleet-map-layout.ts
@@ -13,6 +13,21 @@ import type { OperationGeometry, OperationNode } from "../types.js";
 export const FLEET_MAP_ENTER_ZOOM = 0.2;
 export const FLEET_MAP_EXIT_ZOOM = 0.24;
 
+// 축소의 바닥 — 판이 반드시 서 있는 첫 배율이다(진입 임계 바로 아래). 함대가 점으로 잦아든
+// 뒤의 추가 축소는 아무 정보도 더 주지 못한다: 판은 화면 고정 층이라 그대로고, 바다만 계속
+// 옅어진다. 그 구간을 열어 두면 "끝까지 축소했다"는 감각이 사라지고, 되돌아오는 데 휠 노치만
+// 늘어난다. 그래서 휠 축소는 이 층에서 멈춘다.
+export const FLEET_MAP_FLOOR_ZOOM = 0.19;
+
+/** 휠 축소가 내려갈 수 있는 하한. 상수 하나로 고정하지 않는 이유는 fit-all(FIT_ALL_MIN_ZOOM
+ *  0.02)이 판보다 깊은 배율로 뷰포트를 데려갈 수 있기 때문이다 — 그 자리에서 하한을 0.19로
+ *  들이대면 축소 휠이 하한으로 튀어 올라 방향이 뒤집힌다. 이미 바닥보다 깊은 뷰포트에서는
+ *  그 자리를 바닥으로 삼아, 축소는 정지하고 확대만 열어 둔다. */
+export function resolveWheelZoomFloor(currentZoom: number): number {
+  if (!Number.isFinite(currentZoom) || currentZoom <= 0) return FLEET_MAP_FLOOR_ZOOM;
+  return Math.min(FLEET_MAP_FLOOR_ZOOM, currentZoom);
+}
+
 /** 줌 히스테리시스 — 진입은 0.2 미만, 이탈은 0.24 초과. 경계 위에서 휠 한 노치가 판을 두 번
  *  뒤집지 않게 한다. previous는 직전 판정(캔버스가 ref로 든다). */
 export function resolveFleetMapActive(previous: boolean, zoom: number): boolean {

--- a/runtime/fleet-console/core/client/src/canvas/use-canvas-interaction.ts
+++ b/runtime/fleet-console/core/client/src/canvas/use-canvas-interaction.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
 
 import { screenToCanvas, type CanvasPoint, type CanvasRect, type CanvasViewport } from "./coordinates.js";
+import { resolveWheelZoomFloor } from "./fleet-map-layout.js";
 
 interface CanvasInteractionOptions {
   readonly viewport: CanvasViewport;
@@ -37,9 +38,9 @@ interface DragState {
   readonly startViewport: CanvasViewport;
 }
 
-// 휠 줌 하한은 fit-all의 FIT_ALL_MIN_ZOOM(0.02)과 같은 도메인이어야 한다 — 더 높으면
-// fit으로 깊게 나간 뷰포트에서 축소 휠이 하한으로 튀어 방향이 뒤집힌다.
-const MIN_ZOOM = 0.02;
+// 휠 줌 하한은 함대 지도가 서는 층이다(resolveWheelZoomFloor) — 함대가 점으로 잦아든 뒤의
+// 축소는 판을 바꾸지 못한다. fit-all(FIT_ALL_MIN_ZOOM 0.02)이 그 층보다 깊게 데려간 뷰포트에서는
+// 하한이 현재 배율까지 따라 내려가, 축소 휠이 하한으로 튀어 방향이 뒤집히는 일이 없다.
 const MAX_ZOOM = 2;
 const MIN_CREATE_WIDTH = 200;
 const MIN_CREATE_HEIGHT = 150;
@@ -135,7 +136,7 @@ export function useCanvasInteraction({ viewport, disabled = false, consumePointe
     const current = viewportRef.current;
     // 기본 휠 업/다운으로 포인터 위치를 기준점 삼아 줌 인/아웃한다(Ctrl/⌘ 보조키 없이). 맵 이동은 드래그가 담당한다.
     // 줌 목표는 보간 경로(onZoom)로 보내 스토어 rAF tween이 부드럽게 수렴시킨다(기준점은 현재 viewport 기준으로 계산).
-    const zoom = clamp(current.zoom * Math.exp(-event.deltaY * ZOOM_STEP), MIN_ZOOM, MAX_ZOOM);
+    const zoom = clamp(current.zoom * Math.exp(-event.deltaY * ZOOM_STEP), resolveWheelZoomFloor(current.zoom), MAX_ZOOM);
     const canvas = screenToCanvas(screen, current);
     onZoom({
       x: screen.x - canvas.x * zoom,

--- a/runtime/fleet-console/tests/fleet-map.test.ts
+++ b/runtime/fleet-console/tests/fleet-map.test.ts
@@ -10,6 +10,8 @@ import {
   resolveFleetMapZoomAnchor,
   FLEET_MAP_ENTER_ZOOM,
   FLEET_MAP_EXIT_ZOOM,
+  FLEET_MAP_FLOOR_ZOOM,
+  resolveWheelZoomFloor,
   resolveFleetContentCenter,
   resolveFleetMapActive,
   resolveFleetMapDriftStyle,
@@ -39,6 +41,20 @@ describe("fleet map activation", () => {
     // 이탈 뒤 같은 배율은 다시 진입하지 않는다.
     expect(resolveFleetMapActive(false, 0.22)).toBe(false);
     expect(resolveFleetMapActive(true, Number.NaN)).toBe(false);
+  });
+
+  it("stops the wheel at the plate — the floor stands the map and never rebounds a deeper viewport", () => {
+    // 바닥은 판이 반드시 서 있는 배율이다: 진입 임계 미만이라야 그 자리에서 지도가 서고,
+    // 축소가 멈춘 화면이 곧 함대 점 판이 된다.
+    expect(FLEET_MAP_FLOOR_ZOOM).toBeLessThan(FLEET_MAP_ENTER_ZOOM);
+    expect(resolveFleetMapActive(false, FLEET_MAP_FLOOR_ZOOM)).toBe(true);
+    expect(resolveWheelZoomFloor(1)).toBe(FLEET_MAP_FLOOR_ZOOM);
+    expect(resolveWheelZoomFloor(FLEET_MAP_FLOOR_ZOOM)).toBe(FLEET_MAP_FLOOR_ZOOM);
+    // fit-all은 판보다 깊은 배율까지 데려간다 — 그 자리에서 하한을 들이대면 축소 휠이
+    // 확대로 뒤집힌다. 바닥이 현재 배율까지 따라 내려가 축소만 정지시킨다.
+    expect(resolveWheelZoomFloor(0.02)).toBe(0.02);
+    expect(resolveWheelZoomFloor(Number.NaN)).toBe(FLEET_MAP_FLOOR_ZOOM);
+    expect(resolveWheelZoomFloor(0)).toBe(FLEET_MAP_FLOOR_ZOOM);
   });
 
   it("anchors zoom on the visible fleet's center so the panels come back on screen", () => {


### PR DESCRIPTION
## Summary
- Cruise 캔버스의 휠 축소가 함대 지도가 서는 층(줌 0.19)에서 멈춥니다. 모든 Operation이 점으로 잦아든 뒤의 추가 축소는 화면 고정 층인 판을 바꾸지 못한 채 바다만 옅게 만들었고, 되돌아오는 데 휠 노치만 늘렸습니다.
- 하한은 상수 하나로 못박지 않고 `resolveWheelZoomFloor(current)`가 현재 배율까지 따라 내려갑니다 — fit-all(`FIT_ALL_MIN_ZOOM` 0.02)이 판보다 깊게 데려간 뷰포트에서 하한을 그대로 들이대면 축소 휠이 확대로 뒤집히기 때문입니다.
- 확대 방향은 손대지 않았습니다: 지도 이탈 임계(0.24)와 상한(2.0)은 그대로입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 199 파일 / 2365 테스트 통과
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] 격리 콘솔 실측(CDP 실제 마우스 휠): 축소 1.0 → 0.59 → 0.35 → 0.21 → 0.19에서 지도 진입 후 5노치 추가 축소에도 0.19 고정, 확대 복귀 시 0.32 → 0.55에서 판이 걷히고 패널 복귀, 상한 2.0