### PR TITLE
feat(ai-gateway): offer Cursor Fable 5.1 in the model catalog

### DIFF
--- a/.changelog.d/cursor-fable-5-1.md
+++ b/.changelog.d/cursor-fable-5-1.md
@@ -1,0 +1,13 @@
+---
+branch: cursor-fable-5-1
+---
+
+### fleet-cli
+#### Added
+- Offer Cursor's Fable 5.1 as a gateway model, with Low through Max reasoning and a Max Mode 1M variant billed against the Cursor API pool.
+  ko: Cursor의 Fable 5.1을 게이트웨이 모델로 제공합니다. Low부터 Max까지의 추론 단계와, Cursor API 풀에서 차감되는 Max Mode 1M 변형을 함께 지원합니다.
+
+### fleet-console
+#### Added
+- Offer Cursor's Fable 5.1 as a gateway model, with Low through Max reasoning and a Max Mode 1M variant billed against the Cursor API pool.
+  ko: Cursor의 Fable 5.1을 게이트웨이 모델로 제공합니다. Low부터 Max까지의 추론 단계와, Cursor API 풀에서 차감되는 Max Mode 1M 변형을 함께 지원합니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-09-06T00:00:00Z",
+  "updatedAt": "2026-09-07T00:00:00Z",
   "providers": {
     "antigravity": {
       "name": "Antigravity",
@@ -580,7 +580,7 @@
     "cursor": {
       "name": "Cursor",
       "defaultModel": "auto",
-      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); cursor-agent 2026.08.11-e8db854 observed 2026-08-13 for grok-4.6; claude-opus-5 and claude-fable-5 standard/Max Mode windows observed 2026-08-10; quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05); gpt-5.6-sol/terra/luna, gemini-3.7-flash, and kimi-k3 ids, effort rungs, and api quotaScope observed 2026-08-20 from live GetUsableModels (cursor-agent 2026.08.11-e8db854) and GetCurrentPeriodUsage autoBucketModels. Their windows are unmeasured because Cursor answers a first-turn Run with an empty token_details, so each carries the conservative cross-provider figure (272000 from the Codex catalog for the GPT-5.6 lineup, 256000 elsewhere); no Max Mode or -fast sibling is published for them",
+      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); cursor-agent 2026.08.11-e8db854 observed 2026-08-13 for grok-4.6; claude-opus-5 and claude-fable-5 standard/Max Mode windows observed 2026-08-10; quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05); gpt-5.6-sol/terra/luna, gemini-3.7-flash, and kimi-k3 ids, effort rungs, and api quotaScope observed 2026-08-20 from live GetUsableModels (cursor-agent 2026.08.11-e8db854) and GetCurrentPeriodUsage autoBucketModels. Their windows are unmeasured because Cursor answers a first-turn Run with an empty token_details, so each carries the conservative cross-provider figure (272000 from the Codex catalog for the GPT-5.6 lineup, 256000 elsewhere); no Max Mode or -fast sibling is published for them. claude-fable-5.1 standard/Max Mode entries added 2026-09-07 from live cursor-agent 2026.08.25-3e8eec8 `models` (claude-fable-5-1-{low,medium,high,xhigh,max}; no -fast sibling published). Its windows are unmeasured and mirror the measured claude-fable-5 lineage figures, and it carries no benchmarkKey because the cohort has no Fable 5.1 entry",
       "models": [
         {
           "modelId": "auto",
@@ -760,6 +760,45 @@
             "upstreamModelIdTemplate": "claude-fable-5-{effort}"
           },
           "benchmarkKey": "claude-fable-5"
+        },
+        {
+          "modelId": "claude-fable-5.1",
+          "name": "Fable-5.1",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "description": "NO ZDR",
+          "contextWindow": 300000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "claude-fable-5-1-{effort}"
+          }
+        },
+        {
+          "modelId": "claude-fable-5.1-1m",
+          "name": "Fable-5.1-1M",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "description": "NO ZDR",
+          "contextWindow": 1000000,
+          "cursorMaxMode": true,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "claude-fable-5-1-{effort}"
+          }
         },
         {
           "modelId": "gpt-5.6-sol",


### PR DESCRIPTION
## Summary
- Register `claude-fable-5.1` and its Max Mode 1M sibling on the Cursor provider, both driving the `claude-fable-5-1-{effort}` wire template across the low/medium/high/xhigh/max rungs the live `cursor-agent models` catalog publishes. Cursor ships no `-fast` sibling for this lineup, so none is registered.
- Windows mirror the measured `claude-fable-5` lineage (300000 standard, 1000000 Max Mode) and are declared as unmeasured in the provider `source` note, which also records the 2026-09-07 observation and the CLI build it came from.
- No `benchmarkKey`: the CursorBench cohort has no Fable 5.1 entry, and inheriting Fable 5's score would assert evidence that does not exist.

## Test Plan
- [x] `packages/core-ai-gateway`: `pnpm build`, `pnpm vitest run` (28 files, 192 tests)
- [x] `packages/fleet-admiral`: `pnpm build`, `pnpm vitest run` (11 files, 39 tests)
- [x] `runtime/fleet-plugins/terminal`: `pnpm vitest run client/agent/ai-gateway-base-models.test.tsx`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Wire resolution against the built bundle: `cursor--claude-fable-5.1` @high -> `claude-fable-5-1-high` (maxMode false); `cursor--claude-fable-5.1-1m` @xhigh -> `claude-fable-5-1-xhigh` (maxMode true)
- [ ] Not run: a live Cursor Run to confirm serving and measure the real context window (billable; deliberately skipped, and the catalog declares the windows as unmeasured)