### PR TITLE
fix(settings): place terminal before harness categories

### DIFF
--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -210,7 +210,7 @@ function resumeFailureMessage(error: unknown, locale?: ConsoleLocale): string {
 export const agentPlugin = definePlugin({
   id: "terminal",
   operationKinds: [agentOperationKind],
-  settingsSections: [harnessSettingsSection, generalSettingsSection, agentSettingsSection],
+  settingsSections: [generalSettingsSection, harnessSettingsSection, agentSettingsSection],
   notificationKinds: [agentAttentionNotification, agentEndedNotification, agentResumeFailedNotification],
   install: (ctx) => installAgentPlugin(ctx),
   closeOperation: async (operationId) => {

--- a/runtime/fleet-plugins/terminal/client/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/index.tsx
@@ -19,7 +19,7 @@ const AGENT_OPERATION_TYPES = new Set(["agent"]);
 const terminalPlugin = definePlugin({
   id: "terminal",
   operationKinds: [agentOperationKind],
-  settingsSections: [harnessSettingsSection, generalSettingsSection, agentSettingsSection],
+  settingsSections: [generalSettingsSection, harnessSettingsSection, agentSettingsSection],
   notificationKinds: [agentAttentionNotification],
   railEntries: [globalShellEntry],
   expandedSurfaces: [shellSurface],
@@ -63,7 +63,7 @@ const terminalPlugin = definePlugin({
 });
 
 export const operationKinds = [agentOperationKind] as const;
-export const settingsSections = [harnessSettingsSection, generalSettingsSection, agentSettingsSection] as const;
+export const settingsSections = [generalSettingsSection, harnessSettingsSection, agentSettingsSection] as const;
 export const notificationKinds = [agentAttentionNotification] as const;
 export const plugins = [terminalPlugin] as const;
 


### PR DESCRIPTION
## Summary
- 설정 카테고리에서 터미널을 하네스보다 앞에 배치합니다.
- 세 설정 섹션 등록 위치의 순서를 동일하게 유지하며, 설정 내용과 식별자는 변경하지 않습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `git diff --check`
- [x] 격리 Console의 실제 headless 브라우저에서 카테고리 순서, 터미널·하네스 왕복 선택 및 새로고침 확인
- [x] 브라우저 오류·unhandled rejection 없음 및 검증 프로세스 정리 확인
