### PR TITLE
feat(ai-gateway): add Codex GPT-6-Astra

### DIFF
--- a/.changelog.d/codex-gpt-6-astra.md
+++ b/.changelog.d/codex-gpt-6-astra.md
@@ -1,0 +1,13 @@
+---
+branch: codex-gpt-6-astra
+---
+
+### fleet-console
+#### Added
+- Offer GPT-6-Astra in the Fleet Console Codex model loadout, with 272K, 524K, and 1M context variants and a Fast priority-tier twin for each, alongside the GPT-5.6 models that stay available.
+  ko: Fleet Console의 Codex 모델 선별에서 GPT-6-Astra를 제공하며, 272K/524K/1M 컨텍스트 변형과 각 변형의 Fast 우선 등급 짝을 함께 싣고, 기존 GPT-5.6 모델도 그대로 유지합니다.
+
+### fleet-cli
+#### Added
+- Offer GPT-6-Astra in the fleet gateway Codex model picker, with 272K, 524K, and 1M context variants and a Fast priority-tier twin for each, alongside the GPT-5.6 models that stay available.
+  ko: fleet gateway의 Codex 모델 선택기에서 GPT-6-Astra를 제공하며, 272K/524K/1M 컨텍스트 변형과 각 변형의 Fast 우선 등급 짝을 함께 싣고, 기존 GPT-5.6 모델도 그대로 유지합니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-09-03T12:58:55Z",
+  "updatedAt": "2026-09-05T05:13:34Z",
   "providers": {
     "antigravity": {
       "name": "Antigravity",
@@ -64,9 +64,49 @@
     },
     "codex": {
       "name": "Codex",
-      "defaultModel": "gpt-5.6-sol",
-      "source": "codex app-server model/list (codex-cli 0.147.0, observed 2026-08-11) for model/effort/service-tier and the unsuffixed 272000 defaults; Fleet catalog effort ladders are capped at max because harness launch capabilities are not model rungs; 2026-08-17 production Codex live observations added explicit 524K (524288) and explicit 1M (1000000) variants on the same upstream bases",
+      "defaultModel": "gpt-6-astra",
+      "source": "codex app-server model/list (codex-cli 0.147.0, observed 2026-08-11) for model/effort/service-tier and the unsuffixed 272000 defaults; Fleet catalog effort ladders are capped at max because harness launch capabilities are not model rungs; 2026-08-17 production Codex live observations added explicit 524K (524288) and explicit 1M (1000000) variants on the same upstream bases; 2026-09-05 codex app-server model/list (codex-cli 0.153.4) added gpt-6-astra as the lineup's new flagship and the entry that now carries isDefault, reporting low/medium/high/xhigh/max/ultra reasoning efforts (ultra stays out of the catalog under the same launch-capability cap), additionalSpeedTiers [\"fast\"], and a priority \"Fast\" tier at 2x speed. A live app-server turn that day reported modelContextWindow 258400 for gpt-6-astra and the identical figure for gpt-5.6-sol, so Astra shares the 272000 base this catalog records for that lineup and takes the same explicit 524K/1M variants. The GPT-5.6 models stay listed because the same model/list still serves them with no upgrade pointer and no retirement date, unlike its deprecated gpt-5.4-mini entry",
       "models": [
+        {
+          "modelId": "gpt-6-astra",
+          "name": "GPT-6-Astra",
+          "capabilityClass": "flagship",
+          "contextWindow": 272000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-6-astra"
+          ]
+        },
+        {
+          "modelId": "gpt-6-astra-fast",
+          "name": "GPT-6-Astra-Fast",
+          "capabilityClass": "flagship",
+          "providerModelId": "gpt-6-astra",
+          "serviceTier": "priority",
+          "contextWindow": 272000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-6-astra-fast"
+          ]
+        },
         {
           "modelId": "gpt-5.6-sol",
           "name": "GPT-5.6-Sol",
@@ -192,6 +232,47 @@
             "gpt-5.6-luna-fast"
           ],
           "benchmarkKey": "gpt-5.6-luna"
+        },
+        {
+          "modelId": "gpt-6-astra-524k",
+          "name": "GPT-6-Astra-524K",
+          "capabilityClass": "flagship",
+          "providerModelId": "gpt-6-astra",
+          "contextWindow": 524288,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-6-astra-524k"
+          ]
+        },
+        {
+          "modelId": "gpt-6-astra-524k-fast",
+          "name": "GPT-6-Astra-524K-Fast",
+          "capabilityClass": "flagship",
+          "providerModelId": "gpt-6-astra",
+          "serviceTier": "priority",
+          "contextWindow": 524288,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-6-astra-524k-fast"
+          ]
         },
         {
           "modelId": "gpt-5.6-sol-524k",
@@ -321,6 +402,47 @@
             "gpt-5.6-terra-524k-fast"
           ],
           "benchmarkKey": "gpt-5.6-terra"
