### PR TITLE
feat(repository): organize navigation around history and changes

### DIFF
--- a/.changelog.d/repository-ux-review-0905.md
+++ b/.changelog.d/repository-ux-review-0905.md
@@ -1,0 +1,8 @@
+---
+branch: repository-ux-review-0905
+---
+
+### fleet-console
+#### Changed
+- Organize Repository around History and Changes with a single repository/worktree picker, scoped reference search, a calm empty state with Amend access, checkout-specific in-memory commit drafts, and a fixed action-result line.
+  ko: Repository를 History와 Changes 중심으로 정리하고, 통합 저장소·워크트리 선택기, 범위가 명확한 참조 검색, Amend 진입을 보존한 빈 상태, 체크아웃별 메모리 커밋 초안, 고정 작업 결과 행을 제공합니다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -639,6 +639,12 @@ importers:
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3

--- a/runtime/fleet-plugins/repository/client/i18n/index.ts
+++ b/runtime/fleet-plugins/repository/client/i18n/index.ts
@@ -17,6 +17,8 @@ const repositoryEn = {
   "repository.staging.cleanHint": "Changes appear here when you edit files. Browse History to review earlier work.",
   "repository.staging.viewHistory": "View History",
   "repository.staging.editLastCommit": "Edit last commit",
+  "repository.staging.amendChecking": "Checking the commit for this Amend draft…",
+  "repository.staging.amendHeadChanged": "HEAD changed since this Amend draft. Your message is preserved. Turn Amend off, review History, then select Amend again if you want to edit the current commit.",
   "repository.sync.button": "Fetch",
   "repository.sync.title": "Update remote-tracking branches",
 
@@ -295,6 +297,8 @@ const repositoryKo: Record<keyof typeof repositoryEn, string> = {
   "repository.staging.cleanHint": "파일을 수정하면 여기에 나타납니다. 이전 작업은 기록에서 확인하세요.",
   "repository.staging.viewHistory": "기록 보기",
   "repository.staging.editLastCommit": "마지막 커밋 수정",
+  "repository.staging.amendChecking": "Amend 초안의 대상 커밋을 확인하고 있습니다…",
+  "repository.staging.amendHeadChanged": "Amend 초안을 작성한 뒤 HEAD가 바뀌었습니다. 메시지는 보존했습니다. Amend를 끄고 기록을 확인한 뒤, 현재 커밋을 수정하려면 Amend를 다시 선택하세요.",
   "repository.sync.button": "Fetch",
   "repository.sync.title": "원격 추적 브랜치를 갱신합니다",
 

--- a/runtime/fleet-plugins/repository/client/i18n/index.ts
+++ b/runtime/fleet-plugins/repository/client/i18n/index.ts
@@ -6,6 +6,17 @@ import { createTranslator } from "@fleet-console/sdk/i18n/translate";
 const repositoryEn = {
   // panel / identity
   "repository.panel.title": "Repository",
+  "repository.feedback.ready": "Local working tree · Fetch updates remote-tracking branches",
+  "repository.context.choose": "Choose repository or worktree",
+  "repository.context.empty": "No repositories found. Try scanning deeper.",
+  "repository.source.aria": "Repository views",
+  "repository.refs.search": "Find branches, tags, stashes",
+  "repository.refs.noMatching": "No matching refs",
+  "repository.refs.empty": "No refs",
+  "repository.staging.cleanTitle": "No changes to commit",
+  "repository.staging.cleanHint": "Changes appear here when you edit files. Browse History to review earlier work.",
+  "repository.staging.viewHistory": "View History",
+  "repository.staging.editLastCommit": "Edit last commit",
   "repository.sync.button": "Fetch",
   "repository.sync.title": "Update remote-tracking branches",
 
@@ -273,7 +284,18 @@ const repositoryEn = {
 
 const repositoryKo: Record<keyof typeof repositoryEn, string> = {
   "repository.panel.title": "저장소",
-  "repository.sync.button": "가져오기",
+  "repository.feedback.ready": "로컬 작업 트리 · Fetch로 원격 추적 정보를 갱신합니다",
+  "repository.context.choose": "저장소·워크트리 선택",
+  "repository.context.empty": "발견한 저장소가 없습니다. 탐색 깊이를 늘려 보세요.",
+  "repository.source.aria": "저장소 작업 보기",
+  "repository.refs.search": "브랜치·태그·스태시 찾기",
+  "repository.refs.noMatching": "일치하는 참조가 없습니다",
+  "repository.refs.empty": "참조가 없습니다",
+  "repository.staging.cleanTitle": "커밋할 변경이 없습니다",
+  "repository.staging.cleanHint": "파일을 수정하면 여기에 나타납니다. 이전 작업은 기록에서 확인하세요.",
+  "repository.staging.viewHistory": "기록 보기",
+  "repository.staging.editLastCommit": "마지막 커밋 수정",
+  "repository.sync.button": "Fetch",
   "repository.sync.title": "원격 추적 브랜치를 갱신합니다",
 
   "repository.section.context": "컨텍스트",

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from "react";
 
 import type { Translate } from "@fleet-console/sdk/i18n";
 import type { RailEntryDescriptor } from "@fleet-console/sdk/rail";
@@ -152,34 +152,6 @@ function mapSharedVerbError(code: string, t: T): string | null {
   }
 }
 
-export interface CheckoutTab {
-  readonly relPath: string;
-  readonly label: string;
-  readonly worktree: boolean;
-}
-
-/**
- * Fork의 상단 레포 탭 — 루트 체크아웃과 워크트리들이 한 줄에 선다.
- * 중첩 저장소는 트리에서 고르되, 선택 중이면 자기 탭이 임시로 나타난다.
- */
-function buildCheckoutTabs(repos: readonly RepoCandidate[], worktrees: readonly WorktreeCandidate[], selectedRel: string): readonly CheckoutTab[] {
-  const tabs: CheckoutTab[] = [];
-  const seen = new Set<string>();
-  const push = (relPath: string, label: string, worktree: boolean) => {
-    if (seen.has(relPath)) return;
-    seen.add(relPath);
-    tabs.push({ relPath, label, worktree });
-  };
-  const root = repos.find((repo) => repo.kind === "root");
-  if (root) push(root.relPath, root.name, false);
-  for (const worktree of worktrees) push(worktree.relPath, worktree.name, true);
-  if (!seen.has(selectedRel)) {
-    const selected = repos.find((repo) => repo.relPath === selectedRel);
-    if (selected) push(selected.relPath, selected.name, false);
-  }
-  return tabs;
-}
-
 export function RepositoryPanel({ ctx }: RepositoryPanelProps) {
   return <RepositoryPanelBody key={ctx.theaterId} ctx={ctx} />;
 }
@@ -246,6 +218,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   // 로컬 상태 새로 읽기가 오를 때마다 함께 오른다 — 스테이징 뷰는 자기 상태를 따로 읽으므로
   // 이 토큰이 없으면 트리 수치만 갱신되고 목록·파괴적 동사는 낡은 채로 남는다.
   const [stateReloadToken, setStateReloadToken] = useState(0);
+  const [stagingBusy, setStagingBusy] = useState(false);
   const [workstate, setWorkstate] = useState<WorkstateResult | null>(null);
   const [workstateRetry, setWorkstateRetry] = useState(0);
   const [workstateFailed, setWorkstateFailed] = useState(false);
@@ -267,6 +240,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   // "작업 중 변경 전체를 스태시" 버튼에 ✓와 실패 점이 붙어, 행 메뉴에서 고른 동작의 결과가 누르지도
   // 않은 명령에 귀속된다. 행 동작은 자기 행이 곧 사라질 수 있어 행 자리에도 답할 수 없으므로,
   // 이 개편 이전과 같이 패널 알림으로 답한다 — 버튼 문법은 툴바 동사만의 것이다.
+  const [feedback, setFeedback] = useState<{ readonly kind: "success" | "error"; readonly text: string } | null>(null);
   const [rowNotice, setRowNotice] = useState<{ readonly kind: "success" | "error"; readonly text: string } | null>(null);
   const rowNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const writeLockedRef = useRef(false);
@@ -394,6 +368,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     setVerbSettled(false);
     setVerbHinting(false);
     setRowNotice(null);
+    setFeedback(null);
     setWorkstate(null);
     setChangedFiles({ kind: "loading" });
     setCompareRequest(null);
@@ -548,6 +523,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const showRowNotice = useCallback((notice: { readonly kind: "success" | "error"; readonly text: string }) => {
     if (rowNoticeTimerRef.current !== null) clearTimeout(rowNoticeTimerRef.current);
     setRowNotice(notice);
+    setFeedback(notice);
     rowNoticeTimerRef.current = setTimeout(() => {
       rowNoticeTimerRef.current = null;
       setRowNotice(null);
@@ -561,6 +537,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       }
     }
     setVerbOutcome(outcome);
+    setFeedback(outcome);
     setVerbSettled(outcome.kind === "success");
     setVerbHinting(true);
     if (outcome.kind === "success") {
@@ -649,6 +626,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const showSyncSettled = useCallback(() => {
     if (syncSettledTimerRef.current !== null) clearTimeout(syncSettledTimerRef.current);
     if (syncHintTimerRef.current !== null) clearTimeout(syncHintTimerRef.current);
+    setFeedback({ kind: "success", text: t("repository.sync.upToDate") });
     setSyncSettled(true);
     setSyncHinting(true);
     setSyncHintAvailable(true);
@@ -660,7 +638,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       syncHintTimerRef.current = null;
       setSyncHinting(false);
     }, SYNC_HINT_MS);
-  }, []);
+  }, [t]);
   // 한 시도의 답은 배너·✓·말풍선 세 표면에 나뉘어 앉는다. 새 시도를 시작할 때 셋을 함께 걷지 않으면
   // 앞 시도의 배너가 자기 6초를 사는 동안 뒤 시도의 ✓가 겹쳐, 실패 배너와 "이미 최신 상태"가 동시에 뜬다.
   // 수동 동기화에는 throttle이 없어 두 번 누르는 것으로 재현된다. 지속 실패 점은 시도별 알림이 아니라
@@ -790,7 +768,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
 
   const wipFiles = changedFiles.kind === "ok" ? changedFiles.files : [];
   const selectedRepo = repos.find((repo) => repo.relPath === repoRel) ?? worktrees.find((worktree) => worktree.relPath === repoRel);
-  const checkoutTabs = buildCheckoutTabs(repos, worktrees, repoRel);
+  const sourceTabsId = useId();
   const writeGuardMessage = workstateFailed ? t("repository.guard.stateUnknown") : guardMessageOf(workstate, t);
   const writeLocked = writeGuardMessage !== null;
   writeLockedRef.current = writeLocked;
@@ -798,7 +776,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   // WORKING > Changes는 Fork 문법의 스테이징 뷰다 — 목록·diff·커밋 상자를 StagingView가 소유한다.
   // 체크아웃마다 새 인스턴스를 세운다 — 키 없이 재사용하면 이전 체크아웃의 목록·커밋 초안 위에서
   // 파괴 동사가 다른 체크아웃을 때릴 수 있다.
-  const changesView = <StagingView key={`${ctx.theaterId ?? ""}\u0000${repoRel}`} ctx={ctx} repoRel={repoRel} workstate={workstate} stateUnknown={workstateFailed} reloadToken={stateReloadToken} onMutated={handleWorkspaceMutated} />;
+  const changesView = <StagingView key={`${ctx.theaterId ?? ""}\u0000${repoRel}`} ctx={ctx} repoRel={repoRel} workstate={workstate} stateUnknown={workstateFailed} reloadToken={stateReloadToken} onMutated={handleWorkspaceMutated} onBusyChange={setStagingBusy} onReturnToHistory={() => setSource("history")} />;
   const syncNoticeMessage = syncNotice == null ? null
     : syncNotice.kind === "error"
       ? t(syncNotice.code === "auth_failed" ? "repository.sync.failedAuth"
@@ -807,12 +785,15 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
         : syncNotice.code === "no_remote" ? "repository.sync.failedNoRemote"
         : "repository.sync.failedGit")
       : t("repository.sync.summary", { newRefs: syncNotice.newRefs, updatedRefs: syncNotice.updatedRefs, pruned: syncNotice.pruned });
+  useEffect(() => {
+    if (syncNotice && syncNoticeMessage) setFeedback({ kind: syncNotice.kind, text: syncNoticeMessage });
+  }, [syncNotice, syncNoticeMessage]);
   // Changes만 hidden으로 상시 마운트해 섹션 전환에도 내부 상태를 보존한다.
   const workspaceMainVisible = source === "changes";
   const workspaceMain = <div className="repository-source-fill" hidden={source !== "changes"}>{changesView}</div>;
   return (
     <div className="repository-unified is-workspace">
-      <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? t("repository.panel.title")}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}<button type="button" className={`repository-sync-button${syncing ? " is-syncing" : ""}`} title={t("repository.sync.title")} aria-label={t("repository.sync.title")} disabled={syncing} onClick={() => { void syncRepository(); }}><span className={`repository-sync-icon${syncSettled ? " is-settled" : ""}`} aria-hidden="true"><span className="repository-sync-glyph repository-sync-glyph-idle">↻</span><span className="repository-sync-glyph repository-sync-glyph-settled">✓</span></span>{t("repository.sync.button")}{syncFailed && <span className="repository-sync-dot" title={t("repository.sync.lastFailed")} aria-hidden="true" />}{syncHintAvailable && <span className={`repository-sync-hint${syncHinting ? " is-open" : ""}`} aria-hidden="true">{t("repository.sync.upToDate")}</span>}</button><span className="repository-verb-cluster">
+      <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryPicker t={t} repos={repos} worktrees={worktrees} selectedRel={repoRel} selectedRepo={selectedRepo} reposError={reposError} worktreesError={worktreesError} truncated={reposTruncated} scanDepth={scanDepth} onScanDepth={setScanDepth} onReload={refreshRepositoryData} onRetryRepos={() => setReposRetry((value) => value + 1)} onRetryWorktrees={() => setWorktreesRetry((value) => value + 1)} onRepository={handleSelectRepository} disabled={verbBusy !== null || stagingBusy} /><button type="button" className={`repository-sync-button${syncing ? " is-syncing" : ""}`} title={t("repository.sync.title")} aria-label={t("repository.sync.title")} disabled={syncing} onClick={() => { void syncRepository(); }}><span className={`repository-sync-icon${syncSettled ? " is-settled" : ""}`} aria-hidden="true"><span className="repository-sync-glyph repository-sync-glyph-idle">↻</span><span className="repository-sync-glyph repository-sync-glyph-settled">✓</span></span>{t("repository.sync.button")}{syncFailed && <span className="repository-sync-dot" title={t("repository.sync.lastFailed")} aria-hidden="true" />}{syncHintAvailable && <span className={`repository-sync-hint${syncHinting ? " is-open" : ""}`} aria-hidden="true">{t("repository.sync.upToDate")}</span>}</button><span className="repository-verb-cluster">
         <VerbToolbarButton glyph="⇩" label={t("repository.verb.pull")} title={t("repository.verb.pullTitle")} count={workstate?.behind ? <em className="repository-verb-count" title={t("repository.verb.behindCount", { count: workstate.behind })}>{workstate.behind}↓</em> : null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "pull"} outcome={verbOutcome?.verb === "pull" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "pull"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handlePull} />
         <VerbToolbarButton glyph="⇧" label={t("repository.verb.push")} title={t("repository.verb.pushTitle")} count={workstate?.ahead ? <em className="repository-verb-count" title={t("repository.verb.aheadCount", { count: workstate.ahead })}>{workstate.ahead}↑</em> : null} disabled={verbBusy !== null || writeLocked} busy={verbBusy?.surface === "button" && verbBusy.verb === "push"} outcome={verbOutcome?.verb === "push" ? verbOutcome : null} settled={verbSettled && verbOutcome?.verb === "push"} hinting={verbHinting} failedTitle={t("repository.verb.lastFailed")} onClick={handlePush} />
         <span className="repository-stash-anchor" ref={stashButtonHostRef}>
@@ -820,30 +801,37 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
           {stashPromptOpen && <StashSavePopover t={t} hostRef={stashButtonHostRef} onSave={handleStashSave} onClose={() => setStashPromptOpen(false)} />}
         </span>
       </span></div>
-      <div className="repository-checkout-tabs" role="tablist" aria-label={t("repository.tabs.aria")}>
-        {checkoutTabs.map((tab) => <button
-          key={tab.relPath || "\u0000root"}
-          type="button"
-          role="tab"
-          className={`repository-checkout-tab${tab.relPath === repoRel ? " is-active" : ""}`}
-          aria-selected={tab.relPath === repoRel}
-          title={tab.relPath || tab.label}
-          onClick={() => handleSelectRepository({ relPath: tab.relPath })}
-        >
-          <span className="repository-checkout-tab-label">{tab.label}</span>
-          {tab.worktree && <i className="repository-checkout-tab-mark" title={t("repository.tabs.worktreeMark")}>wt</i>}
-        </button>)}
-      </div>
       {/* 동사 결과는 말풍선이 물러난 뒤에도 hover 재개방을 위해 남아 있으므로, 한 라이브 리전을 동기화와
           나눠 쓰면 남아 있는 동사 문면이 뒤이은 동기화 결과의 낭독을 영원히 가린다 — 리전을 분리한다. */}
       <span className="repository-sr-only" role="status">{syncHinting ? t("repository.sync.upToDate") : ""}</span>
       <span className="repository-sr-only" role="status">{verbOutcome ? verbOutcome.text : ""}</span>
-      {syncNotice && syncNoticeMessage ? <div className={`repository-sync-toast is-${syncNotice.kind === "error" ? "error" : "success"}`} role="status"><span>{syncNoticeMessage}</span><button type="button" aria-label={t("repository.sync.dismiss")} onClick={() => setSyncNotice(null)}>✕</button></div> : null}
-      {rowNotice ? <div className={`repository-sync-toast is-${rowNotice.kind}`} role="status"><span>{rowNotice.text}</span><button type="button" aria-label={t("repository.sync.dismiss")} onClick={() => setRowNotice(null)}>✕</button></div> : null}
+      <span className="repository-sr-only" role="status">{syncNoticeMessage ?? ""}</span>
+      <span className="repository-sr-only" role="status">{rowNotice?.text ?? ""}</span>
       <div ref={layoutRef} className={`repository-ws-layout${isTreeDragging ? " is-dragging" : ""}`} style={{ "--ws-tree-width": `${treeWidth}px` } as React.CSSProperties}>
-        <WorkspaceTree theaterId={ctx.theaterId ?? ""} t={t} repos={repos} reposError={reposError} reposTruncated={reposTruncated} scanDepth={scanDepth} worktrees={worktrees} worktreesError={worktreesError} refs={refs} refsError={refsError} changedFiles={changedFiles} selectedRel={repoRel} source={source} refFilter={refFilter} onRepository={handleSelectRepository} onScanDepth={setScanDepth} onRetryRepos={() => setReposRetry((value) => value + 1)} onReloadState={refreshRepositoryData} onRetryWorktrees={() => setWorktreesRetry((value) => value + 1)} onRetryRefs={() => setRefsRetry((value) => value + 1)} onSource={setSource} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} onCompare={openCompare} onStashInspect={openStashInspect} onStashAction={handleStashRowAction} />
+        <WorkspaceTree theaterId={ctx.theaterId ?? ""} t={t} refs={refs} refsError={refsError} source={source} refFilter={refFilter} onRetryRefs={() => setRefsRetry((value) => value + 1)} onReloadState={refreshRepositoryData} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} onCompare={openCompare} onStashInspect={openStashInspect} onStashAction={handleStashRowAction} />
         <div className="repository-divider repository-ws-tree-divider" onPointerDown={handleTreeDividerDown} role="separator" aria-orientation="vertical" aria-label={t("repository.common.resizeSourceTree")} />
