### PR TITLE
feat(ai-gateway): overlap Astra read-only tools with independent work

### DIFF
--- a/.changelog.d/astra-low-optimization.md
+++ b/.changelog.d/astra-low-optimization.md
@@ -1,0 +1,13 @@
+---
+branch: astra-low-optimization
+---
+
+### fleet-cli
+#### Changed
+- Let GPT-6 Astra overlap read-only tools with independent work in streaming Claude Code sessions while preserving tool permissions and sequential-call constraints.
+  ko: 스트리밍 Claude Code 세션에서 GPT-6 Astra가 도구 권한과 순차 호출 제약을 유지하면서 읽기 전용 도구 실행과 독립 작업을 겹쳐 처리하도록 개선했습니다.
+
+### fleet-console
+#### Changed
+- Let GPT-6 Astra overlap read-only tools with independent work in streaming Claude Code sessions while preserving tool permissions and sequential-call constraints.
+  ko: 스트리밍 Claude Code 세션에서 GPT-6 Astra가 도구 권한과 순차 호출 제약을 유지하면서 읽기 전용 도구 실행과 독립 작업을 겹쳐 처리하도록 개선했습니다.

--- a/packages/core-ai-gateway/src/downstream/harness/claude-code/profile.ts
+++ b/packages/core-ai-gateway/src/downstream/harness/claude-code/profile.ts
@@ -63,6 +63,7 @@ export const claudeCodeHarnessProfile: GatewayHarnessProfile = {
   ),
   retryableStatus: claudeRetryableUpstreamStatus,
   transientErrorStatus: GATEWAY_TRANSIENT_ERROR_STATUS,
+  asyncToolNames: ["Read", "Grep", "Glob"],
 };
 
 export { ANTHROPIC_CREDENTIAL_PREFIX };

