### PR TITLE
feat(console): unify Settings model selectors into one ModelPicker

### DIFF
--- a/.changelog.d/settings-model-picker.md
+++ b/.changelog.d/settings-model-picker.md
@@ -1,0 +1,8 @@
+---
+branch: settings-model-picker
+---
+
+### fleet-console
+#### Changed
+- Unify every model selector in Settings (AI extensions, Quaker Aides, compact timing preview) into one ModelPicker with provider bands, context-window meta, and an attached effort segment.
+  ko: 설정의 모든 모델 선택기(AI 확장, 퀘이커 부관단, 압축 시점 미리보기)를 프로바이더 밴드·컨텍스트 창 메타·붙은 강도 세그먼트를 갖춘 하나의 ModelPicker로 통일합니다.

--- a/runtime/fleet-console/core/client/src/settings/experiments-section.tsx
+++ b/runtime/fleet-console/core/client/src/settings/experiments-section.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useState } from "react";
-import { Select } from "@fleet-console/sdk/react/browser";
-import { CLAUDE_EXPERIMENT_MODEL_OPTIONS, ExperimentalBadge } from "@fleet-console/sdk/settings/browser";
-import type { ConsoleExperimentSettings, ExperimentFeatureId, ExperimentModelFeatureId, ExperimentModelOption } from "@fleet-console/sdk/settings";
+import { ExperimentalBadge, ModelPicker, useModelPickerOptions } from "@fleet-console/sdk/settings/browser";
+import type { ConsoleExperimentSettings, ExperimentFeatureId, ExperimentModelFeatureId } from "@fleet-console/sdk/settings";
 
 import { SettingsHelp } from "../components/settings-help.js";
 import { setGlobalSettingsField } from "../global-settings-store.js";
@@ -26,20 +24,10 @@ const FEATURE_ROWS: readonly FeatureRow[] = [
   { id: "sessionWatch", titleKey: "settings.experiments.sessionWatch.title", helpKey: "settings.experiments.sessionWatch.help", model: "sessionWatch" },
 ];
 