+        <div className="repository-work-area">
+          <div className="repository-source-tabs" role="tablist" aria-label={t("repository.source.aria")} onKeyDown={(event) => {
+            if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+            event.preventDefault();
+            event.stopPropagation();
+            const next = event.key === "Home" ? "history" : event.key === "End" ? "changes" : source === "history" ? "changes" : "history";
+            setSource(next);
+            event.currentTarget.querySelector<HTMLButtonElement>(`[data-source="${next}"]`)?.focus();
+          }}>
+            {(["history", "changes"] as const).map((item) => <button key={item} type="button" role="tab" data-source={item} id={`${sourceTabsId}-${item}`} aria-controls={`${sourceTabsId}-panel`} aria-selected={source === item} tabIndex={source === item ? 0 : -1} onClick={() => setSource(item)}>
+              {t(item === "history" ? "repository.source.history" : "repository.source.changes")}
+              {item === "changes" && <span>{changedFiles.kind === "ok" ? wipFiles.length : "—"}</span>}
+            </button>)}
+          </div>
+          <div className="repository-work-panel" role="tabpanel" id={`${sourceTabsId}-panel`} aria-labelledby={`${sourceTabsId}-${source}`}>
         <HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} cacheScope={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} externalRefreshToken={historyExternalRefreshToken} active refFilter={refFilter} wipFiles={wipFiles} workspace workspaceMain={workspaceMain} workspaceMainVisible={workspaceMainVisible} compareRequest={compareRequest} inspectRequest={inspectRequest} stashRequest={stashRequest} onStashAction={handleStashRowAction} onReturnToHistory={() => setSource("history")} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} />
