### PR TITLE
ci(mobile): retry transient App Store Connect failures

### DIFF
--- a/runtime/fleet-mobile/scripts/lib/asc-api.mjs
+++ b/runtime/fleet-mobile/scripts/lib/asc-api.mjs
@@ -20,11 +20,24 @@ export const TOKEN_LIFETIME_SECONDS = 900;
 // 오류와 Apple의 혼잡 응답은 재시도로 흡수하고, 영구적인 거절만 호출자에게 올린다.
 export const RETRY_ATTEMPTS = 4;
 export const RETRY_BASE_DELAY_MS = 2000;
+// Apple이 Retry-After로 지정한 대기가 이보다 길면 재시도해도 백오프 안에서 같은 창에 갇힌다.
+// 그때는 조용히 소진하는 대신 서버가 요구한 대기 시간을 담아 즉시 실패시킨다.
+export const RETRY_AFTER_CAP_MS = 60_000;
 const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
 
 /** 재시도가 의미 있는 상태 코드인지. 4xx 인증·검증 실패는 다시 보내도 같은 답이 온다. */
 export function isRetryableStatus(status) {
   return RETRYABLE_STATUS.has(status);
+}
+
+/** Retry-After는 초 또는 HTTP-date로 온다. 읽을 수 없으면 백오프만 쓰도록 undefined를 준다. */
+export function parseRetryAfter(raw, nowMs = Date.now()) {
+  const value = String(raw ?? "").trim();
+  if (!value) return undefined;
+  if (/^\d+$/.test(value)) return Number(value) * 1000;
+  const at = Date.parse(value);
+  if (Number.isNaN(at)) return undefined;
+  return Math.max(0, at - nowMs);
 }
 
 export function parseGroupNames(raw) {
@@ -101,7 +114,11 @@ export function createAscClient({ keyId, issuerId, keyPath, fetchImpl = fetch, n
     });
     if (response.status === 204) return { status: 204, data: null };
     const text = await response.text();
-    if (!response.ok) return { status: response.status, error: describeApiError(method, path, response.status, text) };
+    if (!response.ok) {
+      // Apple이 얼마나 기다리라고 했는지는 여기서만 볼 수 있다 — 오류와 함께 위로 넘긴다.
+      const retryAfterMs = parseRetryAfter(response.headers?.get?.("retry-after"), now());
+      return { status: response.status, error: describeApiError(method, path, response.status, text), retryAfterMs };
+    }
     try {
       return { status: response.status, data: text ? JSON.parse(text) : null };
     } catch {
@@ -127,12 +144,20 @@ export function createAscClient({ keyId, issuerId, keyPath, fetchImpl = fetch, n
         continue;
       }
       if (!result.error || !isRetryableStatus(result.status) || attempt >= RETRY_ATTEMPTS) return result;
-      await backoff(method, path, attempt, `HTTP ${result.status}`);
+      // 고정 백오프로 다시 보내면 Apple이 지정한 창 안에 그대로 갇힌다. 서버가 말한 대기가 더
+      // 길면 그만큼 기다리고, 백오프로는 도저히 넘길 수 없는 창이면 재시도를 접는다.
+      if (result.retryAfterMs !== undefined && result.retryAfterMs > RETRY_AFTER_CAP_MS) {
+        return {
+          ...result,
+          error: `${result.error} — Apple asked to wait ${Math.round(result.retryAfterMs / 1000)}s, longer than this job retries`,
+        };
+      }
+      await backoff(method, path, attempt, `HTTP ${result.status}`, result.retryAfterMs);
     }
   }
 
-  async function backoff(method, path, attempt, reason) {
-    const waitMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+  async function backoff(method, path, attempt, reason, retryAfterMs) {
+    const waitMs = Math.max(RETRY_BASE_DELAY_MS * 2 ** (attempt - 1), retryAfterMs ?? 0);
     process.stdout.write(
       `  ${method} ${path} failed (${reason}); retrying in ${Math.round(waitMs / 1000)}s ` +
         `(attempt ${attempt + 1}/${RETRY_ATTEMPTS})\n`,

--- a/runtime/fleet-mobile/scripts/lib/asc-api.mjs
+++ b/runtime/fleet-mobile/scripts/lib/asc-api.mjs
@@ -1,5 +1,6 @@
 import { createPrivateKey, sign } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
 import { fail } from "./android-tools.mjs";
 
 /**
@@ -14,6 +15,17 @@ export const ASC_GROUPS_ENV = "FLEET_ASC_BETA_GROUPS";
 export const WHATS_NEW_LOCALE = "en-US";
 // Apple은 20분을 넘는 만료를 거부한다. 폴링이 길어져도 만료 전에 새로 발급하도록 짧게 잡는다.
 export const TOKEN_LIFETIME_SECONDS = 900;
+// 처리 대기 폴링은 30분을 넘게 이 API를 두드린다. 그 사이 러너와 Apple 사이의 연결이 한 번
+// 끊기면(ConnectTimeoutError 등) 업로드가 이미 성공한 배포가 통째로 실패한다. 일시적 전송
+// 오류와 Apple의 혼잡 응답은 재시도로 흡수하고, 영구적인 거절만 호출자에게 올린다.
+export const RETRY_ATTEMPTS = 4;
+export const RETRY_BASE_DELAY_MS = 2000;
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+/** 재시도가 의미 있는 상태 코드인지. 4xx 인증·검증 실패는 다시 보내도 같은 답이 온다. */
+export function isRetryableStatus(status) {
+  return RETRYABLE_STATUS.has(status);
+}
 
 export function parseGroupNames(raw) {
   return [...new Set(String(raw ?? "").split(",").map((name) => name.trim()).filter(Boolean))];
@@ -66,7 +78,7 @@ export function pickBuild(builds, buildNumber) {
   return builds.find((entry) => entry?.attributes?.version === buildNumber) ?? null;
 }
 
-export function createAscClient({ keyId, issuerId, keyPath, fetchImpl = fetch, now = () => Date.now() }) {
+export function createAscClient({ keyId, issuerId, keyPath, fetchImpl = fetch, now = () => Date.now(), sleep = delay }) {
   const privateKeyPem = readFileSync(keyPath, "utf8");
   let cached = null;
 
@@ -78,7 +90,7 @@ export function createAscClient({ keyId, issuerId, keyPath, fetchImpl = fetch, n
     return cached.value;
   }
 
-  async function request(method, path, body) {
+  async function send(method, path, body) {
     const response = await fetchImpl(`${ASC_BASE_URL}${path}`, {
       method,
       headers: {
@@ -95,6 +107,37 @@ export function createAscClient({ keyId, issuerId, keyPath, fetchImpl = fetch, n
     } catch {
       return { status: response.status, error: describeApiError(method, path, response.status, text) };
     }
+  }
+
+  /**
+   * 전송이 끊기거나 Apple이 혼잡을 알리면 지수 백오프로 다시 보낸다. 재시도가 소진되면 마지막
+   * 결과를 그대로 돌려주므로, 호출자가 보는 성공/실패 모양은 달라지지 않는다. 이미 처리된 POST를
+   * 다시 보낼 가능성은 남지만 생성 계열 호출은 모두 중복(409·이미 배정됨) 복구 경로를 갖고 있다.
+   */
+  async function request(method, path, body) {
+    for (let attempt = 1; ; attempt += 1) {
+      let result;
+      try {
+        result = await send(method, path, body);
+      } catch (cause) {
+        if (attempt >= RETRY_ATTEMPTS) {
+          return { status: 0, error: `App Store Connect ${method} ${path} could not be reached: ${cause?.message ?? cause}` };
+        }
+        await backoff(method, path, attempt, cause?.message ?? String(cause));
+        continue;
+      }
+      if (!result.error || !isRetryableStatus(result.status) || attempt >= RETRY_ATTEMPTS) return result;
+      await backoff(method, path, attempt, `HTTP ${result.status}`);
+    }
+  }
+
+  async function backoff(method, path, attempt, reason) {
+    const waitMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    process.stdout.write(
+      `  ${method} ${path} failed (${reason}); retrying in ${Math.round(waitMs / 1000)}s ` +
+        `(attempt ${attempt + 1}/${RETRY_ATTEMPTS})\n`,
+    );
+    await sleep(waitMs);
   }
 
   async function requireOk(method, path, body) {

--- a/runtime/fleet-mobile/tests/ios-tools.test.ts
+++ b/runtime/fleet-mobile/tests/ios-tools.test.ts
@@ -159,6 +159,14 @@ describe("App Store Connect transport", () => {
   const ok = (body: unknown) =>
     ({ status: 200, ok: true, text: async () => JSON.stringify(body) }) as unknown as Response;
 
+  const throttled = (retryAfter: string) =>
+    ({
+      status: 429,
+      ok: false,
+      headers: { get: (name: string) => (name.toLowerCase() === "retry-after" ? retryAfter : null) },
+      text: async () => '{"errors":[{"title":"RATE_LIMIT"}]}',
+    }) as unknown as Response;
+
   it("retries a dropped connection instead of aborting the distribution", async () => {
     let calls = 0;
     const build = await client(async () => {
@@ -189,6 +197,39 @@ describe("App Store Connect transport", () => {
         return { status: 401, ok: false, text: async () => '{"errors":[{"title":"NOT_AUTHORIZED"}]}' } as unknown as Response;
       }).findBuild("app1", "0.3.1", "4"),
     ).rejects.toThrow(/401/);
+    expect(calls).toBe(1);
+  });
+
+  // 고정 백오프로 다시 보내면 Apple이 지정한 창 안에 그대로 갇혀 네 번 모두 헛돈다.
+  it("waits at least as long as Retry-After before retrying a throttled request", async () => {
+    const waits: number[] = [];
+    let calls = 0;
+    const build = await createAscClient({
+      keyId: "TESTKEYID",
+      issuerId: "test-issuer",
+      keyPath: keyFile,
+      sleep: async (ms: number) => void waits.push(ms),
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? throttled("30")
+          : ok({ data: [{ id: "b1", attributes: { version: "4", processingState: "VALID" } }] });
+      },
+    }).findBuild("app1", "0.3.1", "4");
+
+    expect(waits).toEqual([30_000]);
+    expect(build?.id).toBe("b1");
+  });
+
+  // 재시도로는 넘길 수 없는 창이면, 네 번 헛돌고 끝나는 대신 요구된 대기를 알리며 바로 실패한다.
+  it("stops retrying when Retry-After exceeds what the job can wait out", async () => {
+    let calls = 0;
+    await expect(
+      client(async () => {
+        calls += 1;
+        return throttled("3600");
+      }).findBuild("app1", "0.3.1", "4"),
+    ).rejects.toThrow(/Apple asked to wait 3600s/);
     expect(calls).toBe(1);
   });
 });

--- a/runtime/fleet-mobile/tests/ios-tools.test.ts
+++ b/runtime/fleet-mobile/tests/ios-tools.test.ts
@@ -1,7 +1,9 @@
+import { generateKeyPairSync } from "node:crypto";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { createAscClient } from "../scripts/lib/asc-api.mjs";
 import {
   BUNDLE_ID,
   inspectInfoPlist,
@@ -138,5 +140,55 @@ describe.skipIf(process.platform !== "darwin")("provisioning profile fields", ()
       <key>UUID</key><string>u</string>${CERTIFICATE_DATA}
       <key>Entitlements</key><dict><key>application-identifier</key><string>8TJ9GTYF8J.com.example.other</string></dict>`);
     expect(() => readProfileFields(file)).toThrow(/com\.example\.other/);
+  });
+});
+
+// 처리 대기 폴링은 30분 동안 App Store Connect를 두드린다. 여기서 연결이 한 번 끊겨 예외가
+// 그대로 올라오면, 업로드가 이미 받아들여진 릴리스가 그룹 배정도 노트도 없이 실패로 끝난다.
+describe("App Store Connect transport", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "fleet-asc-"));
+  const keyFile = path.join(dir, "AuthKey_TEST.p8");
+  writeFileSync(
+    keyFile,
+    generateKeyPairSync("ec", { namedCurve: "P-256" }).privateKey.export({ type: "pkcs8", format: "pem" }) as string,
+  );
+
+  const client = (fetchImpl: typeof fetch) =>
+    createAscClient({ keyId: "TESTKEYID", issuerId: "test-issuer", keyPath: keyFile, fetchImpl, sleep: async () => {} });
+
+  const ok = (body: unknown) =>
+    ({ status: 200, ok: true, text: async () => JSON.stringify(body) }) as unknown as Response;
+
+  it("retries a dropped connection instead of aborting the distribution", async () => {
+    let calls = 0;
+    const build = await client(async () => {
+      calls += 1;
+      if (calls < 3) throw new TypeError("fetch failed");
+      return ok({ data: [{ id: "b1", attributes: { version: "4", processingState: "VALID" } }] });
+    }).findBuild("app1", "0.3.1", "4");
+
+    expect(calls).toBe(3);
+    expect(build?.id).toBe("b1");
+  });
+
+  // 재시도가 소진되면 조용히 성공한 척하지 않고, 원인을 담은 실패로 끝나야 한다.
+  it("fails with the transport cause once retries are exhausted", async () => {
+    await expect(
+      client(async () => {
+        throw new TypeError("fetch failed");
+      }).findBuild("app1", "0.3.1", "4"),
+    ).rejects.toThrow(/could not be reached: fetch failed/);
+  });
+
+  // 인증·검증 실패는 다시 보내도 같은 답이 온다 — 잡을 몇 배로 늘리기만 한다.
+  it("does not retry a permanent rejection", async () => {
+    let calls = 0;
+    await expect(
+      client(async () => {
+        calls += 1;
+        return { status: 401, ok: false, text: async () => '{"errors":[{"title":"NOT_AUTHORIZED"}]}' } as unknown as Response;
+      }).findBuild("app1", "0.3.1", "4"),
+    ).rejects.toThrow(/401/);
+    expect(calls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- The v1.85.0 Stable Release TestFlight job uploaded the IPA (`Upload accepted`, build 0.3.1 (4)) and then died with an unhandled `ConnectTimeoutError` while polling App Store Connect for processing to finish — one dropped connection ended a distribution Apple had already accepted.
- Every ASC request now retries with exponential backoff (4 attempts, 2s/4s/8s) on transport failures and 429/5xx, while permanent rejections (401/403/404/409) still fail on the first response.
- Applied at the request layer rather than only in the poll loop, so the tester assignment, release notes, and beta review calls are covered too; those create-style calls already recover from duplicates.

## Test Plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `runtime/fleet-mobile` — new `App Store Connect transport` cases: dropped connection is retried then succeeds, exhausted retries fail naming the transport cause, a permanent 401 is not retried