### PR TITLE
fix(repository): make repository picker background opaque

### DIFF
--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1885,7 +1885,8 @@
 .repository-context-trigger strong { flex: 1; }
 .repository-context-trigger .repository-context-branch { max-width: 32%; }
 .repository-context-trigger:focus-visible, .repository-source-tabs button:focus-visible, .repository-staging-amend-entry:focus-visible { outline: 2px solid var(--brass); outline-offset: -2px; }
-.repository-context-popover { position: absolute; left: 0; top: calc(100% + 6px); z-index: 30; width: min(480px, calc(100cqw - 24px)); max-height: min(440px, 65vh); display: flex; flex-direction: column; border: 1px solid var(--surface-rim); border-radius: var(--radius-md); background: var(--surface-glass-strong); box-shadow: var(--shadow-floating); overflow: hidden; }
+/* 반투명 테마 재질 아래 불투명 바탕을 깔아 뒤쪽 브랜치·커밋 텍스트를 차폐한다. */
+.repository-context-popover { position: absolute; left: 0; top: calc(100% + 6px); z-index: 30; width: min(480px, calc(100cqw - 24px)); max-height: min(440px, 65vh); display: flex; flex-direction: column; border: 1px solid var(--surface-rim); border-radius: var(--radius-md); background: linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)), var(--ink-deep); box-shadow: var(--shadow-floating); overflow: hidden; }
 .repository-context-options { min-height: 0; overflow-y: auto; }
 .repository-identity .repository-context-options span { color: inherit; font: inherit; }
 .repository-context-heading { padding: 9px 12px 4px; font-size: var(--t-xs); font-weight: var(--weight-medium); color: var(--text-tertiary); }


### PR DESCRIPTION
## Summary
- Repository 저장소·워크트리 선택기의 테마 표면 아래 불투명 배경을 추가해 뒤쪽 브랜치·커밋 텍스트가 비치지 않도록 수정합니다.
- 사용자 요청으로 함께 수정한 Terminal mock의 `resync()` 누락은 리뷰 중 canary에 동일 목적으로 선반영되어, rebase에서 canary의 `vi.fn()` 구현을 보존했습니다. 최종 PR diff는 Repository CSS만 포함합니다.
- 메뉴 배치·동작과 전역 테마 토큰은 변경하지 않습니다.

## Test Plan
- [x] `pnpm install --frozen-lockfile` 및 postinstall 빌드
- [x] Repository·Terminal 플러그인 빌드와 Console 빌드
- [x] Terminal 프롬프트 다듬기 계약 테스트 2개
- [x] Console 디자인 계약 테스트 97개
- [x] 격리 Console의 Carbon·Maritime·Whites 메뉴 스크린샷 확인
- [x] 메뉴 열기·검색·선택·Escape·바깥 클릭·포커스 복귀 확인
- [x] 인도용 Console에서 사용자 확인 완료
- [x] `git diff --check`

브라우저 자동화의 일시적 통신 오류 후 재검증을 완료했습니다. 검증 및 인도용 Console은 종료했습니다.