+          </div>
+        </div>
+      </div>
+      <div className={`repository-feedback${feedback?.kind === "error" ? " is-error" : ""}`}>
+        <span>{feedback?.text ?? (writeGuardMessage || t("repository.feedback.ready"))}</span>
+        {feedback && <button type="button" aria-label={t("repository.sync.dismiss")} onClick={() => setFeedback(null)}>✕</button>}
       </div>
     </div>
   );
@@ -852,68 +840,31 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
 interface WorkspaceTreeProps {
   readonly theaterId?: string;
   readonly t: T;
-  readonly repos: readonly RepoCandidate[];
-  readonly reposError: boolean;
-  readonly reposTruncated: boolean;
-  readonly scanDepth: number;
-  readonly worktrees: readonly WorktreeCandidate[];
-  readonly worktreesError: boolean;
   readonly refs: Refs;
   readonly refsError: boolean;
-  readonly changedFiles: ChangedFilesState;
-  readonly selectedRel: string;
   readonly source: Source;
   readonly refFilter: string | null;
-  readonly onRepository: (repo: RepoCandidate | WorktreeCandidate) => void;
-  readonly onScanDepth: (depth: number) => void;
-  readonly onRetryRepos: () => void;
-  /** 로컬 저장소 상태(작업·스태시·refs·ahead)를 원격 fetch 없이 다시 읽는다. */
-  readonly onReloadState: () => void;
-  readonly onRetryWorktrees: () => void;
   readonly onRetryRefs: () => void;
-  readonly onSource: (source: Source) => void;
+  readonly onReloadState: () => void;
   readonly onRef: (ref: string) => void;
   readonly onCompare: (base: string, head: string) => void;
   readonly onStashInspect: (stash: { readonly name: string; readonly sha: string; readonly subject: string }) => void;
   readonly onStashAction?: (action: "apply" | "pop" | "drop", name: string, sha: string) => void;
 }
 
-export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTruncated, scanDepth, worktrees, worktreesError, refs, refsError, changedFiles, selectedRel, source, refFilter, onRepository, onScanDepth, onRetryRepos, onReloadState, onRetryWorktrees, onRetryRefs, onSource, onRef, onCompare, onStashInspect, onStashAction }: WorkspaceTreeProps) {
+export function WorkspaceTree({ theaterId = "", t, refs, refsError, source, refFilter, onReloadState, onRetryRefs, onRef, onCompare, onStashInspect, onStashAction }: WorkspaceTreeProps) {
   const [initialTreeState] = useState(() => readWorkspaceTreeState(theaterId));
   const [query, setQuery] = useState(initialTreeState?.query ?? "");
   const [collapsedSections, setCollapsedSections] = useState(() => new Set(initialTreeState?.collapsedSections ?? ["tags", "stashes"]));
-  const [collapsedFolders, setCollapsedFolders] = useState(() => new Set(initialTreeState?.collapsedFolders ?? []));
+  const [collapsedFolders] = useState(() => new Set(initialTreeState?.collapsedFolders ?? []));
   const [refContextMenu, setRefContextMenu] = useState<RefContextMenuState | null>(null);
   const [treeRef] = useState<RefObject<HTMLElement | null>>(() => ({ current: null }));
-  const handleToggleRepoFolder = (path: string) => {
-    setCollapsedFolders((current) => {
-      const next = new Set(current);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      return next;
-    });
-  };
-  const rootRepos = repos.filter((repo) => repo.kind === "root").sort((a, b) => a.name.localeCompare(b.name));
-  const nestedRepos = repos.filter((repo) => repo.kind === "nested");
-  const nestedTree = buildRepoTree(nestedRepos);
-  const matchRepository = (repo: RepoCandidate) => fuzzyMatch(query, repo.name) ?? fuzzyMatch(query, repo.relPath);
-  const rootMatches = query ? rootRepos.filter((repo) => matchRepository(repo) !== null) : rootRepos;
-  const nestedMatches = query ? nestedRepos.filter((repo) => matchRepository(repo) !== null) : nestedRepos;
-  const matchedCount = rootMatches.length + nestedMatches.length;
   const branchCount = refs.branches.length + refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)).length;
   const refRowCount = refs.branches.length + refs.remotes.length + refs.tags.length + refs.stashes.length;
