### PR TITLE
fix(repository): preserve CJK paths in history file lists

### DIFF
--- a/runtime/fleet-plugins/repository/server/commit.ts
+++ b/runtime/fleet-plugins/repository/server/commit.ts
@@ -74,8 +74,8 @@ export async function handleRepositoryCommit(
   try {
     const [metaResult, nameStatusResult, numstatResult] = await Promise.all([
       runGit(["show", "-s", "--format=%an%x00%ae%x00%at%x00%s%x00%P%x00%b", ref], { cwd: gitCwd }),
-      runGit(["show", "--first-parent", "--format=", "--relative", "--name-status", "--diff-filter=MADRT", ref, "--", "."], { cwd: gitCwd }),
-      runGit(["show", "--first-parent", "--format=", "--relative", "--numstat", "--diff-filter=MADRT", ref, "--", "."], { cwd: gitCwd }),
+      runGit(["show", "--first-parent", "--format=", "--relative", "--name-status", "-z", "--diff-filter=MADRT", ref, "--", "."], { cwd: gitCwd }),
+      runGit(["show", "--first-parent", "--format=", "--relative", "--numstat", "-z", "--diff-filter=MADRT", ref, "--", "."], { cwd: gitCwd }),
     ]);
     const meta = parseCommitMeta(metaResult.stdout);
     if (!meta) { ctx.host.http.writeJson(res, 500, { error: "git_failed" }); return; }

--- a/runtime/fleet-plugins/repository/server/compare.ts
+++ b/runtime/fleet-plugins/repository/server/compare.ts
@@ -102,8 +102,8 @@ export async function handleRepositoryCompare(
     const [mergeBaseResult, nameStatusResult, numstatResult] = await Promise.all([
       // 비교 컨텍스트 표기용 — 실패하면 응답에서 생략한다
       runGit(["merge-base", "--end-of-options", base, head], { cwd: gitCwd }).catch(() => null),
-      runGit(["diff", "--relative", "--name-status", "--diff-filter=MADRT", "-M", "--end-of-options", range, "--", "."], { cwd: gitCwd }),
-      runGit(["diff", "--relative", "--numstat", "--diff-filter=MADRT", "-M", "--end-of-options", range, "--", "."], { cwd: gitCwd }),
+      runGit(["diff", "--relative", "--name-status", "-z", "--diff-filter=MADRT", "-M", "--end-of-options", range, "--", "."], { cwd: gitCwd }),
+      runGit(["diff", "--relative", "--numstat", "-z", "--diff-filter=MADRT", "-M", "--end-of-options", range, "--", "."], { cwd: gitCwd }),
     ]);
     const mergeBase = mergeBaseResult?.stdout.trim().slice(0, 9);
     ctx.host.http.writeJson(res, 200, {

--- a/runtime/fleet-plugins/repository/server/diff.ts
+++ b/runtime/fleet-plugins/repository/server/diff.ts
@@ -19,41 +19,42 @@ function literalPathspec(relativePath: string): string {
   return `:(literal)${relativePath}`;
 }
 
-// git numstat 리네임 압축 표기 `{old => new}` 에서 new 경로를 추출
-function normalizeNumstatPath(p: string): string {
-  const match = /^(.*?)\{[^}]* => ([^}]*)\}(.*)$/.exec(p);
-  if (match) return (match[1] ?? "") + (match[2] ?? "") + (match[3] ?? "");
-  // Limitation: a literal filename containing ` => ` is indistinguishable from Git's non-NUL rename notation and gets zero stats.
-  const plainRename = /^.+ => (.+)$/.exec(p);
-  return plainRename?.[1] ?? p;
+export function parseNumstat(stdout: string): ReadonlyMap<string, { readonly additions: number; readonly deletions: number }> {
+  const map = new Map<string, { readonly additions: number; readonly deletions: number }>();
+  // -z는 경로를 인용하지 않는다. 마지막 NUL이 없는 잘린 레코드는 제외한다.
+  const records = stdout.split("\0").slice(0, -1);
+  for (let index = 0; index < records.length; index += 1) {
+    const match = /^(\d+|-)\t(\d+|-)\t([\s\S]*)$/.exec(records[index]!);
+    if (!match) continue;
+    let filePath = match[3]!;
+    // 리네임은 통계 뒤에 빈 경로, 이전 경로, 새 경로가 각각 NUL로 구분된다.
+    if (filePath === "") {
+      filePath = records[index + 2] ?? "";
+      index += 2;
+    }
+    if (!filePath) continue;
+    map.set(filePath, {
+      additions: Number.parseInt(match[1]!, 10) || 0,
+      deletions: Number.parseInt(match[2]!, 10) || 0,
+    });
+  }
+  return map;
 }
 
 export function parseDiffFileList(nameStatusOutput: string, numstatOutput: string): DiffFileEntry[] {
-  const numstatMap = new Map<string, { readonly additions: number; readonly deletions: number }>();
-  for (const line of numstatOutput.split("\n")) {
-    const parts = line.split("\t");
-    if (parts.length < 3) continue;
-    const [adds, dels] = parts;
-    const filePath = parts.length > 3 ? parts[parts.length - 1] : parts[2];
-    if (!filePath) continue;
-    numstatMap.set(normalizeNumstatPath(filePath), {
-      additions: parseInt(adds ?? "0", 10) || 0,
-      deletions: parseInt(dels ?? "0", 10) || 0,
-    });
-  }
-
+  const numstatMap = parseNumstat(numstatOutput);
+  const records = nameStatusOutput.split("\0").slice(0, -1);
   const files: DiffFileEntry[] = [];
-  for (const line of nameStatusOutput.split("\n")) {
-    if (!line.trim()) continue;
-    const [rawStatus, ...pathParts] = line.split("\t");
-    if (!rawStatus || pathParts.length === 0) continue;
-    const statusChar = rawStatus.charAt(0).toUpperCase();
+  for (let index = 0; index < records.length; index += 1) {
+    const statusChar = records[index]!.charAt(0);
+    const firstPath = records[++index];
+    const isRename = statusChar === "R" || statusChar === "C";
+    const filePath = isRename ? records[++index] : firstPath;
     if (statusChar !== "M" && statusChar !== "A" && statusChar !== "D" && statusChar !== "R" && statusChar !== "T") continue;
-    const oldPath = statusChar === "R" ? pathParts[0] : undefined;
-    const filePath = statusChar === "R" ? (pathParts[1] ?? pathParts[0] ?? "") : (pathParts[0] ?? "");
     if (!filePath) continue;
+    const oldPath = statusChar === "R" ? firstPath : undefined;
     const nums = numstatMap.get(filePath) ?? { additions: 0, deletions: 0 };
-    files.push({ path: filePath, ...(oldPath ? { oldPath } : {}), status: statusChar as "M" | "A" | "D" | "R" | "T", ...nums });
+    files.push({ path: filePath, ...(oldPath ? { oldPath } : {}), status: statusChar, ...nums });
   }
   return files;
 }
@@ -61,8 +62,8 @@ export function parseDiffFileList(nameStatusOutput: string, numstatOutput: strin
 // untracked 파일은 추가 줄 수를 계산하지 않는다.
 // 파일별 git spawn(프로세스 폭주 위험)과 심링크를 통한 외부 파일 크기 노출을 동시에 방지.
 async function fetchUntrackedFiles(cwd: string): Promise<DiffFileEntry[]> {
-  const result = await runGit(["ls-files", "--others", "--exclude-standard", "--", "."], { cwd });
-  return result.stdout.split("\n").filter((p) => p.trim()).map((p): DiffFileEntry => ({
+  const result = await runGit(["ls-files", "--others", "--exclude-standard", "-z", "--", "."], { cwd });
+  return result.stdout.split("\0").slice(0, -1).filter(Boolean).map((p): DiffFileEntry => ({
     path: p,
     status: "U",
     additions: 0,
@@ -146,8 +147,8 @@ export async function handleRepositoryChanged(
     // git diff HEAD 통합 목록 시도 (staged+unstaged 합산)
     try {
       const [nameStatusResult, numstatResult] = await Promise.all([
-        runGit(["diff", "HEAD", "--relative", "--name-status", "--diff-filter=MADRT", "--", "."], { cwd: gitCwd }),
-        runGit(["diff", "HEAD", "--relative", "--numstat", "--diff-filter=MADRT", "--", "."], { cwd: gitCwd }),
+        runGit(["diff", "HEAD", "--relative", "--name-status", "-z", "--diff-filter=MADRT", "--", "."], { cwd: gitCwd }),
+        runGit(["diff", "HEAD", "--relative", "--numstat", "-z", "--diff-filter=MADRT", "--", "."], { cwd: gitCwd }),
       ]);
       files = parseDiffFileList(nameStatusResult.stdout, numstatResult.stdout);
       truncated = nameStatusResult.truncated || numstatResult.truncated;
@@ -155,8 +156,8 @@ export async function handleRepositoryChanged(
       if (!isNoHeadError(err)) throw err;
       // no-HEAD 신규 저장소: staged 목록으로 graceful fallback
       const [nsResult, nsNumstat] = await Promise.all([
-        runGit(["diff", "--cached", "--relative", "--name-status", "--diff-filter=MADRT", "--", "."], { cwd: gitCwd }),
-        runGit(["diff", "--cached", "--relative", "--numstat", "--diff-filter=MADRT", "--", "."], { cwd: gitCwd }),
+        runGit(["diff", "--cached", "--relative", "--name-status", "-z", "--diff-filter=MADRT", "--", "."], { cwd: gitCwd }),
+        runGit(["diff", "--cached", "--relative", "--numstat", "-z", "--diff-filter=MADRT", "--", "."], { cwd: gitCwd }),
       ]);
       files = parseDiffFileList(nsResult.stdout, nsNumstat.stdout);
       truncated = nsResult.truncated || nsNumstat.truncated;

--- a/runtime/fleet-plugins/repository/server/status.ts
+++ b/runtime/fleet-plugins/repository/server/status.ts
@@ -2,7 +2,7 @@ import type http from "node:http";
 
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 
-import { InvalidRepoError, resolveGitCwd } from "./diff.js";
+import { InvalidRepoError, parseNumstat, resolveGitCwd } from "./diff.js";
 import { GitExecutorError, runGit } from "./git-executor.js";
 import type { DiffFileEntry, StatusResult } from "./types.js";
 
@@ -11,28 +11,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 type NumstatMap = ReadonlyMap<string, { readonly additions: number; readonly deletions: number }>;
-
-function parseNumstat(stdout: string): NumstatMap {
-  const map = new Map<string, { readonly additions: number; readonly deletions: number }>();
-  // -z numstat: `adds\tdels\t경로` — 리네임은 경로 필드가 NUL로 갈라져 `adds\tdels\t` + `old` + `new`로 온다.
-  const records = stdout.split("\0");
-  for (let index = 0; index < records.length; index += 1) {
-    const record = records[index]!;
-    const parts = record.split("\t");
-    if (parts.length < 3) continue;
-    let filePath = parts[2]!;
-    if (filePath === "" && index + 2 < records.length) {
-      filePath = records[index + 2]!;
-      index += 2;
-    }
-    if (!filePath) continue;
-    map.set(filePath, {
-      additions: Number.parseInt(parts[0] ?? "0", 10) || 0,
-      deletions: Number.parseInt(parts[1] ?? "0", 10) || 0,
-    });
-  }
-  return map;
-}
 
 const STATUS_CHARS = new Set(["M", "A", "D", "R", "T"]);
 

--- a/runtime/fleet-plugins/repository/tests/root-scoped-routes.test.ts
+++ b/runtime/fleet-plugins/repository/tests/root-scoped-routes.test.ts
@@ -216,6 +216,28 @@ describe("Repository Theater-root Git routes", () => {
     const file = readPayload<ContentPayload>(fileWrites);
     expect(file.content).toContain("diff --git a/inside/changed.txt b/inside/changed.txt");
     expect(file.content).toContain("+after");
+
+    // 목록의 경로를 그대로 다시 열 수 있어야 한다. 인용된 Git 출력은 이 계약을 깨뜨린다.
+    const filePath = "문서/변경 이력.txt";
+    await runGit(["config", "core.quotePath", "true"], { cwd: fixture.theaterPath });
+    await fs.mkdir(path.join(fixture.theaterPath, "문서"));
+    await fs.writeFile(path.join(fixture.theaterPath, filePath), "CJK history content\n");
+    await runGit(["add", "."], { cwd: fixture.theaterPath });
+    await runGit(["commit", "-m", "CJK history"], { cwd: fixture.theaterPath });
+    const ref = (await runGit(["rev-parse", "HEAD"], { cwd: fixture.theaterPath })).stdout.trim();
+    const commitWrites: JsonWrite[] = [];
+    await handleRepositoryCommit(
+      { method: "POST" } as never, {} as never,
+      makeContext(fixture.theaterPath, { theaterId: "theater", ref }, commitWrites),
+    );
+    const entry = readPayload<CommitPayload>(commitWrites).files.find((entry) => entry.path === filePath);
+    expect(entry).toEqual({ path: filePath, status: "A", additions: 1, deletions: 0 });
+    const commitFileWrites: JsonWrite[] = [];
+    await handleRepositoryCommitFile(
+      { method: "POST" } as never, {} as never,
+      makeContext(fixture.theaterPath, { theaterId: "theater", ref, filePath: entry!.path }, commitFileWrites),
+    );
+    expect(readPayload<ContentPayload>(commitFileWrites).content).toContain("+CJK history content");
   });
 
   it("하위 디렉터리 Theater의 history는 Theater 밖 커밋을 제외한다", async () => {


### PR DESCRIPTION
## Summary
- Repository 변경 이력에서 한글·일본어·중국어 경로가 Git의 8진수 escape로 표시되는 문제를 격리 Console E2E로 재현하고 수정했습니다.
- 커밋·비교·작업 파일 목록을 NUL 구분 Git 출력으로 파싱하여 원래 경로와 리네임 통계를 보존합니다. 사용자 Git 설정은 변경하지 않으며 status에서도 같은 numstat 파서를 재사용합니다.
- 기존 대표 route 테스트를 확장해 목록의 한글 경로로 실제 commit diff를 열 수 있는지 검증합니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/repository test` — 15 files, 76 tests passed
- [x] `pnpm --filter @fleet-plugins/repository build`
- [x] `pnpm --filter @fleet-plugins/repository typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 배포·경계 검사 포함
- [x] macOS arm64, headless Console E2E: 같은 커밋의 CJK 이름 정상 표시 및 한글·일본어·중국어 diff 탐색
- [x] 빌드 서버 API: 한글 리네임의 old/new 경로와 +1 통계, 커밋 비교, tracked/untracked 및 탭·개행·따옴표 경로
- [x] 격리 서버와 소유 브라우저 session/PID 정리 완료, 실제 사용자 데이터 미사용

## Product Context Record
- 요청: Repository 변경 이력의 CJK(우선 한글) 파일·디렉터리 이름 깨짐을 E2E 재현 후 수정하고 PR lifecycle 진행.
- 수용 기준: 경로 원문과 파일 diff 조회를 보존하고 관련 Git 목록·리네임 통계가 회귀하지 않아야 합니다.
- 제외: UI 재설계, Git 전역 설정 변경, Electron/Windows 검증, 릴리스 배포.
- 절충: Git의 기계 판독용 `-z` 출력을 사용하며 C-style escape decoder나 언어별 보정은 추가하지 않습니다. 기존 권한·containment·ref 검증은 유지합니다.
- 증거: 수정 전 `문서/변경 이력.txt`가 `\353\254...`로 표시됨. 수정 후 원문과 `+after CJK change` hunk 확인. 한글 리네임과 비교도 실제 빌드 API에서 검증.
- REVIEW_BASE_HEAD: b06029dc7ef185713c2f7e3fb66ede25ace9eb12