--- a/packages/core-ai-gateway/src/downstream/harness/contract.ts
+++ b/packages/core-ai-gateway/src/downstream/harness/contract.ts
@@ -79,6 +79,8 @@ export interface GatewayHarnessProfile {
   readonly retryableStatus?: (status: number) => number;
   /** The status that carries a gateway-side fault this client should retry. */
   readonly transientErrorStatus: number;
+  /** 완성된 스트리밍 호출부터 실행할 수 있는 읽기 전용 도구. 부재는 async 실행 미지원이다. */
+  readonly asyncToolNames?: readonly string[];
   /**
    * 이 클라이언트가 한 대화를 식별하는 값을, 그 클라이언트의 요청 헤더에서 읽는다.
    *

--- a/packages/core-ai-gateway/src/router/router.ts
+++ b/packages/core-ai-gateway/src/router/router.ts
@@ -585,6 +585,9 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
             accountId: chatgptAccountId,
             headers: { originator: deps.originator },
             fetch: fetchImpl,
+            ...(body.stream === true && harness.asyncToolNames
+              ? { asyncToolNames: harness.asyncToolNames }
+              : {}),
           })
         : undefined;
       const gateway = deps.gateway

--- a/packages/core-ai-gateway/src/upstream/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/codex/responses/adapter.ts
@@ -48,6 +48,14 @@ const DEFAULT_MAX_UPSTREAM_BODY_BYTES = 64 * 1024 * 1024;
  */
 const DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS = 300_000;
 const CODEX_RETRY_DELAY_MS = 200;
+// HTTP caller는 응답이 끝난 뒤 결과를 반환한다. 이 경계를 알리지 않으면 Astra가
+// pending 도구를 polling하거나 재호출하므로 async 선언과 함께 전달한다.
+const ASYNC_TOOL_RESULT_INSTRUCTIONS = [
+  "Async tool results are delivered by the application after this response ends, not within this response.",
+  "After launching async tools, do independent work if useful, then END this response to wait for their results.",
+  "Never repeat a pending call or poll for it. Do not invent results.",
+  "Resume dependent work only after the next request supplies the original tool results.",
+].join(" ");
 
 // ChatGPT 백엔드는 Platform API가 받는 샘플링 파라미터를 400으로 거절한다.
 // 실측으로 확정한 거부 목록. metadata는 "Unsupported parameter", 샘플링 필드는 400으로 돌아온다.
@@ -77,6 +85,7 @@ interface OpenAIResponsesWireFunctionTool {
   description?: string;
   parameters: Record<string, unknown>;
   strict?: boolean;
+  async?: boolean;
 }
 
 /**
@@ -115,6 +124,8 @@ export interface OpenAIResponsesAdapterOptions {
   headers?: Readonly<Record<string, string>>;
   /** ChatGPT 백엔드가 거절하는 샘플링 필드를 제거한다. */
   dropSamplingParams?: boolean;
+  /** 호출자가 스트림 소비 중 안전하게 실행할 수 있는 도구. Codex Astra에만 적용한다. */
+  asyncToolNames?: readonly string[];
 }
 
 export class OpenAIResponsesAdapter implements AiGatewayAdapter {
@@ -125,11 +136,13 @@ export class OpenAIResponsesAdapter implements AiGatewayAdapter {
   private readonly url: string;
   private readonly extraHeaders: Readonly<Record<string, string>>;
   private readonly dropSamplingParams: boolean;
+  private readonly asyncToolNames: ReadonlySet<string>;
 
   constructor(options: OpenAIResponsesAdapterOptions = {}) {
     this.url = options.url ?? OPENAI_RESPONSES_URL;
     this.extraHeaders = options.headers ?? {};
     this.dropSamplingParams = options.dropSamplingParams ?? false;
+    this.asyncToolNames = new Set(options.asyncToolNames);
     this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
     this.maxBodyBytes = positiveInteger(
       options.maxBodyBytes ?? DEFAULT_MAX_UPSTREAM_BODY_BYTES,
@@ -160,6 +173,19 @@ export class OpenAIResponsesAdapter implements AiGatewayAdapter {
     const controller = new AbortController();
     const unlinkAbort = linkAbortSignal(options.signal, controller);
     const payload = forOpenAIResponsesBackend(request, this.dropSamplingParams);
+    if (this.dropSamplingParams && request.model === "gpt-6-astra"
+      && request.parallel_tool_calls !== false && request.tool_choice !== "none") {
+      let hasAsyncTools = false;
+      for (const tool of payload.tools ?? []) {
+        if (tool.type === "function" && this.asyncToolNames.has(tool.name)) {
+          tool.async = true;
+          hasAsyncTools = true;
+        }
+      }
+      if (hasAsyncTools) {
+        payload.instructions = [payload.instructions, ASYNC_TOOL_RESULT_INSTRUCTIONS].filter(Boolean).join("\n\n");
+      }
+    }
     // Exact JSON body sent upstream, including each tool's `parameters` and any `strict` flag.
     wireLog("openai.wire.request", { url: this.url, payload });
     let response: Response;
@@ -219,6 +245,8 @@ export class OpenAIResponsesAdapter implements AiGatewayAdapter {
 }
 
 export interface CodexResponsesAdapterOptions {
+  /** 스트리밍 호출자가 비동기로 실행할 수 있는 읽기 전용 도구 이름. 기본은 비활성화다. */
+  asyncToolNames?: readonly string[];
   /** ChatGPT subscription account id; sent as the `chatgpt-account-id` header. */
   accountId?: string;
   /** 구독 경로가 요구하는 추가 헤더(예: originator). */
@@ -244,6 +272,7 @@ export class CodexResponsesAdapter extends OpenAIResponsesAdapter {
     super({
       url: CHATGPT_CODEX_RESPONSES_URL,
       dropSamplingParams: true,
+      ...(options.asyncToolNames ? { asyncToolNames: options.asyncToolNames } : {}),
       headers: {
         ...(options.accountId ? { "chatgpt-account-id": options.accountId } : {}),
         ...options.headers,

--- a/packages/core-ai-gateway/tests/router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/router/routes.test.ts
@@ -152,6 +152,46 @@ describe("oversized skill payloads", () => {
 // 선별은 광고 목록이 아니라 지출 계약이다. 디스커버리가 켠 모델만 내놓아도 실행 경로가 카탈로그
 // 전체를 받아 주면, raw id를 아는 호출자가 사용자가 끈 모델로 그 구독을 그대로 쓴다.
 
+describe("Astra asynchronous tools", () => {
+  it("opts streaming read-only calls into async without widening caller execution authority", async () => {
+    const bodies: Array<Record<string, any>> = [];
+    const fetchMock = vi.fn<typeof fetch>(async (_url, init) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return new Response('data: {"type":"response.completed","response":{"id":"r","model":"gpt-6-astra","usage":{"input_tokens":1,"output_tokens":1}}}\n\n', {
+        headers: { "content-type": "text/event-stream" },
+      });
+    });
+    const router = createAiGatewayRouter({ fetch: fetchMock, readAuth });
+    const tools = ["Read", "Grep", "Glob", "Bash", "Edit", "AskUserQuestion", "mcp__other__Read"]
+      .map((name) => ({ name, input_schema: { type: "object", properties: {}, additionalProperties: false } }));
+    const base = {
+      model: "claude-gateway--codex--gpt-6-astra-1m[1m]",
+      messages: [{ role: "user", content: "read the files" }], tools, stream: true, max_tokens: 128,
+    };
+    try {
+      for (const rawBody of [
+        base,
+        { ...base, stream: false },
+        { ...base, tool_choice: { type: "auto", disable_parallel_tool_use: true } },
+        { ...base, model: "claude-gateway--codex--gpt-5.6-sol" },
+      ]) {
+        const res = response();
+        await router.handle(ctx({ res, token: ANTHROPIC_CRED, rawBody }));
+        expect(res.status).toBe(200);
+      }
+      expect(bodies[0]?.tools.filter((tool: { async?: boolean }) => tool.async).map((tool: { name: string }) => tool.name))
+        .toEqual(["Read", "Grep", "Glob"]);
+      for (const body of bodies.slice(1)) {
+        expect(body.tools.every((tool: { async?: boolean }) => tool.async === undefined)).toBe(true);
+      }
+      expect(bodies[0]?.store).toBe(false);
+      expect(bodies[2]?.parallel_tool_calls).toBe(false);
+    } finally {
+      router.dispose();
+    }
+  });
+});
+
 describe("request body limit", () => {
   it("refuses a body past the limit with a 413 that does not arm reactive compaction", async () => {
     // "context window"가 들어간 413만 Claude Code의 압축을 무장시킨다(canonical/index.ts).


### PR DESCRIPTION
## Summary
- 스트리밍 Claude Code의 `Read`·`Grep`·`Glob` 실행 capability를 명시적으로 주입하고, Codex의 정확한 `gpt-6-astra` 경로에서만 `async:true`를 선언합니다. 비스트리밍·순차 호출 강제·다른 모델·쓰기/셸/MCP near-match는 기존 동작을 유지합니다.
- HTTP 응답이 끝난 뒤 실제 도구 결과가 반환되는 계약을 함께 전달합니다. 플래그 단독 후보에서 관측된 pending 호출 반복/대기를 피하면서 독립 모델 생성과 도구 실행을 겹칩니다. 실행기, 권한, 원래 call_id, stateless/retry 계약은 바꾸지 않습니다.
- 3개 독립 읽기(각 4초 지연 fixture) 통제 실측은 전후 각각 5/5 성공: 평균 19.63→16.27초(-17.1%), 중앙값 19.72→15.72초, 응답 종료 후 도구 대기 3.99→0초입니다. 호출/결과는 각각 15/15, provider 요청은 각각 10회로 동일합니다. 입력 tokens는 1,760→3,602로 증가하므로 비용 절감을 주장하지 않습니다. instruction-only 대조는 18.15초였습니다. 실제 disk 읽기 전체에 대한 속도 보장은 아닙니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 28 files / 192 tests 통과
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`
- [x] 실제 Claude Code의 도구 블록 완료→MCP 시작 27ms, 응답 종료 전 실행 확인
- [x] 실제 Claude Code + 실제 Astra low에서 3파일 읽기, 결과 3개, `SUM=60`, 정상 종료 확인
- [x] 실제 Astra에서 의존 읽기 순서·권한 거절 결과·재호출 없음·abort 검증

### Scope and limitations
현재 검증된 읽기 도구 범위만 포함합니다. Bash/Agent/MCP 확장, WebSocket steering, programmatic tool calling, hosted multi-agent, reasoning 보존 후보는 제외합니다. 초기 calibration의 과도한 최종 형식 검사와 async 플래그 단독 실패는 성공 표본에 혼합하지 않았습니다. 실측 runner와 payload-free 증거는 로컬 scratchpad에 보존했으며 영구 CI에는 유료 호출을 추가하지 않았습니다. 사용자 운영 Console 설정이나 데이터는 변경하지 않았습니다.