-  const changesCount = changedFiles.kind === "ok" ? changedFiles.files.length : 0;
-  const sections = buildWorkspaceTreeSections({
-    context: repos.length,
-    changes: changesCount,
-    worktrees: worktrees.length,
-    branches: branchCount,
-    tags: refs.tags.length,
-    stashes: refs.stashes.length,
-  }, t);
+  const sections = buildWorkspaceTreeSections({ context: 0, changes: 0, worktrees: 0, branches: branchCount, tags: refs.tags.length, stashes: refs.stashes.length }, t).filter((section) => ["branches", "tags", "stashes"].includes(section.id));
   const sectionHeader = (id: (typeof sections)[number]["id"]) => {
     const section = sections.find((item) => item.id === id)!;
-    const collapsed = collapsedSections.has(id);
+    const collapsed = !query && collapsedSections.has(id);
     return <button type="button" className="repository-ws-section-head" aria-expanded={!collapsed} onClick={() => {
       setCollapsedSections((current) => {
         const next = new Set(current);
@@ -929,7 +880,7 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
     </button>;
   };
   const currentBranchRef = refs.branches.find((item) => item.current)?.ref ?? null;
-  // 발견 검색창 하나가 트리 전체를 거른다 — 저장소뿐 아니라 브랜치·태그·스태시 행도 같은 질의를 따른다(Fork 문법).
+  // 검색은 참조에만 적용한다. 현재 저장소 컨텍스트는 결과와 무관하게 상단에 남는다.
   const refRows = (refSource: RefSource) => buildRefListGroups(refSource, refs).map((group) => ({ ...group, rows: query ? group.rows.filter((row) => fuzzyMatch(query, row.primary) !== null || (row.sub ? fuzzyMatch(query, row.sub) !== null : false)) : group.rows })).filter((group) => group.rows.length > 0).map((group) => <div key={group.label ?? refSource} className="repository-ws-ref-group">
     {group.label && <span className="repository-ws-ref-subhead">{t(group.label === "LOCAL" ? "repository.refs.local" : "repository.refs.remotes")}</span>}
     {/* 브랜치 행은 role=button 자손에 interactive content가 금지되므로(ARIA-in-HTML)
@@ -955,32 +906,17 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
     </button>)}
   </div>);
   return <aside ref={treeRef} className="repository-ws-tree">
-    <RepositoryDiscovery t={t} query={query} onQuery={setQuery} totalCount={repos.length} matchedCount={matchedCount} scanDepth={scanDepth} onScanDepth={onScanDepth} truncated={reposTruncated} onReload={onReloadState} onEnter={() => {
-      const first = rootMatches[0] ?? nestedMatches[0];
-      if (first) onRepository(first);
-    }} />
-    <WorkspaceTreeScroll theaterId={theaterId} query={query} collapsedSections={collapsedSections} collapsedFolders={collapsedFolders} initialScrollTop={initialTreeState?.scrollTop ?? 0} contentVersion={`${repos.length}:${worktrees.length}:${refRowCount}:${changesCount}:${collapsedSections.size}:${collapsedFolders.size}`}>
-      <section className={`repository-ws-section${collapsedSections.has("context") ? " is-collapsed" : ""}`}>{sectionHeader("context")}
-        {!collapsedSections.has("context") && (reposError ? <WorkspaceTreeError t={t} label={t("repository.discovery.loadReposFailed")} onRetry={onRetryRepos} /> : <>
-          {rootMatches.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />)}
-          {query ? nestedMatches.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />) : <RepoTreeChildren node={nestedTree} depth={0} parentPath="" collapsedFolders={collapsedFolders} onToggleFolder={handleToggleRepoFolder} selectedRel={selectedRel} onRepository={onRepository} />}
-          {query && matchedCount === 0 && <div className="repository-empty-row">{t("repository.discovery.noMatching")}</div>}
-        </>)}
+    <div className="repository-discovery">
+      <input className="repository-filter-input" aria-label={t("repository.refs.search")} placeholder={t("repository.refs.search")} value={query} onChange={(event) => setQuery(event.target.value)} />
+      {query && <button type="button" className="repository-filter-clear" aria-label={t("repository.discovery.clearSearch")} onClick={() => setQuery("")}>✕</button>}
+      <button type="button" className="repository-reload-state" aria-label={t("repository.common.reloadState")} title={t("repository.common.reloadState")} onClick={onReloadState}>↻</button>
+    </div>
+    <WorkspaceTreeScroll theaterId={theaterId} query={query} collapsedSections={collapsedSections} collapsedFolders={collapsedFolders} initialScrollTop={initialTreeState?.scrollTop ?? 0} contentVersion={`${refRowCount}:${collapsedSections.size}`}>
+      <section className={`repository-ws-section${!query && collapsedSections.has("branches") ? " is-collapsed" : ""}`}>{sectionHeader("branches")}
+        {(query || !collapsedSections.has("branches")) && (refsError ? <WorkspaceTreeError t={t} label={t("repository.discovery.loadRefsFailed")} onRetry={onRetryRefs} /> : (refRows("branches").length ? refRows("branches") : <div className="repository-empty-row">{t(query ? "repository.refs.noMatching" : "repository.refs.empty")}</div>))}
       </section>
-      <section className={`repository-ws-section${collapsedSections.has("working") ? " is-collapsed" : ""}`}>{sectionHeader("working")}
-        {!collapsedSections.has("working") && <>
-          <button type="button" className={`repository-ws-tree-row${source === "history" ? " is-active" : ""}`} onClick={() => onSource("history")}><SourceIcon source="history" /><span>{t("repository.source.history")}</span></button>
-          <button type="button" className={`repository-ws-tree-row${source === "changes" ? " is-active" : ""}`} onClick={() => onSource("changes")}><SourceIcon source="changes" /><span>{t("repository.source.changes")}</span><i>{changesCount}</i></button>
-        </>}
-      </section>
-      <section className={`repository-ws-section${collapsedSections.has("worktrees") ? " is-collapsed" : ""}`}>{sectionHeader("worktrees")}
-        {!collapsedSections.has("worktrees") && (worktreesError ? <WorkspaceTreeError t={t} label={t("repository.discovery.loadWorktreesFailed")} onRetry={onRetryWorktrees} /> : worktrees.filter((worktree) => !query || fuzzyMatch(query, worktree.name) !== null).map((worktree) => <button type="button" key={worktree.relPath} className={`repository-ws-tree-row${worktree.relPath === selectedRel ? " is-current" : ""}`} title={worktree.relPath} onClick={() => onRepository(worktree)}><SourceIcon source="worktrees" /><span>{worktree.name}</span>{worktree.current && <i>HEAD</i>}</button>))}
-      </section>
-      <section className={`repository-ws-section${collapsedSections.has("branches") ? " is-collapsed" : ""}`}>{sectionHeader("branches")}
-        {!collapsedSections.has("branches") && (refsError ? <WorkspaceTreeError t={t} label={t("repository.discovery.loadRefsFailed")} onRetry={onRetryRefs} /> : refRows("branches"))}
-      </section>
-      <section className={`repository-ws-section${collapsedSections.has("tags") ? " is-collapsed" : ""}`}>{sectionHeader("tags")}{!collapsedSections.has("tags") && !refsError && refRows("tags")}</section>
-      <section className={`repository-ws-section${collapsedSections.has("stashes") ? " is-collapsed" : ""}`}>{sectionHeader("stashes")}{!collapsedSections.has("stashes") && !refsError && refRows("stashes")}</section>
+      <section className={`repository-ws-section${!query && collapsedSections.has("tags") ? " is-collapsed" : ""}`}>{sectionHeader("tags")}{(query || !collapsedSections.has("tags")) && !refsError && (refRows("tags").length ? refRows("tags") : <div className="repository-empty-row">{t(query ? "repository.refs.noMatching" : "repository.refs.empty")}</div>)}</section>
+      <section className={`repository-ws-section${!query && collapsedSections.has("stashes") ? " is-collapsed" : ""}`}>{sectionHeader("stashes")}{(query || !collapsedSections.has("stashes")) && !refsError && (refRows("stashes").length ? refRows("stashes") : <div className="repository-empty-row">{t(query ? "repository.refs.noMatching" : "repository.refs.empty")}</div>)}</section>
     </WorkspaceTreeScroll>
     {refContextMenu && refContextMenu.row.source === "stashes" && onStashAction ? <StashRowContextMenu
       key={`${refContextMenu.row.key}:${refContextMenu.anchor.x}:${refContextMenu.anchor.y}`}
@@ -1288,6 +1224,79 @@ function RepositoryDiscovery({ t, query, onQuery, totalCount, matchedCount, scan
     <span className="repository-scan-count">{query ? t("repository.discovery.countMatched", { matched: matchedCount, total: totalCount }) : truncated ? t("repository.discovery.countFoundLimited", { count: totalCount }) : t("repository.discovery.countFound", { count: totalCount })}</span>
   </div>;
 }
+function RepositoryPicker({ t, repos, worktrees, selectedRel, selectedRepo, reposError, worktreesError, truncated, scanDepth, onScanDepth, onReload, onRetryRepos, onRetryWorktrees, onRepository, disabled }: {
+  readonly t: T;
+  readonly repos: readonly RepoCandidate[];
+  readonly worktrees: readonly WorktreeCandidate[];
+  readonly selectedRel: string;
+  readonly selectedRepo: RepoCandidate | WorktreeCandidate | undefined;
+  readonly reposError: boolean;
+  readonly worktreesError: boolean;
+  readonly truncated: boolean;
+  readonly scanDepth: number;
+  readonly onScanDepth: (depth: number) => void;
+  readonly onReload: () => void;
+  readonly onRetryRepos: () => void;
+  readonly onRetryWorktrees: () => void;
+  readonly onRepository: (repo: RepoCandidate | WorktreeCandidate) => void;
+  readonly disabled: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [collapsedFolders, setCollapsedFolders] = useState<ReadonlySet<string>>(() => new Set());
+  const hostRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelId = useId();
+  const close = useCallback((returnFocus: boolean) => {
+    setOpen(false);
+    if (returnFocus) triggerRef.current?.focus();
+  }, []);
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => hostRef.current?.querySelector<HTMLInputElement>("input")?.focus());
+    const outside = (event: PointerEvent) => {
+      if (event.target instanceof Node && !hostRef.current?.contains(event.target)) close(false);
+    };
+    document.addEventListener("pointerdown", outside, true);
+    return () => { cancelAnimationFrame(frame); document.removeEventListener("pointerdown", outside, true); };
+  }, [close, open]);
+  useEffect(() => { if (disabled) setOpen(false); }, [disabled]);
+  const matches = (repo: RepoCandidate | WorktreeCandidate) => !query || fuzzyMatch(query, repo.name) !== null || fuzzyMatch(query, repo.relPath) !== null || (repo.branch !== null && fuzzyMatch(query, repo.branch) !== null);
+  const rootRepos = repos.filter((repo) => repo.kind === "root" && matches(repo));
+  const nestedRepos = repos.filter((repo) => repo.kind === "nested" && matches(repo));
+  const matchedWorktrees = worktrees.filter((worktree) => !repos.some((repo) => repo.relPath === worktree.relPath) && matches(worktree));
+  const select = (repo: RepoCandidate | WorktreeCandidate) => { close(true); onRepository(repo); };
+  const toggleFolder = (path: string) => setCollapsedFolders((current) => {
+    const next = new Set(current);
+    if (next.has(path)) next.delete(path); else next.add(path);
+    return next;
+  });
+  return <div className="repository-context-picker" ref={hostRef} onKeyDown={(event) => {
+    if (!open) return;
+    if (event.key === "Escape") { event.preventDefault(); event.stopPropagation(); close(true); }
+    // 비모달 선택기는 Tab으로 벗어날 수 있다. 앱 단축키는 열린 선택기 뒤에서 발동하지 않는다.
+    else event.stopPropagation();
+  }} onBlur={(event) => { if (event.relatedTarget instanceof Node && !event.currentTarget.contains(event.relatedTarget)) close(false); }}>
+    <button ref={triggerRef} type="button" className="repository-context-trigger" aria-label={t("repository.context.choose")} aria-expanded={open} aria-controls={panelId} disabled={disabled} onClick={() => setOpen((value) => !value)}>
+      <RepositoryIcon /><strong title={selectedRepo?.name}>{selectedRepo?.name ?? t("repository.panel.title")}</strong>
+      {selectedRepo?.branch && <span className="repository-context-branch" title={selectedRepo.branch}>{selectedRepo.branch}</span>}
+      <span aria-hidden="true">⌄</span>
+    </button>
+    {open && <section id={panelId} className="repository-context-popover" aria-label={t("repository.context.choose")}>
+      <RepositoryDiscovery t={t} query={query} onQuery={setQuery} totalCount={repos.length} matchedCount={rootRepos.length + nestedRepos.length} scanDepth={scanDepth} onScanDepth={onScanDepth} truncated={truncated} onReload={onReload} onEnter={() => { const first = rootRepos[0] ?? nestedRepos[0] ?? matchedWorktrees[0]; if (first) select(first); }} />
+      <div className="repository-context-options">
+        {reposError ? <WorkspaceTreeError t={t} label={t("repository.discovery.loadReposFailed")} onRetry={onRetryRepos} /> : <>
+          {rootRepos.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={select} />)}
+          {query ? nestedRepos.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={select} />) : <RepoTreeChildren node={buildRepoTree(nestedRepos)} depth={0} parentPath="" selectedRel={selectedRel} onRepository={select} collapsedFolders={collapsedFolders} onToggleFolder={toggleFolder} />}
+        </>}
+        {(worktrees.length > 0 || worktreesError) && <div className="repository-context-heading">{t("repository.section.worktrees")}</div>}
+        {worktreesError ? <WorkspaceTreeError t={t} label={t("repository.discovery.loadWorktreesFailed")} onRetry={onRetryWorktrees} /> : matchedWorktrees.map((repo) => <button type="button" key={repo.relPath} className={`repository-ref-row${selectedRel === repo.relPath ? " is-current" : ""}`} title={repo.relPath} onClick={() => select(repo)}><SourceIcon source="worktrees" /><span className="repository-ref-name">{repo.name}</span>{repo.branch && <span className="repository-ref-sub">{repo.branch}</span>}</button>)}
+        {!reposError && !worktreesError && rootRepos.length + nestedRepos.length + matchedWorktrees.length === 0 && <div className="repository-empty-row">{t(query ? "repository.discovery.noMatching" : "repository.context.empty")}</div>}
+      </div>
+    </section>}
+  </div>;
+}
+
 interface RepoTreeCommonProps {
   readonly selectedRel: string;
   readonly onRepository: (repo: RepoCandidate) => void;

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -1264,7 +1264,8 @@ function RepositoryPicker({ t, repos, worktrees, selectedRel, selectedRepo, repo
   const matches = (repo: RepoCandidate | WorktreeCandidate) => !query || fuzzyMatch(query, repo.name) !== null || fuzzyMatch(query, repo.relPath) !== null || (repo.branch !== null && fuzzyMatch(query, repo.branch) !== null);
   const rootRepos = repos.filter((repo) => repo.kind === "root" && matches(repo));
   const nestedRepos = repos.filter((repo) => repo.kind === "nested" && matches(repo));
-  const matchedWorktrees = worktrees.filter((worktree) => !repos.some((repo) => repo.relPath === worktree.relPath) && matches(worktree));
+  const distinctWorktrees = worktrees.filter((worktree) => !repos.some((repo) => repo.relPath === worktree.relPath));
+  const matchedWorktrees = distinctWorktrees.filter(matches);
   const select = (repo: RepoCandidate | WorktreeCandidate) => { close(true); onRepository(repo); };
   const toggleFolder = (path: string) => setCollapsedFolders((current) => {
     const next = new Set(current);
@@ -1283,7 +1284,7 @@ function RepositoryPicker({ t, repos, worktrees, selectedRel, selectedRepo, repo
       <span aria-hidden="true">⌄</span>
     </button>
     {open && <section id={panelId} className="repository-context-popover" aria-label={t("repository.context.choose")}>
-      <RepositoryDiscovery t={t} query={query} onQuery={setQuery} totalCount={repos.length} matchedCount={rootRepos.length + nestedRepos.length} scanDepth={scanDepth} onScanDepth={onScanDepth} truncated={truncated} onReload={onReload} onEnter={() => { const first = rootRepos[0] ?? nestedRepos[0] ?? matchedWorktrees[0]; if (first) select(first); }} />
+      <RepositoryDiscovery t={t} query={query} onQuery={setQuery} totalCount={repos.length + distinctWorktrees.length} matchedCount={rootRepos.length + nestedRepos.length + matchedWorktrees.length} scanDepth={scanDepth} onScanDepth={onScanDepth} truncated={truncated} onReload={onReload} onEnter={() => { const first = rootRepos[0] ?? nestedRepos[0] ?? matchedWorktrees[0]; if (first) select(first); }} />
       <div className="repository-context-options">
         {reposError ? <WorkspaceTreeError t={t} label={t("repository.discovery.loadReposFailed")} onRetry={onRetryRepos} /> : <>
           {rootRepos.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={select} />)}

--- a/runtime/fleet-plugins/repository/client/repository-state.ts
+++ b/runtime/fleet-plugins/repository/client/repository-state.ts
@@ -85,6 +85,26 @@ export interface RepoViewState {
   readonly collapsedFolders: readonly string[];
 }
 
+export interface CommitDraft {
+  readonly subject: string;
+  readonly body: string;
+  readonly amend: boolean;
+}
+
+// 초안은 플러그인 번들의 메모리에만 둔다. 체크아웃 전환과 패널 재개방은 넘지만 디스크에는 쓰지 않는다.
+const commitDrafts = new Map<string, CommitDraft>();
+const commitDraftKey = (theaterId: string, repoRel: string): string => JSON.stringify([theaterId, repoRel]);
+
+export function readCommitDraft(theaterId: string, repoRel: string): CommitDraft | undefined {
+  return commitDrafts.get(commitDraftKey(theaterId, repoRel));
+}
+
+export function writeCommitDraft(theaterId: string, repoRel: string, draft: CommitDraft): void {
+  const key = commitDraftKey(theaterId, repoRel);
+  if (!draft.subject && !draft.body && !draft.amend) commitDrafts.delete(key);
+  else commitDrafts.set(key, draft);
+}
+
 const workspaceTreeCache = new Map<string, WorkspaceTreeState>();
 const repoViewCache = new Map<string, RepoViewState>();
 

--- a/runtime/fleet-plugins/repository/client/repository-state.ts
+++ b/runtime/fleet-plugins/repository/client/repository-state.ts
@@ -89,6 +89,7 @@ export interface CommitDraft {
   readonly subject: string;
   readonly body: string;
   readonly amend: boolean;
+  readonly amendHeadSha?: string | null;
 }
 
 // 초안은 플러그인 번들의 메모리에만 둔다. 체크아웃 전환과 패널 재개방은 넘지만 디스크에는 쓰지 않는다.

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1874,50 +1874,39 @@
 }
 
 
-/* ═══ Fork 워크벤치 — 체크아웃 탭 ═══════════════════════════════════════════ */
-/* 루트 체크아웃과 워크트리가 한 줄에 서는 상단 탭 — 컨텍스트 트리의 빠른 길이다. */
-.repository-checkout-tabs {
-  display: flex;
-  align-items: flex-end;
-  gap: 2px;
-  padding: 4px 10px 0;
-  border-bottom: 1px solid var(--hairline);
-  /* identity 캡과 같은 위스퍼 한 단 — 캡 구역(identity+탭)이 하나의 띠로 이어진다(밴드 정합). */
-  background: color-mix(in oklch, var(--ink-fog) 5%, transparent);
-  overflow-x: auto;
-  scrollbar-width: none;
-  flex: none;
-}
-.repository-checkout-tabs::-webkit-scrollbar { display: none; }
-.repository-checkout-tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 12px;
-  border: 1px solid transparent;
-  border-bottom: none;
-  border-radius: var(--radius-xs) var(--radius-xs) 0 0;
-  background: transparent;
-  color: var(--text-tertiary);
-  font: inherit;
-  font-size: var(--t-sm);
-  white-space: nowrap;
-  cursor: pointer;
-}
-.repository-checkout-tab:hover { color: var(--text-primary); background: var(--ink-mid); }
-.repository-checkout-tab.is-active {
-  color: var(--text-primary);
-  background: var(--ink-mid);
-  border-color: var(--hairline);
-  position: relative;
-  top: 1px;
-}
-.repository-checkout-tab-label { overflow: hidden; text-overflow: ellipsis; max-width: 18ch; }
-.repository-checkout-tab-mark {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-style: normal;
-  font-size: var(--t-xs);
-  color: var(--text-tertiary);
+/* 저장소 맥락은 상단 선택기 하나가, 주 작업은 작업면 탭이 소유한다. */
+.repository-feedback { display: flex; align-items: center; gap: 8px; flex: none; height: 36px; padding: 4px 12px; border-top: 1px solid var(--surface-rim); color: var(--text-secondary); font-size: var(--t-xs); }
+.repository-feedback > span { flex: 1; min-width: 0; max-height: 100%; overflow-y: auto; overflow-wrap: anywhere; }
+.repository-feedback.is-error { color: var(--coral-ink); }
+.repository-feedback button { flex: none; border: 0; background: transparent; color: inherit; cursor: pointer; }
+.repository-context-picker { position: relative; min-width: 0; flex: 1; }
+.repository-context-trigger { display: flex; align-items: center; gap: 8px; width: 100%; min-width: 0; padding: 5px 8px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--control-rest); color: var(--text-secondary); cursor: pointer; text-align: left; }
+.repository-context-trigger:hover { background: var(--control-rest-hover); }
+.repository-context-trigger strong { flex: 1; }
+.repository-context-trigger .repository-context-branch { max-width: 32%; }
+.repository-context-trigger:focus-visible, .repository-source-tabs button:focus-visible, .repository-staging-amend-entry:focus-visible { outline: 2px solid var(--brass); outline-offset: -2px; }
+.repository-context-popover { position: absolute; left: 0; top: calc(100% + 6px); z-index: 30; width: min(480px, calc(100cqw - 24px)); max-height: min(440px, 65vh); display: flex; flex-direction: column; border: 1px solid var(--surface-rim); border-radius: var(--radius-md); background: var(--surface-glass-strong); box-shadow: var(--shadow-floating); overflow: hidden; }
+.repository-context-options { min-height: 0; overflow-y: auto; }
+.repository-identity .repository-context-options span { color: inherit; font: inherit; }
+.repository-context-heading { padding: 9px 12px 4px; font-size: var(--t-xs); font-weight: var(--weight-medium); color: var(--text-tertiary); }
+.repository-work-area { display: flex; flex-direction: column; min-width: 0; min-height: 0; overflow: hidden; }
+.repository-work-panel { flex: 1; min-height: 0; min-width: 0; }
+.repository-work-panel > .history-root { height: 100%; }
+.repository-source-tabs { display: flex; gap: 12px; padding: 0 12px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--ink-fog) 5%, transparent); flex: none; }
+.repository-source-tabs button { display: inline-flex; align-items: center; gap: 7px; padding: 9px 4px; border: 0; border-bottom: 2px solid transparent; background: transparent; color: var(--text-secondary); font: inherit; font-size: var(--t-sm); cursor: pointer; }
+.repository-source-tabs button:hover { color: var(--text-primary); }
+.repository-source-tabs button[aria-selected="true"] { border-bottom-color: var(--brass); color: var(--text-primary); font-weight: var(--weight-medium); }
+.repository-source-tabs button span { font-family: var(--font-mono); font-size: var(--t-xs); color: var(--text-tertiary); }
+.repository-staging-empty { flex: 1; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; padding: 24px; text-align: center; }
+.repository-staging-empty strong { color: var(--text-primary); font-size: var(--t-lg); font-weight: var(--weight-medium); }
+.repository-staging-empty p { max-width: 36ch; margin: 0; color: var(--text-secondary); font-size: var(--t-sm); }
+.repository-staging-clean-mark { color: var(--positive-ink); font-size: var(--t-lg); }
+.repository-staging-amend-entry { padding: 5px 8px; border: 0; background: transparent; color: var(--text-secondary); font: inherit; font-size: var(--t-xs); cursor: pointer; }
+.repository-staging-amend-entry:hover { color: var(--brass-ink); }
+@container (width < 720px) {
+  .repository-identity { flex-wrap: wrap; }
+  .repository-context-picker { flex-basis: 100%; }
+  .repository-identity > .repository-sync-button { margin-left: 0; }
 }
 
 /* ═══ Fork 워크벤치 — 툴바 동사(Pull/Push/Stash) ══════════════════════════ */

--- a/runtime/fleet-plugins/repository/client/staging-view.tsx
+++ b/runtime/fleet-plugins/repository/client/staging-view.tsx
@@ -5,6 +5,7 @@ import type { RepositoryContext } from "./repository-context.js";
 
 import type { CommitResult, DiffFileEntry, StatusResult, WorkstateResult } from "../server/types.js";
 import { getT, readErrorSentence, type RepositoryMessageKey } from "./i18n/index.js";
+import { readCommitDraft, writeCommitDraft } from "./repository-state.js";
 import { FilesViewToggle, readFilesViewMode, saveFilesViewMode, type FilesViewMode } from "./changed-files.js";
 import { HunkView } from "./hunk-view.js";
 import { DiffTreeView } from "./repository-tree.js";
@@ -36,6 +37,8 @@ interface StagingViewProps {
   readonly stateUnknown?: boolean;
   /** 패널이 로컬 상태를 다시 읽을 때 함께 오르는 토큰 — 이 값이 바뀌면 스테이징 목록도 다시 읽는다. */
   readonly reloadToken?: number;
+  readonly onReturnToHistory: () => void;
+  readonly onBusyChange: (busy: boolean) => void;
   /** 변이 후 패널 전역 갱신 — history:true는 커밋처럼 기록 축이 실제로 움직인 변이에만 쓴다. */
   readonly onMutated: (options: { readonly history: boolean }) => void;
 }
@@ -76,17 +79,23 @@ function readListPaneWidth(): number {
  * Local Changes 스테이징 뷰 — Fork 문법의 심장부.
  * 왼쪽은 Unstaged/Staged 두 단, 오른쪽은 선택한 축의 diff, 아래는 커밋 상자다.
  */
-export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, reloadToken = 0, onMutated }: StagingViewProps) {
+export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, reloadToken = 0, onMutated, onReturnToHistory, onBusyChange }: StagingViewProps) {
   const t = getT(ctx.language);
   const [status, setStatus] = useState<StatusState>({ kind: "loading" });
   const [statusRetry, setStatusRetry] = useState(0);
   const [selection, setSelection] = useState<Selection | null>(null);
   const [armedDiscard, setArmedDiscard] = useState<string | null>(null);
   const armTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [subject, setSubject] = useState("");
-  const [bodyText, setBodyText] = useState("");
-  const [amend, setAmend] = useState(false);
+  const [initialDraft] = useState(() => readCommitDraft(ctx.theaterId ?? "", repoRel));
+  const [subject, setSubject] = useState(initialDraft?.subject ?? "");
+  const [bodyText, setBodyText] = useState(initialDraft?.body ?? "");
+  const [amend, setAmend] = useState(initialDraft?.amend ?? false);
+  useEffect(() => {
+    writeCommitDraft(ctx.theaterId ?? "", repoRel, { subject, body: bodyText, amend });
+  }, [ctx.theaterId, repoRel, subject, bodyText, amend]);
   const [busy, setBusy] = useState(false);
+  useEffect(() => { onBusyChange(busy); }, [busy, onBusyChange]);
+  useEffect(() => () => onBusyChange(false), [onBusyChange]);
   const [notice, setNotice] = useState<StagingNotice | null>(null);
   const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // 커밋 인스펙터와 같은 선호 키를 읽는다 — 목록/트리는 화면마다 다른 취향이 아니라 한 문법이다.
@@ -288,6 +297,8 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
   const commitCount = staged.length;
   const commitDisabled = busy || writeLocked || subject.trim() === "" || (commitCount === 0 && !amend);
   const hunkSelection = selection;
+  const clean = status.kind === "ok" && !status.truncated && staged.length === 0 && unstaged.length === 0;
+  const showComposer = !clean || amend || subject !== "" || bodyText !== "";
 
   return <div className="repository-staging">
     {(guardMessage || stationedMessage) && <div className={`repository-staging-guard${guardMessage ? " is-locked" : ""}`} role="status">
@@ -297,7 +308,13 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
     {/* 끌어서 정한 목록 폭은 인라인 grid-template-columns가 아니라 변수로 들어온다 — 인라인 값은
         좁은 폭에서 세로로 쌓는 컨테이너 쿼리를 이겨, 실측에서 본 목록 82px·파일명 폭 0px 붕괴를
         되살린다(독이 이미 같은 이유로 변수를 쓴다). */}
-    <div ref={rootRef} className={`repository-root repository-staging-root${hunkSelection ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={hunkSelection ? ({ "--staging-list-width": `${listPaneWidth}px` } as CSSProperties) : undefined}>
+    {clean && !amend ? <div className="repository-staging-empty">
+      <span className="repository-staging-clean-mark" aria-hidden="true">✓</span>
+      <strong>{t("repository.staging.cleanTitle")}</strong>
+      <p>{t("repository.staging.cleanHint")}</p>
+      <button type="button" className="repository-refresh-btn" onClick={onReturnToHistory}>{t("repository.staging.viewHistory")}</button>
+      {workstate?.headSha && <button type="button" className="repository-staging-amend-entry" disabled={busy || writeLocked} onClick={toggleAmend}>{t("repository.staging.editLastCommit")}</button>}
+    </div> : <div ref={rootRef} className={`repository-root repository-staging-root${hunkSelection ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={hunkSelection ? ({ "--staging-list-width": `${listPaneWidth}px` } as CSSProperties) : undefined}>
       <div className="repository-list-pane repository-staging-lists">
         {status.kind === "loading" && <div className="repository-sections-loading">{t("repository.common.loading")}</div>}
         {status.kind === "error" && <div className="repository-sections-error"><span>{readErrorSentence(t, status.message)}</span><button type="button" className="repository-refresh-btn" onClick={() => setStatusRetry((value) => value + 1)}>{t("repository.common.retry")}</button></div>}
@@ -379,8 +396,8 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
         </div>
         <HunkView key={`${hunkSelection.axis}:${hunkSelection.entry.path}`} ctx={ctx} repoRel={repoRel} file={hunkSelection.entry} mode={hunkModeOf(hunkSelection)} />
       </div>}
-    </div>
-    <div className="repository-commit-box">
+    </div>}
+    {showComposer && <div className="repository-commit-box">
       <input
         type="text"
         className="repository-commit-subject"
@@ -408,7 +425,7 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
           {amend ? t("repository.staging.commitAmend") : t(commitCount === 1 ? "repository.staging.commit_one" : "repository.staging.commit_other", { count: commitCount })}
         </button>
       </div>
-    </div>
+    </div>}
   </div>;
 }
 

--- a/runtime/fleet-plugins/repository/client/staging-view.tsx
+++ b/runtime/fleet-plugins/repository/client/staging-view.tsx
@@ -90,9 +90,11 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
   const [subject, setSubject] = useState(initialDraft?.subject ?? "");
   const [bodyText, setBodyText] = useState(initialDraft?.body ?? "");
   const [amend, setAmend] = useState(initialDraft?.amend ?? false);
+  const [amendHeadSha, setAmendHeadSha] = useState(initialDraft?.amendHeadSha ?? null);
+  const amendReady = !amend || (!stateUnknown && !!amendHeadSha && workstate?.headSha === amendHeadSha);
   useEffect(() => {
-    writeCommitDraft(ctx.theaterId ?? "", repoRel, { subject, body: bodyText, amend });
-  }, [ctx.theaterId, repoRel, subject, bodyText, amend]);
+    writeCommitDraft(ctx.theaterId ?? "", repoRel, { subject, body: bodyText, amend, amendHeadSha });
+  }, [ctx.theaterId, repoRel, subject, bodyText, amend, amendHeadSha]);
   const [busy, setBusy] = useState(false);
   useEffect(() => { onBusyChange(busy); }, [busy, onBusyChange]);
   useEffect(() => () => onBusyChange(false), [onBusyChange]);
