### PR TITLE
fix(console): suppress duplicate activity warning while disconnected

### DIFF
--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -411,7 +411,7 @@ export function App() {
           {/* 런타임 축이 degraded면 화면의 활동 표시는 마지막으로 알던 값일 뿐 지금의 사실이 아니다.
               칩마다 물음표를 뿌리는 대신 배너 하나로만 말한다(제품 결정) — 어느 쪽이든 모르는 상태를
               유휴나 휴면으로 추정하지는 않는다. */}
-          {state.operationRuntimeHydration === "degraded" && !updateProgress.watching ? (
+          {state.connection === "live" && state.operationRuntimeHydration === "degraded" && !updateProgress.watching ? (
             <div className="console-link-banner" role="status" aria-live="polite">
               <span>{t("chrome.runtime.degraded")}</span>
             </div>

--- a/runtime/fleet-plugins/terminal/tests/prompt-refinement.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/prompt-refinement.test.ts
@@ -50,6 +50,7 @@ function harness() {
         return new Response(JSON.stringify(result.body), { status: result.status });
       },
       subscribe: () => () => {},
+      resync: vi.fn(),
     },
   };
 }


### PR DESCRIPTION
## Summary
- Console 연결이 끊기거나 재연결 중일 때 중복되는 Operation 활동 상태 경고를 숨기고, 기존 연결 안내와 다시 연결 버튼을 유지합니다.
- 연결이 정상인 상태에서 활동 정보만 저하된 경우의 경고와 기존 상태 판단은 유지합니다.
- 설치를 막던 프롬프트 다듬기 테스트 mock의 `ClientApiCapability.resync` 누락을 수정합니다.

## Test Plan
- [x] `pnpm install --frozen-lockfile` — 전체 postinstall 빌드 통과
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal test tests/prompt-refinement.test.ts` — 2건 통과
- [x] 격리 Console의 실제 빌드 자산 일치 확인 및 headless 브라우저 검증: 정상 연결 시 배너 0개, 서버 종료 후 연결 안내 배너 1개, 중복 경고 없음, 오류·미처리 rejection 0개
- [x] `git diff --check`

## Product Context Record
- 요청: 연결 끊김 시 중복되는 Operation 활동 상태 경고 제거. 후속 요청으로 기존 설치 오류 수정도 이번 PR에 포함.
- 제외: 연결·런타임 상태 모델 변경, 정상 연결에서 독립적으로 발생하는 활동 정보 저하 경고 제거, 새로운 영구 UI 문구 테스트 추가.
- 보존: 연결 끊김/재연결 안내와 재연결 버튼, 마지막 갱신 시각, 활동 정보가 불명확할 때 유휴로 추정하지 않는 동작.
- REVIEW_BASE_HEAD: b26cdf966