+        },
+        {
+          "modelId": "gpt-6-astra-1m",
+          "name": "GPT-6-Astra-1M",
+          "capabilityClass": "flagship",
+          "providerModelId": "gpt-6-astra",
+          "contextWindow": 1000000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-6-astra-1m"
+          ]
+        },
+        {
+          "modelId": "gpt-6-astra-1m-fast",
+          "name": "GPT-6-Astra-1M-Fast",
+          "capabilityClass": "flagship",
+          "providerModelId": "gpt-6-astra",
+          "serviceTier": "priority",
+          "contextWindow": 1000000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "aliases": [
+            "gpt-6-astra-1m-fast"
+          ]
         },
         {
           "modelId": "gpt-5.6-sol-1m",

--- a/packages/core-ai-gateway/tests/downstream/harness/grok-build/discovery.test.ts
+++ b/packages/core-ai-gateway/tests/downstream/harness/grok-build/discovery.test.ts
@@ -57,7 +57,10 @@ describe("grok build model id grammar", () => {
   });
 
   it("refuses every spelling this harness does not publish", () => {
-    const sample = GATEWAY_MODELS[0]!;
+    // 아래 "점이 살아 있는 형태"가 실제 거부 대상이 되려면 표본 자체가 점을 품어야 한다 —
+    // 카탈로그 선두 항목은 점 없는 id일 수 있다(codex--gpt-6-astra).
+    const sample = GATEWAY_MODELS.find((model) => model.id.includes("."))!;
+    expect(sample).toBeDefined();
     // 접두 없는 카탈로그 고유 id — Claude Code 쪽은 옛 영속 값 때문에 받아 주지만
     // 이 하네스에는 그런 값이 없다.
     expect(findGrokGatewayModel(sample.id)).toBeUndefined();

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -1026,27 +1026,33 @@ describe("model catalog", () => {
   });
 
   it("contains only the approved provider families", () => {
-    expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(18);
+    expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(24);
     expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(16);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(13);
-    expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
+    expect(CODEX_SUBSCRIPTION_MODELS.every((model) => /^gpt-(6-astra|5\.6-)/.test(model.upstreamId ?? ""))).toBe(true);
     expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => model.id.includes("524k")).every((model) => model.contextWindow === 524_288)).toBe(true);
     expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => model.id.includes("-1m")).every((model) => model.contextWindow === 1_000_000)).toBe(true);
     expect(CODEX_SUBSCRIPTION_MODELS.filter((model) => !model.id.includes("524k") && !model.id.includes("-1m")).every((model) => model.contextWindow === 272_000)).toBe(true);
     expect(CODEX_SUBSCRIPTION_MODELS.map((model) => model.id.replace(/^codex--/, ""))).toEqual([
+      "gpt-6-astra",
+      "gpt-6-astra-fast",
       "gpt-5.6-sol",
       "gpt-5.6-sol-fast",
       "gpt-5.6-terra",
       "gpt-5.6-terra-fast",
       "gpt-5.6-luna",
       "gpt-5.6-luna-fast",
+      "gpt-6-astra-524k",
+      "gpt-6-astra-524k-fast",
       "gpt-5.6-sol-524k",
       "gpt-5.6-sol-524k-fast",
       "gpt-5.6-luna-524k",
       "gpt-5.6-luna-524k-fast",
       "gpt-5.6-terra-524k",
       "gpt-5.6-terra-524k-fast",
+      "gpt-6-astra-1m",
+      "gpt-6-astra-1m-fast",
       "gpt-5.6-sol-1m",
       "gpt-5.6-sol-1m-fast",
       "gpt-5.6-luna-1m",

--- a/packages/core-ai-gateway/tests/router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/router/routes.test.ts
@@ -2371,12 +2371,18 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(54);
+    expect(list.data).toHaveLength(60);
     // All Antigravity models carry a real 1M window, so they are advertised on
     // Claude Code's `[1m]` coordinate rather than its unmarked 200k one.
     expect(ids).toContain("claude-gateway--antigravity--gemini-3.8-flash[1m]");
     expect(ids).toContain("claude-gateway--antigravity--gemini-3.7-flash[1m]");
     expect(ids).toContain("claude-gateway--antigravity--gemini-3.1-pro[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra-fast");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra-524k");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra-524k-fast");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra-1m[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra-1m-fast[1m]");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-luna");

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -734,8 +734,11 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(54);
+    expect(cache.models).toHaveLength(60);
     expect(ids).toContain("claude-gateway--antigravity--gemini-3.8-flash[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra-fast");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra-524k-fast");
+    expect(ids).toContain("claude-gateway--codex--gpt-6-astra-1m-fast[1m]");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-524k-fast");
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-1m-fast[1m]");


### PR DESCRIPTION
## Summary

- Codex 카탈로그에 `gpt-6-astra`를 추가하고, 기존 GPT-5.6 계열과 동일한 형태로 272K/524K/1M 컨텍스트 변형과 각 변형의 `priority` 티어 Fast 짝까지 6종을 노출합니다.
- Codex provider의 `defaultModel`을 `gpt-6-astra`로 옮겼습니다 — upstream `model/list`가 이 항목에 `isDefault: true`를 답합니다.
- 기존 GPT-5.6 모델 18종은 전부 유지합니다. 같은 `model/list`가 여전히 upgrade 포인터도 retirement 날짜도 없이 이들을 제공하기 때문입니다.

## 근거 (라이브 관측, 2026-09-05)

- `codex app-server model/list` (codex-cli 0.153.4): `gpt-6-astra` / `displayName: GPT-6-Astra` / `isDefault: true`, `supportedReasoningEfforts: low, medium, high, xhigh, max, ultra`, `additionalSpeedTiers: ["fast"]`, `serviceTiers: [{ id: priority, name: "Fast", "2x speed, increased usage" }]`.
- `ultra`는 카탈로그 사다리에 넣지 않았습니다 — 기존 Codex 정책(harness launch capability는 모델 rung이 아니다)이 그대로 적용되어 `max`에서 캡됩니다.
- 라이브 app-server 턴의 `thread/tokenUsage/updated`가 `gpt-6-astra`에 `modelContextWindow: 258400`을 보고했고, 같은 방법으로 잰 `gpt-5.6-sol`도 동일한 258400이었습니다. 따라서 Astra는 이 카탈로그가 해당 lineup에 기록해 온 272000 베이스를 공유하며, 명시 524K/1M 변형도 같은 근거로 성립합니다.
- CursorBench에 GPT-6-Astra 행이 없으므로 `benchmarkKey`는 붙이지 않았습니다 (단일 소스 정책 — 무증거 모델은 `capabilityClass`만 사전 확률로 남깁니다).

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 999 passed
- [x] `pnpm test` (전체 재귀) — 전 워크스페이스 통과
- [x] `pnpm typecheck` — 전 워크스페이스 통과
- [x] `pnpm check:core-boundary` / `check:claude-agent-sdk-boundary` / `check:core-unified-agent-absent` / `check:localized-attributes` — 위반 없음
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 2 entries validated

## Notes for Reviewers

- `grok-build/discovery.test.ts`의 표본을 `GATEWAY_MODELS[0]`에서 "점을 포함한 첫 항목"으로 바꿨습니다. 카탈로그 선두가 점 없는 `codex--gpt-6-astra`가 되면서 "점이 살아 있는 철자는 거부한다"는 단언이 자동으로 무의미해지기 때문이며, 테스트 원래 의도를 복원한 것입니다.
- `defaultModel` 이동은 `DEFAULT_CODEX_MODEL` 폴백에만 영향을 줍니다 — 라우터는 항상 명시 override를 보냅니다.