@@ -242,14 +244,15 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
   const toggleAmend = useCallback(() => {
     setAmend((current) => {
       const next = !current;
+      setAmendHeadSha(next ? workstate?.headSha ?? null : null);
       if (next) prefillFromHead();
       return next;
     });
-  }, [prefillFromHead]);
+  }, [prefillFromHead, workstate?.headSha]);
 
   const commit = useCallback(async () => {
     const trimmedSubject = subject.trim();
-    if (trimmedSubject === "") return;
+    if (trimmedSubject === "" || !amendReady) return;
     const payload = await runVerb("commit-create", {
       subject: trimmedSubject,
       ...(bodyText.trim() ? { message: bodyText.trim() } : {}),
@@ -265,7 +268,7 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
       setBodyText("");
       setAmend(false);
     }
-  }, [amend, bodyText, runVerb, showNotice, subject, t]);
+  }, [amend, amendReady, bodyText, runVerb, showNotice, subject, t]);
 
   const handleDividerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -295,12 +298,13 @@ export function StagingView({ ctx, repoRel, workstate, stateUnknown = false, rel
   const staged = status.kind === "ok" ? status.staged : [];
   const unstaged = status.kind === "ok" ? status.unstaged : [];
   const commitCount = staged.length;
-  const commitDisabled = busy || writeLocked || subject.trim() === "" || (commitCount === 0 && !amend);
+  const commitDisabled = busy || writeLocked || !amendReady || subject.trim() === "" || (commitCount === 0 && !amend);
   const hunkSelection = selection;
   const clean = status.kind === "ok" && !status.truncated && staged.length === 0 && unstaged.length === 0;
   const showComposer = !clean || amend || subject !== "" || bodyText !== "";
 
   return <div className="repository-staging">
+    {amend && !amendReady && <div className="repository-staging-guard" role="status">{t(!workstate || stateUnknown ? "repository.staging.amendChecking" : "repository.staging.amendHeadChanged")}</div>}
     {(guardMessage || stationedMessage) && <div className={`repository-staging-guard${guardMessage ? " is-locked" : ""}`} role="status">
       {guardMessage ?? stationedMessage}
     </div>}

--- a/runtime/fleet-plugins/repository/package.json
+++ b/runtime/fleet-plugins/repository/package.json
@@ -16,6 +16,8 @@
   "devDependencies": {
     "@types/node": "^24.10.0",
     "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "react-dom": "^19.2.7",
     "typescript": "^6.0.2",
     "vitest": "^4.1.5"
   }

--- a/runtime/fleet-plugins/repository/tests/commit-draft.test.ts
+++ b/runtime/fleet-plugins/repository/tests/commit-draft.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { readCommitDraft, writeCommitDraft } from "../client/repository-state.js";
+
+describe("저장소별 커밋 초안", () => {
+  it("같은 Theater의 서로 다른 체크아웃에 초안을 분리한다", () => {
+    const first = { subject: "첫 번째 초안", body: "설명", amend: false };
+    const second = { subject: "다른 초안", body: "", amend: true };
+    writeCommitDraft("draft-test", "", first);
+    writeCommitDraft("draft-test", "nested/repo", second);
+    expect(readCommitDraft("draft-test", "")).toEqual(first);
+    expect(readCommitDraft("draft-test", "nested/repo")).toEqual(second);
+    expect(readCommitDraft("other-theater", "")).toBeUndefined();
+  });
+
+  it("빈 초안으로 저장하면 해당 저장소만 지운다", () => {
+    writeCommitDraft("draft-clear", "one", { subject: "초안", body: "", amend: false });
+    writeCommitDraft("draft-clear", "two", { subject: "유지", body: "", amend: false });
+    writeCommitDraft("draft-clear", "one", { subject: "", body: "", amend: false });
+    expect(readCommitDraft("draft-clear", "one")).toBeUndefined();
+    expect(readCommitDraft("draft-clear", "two")?.subject).toBe("유지");
+  });
+});

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -226,7 +226,7 @@ describe("Repository design grammar", () => {
     // 캔버스 톤은 이 패널에서 퇴역했다 — 남은 언급은 독트린 주석뿐이어야 한다.
     expect(css).not.toContain("var(--surface-band)");
 
-    for (const selector of [".repository-toolbar", ".repository-plugin-toolbar", ".history-toolbar", ".repository-line-file-label", ".repository-discovery", ".repository-identity", ".repository-checkout-tabs", ".repository-ws-peek"]) {
+    for (const selector of [".repository-toolbar", ".repository-plugin-toolbar", ".history-toolbar", ".repository-line-file-label", ".repository-discovery", ".repository-identity", ".repository-source-tabs", ".repository-ws-peek"]) {
       expect(blockOf(selector), selector).toContain("var(--ink-fog) 5%");
     }
     expect(blockOf(".repository-ws-tree")).toContain("background: transparent");

--- a/runtime/fleet-plugins/repository/tests/read-honesty-contract.test.ts
+++ b/runtime/fleet-plugins/repository/tests/read-honesty-contract.test.ts
@@ -87,6 +87,14 @@ describe("honesty copy exists in both locales", () => {
 // 앉아 있으면 "모두 스테이지"는 여전히 보이지 않는 나머지를 건드린다.
 const stagingSource = await fs.readFile(new URL("../client/staging-view.tsx", import.meta.url), "utf8");
 
+it("통합 선택기 카운터는 중복을 제외한 worktree 검색 결과도 센다", async () => {
+  const source = await fs.readFile(new URL("../client/rail-panel.tsx", import.meta.url), "utf8");
+  expect(source).toContain("const distinctWorktrees = worktrees.filter((worktree) => !repos.some((repo) => repo.relPath === worktree.relPath))");
+  expect(source).toContain("const matchedWorktrees = distinctWorktrees.filter(matches)");
+  expect(source).toContain("totalCount={repos.length + distinctWorktrees.length}");
+  expect(source).toContain("matchedCount={rootRepos.length + nestedRepos.length + matchedWorktrees.length}");
+});
+
 describe("the staging surface carries its own honesty", () => {
   const source = stagingSource;
 

--- a/runtime/fleet-plugins/repository/tests/staging-empty-state.test.tsx
+++ b/runtime/fleet-plugins/repository/tests/staging-empty-state.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StagingView } from "../client/staging-view.js";
+import type { RepositoryContext } from "../client/repository-context.js";
+import { readCommitDraft, writeCommitDraft } from "../client/repository-state.js";
+
+let host: HTMLDivElement;
+let root: Root;
+const onReturnToHistory = vi.fn();
+const ctx = { theaterId: "empty-state-test", language: "en", api: { fetch: vi.fn() } } as unknown as RepositoryContext;
+const props = { ctx, repoRel: "", workstate: null, onMutated: vi.fn(), onReturnToHistory, onBusyChange: vi.fn() };
+
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  onReturnToHistory.mockClear();
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ staged: [], unstaged: [] }), { status: 200 })));
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  host.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("변경 없음과 커밋 초안", () => {
+  it("깨끗한 저장소에서는 커밋 폼 대신 기록 진입을 제공한다", async () => {
+    await act(async () => root.render(createElement(StagingView, props)));
+    expect(host.textContent).toContain("No changes to commit");
+    expect(host.querySelector(".repository-commit-box")).toBeNull();
+    const history = host.querySelector<HTMLButtonElement>(".repository-staging-empty button")!;
+    await act(async () => history.click());
+    expect(onReturnToHistory).toHaveBeenCalledOnce();
+  });
+
+  it("빈 목록이 잘린 응답이면 깨끗한 저장소로 단정하지 않는다", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ staged: [], unstaged: [], truncated: true }), { status: 200 }));
+    await act(async () => root.render(createElement(StagingView, props)));
+    expect(host.querySelector(".repository-staging-empty")).toBeNull();
+    expect(host.querySelector(".repository-truncated-note")).not.toBeNull();
+  });
+
+  it("체크아웃별 초안을 복원하되 깨끗해졌다고 기존 초안을 숨기지 않는다", async () => {
+    writeCommitDraft(ctx.theaterId!, "draft-repo", { subject: "보존할 제목", body: "설명", amend: false });
+    await act(async () => root.render(createElement(StagingView, { ...props, repoRel: "draft-repo" })));
+    expect(host.querySelector<HTMLInputElement>(".repository-commit-subject")?.value).toBe("보존할 제목");
+    expect(readCommitDraft(ctx.theaterId!, "draft-repo")?.body).toBe("설명");
+  });
+
+  it("상태 읽기 실패를 변경 없음으로 표시하지 않는다", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ error: "git_failed" }), { status: 500 }));
+    await act(async () => root.render(createElement(StagingView, props)));
+    expect(host.querySelector(".repository-staging-empty")).toBeNull();
+    expect(host.querySelector(".repository-sections-error")).not.toBeNull();
+  });
+});

