### PR TITLE
fix(console): refresh launch catalog after gateway model changes

### DIFF
--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { useT } from "../i18n/index.js";
 
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
-import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
+import { fetchOperationCatalog, OPERATION_CATALOG_CHANGED_EVENT } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
 import { ApiError, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, patchOperation, patchTheaterOrder, renameOperation, updateGroup, type DeferredDeletionReceipt } from "../api.js";
@@ -141,8 +141,12 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
       setCatalog([]);
       return;
     }
+    window.addEventListener(OPERATION_CATALOG_CHANGED_EVENT, refreshCatalog);
     refreshCatalog();
-    return () => { catalogRequestEpochRef.current += 1; };
+    return () => {
+      window.removeEventListener(OPERATION_CATALOG_CHANGED_EVENT, refreshCatalog);
+      catalogRequestEpochRef.current += 1;
+    };
   }, [refreshCatalog, state.activeTheaterId]);
 
   // Alt+화살표는 캔버스 배치 순서와 패널 문법을 공유하고, Alt+F/Alt+S는 같은 capture/editable 가드 정책을 따른다.

--- a/runtime/fleet-console/sdk/operations/browser.tsx
+++ b/runtime/fleet-console/sdk/operations/browser.tsx
@@ -23,6 +23,8 @@ export class ApiError extends Error {
   }
 }
 
+export const OPERATION_CATALOG_CHANGED_EVENT = "fleet:operation-catalog-changed";
+
 export async function fetchOperationCatalog(signal?: AbortSignal): Promise<readonly OperationCatalogPlugin[]> {
   const response = await fetch("/api/v1/operations/catalog", { signal });
   if (!response.ok) throw new ApiError(response.status, `Operation catalog request failed: ${response.status}`);

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -69,7 +69,10 @@ vi.mock("../core/client/src/api.js", () => ({
   updateGroup: vi.fn(),
 }));
 
-vi.mock("@fleet-console/sdk/operations/browser", () => ({ fetchOperationCatalog: vi.fn().mockResolvedValue([]) }));
+vi.mock("@fleet-console/sdk/operations/browser", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@fleet-console/sdk/operations/browser")>(),
+  fetchOperationCatalog: vi.fn().mockResolvedValue([]),
+}));
 vi.mock("../core/client/src/canvas/canvas.js", () => ({
   OperationsCanvas: ({ catalog, onLaunchAtGeometry, onLaunchKind, onRefreshCatalog }: {
     readonly catalog: readonly OperationCatalogPlugin[];

--- a/runtime/fleet-plugins/terminal/client/agent/settings.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/settings.ts
@@ -1,3 +1,5 @@
+import { OPERATION_CATALOG_CHANGED_EVENT } from "@fleet-console/sdk/operations/browser";
+
 export interface AiGatewayModelSelection {
   readonly id: string;
   /** 정체성으로 내보낼 강도. 부재 = 이 모델의 사다리 전체. */
@@ -99,7 +101,11 @@ export async function saveSystemPromptSettings(settings: SystemPromptSettingsUpd
     signal,
   });
   await assertOk(response);
-  return assertSystemPromptSettingsState(await response.json(), response.status);
+  const state = assertSystemPromptSettingsState(await response.json(), response.status);
+  if ("aiGateway" in settings) {
+    window.dispatchEvent(new Event(OPERATION_CATALOG_CHANGED_EVENT));
+  }
+  return state;
 }
 
 async function assertOk(response: Response): Promise<void> {


### PR DESCRIPTION
## Summary
- AI Gateway 모델 설정 저장 성공 후 공통 실행 카탈로그 갱신 이벤트를 전달합니다.
- Operations가 이벤트를 구독하여 사이드바 우클릭 및 실행 메뉴에 모델 추가·제거를 새로고침 없이 반영합니다.
- 기존 Operations integration mock에서 실제 SDK exports를 유지합니다. 실행 중인 세션 구성은 변경하지 않습니다.

## Test Plan
- [x] Console build (배포/경계 검사 포함)
- [x] Console typecheck
- [x] Terminal build
- [x] Terminal settings / launch-kinds 테스트 6개 통과
- [x] Operations / boot-minimization 테스트 5개 통과
- [x] 격리된 실제 Console 브라우저: Settings에서 Grok-4.6 추가 후 새로고침 없이 사이드바 우클릭 메뉴에 표시, 제거 후 메뉴에서도 제거
- [x] git diff --check 및 소유 브라우저·격리 서버 정리

## Product Context Record
- 요청: Settings → AI Gateway 모델 추가가 우클릭 컨텍스트 메뉴에 즉시 반영되지 않는 문제 해결.
- 완료 기준: 같은 Console 문서에서 설정 저장 후 모델 추가·제거가 실행 메뉴에 반영됨.
- 제외: 실행 중인 Agent 세션 재설정, 다른 브라우저 탭 동기화, provider 인증 정책 및 서버 모델 선택 정책 변경.
- 선택: 성공한 저장 이후에만 브라우저 이벤트로 기존 카탈로그 fetch를 호출. SDK는 이벤트 이름만 공유하며 모듈 singleton을 추가하지 않음. 기존 요청 세대값과 구독 정리를 유지.
- 보존: 기존 모델/variant 선택, Theater 전환, 요청 실패 시 동작, 실행 중인 세션 구성.
- 근거: 사용자 버그 보고, settings.ts 저장 경로 및 operations.tsx 카탈로그 수명 조사, 실제 브라우저에서 추가·제거 검증.
- REVIEW_BASE_HEAD: 1ad6cc3d356161fda311c8ad823f51bfb3b11a74
