### PR TITLE
fix(admiral): clarify gateway quota consumption priorities

### DIFF
--- a/.changelog.d/gateway-models-consumption.md
+++ b/.changelog.d/gateway-models-consumption.md
@@ -1,0 +1,8 @@
+---
+branch: gateway-models-consumption
+---
+
+### fleet-cli
+#### Changed
+- Omit signed-out providers and providers without exposed models from gateway_models, and make quota consumption priorities explicit with numbered ranks.
+  ko: gateway_models에서 로그아웃 상태이거나 노출 모델이 없는 공급자를 제외하고, quota 소비 우선순위를 명시적인 순위 숫자로 제공합니다.

--- a/packages/fleet-admiral/assets/skills/delegation/references/loadout-reading.md
+++ b/packages/fleet-admiral/assets/skills/delegation/references/loadout-reading.md
@@ -5,8 +5,8 @@ The tool returns facts as JSON and stops there: nothing in the payload recommend
 ## The payload's frame
 
 - **Models sit under the allowance they spend.** `providers` is keyed by provider id, and the window to read against a model is one in the same entry — never a join across entries.
-- **The `claude` entry is always present and serves no roster model by design.** It is the allowance an inherited dispatch — one that named no identity — spends, and therefore the baseline any offload is measured against. It can only be spared by naming another identity, never selected.
-- **`revision` moves on deliberate edits only** — exposure, catalog, benchmark refresh, spend priority — never on allowance movement. Equal revisions never mean equal quotas; re-read before a later dispatch instead of carrying a reading forward.
+- **`providers`에는 노출 모델이 있는 공급자만 남고 `signed_out` 공급자는 제외된다.** 호스트 전용 모델이나 상속 실행의 quota를 보여 주려고 빈 공급자를 추가하지 않는다. 공급자 누락은 quota 소진이나 여유의 증거가 아니다.
+- **`revision`은 의도적인 설정 변경에만 바뀐다** — 노출, catalog, benchmark 갱신, 소비 순위. quota나 로그인 상태 변화로는 바뀌지 않는다. 같은 revision에서도 반환 공급자는 달라질 수 있으므로 다음 위임 전에 다시 읽는다.
 - **Absence is never safety.** A derived field is omitted when the reading could not support it, and `status: "unsupported"` means the allowance could not be read at all — not that it is healthy, and not that it is exhausted either.
 
 ## Reading an allowance
@@ -31,7 +31,8 @@ Three constraint fields answer three different questions, and none implies anoth
 
 - **`homolineage` marks a Claude-family model**, derived from the model id alone. It decides independence — shared blind spots with a Claude-based subject — and never cost.
 - **The provider entry a model sits under decides cost** — whose subscription the run bills to — and never independence. The two come apart: a Claude-lineage identity billed elsewhere is a legitimate way to move spend and a useless way to buy an independent verdict.
-- **`providerPriority` is the user's standing spend order, on the allowance axis only.** Listed providers spend first, in order, everywhere allowance decides. It outranks the pressure forecast, `critical` included — the owner chose to drain that allowance — so leave a listed provider only on observed failure: runs returning empty after a retry. It never lifts an identity across a quality band, and an absent field changes nothing.
+- **`quotaConsumptionPriority`는 일반적인 모델 선호도가 아니라 사용자가 정한 quota 우선 소비 순서다.** `source: "user_settings"`는 잔여량으로 자동 계산한 순위가 아님을 뜻한다. `providers`의 `rank`는 1부터 시작하고 `rankMeaning: "1_consumes_first"`대로 작은 숫자의 quota부터 소비한다. 배열 위치로 방향을 추측하지 않는다. 현재 로드아웃에서 제외된 공급자는 순위에서도 빠지고 남은 순위는 1부터 다시 매겨진다. 해당 공급자가 없으면 필드 자체가 생략된다.
+- **소비 순위는 품질 평가를 대체하지 않는다.** `withinQualityBand: true`이므로 같은 품질 밴드 안에서만 적용한다. `overridesQuotaPressure: true`는 `critical`까지 포함한 quota 압력 예측보다 사용자 소비 순서가 우선한다는 뜻이다. `fallback: "observed_failure_after_retry"`대로 재시도 후에도 빈 결과 등 실제 실패가 관측될 때 다음 순위로 이동한다. 미지정 공급자에는 기존 allowance 판단을 적용한다.
 
 ## Names
 