--- a/runtime/fleet-plugins/repository/tests/staging-empty-state.test.tsx
+++ b/runtime/fleet-plugins/repository/tests/staging-empty-state.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { StagingView } from "../client/staging-view.js";
+import type { WorkstateResult } from "../server/types.js";
 import type { RepositoryContext } from "../client/repository-context.js";
 import { readCommitDraft, writeCommitDraft } from "../client/repository-state.js";
 
@@ -29,6 +30,26 @@ afterEach(async () => {
 });
 
 describe("변경 없음과 커밋 초안", () => {
+  it("복원된 Amend 초안은 HEAD가 확인되기 전에는 실행할 수 없다", async () => {
+    const draft = { subject: "이전 커밋 수정", body: "", amend: true, amendHeadSha: "old-head" };
+    writeCommitDraft(ctx.theaterId!, "amend-pending", draft);
+    await act(async () => root.render(createElement(StagingView, { ...props, repoRel: "amend-pending" })));
+    expect(host.querySelector<HTMLButtonElement>(".repository-commit-button")?.disabled).toBe(true);
+  });
+  it("동일 HEAD는 복원하고 다른 HEAD는 메시지를 보존한 채 실행을 막는다", async () => {
+    const draft = { subject: "원래 커밋 제목", body: "보존할 설명", amend: true, amendHeadSha: "original-head" };
+    writeCommitDraft(ctx.theaterId!, "amend-advanced", draft);
+    const workstate = { headSha: "original-head", indexLock: false, inProgress: null, stationedOperations: [] } as unknown as WorkstateResult;
+    const render = (state: WorkstateResult) => root.render(createElement(StagingView, { ...props, repoRel: "amend-advanced", workstate: state }));
+    await act(async () => render(workstate));
+    expect(host.querySelector<HTMLButtonElement>(".repository-commit-button")?.disabled).toBe(false);
+    await act(async () => render({ ...workstate, headSha: "new-head" }));
+    expect(host.querySelector<HTMLButtonElement>(".repository-commit-button")?.disabled).toBe(true);
+    expect(host.textContent).toContain("HEAD changed since this Amend draft");
+    expect(host.querySelector<HTMLInputElement>(".repository-commit-subject")?.value).toBe(draft.subject);
+    expect(readCommitDraft(ctx.theaterId!, "amend-advanced")?.amendHeadSha).toBe("original-head");
+  });
+
   it("깨끗한 저장소에서는 커밋 폼 대신 기록 진입을 제공한다", async () => {
     await act(async () => root.render(createElement(StagingView, props)));
     expect(host.textContent).toContain("No changes to commit");

--- a/runtime/fleet-plugins/repository/tests/sync-client.test.ts
+++ b/runtime/fleet-plugins/repository/tests/sync-client.test.ts
@@ -92,8 +92,10 @@ describe("Repository sync client contracts", () => {
     expect(railPanelSource).not.toContain("setVerbNotice");
     expect(railPanelSource).not.toContain("repository.verb.pulled\"");
     expect(railPanelSource).not.toContain("repository.verb.pushed\"");
-    // 배너를 쓰는 표면은 sync와 스태시 "행" 동작 둘뿐이다 — 툴바 동사가 세 번째로 끼어들면 부활한 것이다.
-    expect(railPanelSource.split("repository-sync-toast").length - 1).toBe(2);
+    // 결과는 높이가 고정된 공통 행에 남긴다. 일시 배너로 작업면을 밀지 않는다.
+    expect(railPanelSource).not.toContain("repository-sync-toast");
+    expect(railPanelSource).toContain("repository-feedback");
+    expect(railPanelSource).toContain("setFeedback(outcome)");
     const verbRun = railPanelSource.slice(railPanelSource.indexOf("const runToolbarVerb"), railPanelSource.indexOf("const handlePull"));
     expect(verbRun).not.toContain("setSyncNotice");
     for (const handler of ["const handlePull", "const handlePush", "const handleStash ="]) {

--- a/runtime/fleet-plugins/repository/tests/workspace-tree-sections.test.ts
+++ b/runtime/fleet-plugins/repository/tests/workspace-tree-sections.test.ts
@@ -69,12 +69,6 @@ function renderWorkspaceTree(): ReactElement<ElementProps> {
   hookHarness.beginRender();
   return WorkspaceTree({
     t: getT("en"),
-    repos: [{ relPath: ".", name: "fleet-harness", branch: "canary", kind: "root" }],
-    reposError: false,
-    reposTruncated: false,
-    scanDepth: 3,
-    worktrees: [{ relPath: ".fleet/worktrees/topic", name: "topic", branch: "topic", current: false }],
-    worktreesError: false,
     refs: {
       branches: [{ label: "canary", ref: "refs/heads/canary", current: true }],
       remotes: [],
@@ -82,17 +76,10 @@ function renderWorkspaceTree(): ReactElement<ElementProps> {
       stashes: [{ name: "stash@{0}", subject: "WIP" }],
     },
     refsError: false,
-    changedFiles: { kind: "ok", files: [] },
-    selectedRel: ".",
     source: "history",
     refFilter: null,
-    onRepository: vi.fn(),
-    onScanDepth: vi.fn(),
-    onRetryRepos: vi.fn(),
     onReloadState: vi.fn(),
-    onRetryWorktrees: vi.fn(),
     onRetryRefs: vi.fn(),
-    onSource: vi.fn(),
     onRef: vi.fn(),
     onCompare: vi.fn(),
     onStashInspect: vi.fn(),
@@ -120,19 +107,13 @@ beforeEach(() => hookHarness.reset());
 describe("WorkspaceTree section collapse", () => {
   it("starts with tags and stashes collapsed while preserving every count badge", () => {
     const state = sectionState(renderWorkspaceTree());
-    expect([...state.keys()]).toEqual(["context", "working", "worktrees", "branches", "tags", "stashes"]);
+    expect([...state.keys()]).toEqual(["branches", "tags", "stashes"]);
     expect(Object.fromEntries([...state].map(([id, section]) => [id, section.expanded]))).toEqual({
-      context: true,
-      working: true,
-      worktrees: true,
       branches: true,
       tags: false,
       stashes: false,
     });
     expect(Object.fromEntries([...state].map(([id, section]) => [id, section.count]))).toEqual({
-      context: "1",
-      working: "0",
-      worktrees: "1",
       branches: "1",
       tags: "1",
       stashes: "1",
@@ -144,12 +125,8 @@ describe("WorkspaceTree section collapse", () => {
   it("toggles expanded state and conditionally renders section bodies", () => {
     const initial = sectionState(renderWorkspaceTree());
     initial.get("tags")?.toggle();
-    initial.get("context")?.toggle();
-    initial.get("working")?.toggle();
 
     const toggled = sectionState(renderWorkspaceTree());
     expect(toggled.get("tags")).toMatchObject({ expanded: true, hasBody: true, count: "1" });
-    expect(toggled.get("context")).toMatchObject({ expanded: false, hasBody: false, count: "1" });
-    expect(toggled.get("working")).toMatchObject({ expanded: false, hasBody: false, count: "0" });
   });
 });


### PR DESCRIPTION
## Summary
- Repository를 상단 저장소·워크트리 선택기와 기록/변경 작업 탭 중심으로 재배치합니다. 참조 검색과 저장소 발견을 분리하고 기존 그래프·풀블리드 선택행·쓰기 안전장치를 보존합니다.
- 변경 없음 안내와 Amend 진입, 체크아웃별 메모리 커밋 초안, 본문을 밀지 않는 고정 작업 결과 행을 제공합니다.
- 빈 상태·오류·잘린 응답·초안 격리의 회귀 테스트와 React DOM 테스트 의존성을 추가합니다.

## Test Plan
- [x] Repository typecheck / build
- [x] Repository tests: 451 passed
- [x] Console build
- [x] Console instrument-design-contract: 97 passed
- [x] Changelog fragment validation / git diff --check
- [x] 격리 Console + 가상 Git fixture: 루트/중첩/worktree 전환, 초안 복원, 방향키 탭, Escape 포커스 복귀, stage/unstage/commit, 빈 상태·Amend 진입, 원격 없음 오류 표시
- [x] 실제 Instrument/Whites 화면, 좁은 패널과 긴 worktree 이름 검증; browser error / unhandled rejection 0
- [ ] 실제 원격 Pull/Push 성공·충돌 복구·모바일·Electron: 이번 로컬 검증에서 실행하지 않음

### 제품 결정 및 보존 경계
사용자가 비교 시안의 B안 진행을 승인했습니다. 저장소 맥락 → 작업 → 상세 순서를 명확하게 만들되 전역 테마, 바깥 패널 기하, 카드형 선택행, 그래프 제거, 별도 Compare 페이지, 자동 checkout 및 쓰기 잠금 완화는 범위 밖입니다. 참조 클릭은 조회이며 checkout이 아닙니다. 초안은 브라우저 메모리에서만 체크아웃별로 보존하며 새로고침 영속성은 의도하지 않습니다. 검색 중 결과를 노출해도 기존 접힘 선호는 덮어쓰지 않습니다.
