### PR TITLE
fix(console): align collapsed Theater highlight with expanded badges

### DIFF
--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5277,7 +5277,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
   gap: var(--space-1);
 }
 
-/* Theater 묶음의 머리 — 목록 헤더와 같은 이니셜 타일이 선다. 활성 Theater는 brass 링(위치 채널). */
+/* Theater 묶음의 머리 — 목록 헤더와 같은 이니셜 배지 채움으로 활성 위치를 표시한다. */
 .side-bar-rail-theater {
   display: grid;
   place-items: center;
@@ -5293,10 +5293,6 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .side-bar-rail-theater:hover {
   border-color: var(--control-hover-rim);
   background: var(--control-hover-fill);
-}
-
-.side-bar-rail-section--theater.is-active .side-bar-rail-theater {
-  border-color: var(--brass);
 }
 
 .side-bar-rail-theater:focus-visible {
@@ -5692,7 +5688,8 @@ body[data-side-bar-animating="true"] .canvas-operation {
    서로 다른 거리에서 말한다. 채움 위 글자는 brass 전용 텍스트 티어를 쓴다 — 라이트에서
    자기 채움 위 AA를 보장하는 유일한 값이다. 대기 tick은 배지 바깥 모서리에 떠 있어 가려지지
    않는다. */
-.side-bar-theater-header.is-active .side-bar-theater-anchor {
+.side-bar-theater-header.is-active .side-bar-theater-anchor,
+.side-bar-rail-section--theater.is-active .side-bar-theater-anchor {
   background: var(--brass);
   color: var(--text-on-brass);
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1963,7 +1963,7 @@ describe("Instrument core design contract", () => {
     const activeSection = components.match(/\.side-bar-theater-section--active \{[^}]*\}/)?.[0] ?? "";
     const headerHover = components.match(/\.side-bar-theater-header:hover,\n\.side-bar-theater-header:focus-visible \{[^}]*\}/)?.[0] ?? "";
     const activeHeader = components.match(/\.side-bar-theater-header\.is-active \{[^}]*\}/)?.[0] ?? "";
-    const activeAnchor = components.match(/\.side-bar-theater-header\.is-active \.side-bar-theater-anchor \{[^}]*\}/)?.[0] ?? "";
+    const activeAnchor = components.match(/\.side-bar-theater-header\.is-active \.side-bar-theater-anchor,\s*\.side-bar-rail-section--theater\.is-active \.side-bar-theater-anchor \{[^}]*\}/)?.[0] ?? "";
     const activeName = components.match(/\.side-bar-theater-header\.is-active \.side-bar-theater-name \{[^}]*\}/)?.[0] ?? "";
 
     // 활성은 구역 왼쪽 2px brass 스파인이 나른다. 헤더가 아니라 구역에 붙으므로 헤더가 스크롤


### PR DESCRIPTION
## Summary
- 접힌 사이드바의 활성 Theater 사각 외곽선을 제거하고, 펼친 목록과 동일한 이니셜 배지 채움·반전 글자색을 공유합니다.
- hover와 키보드 focus-visible 표시는 유지하며, 기존 디자인 계약을 공유 selector에 맞게 갱신합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts` — 97개 통과
- [x] `git diff --check`
- [x] macOS arm64 격리 Console/headless Chromium에서 접기·펼치기, Theater 양방향 전환, 키보드 포커스와 수정 전후 스크린샷 확인
- [x] 활성 버튼 border 투명, 아이콘 brass 채움 확인. 브라우저 오류·unhandled rejection 없음. 검증 브라우저·서버 종료 완료.
- [ ] 전체 테스트 스위트 및 Electron 네이티브 검증 — CSS 변경 범위 밖이므로 실행하지 않음