--- a/packages/fleet-admiral/assets/skills/delegation/references/seat-assignment.md
+++ b/packages/fleet-admiral/assets/skills/delegation/references/seat-assignment.md
@@ -42,7 +42,7 @@ Bulk fan-out on the session's model is the pattern with no case: it concentrates
 ## Sizing a mechanical fan
 
 - **The task sets the branch count.** An allowance reading never trims it below what the work needs, and a window still called `ok` is not a reason to run fewer branches.
-- **A spend priority displaces the even split for the providers it names.** Concentrate on the first listed provider and spill down the list on observed failure; unlisted providers share the remainder evenly.
+- **`quotaConsumptionPriority`는 지정 공급자의 quota를 먼저 소비하도록 균등 분배를 대체한다.** 가장 작은 `rank`부터 소비하고, 재시도 후에도 실행이 실패할 때 다음 순위로 이동한다. 배열 위치가 아니라 명시된 순위 숫자를 따른다. 미지정 공급자는 남은 작업을 균등 분배한다.
 - **Split evenly across eligible providers** — readable window, not `critical` — with no provider more than one branch above another, counting providers rather than identities: a provider exposing two models does not draw twice the share.
 - **One eligible provider left carries the whole fan**, whatever its percentage reads; the only place left to move is the session's own allowance, which the rules above already price.
 - **An unreadable allowance joins no even split** — absence is not headroom — but it is not exhausted either: give it a bounded share and promote it once runs return.

--- a/packages/fleet-admiral/src/ai-gateway/gateway-models-tool.ts
+++ b/packages/fleet-admiral/src/ai-gateway/gateway-models-tool.ts
@@ -43,12 +43,12 @@ const GATEWAY_MODELS_DOCTRINE = {
   // 여기에 둔다. 나머지 판정 규칙 — 응답을 어떻게 읽고 판단하는가 — 은 delegation 스킬의
   // references가 온디맨드로 소유한다. 여기에 겹쳐 실으면 같은 사실이 두 곳에서 따로 늙는다.
   description:
-    `Report the gateway models currently available to this session, each model's routing constraints, capability class, and benchmark evidence, and the current provider allowances and the user's provider spend priority.`
-    + ` The roster is the models the user exposed in the Console minus the ones reserved for the host session, and it is editable while this session runs, so it is resolved at call time rather than remembered.`
+    `Report the gateway models currently available to this session, each model's routing constraints, capability class, and benchmark evidence, and their current allowances with the user's ranked quota consumption priority.`
+    + ` The roster is the models the user exposed in the Console minus the ones reserved for the host session; signed-out providers and providers without roster models are omitted. It is editable while this session runs, so it is resolved at call time rather than remembered.`
     + ` Two spellings, never interchangeable: agentTypes names a registered identity — the Agent tool's subagent_type and a workflow stage's opts.agentType both resolve it from the same registry — while modelId is the model as a value for a field that takes a model rather than a name, such as a workflow stage's opts.model. Neither spelling converts into the other.`
     + ` Names are registered once at session start while this roster is re-read live, so a model or reasoning rung exposed mid-session appears here under a name that will not resolve until a new session.`,
   promptSnippet:
-    `gateway_models — Live roster of assignable gateway models: constraints, capability class, benchmark evidence, provider allowances, and the user's provider priority.`,
+    `gateway_models — Live roster of assignable gateway models: constraints, capability class, benchmark evidence, provider allowances, and the user's ranked quota consumption priority.`,
   whenToUse: [],
   whenNotToUse: [],
   usageGuidelines: [],

--- a/packages/fleet-admiral/src/ai-gateway/model-loadout.ts
+++ b/packages/fleet-admiral/src/ai-gateway/model-loadout.ts
@@ -84,11 +84,7 @@ export interface GatewayLoadoutProviderQuota {
   readonly fetchedAt?: number;
 }
 
-/**
- * Quota keyed by provider id. `claude` is meaningful here even though it serves
- * no gateway model: it is the allowance an inherited (unpinned) stage spends,
- * and therefore the baseline any offload is measured against.
- */
+/** 공급자별 quota 원본. 로드아웃은 노출 모델이 있는 공급자만 사용한다. */
 export type GatewayQuotaSnapshot = Readonly<Record<string, GatewayProviderQuota>>;
 
 /**
@@ -132,12 +128,7 @@ export interface GatewayLoadoutProvider {
    * never that the allowance is healthy.
    */
   readonly quota: GatewayLoadoutProviderQuota | { readonly status: "unsupported" };
-  /**
-   * The exposed models this provider serves. Empty means it serves none of them,
-   * which for `claude` is its permanent state: it is listed because an unpinned
-   * run spends that allowance, making it the baseline an offload is measured
-   * against, not because its models were all turned off.
-   */
+  /** 이 공급자의 노출 모델. 모델이 없거나 signed_out인 공급자는 반환하지 않는다. */
   readonly models: readonly GatewayLoadoutModel[];
 }
 