-function useExperimentModelOptions(): readonly ExperimentModelOption[] {
-  const [options, setOptions] = useState<readonly ExperimentModelOption[]>(CLAUDE_EXPERIMENT_MODEL_OPTIONS);
-  useEffect(() => {
-    let cancelled = false;
-    void collectExperimentModelOptions().then((next) => { if (!cancelled) setOptions(next); });
-    return () => { cancelled = true; };
-  }, []);
-  return options;
-}
-
 export function ExperimentsSection({ state, saving }: { readonly state: GlobalSettingsState; readonly saving: boolean }) {
   const t = useT();
   const experiments = state.experiments;
-  const options = useExperimentModelOptions();
+  const options = useModelPickerOptions(collectExperimentModelOptions);
   const save = (next: ConsoleExperimentSettings) => void setGlobalSettingsField("experiments", next);
 
   return (
@@ -53,11 +41,6 @@ export function ExperimentsSection({ state, saving }: { readonly state: GlobalSe
         const enabled = experiments[row.id];
         const modelField = row.model === null ? null : (`${row.model}Model` as const);
         const current = modelField === null ? null : experiments[modelField];
-        const known = current === null || options.some((option) => option.id === current);
-        const selectOptions = [
-          ...options.map((option) => ({ value: option.id, label: option.label })),
-          ...(known || current === null ? [] : [{ value: current, label: current }]),
-        ];
         return (
           <div className="global-settings-row experiments-row" key={row.id}>
             <div className="global-settings-row-text">
@@ -66,13 +49,13 @@ export function ExperimentsSection({ state, saving }: { readonly state: GlobalSe
                 <SettingsHelp title={t(row.titleKey)}>{t(row.helpKey)}</SettingsHelp>
               </p>
             </div>
-            {/* 한 줄: 모델 선택기와 스위치가 오른쪽에 나란히 선다 — 어느 기능의 모델인지는 왼쪽 제목이 말한다. */}
+            {/* 한 줄: 모델 선택기와 스위치가 오른쪽에 나란히 선다 — 어느 기능의 모델인지는 왼쪽 제목이 말한다.
+                스위치가 행 제목을 이름으로 쓰므로 선택기는 "{기능} 모델"로 구별해 이름 짓는다. */}
             <div className="experiments-row-controls">
               {modelField !== null && current !== null ? (
-                <Select
-                  className="experiments-model-select"
+                <ModelPicker
                   value={current}
-                  options={selectOptions}
+                  options={options}
                   disabled={saving}
                   label={t("settings.experiments.modelAria", { feature: t(row.titleKey) })}
                   onChange={(value) => save({ ...experiments, [modelField]: value })}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -13852,7 +13852,6 @@ body[data-expanded-surface="true"] .operations-canvas .expanded-surface {
   font-weight: var(--weight-regular);
   letter-spacing: 0.04em;
 }
-.fc-model-picker__popup { min-width: min(260px, calc(100vw - 16px)); }
 /* 밴드는 quick-launch-pop-band와 같은 자간·여백 — 두 메뉴가 같은 목록으로 읽혀야 한다. */
 .fc-model-picker__band {
   display: flex;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -845,11 +845,6 @@
   gap: var(--space-3);
 }
 
-.experiments-model-select {
-  width: 22ch;
-  max-width: 40vw;
-}
-
 .operations-mutation-error {
   display: flex;
   align-items: center;
@@ -8686,6 +8681,14 @@ body[data-side-bar-animating="true"] .canvas-operation {
 .quick-launch-pop-band.is-opencode { --launch-provider-tone: var(--provider-opencode); }
 .operation-launch-variant-caption.is-xai,
 .quick-launch-pop-band.is-xai { --launch-provider-tone: var(--provider-xai); }
+/* 설정의 ModelPicker는 런치 메뉴와 같은 공급자 톤을 글리프에 입힌다 — 같은 모델이 두 표면에서 같은 색으로 보여야 한다. */
+.fc-model-picker__glyph.is-antigravity { --launch-provider-tone: var(--provider-antigravity); }
+.fc-model-picker__glyph.is-claude { --launch-provider-tone: var(--provider-claude); }
+.fc-model-picker__glyph.is-codex { --launch-provider-tone: var(--provider-codex); }
+.fc-model-picker__glyph.is-cursor { --launch-provider-tone: var(--provider-cursor); }
+.fc-model-picker__glyph.is-kimi { --launch-provider-tone: var(--provider-kimi); }
+.fc-model-picker__glyph.is-opencode { --launch-provider-tone: var(--provider-opencode); }
+.fc-model-picker__glyph.is-xai { --launch-provider-tone: var(--provider-xai); }
 
 /* Etc는 공급자가 아니므로 캐리어 색을 빌리지 않고 머리글 잉크를 그대로 쓴다. */
 .operation-launch-provider-glyph--etc {
@@ -12057,7 +12060,6 @@ body[data-codex-side="true"] .command-card {
 
 .fc-settings-row__label,
 .fc-settings-toggle__label,
-.fc-settings-select__label,
 .fc-settings-field__label {
   color: var(--text-primary);
   font-size: var(--t-md);
@@ -12200,7 +12202,6 @@ body[data-codex-side="true"] .command-card {
   opacity: var(--control-disabled-opacity);
 }
 
-.fc-settings-select,
 .fc-settings-field {
   display: grid;
   gap: var(--space-2);
@@ -13802,6 +13803,90 @@ body[data-expanded-surface="true"] .operations-canvas .expanded-surface {
   font-family: var(--font-mono); color: var(--fc-select-compact-tone, var(--text-secondary)); padding: 7px 16px 7px 10px;
 }
 .fc-select__popup--compact { min-width: min(160px, calc(100vw - 16px)); }
+
+/* ── ModelPicker — 설정에서 모델 하나를 고르는 단일 문법 ───────────────────────────
+   fc-select의 트리거·팝업 레시피 위에 글리프·메타·프로바이더 밴드를 얹고, 강도는 세그먼트가 이어
+   붙는다. 크기 변형은 없다: 34px 한 높이가 설정 행의 스위치·칩과 같은 무게로 선다. */
+.fc-model-picker {
+  display: inline-flex;
+  align-items: stretch;
+  max-width: 100%;
+}
+/* 선택기는 24ch를 바라되 담긴 열(fc-settings-row의 컨트롤 열 등)이 좁으면 강도 세그먼트를
+   남기고 자기 폭을 내준다 — 세그먼트가 먼저 접히면 "이 모델의 강도"가 다음 줄로 떨어진다. */
+.fc-model-picker__select { flex: 1 1 24ch; min-width: 120px; max-width: 280px; }
+/* 트리거는 Quick Launch의 모델 칩과 같은 알약 — 런치에서 고른 모델을 설정에서 같은 물건으로 알아보게 한다. */
+.fc-model-picker__trigger {
+  min-height: 34px;
+  padding: 0 11px;
+  gap: 7px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--surface-pillar) 40%, transparent);
+  box-shadow: none;
+}
+.fc-model-picker__trigger[aria-expanded="true"] { color: var(--brass); background: var(--brass-glow); }
+.fc-model-picker.has-effort .fc-model-picker__trigger { border-start-end-radius: 0; border-end-end-radius: 0; }
+/* 트리거의 마크는 칩의 종류 글리프처럼 상자 없이 공급자 톤만 입고, 밴드의 마크는 런치 메뉴의 배지 그대로다. */
+.fc-model-picker__glyph--mark {
+  display: inline-flex;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  color: var(--launch-provider-tone, var(--text-tertiary));
+}
+.fc-model-picker__glyph--mark svg { width: 100%; height: 100%; }
+.fc-model-picker__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: start;
+}
+.fc-model-picker__name.is-unknown { font-family: var(--font-mono); font-size: var(--t-sm); color: var(--text-tertiary); }
+.fc-model-picker__meta {
+  flex: none;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  font-weight: var(--weight-regular);
+  letter-spacing: 0.04em;
+}
+.fc-model-picker__popup { min-width: min(260px, calc(100vw - 16px)); }
+/* 밴드는 quick-launch-pop-band와 같은 자간·여백 — 두 메뉴가 같은 목록으로 읽혀야 한다. */
+.fc-model-picker__band {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--space-2) var(--space-2) 6px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--t-2xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.fc-model-picker__band + .fc-model-picker__band { display: none; }
+.fc-model-picker__option { padding: 7px 10px; }
+.fc-model-picker__option .fc-model-picker__name { flex: 1; }
+/* 세그먼트는 트리거의 왼쪽 테두리를 나눠 쓴다 — 한 물건으로 읽혀야 "이 모델의 강도"가 된다. */
+.fc-model-picker__effort {
+  align-self: stretch;
+  gap: 0;
+  padding: 2px 4px 2px 2px;
+  margin-inline-start: -1px;
+  border: 1px solid var(--surface-rim);
+  border-start-end-radius: var(--radius-pill);
+  border-end-end-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--surface-pillar) 40%, transparent);
+}
+.fc-model-picker__effort .segmented-option {
+  min-width: 0;
+  min-height: 0;
+  padding: 0 10px;
+  font-size: var(--t-2xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .fc-select__trigger,

--- a/runtime/fleet-console/sdk/components/launch-provider-glyphs.tsx
+++ b/runtime/fleet-console/sdk/components/launch-provider-glyphs.tsx
@@ -45,13 +45,19 @@ export type LaunchProviderModelGroup<T> = {
   readonly models: readonly T[];
 };
 
-/** Group a flat catalog the way the canvas launch menu bands providers. */
+/**
+ * Group a flat catalog the way the canvas launch menu bands providers.
+ *
+ * `providerOf` overrides the id-format lookup for catalogs whose ids carry no provider
+ * prefix (a raw Gateway catalog keyed per provider); a `null` return falls back to the id.
+ */
 export function groupModelsByLaunchProvider<T extends { readonly id: string }>(
   models: readonly T[],
+  providerOf?: (model: T) => LaunchProviderGlyphId | null,
 ): readonly LaunchProviderModelGroup<T>[] {
   const buckets = new Map<LaunchProviderGlyphId | "etc", T[]>();
   for (const model of models) {
-    const provider = launchProviderFromModelId(model.id);
+    const provider = providerOf?.(model) ?? launchProviderFromModelId(model.id);
     const key = provider ?? "etc";
     const list = buckets.get(key) ?? [];
     list.push(model);

--- a/runtime/fleet-console/sdk/settings/browser.tsx
+++ b/runtime/fleet-console/sdk/settings/browser.tsx
@@ -329,6 +329,23 @@ export function useModelPickerOptions(load: () => Promise<readonly ExperimentMod
   return options;
 }
 
+/** 팝업의 최소 폭 — 트리거가 좁아도 Gateway 모델 이름이 한 줄에 서야 한다. */
+const MODEL_PICKER_POPUP_MIN_WIDTH_PX = 260;
+const MODEL_PICKER_VIEWPORT_MARGIN_PX = 8;
+
+/**
+ * useSelect는 트리거 폭으로 팝업을 놓는다. 여기서 최소 폭을 넓힌 뒤에는 뷰포트 안으로 다시
+ * 잠가야 한다 — CSS min-width로만 넓히면 오른쪽 끝에 선 좁은 트리거의 팝업이 화면 밖으로 나간다.
+ */
+function widenModelPickerPopup(style: React.CSSProperties): React.CSSProperties {
+  if (typeof style.left !== "number" || typeof style.width !== "number") return style;
+  const margin = MODEL_PICKER_VIEWPORT_MARGIN_PX;
+  const viewportWidth = Math.max(0, window.innerWidth);
+  const width = Math.min(Math.max(style.width, MODEL_PICKER_POPUP_MIN_WIDTH_PX), Math.max(0, viewportWidth - 2 * margin));
+  const left = Math.min(Math.max(style.left, margin), Math.max(margin, viewportWidth - width - margin));
+  return { ...style, left, width };
+}
+
 function formatModelContextWindow(contextWindow: number | null | undefined): string | null {
   if (contextWindow === null || contextWindow === undefined || contextWindow <= 0) return null;
   return contextWindow >= 1_000_000 ? "1M" : `${Math.round(contextWindow / 1000)}K`;
@@ -394,7 +411,7 @@ export function ModelPicker({
         </button>
         {select.isOpen
           ? createPortal(
-              <ul {...select.listboxProps} {...nameProps} className={`${select.listboxProps.className} fc-model-picker__popup`}>
+              <ul {...select.listboxProps} {...nameProps} className={`${select.listboxProps.className} fc-model-picker__popup`} style={widenModelPickerPopup(select.listboxProps.style)}>
                 {groups.map((group) => (
                   <React.Fragment key={group.provider ?? "etc"}>
                     {/* 밴드는 옵션이 아니다 — listbox의 activedescendant 순서는 옵션만 센다. */}

--- a/runtime/fleet-console/sdk/settings/browser.tsx
+++ b/runtime/fleet-console/sdk/settings/browser.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
+import { createPortal } from "react-dom";
 
-import { Select } from "../react/browser.js";
+import { groupModelsByLaunchProvider, isLaunchProviderGlyphId, launchProviderCaption, launchProviderGlyph, type LaunchProviderGlyphId } from "../components/launch-provider-glyphs.js";
+import { SegmentedThumb, useSelect } from "../react/browser.js";
+import { CLAUDE_EXPERIMENT_MODEL_OPTIONS, type ExperimentModelOption } from "./experiments.js";
 import type { SettingsSectionDescriptor } from "./types.js";
 
 // 실험 설정의 순수 도우미 — 브라우저 번들은 이 진입점만 공유 shim으로 노출되므로 여기서도 낸다.
@@ -50,19 +53,6 @@ export interface SettingsToggleProps {
   readonly label?: string;
   /** 보이지 않는 접근성 이름 — 행 라벨을 되풀이하는 눈에 띄는 글 없이 스위치를 이름 짓는다. */
   readonly ariaLabel?: string;
-  readonly disabled?: boolean;
-}
-
-export interface SettingsSelectOption {
-  readonly value: string;
-  readonly label: string;
-}
-
-export interface SettingsSelectProps {
-  readonly value: string;
-  readonly options: readonly SettingsSelectOption[];
-  readonly onChange: (next: string) => void;
-  readonly label?: string;
   readonly disabled?: boolean;
 }
 
@@ -296,26 +286,190 @@ export function SettingsToggle({ checked, onChange, label, ariaLabel, disabled =
   );
 }
 
-export function SettingsSelect({ value, options, onChange, label, disabled = false }: SettingsSelectProps): React.ReactElement {
-  const labelId = React.useId();
-  const selectOptions = options.map((option) => ({ value: option.value, label: option.label }));
-  const control = (
-    <Select
-      value={value}
-      options={selectOptions}
-      onChange={onChange}
-      disabled={disabled}
-      label={label ? undefined : "Select setting"}
-      aria-labelledby={label ? labelId : undefined}
-    />
+export interface ModelPickerEffort {
+  readonly value: string;
+  /** 사다리 — 호출자가 자기 계약(기능 고정 사다리 또는 선택된 모델의 `effortLevels`)으로 넘긴다. */
+  readonly levels: readonly string[];
+  readonly onChange: (next: string) => void;
+  readonly ariaLabel: string;
+  /** 단 이름의 표시 문구. 없으면 단 id를 그대로 쓴다. */
+  readonly labelOf?: (level: string) => string;
+}
+
+export interface ModelPickerProps {
+  readonly value: string;
+  readonly options: readonly ExperimentModelOption[];
+  readonly onChange: (next: string) => void;
+  /** 주면 트리거 오른쪽에 강도 세그먼트가 이어 붙는다. 사다리가 비면 그려지지 않는다. */
+  readonly effort?: ModelPickerEffort;
+  readonly disabled?: boolean;
+  readonly id?: string;
+  readonly className?: string;
+  /** 행 제목이 이름이 된다. 행 제목이 없는 자리만 `label`로 보이지 않는 이름을 준다. */
+  readonly "aria-labelledby"?: string;
+  readonly label?: string;
+}
+
+/**
+ * 모델 선택지를 비동기로 채우는 한 훅. Claude 별칭은 즉시 서고, 로더(코어의 수집기 또는
+ * 플러그인 브리지)가 늦거나 실패해도 별칭은 남는다 — 카드마다 같은 useState/useEffect를
+ * 되풀이하면 그중 하나가 빈 목록으로 떨어지는 날이 온다.
+ */
+export function useModelPickerOptions(load: () => Promise<readonly ExperimentModelOption[]>): readonly ExperimentModelOption[] {
+  const [options, setOptions] = React.useState<readonly ExperimentModelOption[]>(CLAUDE_EXPERIMENT_MODEL_OPTIONS);
+  React.useEffect(() => {
+    let cancelled = false;
+    void load().then((next) => {
+      if (!cancelled && next.length > 0) setOptions(next);
+    }).catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+  return options;
+}
+
+function formatModelContextWindow(contextWindow: number | null | undefined): string | null {
+  if (contextWindow === null || contextWindow === undefined || contextWindow <= 0) return null;
+  return contextWindow >= 1_000_000 ? "1M" : `${Math.round(contextWindow / 1000)}K`;
+}
+
+function modelPickerProviderOf(option: ExperimentModelOption): LaunchProviderGlyphId | null {
+  return option.provider !== undefined && isLaunchProviderGlyphId(option.provider) ? option.provider : null;
+}
+
+/**
+ * 설정 화면에서 모델 하나를 고르는 단일 문법.
+ *
+ * 트리거는 프로바이더 글리프·표시 이름·컨텍스트 메타를 한 줄로 말하고, 팝업은 런치 메뉴와 같은
+ * 순서·같은 글리프 배지(공급자 톤)로 프로바이더 밴드를 세운다 — 런치에서 고른 모델이 설정에서 다른 얼굴로 보이면 같은
+ * 모델인지 사람이 대조해야 한다. 크기 변형은 두지 않는다: 실험 카드의 42px 필드와 부관단
+ * 카드의 무테 11px 텍스트가 한 페이지에 서던 것이 이 컴포넌트가 지우는 어긋남이다.
+ *
+ * 저장된 값이 목록에 없으면(플러그인이 꺼졌거나 모델이 사라짐) 그 id를 마지막 밴드에 세워
+ * 선택이 화면에서 사라지지 않게 한다 — 사라지면 첫 옵션이 골라진 것처럼 읽히고, 다음 저장이
+ * 그 값을 조용히 덮어쓴다.
+ */
+export function ModelPicker({
+  value,
+  options,
+  onChange,
+  effort,
+  disabled = false,
+  id,
+  className,
+  "aria-labelledby": ariaLabelledBy,
+  label,
+}: ModelPickerProps): React.ReactElement {
+  const groups = React.useMemo(() => {
+    const known = options.some((option) => option.id === value);
+    const listed = known || value === "" ? options : [...options, { id: value, label: value }];
+    return groupModelsByLaunchProvider(listed, modelPickerProviderOf);
+  }, [options, value]);
+  const flat = React.useMemo(() => groups.flatMap((group) => group.models), [groups]);
+  const selectOptions = React.useMemo(() => flat.map((option) => ({ value: option.id, label: option.label })), [flat]);
+  const select = useSelect({ value, options: selectOptions, onChange, disabled, id });
+  const selected = flat.find((option) => option.id === value);
+  const selectedProvider = selected ? modelPickerProviderOf(selected) ?? groups.find((group) => group.models.includes(selected))?.provider ?? null : null;
+  const selectedMeta = formatModelContextWindow(selected?.contextWindow);
+  const known = options.some((option) => option.id === value);
+
+  const nameProps = ariaLabelledBy
+    ? { "aria-labelledby": ariaLabelledBy }
+    : label
+      ? { "aria-label": label }
+      : {};
+  const levels = effort?.levels ?? [];
+  const rootClassName = ["fc-model-picker", levels.length > 0 ? "has-effort" : "", className ?? ""].filter(Boolean).join(" ");
+
+  let index = -1;
+  return (
+    <div className={rootClassName}>
+      <div ref={select.rootRef} className={`${select.rootProps.className} fc-model-picker__select`}>
+        <button {...select.triggerProps} {...nameProps} className="fc-select__trigger fc-model-picker__trigger">
+          {selectedProvider ? <span className={`fc-model-picker__glyph fc-model-picker__glyph--mark is-${selectedProvider}`} aria-hidden="true">{launchProviderGlyph(selectedProvider)}</span> : null}
+          <span className={`fc-select__value fc-model-picker__name${known ? "" : " is-unknown"}`}>{selected?.label ?? value}</span>
+          {selectedMeta ? <span className="fc-model-picker__meta">{selectedMeta}</span> : null}
+          <span className="fc-select__caret" aria-hidden="true">⌄</span>
+        </button>
+        {select.isOpen
+          ? createPortal(
+              <ul {...select.listboxProps} {...nameProps} className={`${select.listboxProps.className} fc-model-picker__popup`}>
+                {groups.map((group) => (
+                  <React.Fragment key={group.provider ?? "etc"}>
+                    {/* 밴드는 옵션이 아니다 — listbox의 activedescendant 순서는 옵션만 센다. */}
+                    <li role="presentation" className="fc-model-picker__band">
+                      {group.provider ? <span className={`operation-launch-provider-glyph fc-model-picker__glyph is-${group.provider}`} aria-hidden="true">{launchProviderGlyph(group.provider)}</span> : null}
+                      {group.provider ? launchProviderCaption(group.provider) : "…"}
+                    </li>
+                    {group.models.map((option) => {
+                      index += 1;
+                      const meta = formatModelContextWindow(option.contextWindow);
+                      const optionProps = select.getOptionProps(index);
+                      return (
+                        <li key={option.id} {...optionProps} className={`${optionProps.className} fc-model-picker__option`}>
+                          <span className="fc-model-picker__name">{option.label}</span>
+                          {meta ? <span className="fc-model-picker__meta">{meta}</span> : null}
+                        </li>
+                      );
+                    })}
+                  </React.Fragment>
+                ))}
+              </ul>,
+              document.body,
+            )
+          : null}
+      </div>
+      {effort && levels.length > 0 ? (
+        <ModelPickerEffortSegments effort={effort} levels={levels} disabled={disabled} />
+      ) : null}
+    </div>
   );
-  return label ? (
-    <label className="fc-settings-select">
-      <span className="fc-settings-select__label" id={labelId}>{label}</span>
-      {control}
-    </label>
-  ) : (
-    <div className="fc-settings-select">{control}</div>
+}
+
+/**
+ * 강도는 배타 선택이라 세그먼트 문법(SegmentedThumb의 brass 다텀)을 쓴다 — Gateway 로스터의
+ * 다중 on 사다리(잉크 워시)와 모양이 다른 것은 뜻이 다르기 때문이다.
+ */
+function ModelPickerEffortSegments({ effort, levels, disabled }: {
+  readonly effort: ModelPickerEffort;
+  readonly levels: readonly string[];
+  readonly disabled: boolean;
+}): React.ReactElement {
+  const groupRef = React.useRef<HTMLDivElement | null>(null);
+  const current = levels.includes(effort.value) ? effort.value : levels[Math.floor(levels.length / 2)] ?? levels[0]!;
+  const move = (direction: 1 | -1) => {
+    const at = levels.indexOf(current);
+    const next = levels[(at + direction + levels.length) % levels.length];
+    if (next === undefined) return;
+    effort.onChange(next);
+    window.setTimeout(() => groupRef.current?.querySelector<HTMLButtonElement>('[aria-checked="true"]')?.focus(), 0);
+  };
+  return (
+    <div ref={groupRef} className="segmented fc-model-picker__effort" role="radiogroup" aria-label={effort.ariaLabel}>
+      <SegmentedThumb />
+      {levels.map((level) => {
+        const isOn = level === current;
+        return (
+          <button
+            key={level}
+            type="button"
+            role="radio"
+            aria-checked={isOn}
+            tabIndex={isOn ? 0 : -1}
+            className={`segmented-option${isOn ? " is-active" : ""}`}
+            disabled={disabled}
+            onClick={() => effort.onChange(level)}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowRight" || event.key === "ArrowDown") { event.preventDefault(); move(1); }
+              else if (event.key === "ArrowLeft" || event.key === "ArrowUp") { event.preventDefault(); move(-1); }
+            }}
+          >
+            {effort.labelOf ? effort.labelOf(level) : level}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/runtime/fleet-console/sdk/settings/experiments.ts
+++ b/runtime/fleet-console/sdk/settings/experiments.ts
@@ -49,10 +49,18 @@ export const DEFAULT_EXPERIMENT_SETTINGS: ConsoleExperimentSettings = {
   aideConsoleRead: false,
 };
 
-/** 모델 선택지 — 플러그인이 내놓는 모델 한 줄. id는 Claude Code `--model`에 그대로 들어가는 값이다. */
+/**
+ * 모델 선택지 — 플러그인이 내놓는 모델 한 줄. id는 Claude Code `--model`에 그대로 들어가는 값이다.
+ * 나머지 필드는 설정 화면의 ModelPicker가 밴드·메타·강도 사다리를 그리는 데 쓰는 선택 정보다 —
+ * 없으면 밴드는 id 형식(`cursor--…`)에서 읽고, 메타와 사다리는 비운다.
+ */
 export interface ExperimentModelOption {
   readonly id: string;
   readonly label: string;
+  /** 프로바이더 밴드를 id 형식 대신 명시할 때. 런치 글리프 id(`claude`·`cursor`…)여야 한다. */
+  readonly provider?: string;
+  readonly contextWindow?: number | null;
+  readonly effortLevels?: readonly string[];
 }
 
 /**

--- a/runtime/fleet-plugins/scuttlebutt/client/settings-section.tsx
+++ b/runtime/fleet-plugins/scuttlebutt/client/settings-section.tsx
@@ -1,15 +1,14 @@
 import { React, useStoreSnapshot } from "@fleet-console/sdk/plugin/browser";
-import { Select } from "@fleet-console/sdk/react/browser";
-import type { ExperimentModelOption } from "@fleet-console/sdk/settings";
 import {
-  CLAUDE_EXPERIMENT_MODEL_OPTIONS,
   ExperimentalBadge,
+  ModelPicker,
   SettingsCard,
   SettingsHelpTip,
   SettingsRow,
   SettingsSlider,
   SettingsToggle,
   defineSettingsSection,
+  useModelPickerOptions,
 } from "@fleet-console/sdk/settings/browser";
 
 import { isExperimentsSaving, readExperiments, readModelOptions, subscribeConsoleRead, writeConsoleRead } from "./console-read.js";
@@ -192,20 +191,6 @@ function ScuttlebuttSettingsSection() {
   );
 }
 
-function useAideModelOptions(): readonly ExperimentModelOption[] {
-  const [options, setOptions] = React.useState<readonly ExperimentModelOption[]>(CLAUDE_EXPERIMENT_MODEL_OPTIONS);
-  React.useEffect(() => {
-    let cancelled = false;
-    void readModelOptions().then((next) => {
-      if (!cancelled && next.length > 0) setOptions(next);
-    }).catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-  return options;
-}
-
 /**
  * 부관단 공통 모델·강도. 실험 페이지의 규약 — 모델을 쓰는 기능은 자기 선택기를 갖는다 — 를
  * 이 카드도 따른다. 부관마다 다르게 두지 않는다: 셋의 정체성은 목소리이지 모델이 아니다.
@@ -217,13 +202,7 @@ function ModelRow({ t, saving, model, effort, onSave }: {
   readonly effort: AideEffort;
   readonly onSave: (patch: Parameters<typeof writeScuttlebuttSettings>[0]) => Promise<void>;
 }) {
-  const options = useAideModelOptions();
-  const known = options.some((option) => option.id === model);
-  const modelOptions = [
-    ...options.map((option) => ({ value: option.id, label: option.label })),
-    ...(known ? [] : [{ value: model, label: model }]),
-  ];
-  const effortOptions = AIDE_EFFORTS.map((value) => ({ value, label: t(`effort.${value}`) }));
+  const options = useModelPickerOptions(readModelOptions);
   return (
     <SettingsRow
       label={t("settings.section.model")}
@@ -233,24 +212,20 @@ function ModelRow({ t, saving, model, effort, onSave }: {
         </SettingsHelpTip>
       }
     >
-      <div className="scuttlebutt-settings-model">
-        <Select
-          value={model}
-          options={modelOptions}
-          disabled={saving}
-          compact
-          label={t("settings.section.modelAria")}
-          onChange={(next) => void onSave({ model: next })}
-        />
-        <Select
-          value={effort}
-          options={effortOptions}
-          disabled={saving}
-          compact
-          label={t("settings.section.effortAria")}
-          onChange={(next) => void onSave({ effort: next as AideEffort })}
-        />
-      </div>
+      <ModelPicker
+        value={model}
+        options={options}
+        disabled={saving}
+        label={t("settings.section.modelAria")}
+        onChange={(next) => void onSave({ model: next })}
+        effort={{
+          value: effort,
+          levels: AIDE_EFFORTS,
+          ariaLabel: t("settings.section.effortAria"),
+          labelOf: (level) => t(`effort.${level as AideEffort}`),
+          onChange: (next) => void onSave({ effort: next as AideEffort }),
+        }}
+      />
     </SettingsRow>
   );
 }

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -1202,13 +1202,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-.scuttlebutt-settings-model {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: var(--space-2);
-}
-
 .scuttlebutt-visually-hidden {
   position: absolute;
   width: 1px;

--- a/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
+++ b/runtime/fleet-plugins/terminal/client/agent/agent-cli.css
@@ -1142,26 +1142,6 @@
   }
 }
 
-.compact-timing-preview {
-  display: grid;
-  gap: var(--space-2);
-}
-
-/* 라벨과 '?' 팁이 한 줄에 선다 — 팁이 라벨 안에 서면 버튼의 접근성 이름이 셀렉트 이름에 실린다. */
-.compact-timing-preview-head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.compact-timing-preview-label {
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--t-xs);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
 .compact-timing-track-wrap {
   display: grid;
   gap: var(--space-2);

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -14,7 +14,7 @@ import {
   CaptionTerminalGlyph,
   CaptionWatchGlyph,
 } from "@fleet-console/sdk/components/caption-actions";
-import { SettingsHelpTip, SettingsScope, SettingsToggle, defineSettingsSection } from "@fleet-console/sdk/settings/browser";
+import { ModelPicker, SettingsHelpTip, SettingsScope, SettingsToggle, defineSettingsSection } from "@fleet-console/sdk/settings/browser";
 import type { ClientExperimentsCapability, OperationRenderContext, PluginInstallContext } from "@fleet-console/sdk/plugin";
 import { fetchAnalysisCatalog } from "./analysis-api.js";
 import { SESSION_WATCH_EVENT_CHANNEL, getSessionWatchReview, isSessionWatchAlert, isSessionWatchEvent, readWatchEnabled, readWatchLast, recordSessionWatchEvent, refineLaunchPrompt, setSessionWatch, subscribeSessionWatchReviews, type SessionWatchReview } from "./experiments-api.js";
@@ -223,7 +223,7 @@ export const agentPlugin = definePlugin({
   experimentModelOptions: async () => {
     if (!installedApi) return [];
     const catalog = await fetchAnalysisCatalog(installedApi);
-    return catalog.clis.flatMap((cli) => cli.models.map((model) => ({ id: model.id, label: model.label })));
+    return catalog.clis.flatMap((cli) => cli.models.map((model) => ({ id: model.id, label: model.label, effortLevels: model.effortLevels })));
   },
   closeOperation: async (operationId) => {
     try {
@@ -1306,8 +1306,9 @@ function AiGatewayCompactTimingCard() {
 
   const ceiling = state.compactCeiling;
   const policy = compactPolicyFromCeiling(ceiling);
-  const previewModels = state.aiGatewayCatalog.providers.flatMap((provider) => provider.models)
-    .filter((model) => typeof model.contextWindow === "number" && model.contextWindow > 0);
+  const previewModels = state.aiGatewayCatalog.providers.flatMap((provider) => provider.models
+    .filter((model) => typeof model.contextWindow === "number" && model.contextWindow > 0)
+    .map((model) => ({ ...model, provider: provider.id })));
   const preview = previewModels.find((model) => model.id === previewId) ?? previewModels[0];
   const previewWindow = preview?.contextWindow ?? 272_000;
   const liveCeiling: CompactCeiling | null = policy === "custom" && dragPercent !== null
@@ -1382,21 +1383,18 @@ function AiGatewayCompactTimingCard() {
         </div>
       </div>
       {previewModels.length > 0 ? (
-        <div className="compact-timing-preview">
-          {/* 팁은 라벨 밖 형제로 둔다 — 라벨 안의 버튼은 자기 접근성 이름을 셀렉트 이름에 싣는다. */}
-          <div className="compact-timing-preview-head">
-            <label className="compact-timing-preview-label" htmlFor="compact-timing-preview">
-              {t("terminal.settings.compactTimingPreview")}
-            </label>
-            <SettingsHelp title={t("terminal.settings.compactTimingPreview")}>{t("terminal.settings.compactTimingPreviewHelp")}</SettingsHelp>
+        <div className="global-settings-row">
+          <div className="global-settings-row-text">
+            <p className="global-settings-resp-title">
+              {/* id는 제목 글자만 감싼 span이 진다 — 팁 버튼이 제목 안에 서면 그 접근성 이름까지 선택기 이름에 딸려 들어간다. */}
+              <span id="compact-timing-preview-label">{t("terminal.settings.compactTimingPreview")}</span>
+              <SettingsHelp title={t("terminal.settings.compactTimingPreview")}>{t("terminal.settings.compactTimingPreviewHelp")}</SettingsHelp>
+            </p>
           </div>
-          <Select
-            id="compact-timing-preview"
+          <ModelPicker
             value={preview?.id ?? ""}
-            options={previewModels.map((model) => ({
-              value: model.id,
-              label: `${model.name} — ${formatAiGatewayContextWindow(model.contextWindow)}`,
-            }))}
+            options={previewModels.map((model) => ({ id: model.id, label: model.name, provider: model.provider, contextWindow: model.contextWindow }))}
+            aria-labelledby="compact-timing-preview-label"
             onChange={(id) => setPreviewId(id)}
             disabled={saving}
           />


### PR DESCRIPTION
## Summary
- Add `ModelPicker` + `useModelPickerOptions` to `@fleet-console/sdk/settings/browser`: a pill trigger with provider-toned glyph, name and context-window meta, a provider-banded popup that mirrors the Quick Launch model menu, and an attached effort segment (SegmentedThumb grammar). Unknown saved ids stay visible as their own option.
- Replace the three Settings model selectors (AI extensions, Quaker Aides model+effort, compact-timing preview) with `ModelPicker`; delete the per-surface width overrides, inline fallback code, duplicate option-loading hooks, and the eyebrow-label CSS. Remove the unused `SettingsSelect` export.
- Extend `ExperimentModelOption` with optional `provider`, `contextWindow`, `effortLevels`; `groupModelsByLaunchProvider` accepts a provider resolver. Terminal now reports effort ladders in its experiment model options.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`, terminal and scuttlebutt `typecheck`
- [x] Console vitest suite (71 files), terminal (154) and scuttlebutt (10) tests, design contract (97)
- [x] Isolated Console from this build: experiments, Quaker Aides, and compact-timing rows render the same picker; provider bands + selected check in the popup; effort change persists across reopen; keyboard ↓/Enter selection; picker shrinks inside the settings-row control column without wrapping the effort segment