@@ -148,12 +139,15 @@ export interface GatewayLoadout {
    */
   readonly revision: string;
   readonly catalogUpdatedAt: string;
-  /**
-   * The user's opt-in ordered spend preference across providers; it weights the
-   * allowance axis only and never overrides quality evidence; absent when the
-   * user set none.
-   */
-  readonly providerPriority?: readonly GatewayProvider[];
+  /** 사용자 설정의 quota 소비 순서. 현재 로드아웃에 해당 공급자가 없으면 생략한다. */
+  readonly quotaConsumptionPriority?: {
+    readonly source: "user_settings";
+    readonly rankMeaning: "1_consumes_first";
+    readonly withinQualityBand: true;
+    readonly overridesQuotaPressure: true;
+    readonly fallback: "observed_failure_after_retry";
+    readonly providers: readonly { readonly provider: GatewayProvider; readonly rank: number }[];
+  };
   /**
    * Keyed by provider id. Each model sits under the allowance it spends, so the
    * window to read against a model is the one in the same entry — no join.
@@ -177,22 +171,29 @@ export interface BuildGatewayLoadoutInput {
 
 const UNSUPPORTED_QUOTA = Object.freeze({ status: "unsupported" as const });
 
-/** The session's own subscription — what an unpinned stage spends. */
-const PARENT_PROVIDER_ID = "claude";
-
 export function buildGatewayLoadout(input: BuildGatewayLoadoutInput): GatewayLoadout {
   const placed = input.exposed.map((model) => ({
     provider: model.provider as string,
     entry: toLoadoutModel(model, input.effortExposure),
   }));
-  const providerPriority = input.providerPriority
-    ? Object.freeze([...input.providerPriority])
-    : undefined;
+  const providers = buildProviders(placed, input.quota, input.now ?? Date.now);
+  const priority = [...new Set(input.providerPriority ?? [])]
+    .filter((provider) => Object.hasOwn(providers, provider))
+    .map((provider, index) => ({ provider, rank: index + 1 }));
   return {
-    revision: loadoutRevision(placed.map(({ entry }) => entry), providerPriority),
+    revision: loadoutRevision(placed.map(({ entry }) => entry), input.providerPriority),
     catalogUpdatedAt: GATEWAY_MODELS_UPDATED_AT,
-    providers: buildProviders(placed, input.quota, input.now ?? Date.now),
-    ...(providerPriority ? { providerPriority } : {}),
+    providers,
+    ...(priority.length > 0 ? {
+      quotaConsumptionPriority: {
+        source: "user_settings" as const,
+        rankMeaning: "1_consumes_first" as const,
+        withinQualityBand: true as const,
+        overridesQuotaPressure: true as const,
+        fallback: "observed_failure_after_retry" as const,
+        providers: Object.freeze(priority),
+      },
+    } : {}),
   };
 }
 
@@ -242,19 +243,9 @@ function buildProviders(
   quota: GatewayQuotaSnapshot | undefined,
   now: () => number,
 ): Readonly<Record<string, GatewayLoadoutProvider>> {
-  // 어느 예산이 상속분인지는 이 로스터가 알 수 없다. 세션의 시작 모델은 런치 시점에
-  // 프로세스 환경으로 한 번 정해지고 그 뒤 세션 안에서 바뀔 수 있는데, 도구는 런타임
-  // 단위로 한 번 등록되어 모든 세션을 상대하므로 어느 세션이 무엇으로 떴는지 볼 자리가
-  // 없다. 설정값을 대신 추적하면 이미 떠 있는 세션과 어긋난 답을 자신 있게 내놓는다.
-  // 그래서 여기서는 부모 구독을 포함한 모든 프로바이더의 사용량을 사실대로 늘어놓고,
-  // 자기 세션이 무엇으로 도는지 이미 아는 호스트가 그 조인을 맡는다.
-  const ids: string[] = [PARENT_PROVIDER_ID];
-  for (const { provider } of placed) {
-    if (!ids.includes(provider)) ids.push(provider);
-  }
-  for (const id of Object.keys(quota ?? {})) {
-    if (!ids.includes(id)) ids.push(id);
-  }
+  // quota만 있는 공급자는 위임 후보가 아니다. 읽기 실패는 signed_out과 구별해 남긴다.
+  const ids = [...new Set(placed.map(({ provider }) => provider))]
+    .filter((id) => quota?.[id]?.status !== "signed_out");
   return Object.freeze(Object.fromEntries(ids.map((id) => [id, {
     quota: enrichProviderQuota(quota?.[id], now) ?? UNSUPPORTED_QUOTA,
     models: Object.freeze(

--- a/packages/fleet-admiral/tests/agent-runtime-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-runtime-gateway.test.ts
@@ -1,8 +1,12 @@
 import type { AgentToolSpec } from "@dotobokuri/core-agent";
+import { findGatewayModel } from "@dotobokuri/core-ai-gateway";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+	buildGatewayModelsToolSpec,
 	createFleetGatewayAgentRuntimeLifecycle,
+	type GatewayLoadout,
+	type GatewayQuotaSnapshot,
 	isHostSessionToolAllowed,
 	type FleetGatewayAgentRuntimeLifecycle,
 } from "../src/index.js";
@@ -32,9 +36,27 @@ afterEach(async () => {
 
 describe("createFleetGatewayAgentRuntimeLifecycle", () => {
 	it("snapshots only gateway host agent tools and starts a reachable-shaped endpoint", async () => {
+		let models = ["cursor--grok-4.5", "codex--gpt-5.6-sol", "antigravity--gemini-3.8-flash"]
+			.map((id) => {
+				const model = findGatewayModel(id);
+				if (!model) throw new Error(`missing catalog model: ${id}`);
+				return model;
+			});
+		let quota: GatewayQuotaSnapshot | undefined = {
+			claude: { status: "ok" },
+			xai: { status: "ok" },
+			codex: { status: "signed_out" },
+			cursor: { status: "ok", windows: [{ id: "cycle", scope: "auto", usedPercent: 100 }] },
+		};
 		lifecycle = await createFleetGatewayAgentRuntimeLifecycle({
 			wikiToolSpecs: WIKI_TOOL_IDS.map(makeToolSpec),
-			extraAgentTools: [makeToolSpec("gateway_models")],
+			extraAgentTools: [buildGatewayModelsToolSpec({
+				readSelection: () => ({ models, providerPriority: ["codex", "xai", "cursor", "antigravity"] }),
+				readQuota: () => {
+					if (!quota) throw new Error("quota unavailable");
+					return quota;
+				},
+			})],
 		});
 
 		const [serverToken] = lifecycle.dedicatedMcpSession.issueSessionToken({
@@ -63,6 +85,54 @@ describe("createFleetGatewayAgentRuntimeLifecycle", () => {
 		expect(toolIds).toEqual([...WIKI_TOOL_IDS, "gateway_models"].sort());
 		expect(toolIds).not.toContain("carrier_dispatch");
 		expect(toolIds).not.toContain("carrier_jobs");
+
+		async function readLoadout(): Promise<GatewayLoadout> {
+			const call = await fetch(endpoint.servers[0]!.url, {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${serverToken!.token}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					jsonrpc: "2.0", id: "loadout", method: "tools/call",
+					params: { name: "gateway_models", arguments: {} },
+				}),
+			});
+			const payload = await call.json() as {
+				result: { content: { type: string; text: string }[]; isError: boolean };
+			};
+			expect(payload.result.isError).toBe(false);
+			return JSON.parse(payload.result.content[0]!.text) as GatewayLoadout;
+		}
+
+		const loadout = await readLoadout();
+		expect(Object.keys(loadout.providers)).toEqual(["cursor", "antigravity"]);
+		expect(loadout.providers.cursor?.models).toHaveLength(1);
+		expect(loadout.providers.cursor?.quota).toMatchObject({ windows: [{ pressure: "critical" }] });
+		expect(loadout.providers.antigravity?.quota.status).toBe("unsupported");
+		expect(loadout.quotaConsumptionPriority).toEqual({
+			source: "user_settings",
+			rankMeaning: "1_consumes_first",
+			withinQualityBand: true,
+			overridesQuotaPressure: true,
+			fallback: "observed_failure_after_retry",
+			providers: [{ provider: "cursor", rank: 1 }, { provider: "antigravity", rank: 2 }],
+		});
+		expect(loadout).not.toHaveProperty("providerPriority");
+
+		quota = undefined;
+		const unreadable = await readLoadout();
+		expect(unreadable.revision).toBe(loadout.revision);
+		expect(Object.keys(unreadable.providers)).toEqual(["cursor", "codex", "antigravity"]);
+		expect(Object.values(unreadable.providers).every(({ quota }) => quota.status === "unsupported")).toBe(true);
+		expect(unreadable.quotaConsumptionPriority?.providers).toEqual([
+			{ provider: "codex", rank: 1 }, { provider: "cursor", rank: 2 }, { provider: "antigravity", rank: 3 },
+		]);
+
+		models = [];
+		const empty = await readLoadout();
+		expect(empty.providers).toEqual({});
+		expect(empty).not.toHaveProperty("quotaConsumptionPriority");
 	});
 });
 

--- a/packages/fleet-admiral/tests/embedded-skill-assets.test.ts
+++ b/packages/fleet-admiral/tests/embedded-skill-assets.test.ts
@@ -44,7 +44,7 @@ const TAUGHT_LOADOUT_FIELDS = [
   "paceRatio",
   "pressure",
   "projectedExhaustionAt",
-  "providerPriority",
+  "quotaConsumptionPriority",
   "quotaScope",
   "recoveryHalfLifeMs",
   "revision",


### PR DESCRIPTION
## Summary
- `gateway_models`에서 `signed_out` 및 노출 모델이 없는 공급자를 제외합니다.
- 응답의 `providerPriority` 배열을 `quotaConsumptionPriority`로 교체하고, 1부터 시작하는 `rank`, 사용자 설정 출처, 품질 밴드 제한·quota 압력 우선·실패 후 전환 의미를 명시합니다. 저장 설정 형식은 유지합니다.
- delegation 판독 문서를 동기화하고 기존 실제 MCP 통합 테스트를 확장합니다.

## Test Plan
- [x] Admiral typecheck 및 39개 테스트
- [x] Admiral·Console build 및 내장 배포 경계 검사
- [x] Terminal 154개 테스트, CLI gateway policy 3개 테스트
- [x] 변경 기록 검사 및 `git diff --check`
- [x] macOS arm64의 격리 Console + headless 브라우저에서 Codex Luna 실제 프롬프트 2회: `gateway_models` 호출, quota 소비 순위 해석 및 설정 변경 후 재조회
- [x] 실제 wire에서 `claude-gateway--codex--gpt-5.6-luna` → `gpt-5.6-luna`, `cursor → antigravity → codex` 및 역전 후 `antigravity → cursor → codex` 확인. 빈 xAI 공급자는 순위에서도 제외
- [x] 페이지 오류·unhandled rejection 없음, 소유 브라우저·Console 정리 완료

### 검증 제한
- 모델 추가 UI는 클릭 후 저장이 관측되지 않아 격리 Console API로 Luna와 비교 모델을 등록했습니다. UI 추가 경로의 성공을 주장하지 않습니다.
- PTY 경로는 프롬프트 전송 후 종료되어 실제 검증은 Console 채팅 경로로 완료했습니다. 이 작업에서 변경하지 않은 UI/PTY 문제를 PR에 흡수하지 않았습니다.
- Luna 첫 턴에는 `ToolSearch` 외에 요청하지 않은 `CronList` 1회도 관측됐습니다. `gateway_models` 결과 해석은 두 턴 모두 확인했으며 불필요 도구 미호출까지 검증됐다고 주장하지 않습니다.
- signed_out이면서 노출 모델이 있는 경계는 실제 MCP 통합 테스트로 검증했으며, 실제 계정 로그아웃은 수행하지 않았습니다.
