### PR TITLE
feat(console): ink the sidebar chip title with the accent and retire the chip spine

### DIFF
--- a/.changelog.d/sidebar-accent-title.md
+++ b/.changelog.d/sidebar-accent-title.md
@@ -1,0 +1,8 @@
+---
+branch: sidebar-accent-title
+---
+
+### fleet-console
+#### Changed
+- A sidebar chip now shows its Operation's accent as the color of the chip title, matching the panel caption; the 3px accent bar that stood at the chip's left edge is gone. The focused chip and a hovered chip show the full accent, and the rest show it one step quieter.
+  ko: 사이드바 칩이 이제 패널 캡션과 같은 방식으로 Operation의 액센트를 칩 제목 글자색으로 보여 주고, 칩 왼쪽에 서던 3px 액센트 막대는 사라졌습니다. 포커스된 칩과 hover한 칩은 액센트 원색을, 나머지는 한 단계 물러난 색을 씁니다.

--- a/.changelog.d/sidebar-accent-title.md
+++ b/.changelog.d/sidebar-accent-title.md
@@ -4,5 +4,5 @@ branch: sidebar-accent-title
 
 ### fleet-console
 #### Changed
-- A sidebar chip now shows its Operation's accent as the color of the chip title, matching the panel caption; the 3px accent bar that stood at the chip's left edge is gone. The focused chip and a hovered chip show the accent at full strength, and the rest show it one step quieter.
-  ko: 사이드바 칩이 이제 패널 캡션과 같은 방식으로 Operation의 액센트를 칩 제목 글자색으로 보여 주고, 칩 왼쪽에 서던 3px 액센트 막대는 사라졌습니다. 포커스된 칩과 hover한 칩은 액센트를 진하게, 나머지는 한 단계 물러난 색으로 씁니다.
+- A sidebar chip now shows its Operation's accent as the color of the chip title, matching the panel caption; the 3px accent bar that stood at the chip's left edge is gone. The focused chip and a hovered chip show the accent more strongly, and the rest show it one step quieter.
+  ko: 사이드바 칩이 이제 패널 캡션과 같은 방식으로 Operation의 액센트를 칩 제목 글자색으로 보여 주고, 칩 왼쪽에 서던 3px 액센트 막대는 사라졌습니다. 포커스된 칩과 hover한 칩은 액센트를 더 진하게, 나머지는 한 단계 물러난 색으로 씁니다.

--- a/.changelog.d/sidebar-accent-title.md
+++ b/.changelog.d/sidebar-accent-title.md
@@ -4,5 +4,5 @@ branch: sidebar-accent-title
 
 ### fleet-console
 #### Changed
-- A sidebar chip now shows its Operation's accent as the color of the chip title, matching the panel caption; the 3px accent bar that stood at the chip's left edge is gone. The focused chip and a hovered chip show the full accent, and the rest show it one step quieter.
-  ko: 사이드바 칩이 이제 패널 캡션과 같은 방식으로 Operation의 액센트를 칩 제목 글자색으로 보여 주고, 칩 왼쪽에 서던 3px 액센트 막대는 사라졌습니다. 포커스된 칩과 hover한 칩은 액센트 원색을, 나머지는 한 단계 물러난 색을 씁니다.
+- A sidebar chip now shows its Operation's accent as the color of the chip title, matching the panel caption; the 3px accent bar that stood at the chip's left edge is gone. The focused chip and a hovered chip show the accent at full strength, and the rest show it one step quieter.
+  ko: 사이드바 칩이 이제 패널 캡션과 같은 방식으로 Operation의 액센트를 칩 제목 글자색으로 보여 주고, 칩 왼쪽에 서던 3px 액센트 막대는 사라졌습니다. 포커스된 칩과 hover한 칩은 액센트를 진하게, 나머지는 한 단계 물러난 색으로 씁니다.

--- a/runtime/fleet-console/CLAUDE.md
+++ b/runtime/fleet-console/CLAUDE.md
@@ -42,7 +42,7 @@
 
 ## Design invariants
 
-- Every color speaks on exactly one channel: signal tokens (`aurora`/`warn`/`coral`/`positive`) carry state only, `brass` carries location/focus/hover only, and user or agent identity uses the `--id-*` tones only as the caption title ink, the rail-chip spine, and the minimap dot — borders stay state-owned and identity never repaints signal surfaces or the caption fill.
+- Every color speaks on exactly one channel: signal tokens (`aurora`/`warn`/`coral`/`positive`) carry state only, `brass` carries location/focus/hover only, and user or agent identity uses the `--id-*` tones only as the caption and rail-chip title ink and the minimap dot — borders stay state-owned and identity never repaints signal surfaces or the caption fill.
 - Core and built-in plugin CSS consume colors only as theme tokens via `var()`/`color-mix`; chromatic raw literals live solely in `theme.css` token definitions so all three themes retune together. Near-achromatic shadow, scrim, and sheen literals that carry depth rather than hue are the sanctioned exception.
 - `tests/instrument-design-contract.test.ts` pins the design grammar: a legitimate grammar change updates the contract together with the change, and intentional exceptions are recorded as doctrine comments beside the exempted CSS rule.
 

--- a/runtime/fleet-console/core/client/src/canvas/operation-accent.ts
+++ b/runtime/fleet-console/core/client/src/canvas/operation-accent.ts
@@ -16,7 +16,7 @@ type AccentDef = {
 };
 
 // 8톤 정체성 팔레트 — theme.css의 --id-* 토큰을 참조해 테마별 채도 봉투를 그대로 추종한다.
-// 정체성은 스파인·명판 마크·틱·도트 채널만 소유하고, 보더/링/beacon/glow는 상태 신호 전용이다.
+// 정체성은 제목 잉크·틱·도트 채널만 소유하고, 보더/링/beacon/glow는 상태 신호 전용이다.
 const OPERATION_ACCENT_DEFS: readonly AccentDef[] = [
   { key: "crimson", labelKey: "canvas.accent.crimson", color: "var(--id-crimson)" },
   { key: "amber", labelKey: "canvas.accent.amber", color: "var(--id-amber)" },

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5889,6 +5889,13 @@ body[data-side-bar-animating="true"] .canvas-operation {
   color: color-mix(in oklab, var(--user-accent) 75%, var(--text-secondary));
 }
 
+/* 최소화된 칩은 "치워둠" 티어(--ink-muted)를 accent 위에서도 유지한다 — 언포커스보다 한 단계 더 물러난
+   45% 믹스이며 hover로 되살아나지 않는다(무액센트 최소화 칩도 hover에 색을 바꾸지 않는다). 위 hover 규칙과
+   같은 명세성(0,3,1)이므로 반드시 그 뒤에 온다. Whites chrome 위 최소 5.5:1. */
+.side-bar-chip[style*="--user-accent"].side-bar-chip--minimized .side-bar-chip-name {
+  color: color-mix(in oklab, var(--user-accent) 55%, var(--ink-muted));
+}
+
 /* 이름 왼쪽 상태 슬롯 — 조작 표면이 아니라 마크를 담는 자리다(칩 본체가 클릭을 소유한다). */
 .side-bar-chip-beacon-button {
   display: grid;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4457,7 +4457,7 @@
   box-shadow: 0 0 7px color-mix(in oklch, var(--ink-rim) 36%, transparent);
 }
 
-/* 정체성 도트 — 패널 스파인과 같은 --user-accent 채널을 원거리 식별 표면으로 확장한다. */
+/* 정체성 도트 — 캡션·칩 제목 잉크와 같은 --user-accent 채널을 원거리 식별 표면으로 확장한다. */
 .canvas-minimap-operation[style*="--user-accent"]::after {
   content: "";
   position: absolute;
@@ -4958,7 +4958,7 @@ body[data-side-bar-animating="true"] .canvas-operation {
    패널 본문과 캡션 채움은 어떤 정체성 색도 지지 않고, 정체성은 제목의 잉크로 말한다.
    캡션 채움은 액센트가 없을 때와 같다: 언포커스는 --surface-panel, 포커스는 brass 워시.
    패널 보더/글로우/비콘은 상태 채널(brass 포커스·aurora 대기·coral 위험) 전용으로 남는다.
-   사이드바 칩의 3px accent 스파인과 미니맵 도트는 각자의 레일·지도 소속이라 그대로 남는다.
+   사이드바 칩 이름도 같은 잉크 규칙을 따르고(칩 스파인은 폐기), 미니맵 도트는 지도 소속이라 그대로 남는다.
    언포커스 제목은 중립 제목과 같은 한 단계 물러남을 accent 위에서 반복한다 — 면이 아니라 3티어 글자색
    쪽으로 섞는다. 면 쪽으로 섞으면 Whites의 --id-*(L50~56)가 밝아져 13px 본문 AA(4.5:1)를 잃는다(3.1~3.7:1);
    글자색 쪽 30% 믹스는 네 테마 모두 5.1:1 이상을 지키면서 한 단계 물러난 톤을 준다. */
@@ -5874,18 +5874,16 @@ body[data-side-bar-animating="true"] .canvas-operation {
   }
 }
 
-/* User-selected identity stays a small static side spine (same 3px grammar as the
-   canvas panel spine); brass focus and aurora/warn status continue to own their channels. */
-.side-bar-chip[style*="--user-accent"]::before {
-  content: "";
-  position: absolute;
-  top: 7px;
-  bottom: 7px;
-  left: 0;
-  width: 3px;
-  border-radius: 0 3px 3px 0;
-  background: var(--user-accent);
-  pointer-events: none;
+/* 사이드바 칩의 사용자 accent(정체성)는 캡션 제목과 같은 문법으로 이름 글자의 잉크만 소유한다 —
+   3px 좌측 스파인은 폐기됐다. 언포커스는 캡션과 같은 3티어 글자색 쪽 30% 믹스(네 테마 5.1:1 이상),
+   hover·active(brass 배경)는 accent 원색. brass 포커스·aurora/warn 상태는 각자의 채널을 그대로 갖는다. */
+.side-bar-chip[style*="--user-accent"] .side-bar-chip-name {
+  color: color-mix(in oklab, var(--user-accent) 70%, var(--text-tertiary));
+}
+
+.side-bar-chip[style*="--user-accent"]:hover .side-bar-chip-name,
+.side-bar-chip[style*="--user-accent"].side-bar-chip--active .side-bar-chip-name {
+  color: var(--user-accent);
 }
 
 /* 이름 왼쪽 상태 슬롯 — 조작 표면이 아니라 마크를 담는 자리다(칩 본체가 클릭을 소유한다). */

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5875,15 +5875,18 @@ body[data-side-bar-animating="true"] .canvas-operation {
 }
 
 /* 사이드바 칩의 사용자 accent(정체성)는 캡션 제목과 같은 문법으로 이름 글자의 잉크만 소유한다 —
-   3px 좌측 스파인은 폐기됐다. 언포커스는 캡션과 같은 3티어 글자색 쪽 30% 믹스(네 테마 5.1:1 이상),
-   hover·active(brass 배경)는 accent 원색. brass 포커스·aurora/warn 상태는 각자의 채널을 그대로 갖는다. */
+   3px 좌측 스파인은 폐기됐다. 언포커스는 캡션과 같은 3티어 글자색 쪽 30% 믹스(네 테마 5.1:1 이상).
+   hover·active는 한 단계 올라간 2티어 글자색 쪽 25% 믹스다 — 13px 이름을 accent 원색으로 두면
+   Whites의 --id-*(L50~56)가 chrome 면의 hover/active 워시 위에서 AA(4.5:1)를 잃는다(amber 3.8~3.9:1);
+   25% 믹스는 여덟 톤 모두 4.5:1 이상(최소 amber active 4.59:1)을 지키면서 다크 3종에서는 원색과 같은 채도로 읽힌다.
+   brass 포커스·aurora/warn 상태는 각자의 채널을 그대로 갖는다. */
 .side-bar-chip[style*="--user-accent"] .side-bar-chip-name {
   color: color-mix(in oklab, var(--user-accent) 70%, var(--text-tertiary));
 }
 
 .side-bar-chip[style*="--user-accent"]:hover .side-bar-chip-name,
 .side-bar-chip[style*="--user-accent"].side-bar-chip--active .side-bar-chip-name {
-  color: var(--user-accent);
+  color: color-mix(in oklab, var(--user-accent) 75%, var(--text-secondary));
 }
 
 /* 이름 왼쪽 상태 슬롯 — 조작 표면이 아니라 마크를 담는 자리다(칩 본체가 클릭을 소유한다). */

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1360,10 +1360,16 @@ describe("Instrument core design contract", () => {
     expect(chipIdleBlock).toContain("color: color-mix(in oklab, var(--user-accent) 70%, var(--text-tertiary));");
     // hover/active도 원색이 아니라 2티어 글자색 쪽 25% 믹스 — Whites chrome 워시 위 13px AA의 하한이다.
     expect(chipActiveBlock).toContain("color: color-mix(in oklab, var(--user-accent) 75%, var(--text-secondary));");
+    // 최소화 티어는 accent 위에서도 남는다 — hover 규칙과 같은 명세성이라 순서가 곧 계약이다.
+    const chipHoverIndex = components.indexOf('.side-bar-chip[style*="--user-accent"]:hover .side-bar-chip-name');
+    const chipMinimizedIndex = components.indexOf('.side-bar-chip[style*="--user-accent"].side-bar-chip--minimized .side-bar-chip-name {');
+    expect(chipHoverIndex).toBeGreaterThan(-1);
+    expect(chipMinimizedIndex).toBeGreaterThan(chipHoverIndex);
+    expect(components.slice(chipMinimizedIndex).match(/\{[^}]*\}/)?.[0]).toContain("color: color-mix(in oklab, var(--user-accent) 55%, var(--ink-muted));");
     expect(minimapDotBlock).toContain("background: var(--user-accent);");
-    // 5개 소비처: 미니맵 도트 · 캡션 제목(언포커스 믹스 + 포커스/hover) · 사이드바 칩 이름(언포커스 믹스 + hover/active).
+    // 6개 소비처: 미니맵 도트 · 캡션 제목(언포커스 믹스 + 포커스/hover) · 사이드바 칩 이름(언포커스 믹스 + hover/active + 최소화).
     // accent는 어디서나 제목 잉크에만 머물고 면·선 채널은 열지 않는다.
-    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(5);
+    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(6);
     expect(accentSources).not.toMatch(/--op-accent|--chip-accent/);
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1324,13 +1324,14 @@ describe("Instrument core design contract", () => {
     expect(violations).toEqual([]);
   });
 
-  it("keeps user identity on the title ink and mark grammar and off the caption fill and state border channel", () => {
+  it("keeps user identity on the caption and chip title ink and off the caption fill, chip spine, and state border channel", () => {
     const frame = source("canvas/operation-frame.tsx");
     const chip = source("sidebar/operations-side-bar-chip.tsx");
     const components = source("styles/components.css");
     const titleIdleBlock = components.match(/\.canvas-operation\[style\*="--user-accent"\] > \.canvas-operation-titlebar \.canvas-operation-identity-name \{[^}]*\}/)?.[0] ?? "";
     const titleActiveBlock = components.match(/\.canvas-operation\[style\*="--user-accent"\]\.is-active > \.canvas-operation-titlebar \.canvas-operation-identity-name \{[^}]*\}/)?.[0] ?? "";
-    const chipAccentBlock = components.match(/\.side-bar-chip\[style\*="--user-accent"\]::before \{[^}]*\}/)?.[0] ?? "";
+    const chipIdleBlock = components.match(/\.side-bar-chip\[style\*="--user-accent"\] \.side-bar-chip-name \{[^}]*\}/)?.[0] ?? "";
+    const chipActiveBlock = components.match(/\.side-bar-chip\[style\*="--user-accent"\]\.side-bar-chip--active \.side-bar-chip-name \{[^}]*\}/)?.[0] ?? "";
     const minimapDotBlock = components.match(/\.canvas-minimap-operation\[style\*="--user-accent"\]::after \{[^}]*\}/)?.[0] ?? "";
     const accentSources = [frame, chip, components].join("\n");
 
@@ -1353,16 +1354,15 @@ describe("Instrument core design contract", () => {
     expect(titleIdleBlock).toContain("color: color-mix(in oklab, var(--user-accent) 70%, var(--text-tertiary));");
     expect(titleIdleBlock).not.toContain("var(--surface-panel)");
     expect(titleActiveBlock).toContain("color: var(--user-accent);");
-    expect(chipAccentBlock).toContain("width: 3px;");
-    expect(chipAccentBlock).toContain("top: 7px;");
-    expect(chipAccentBlock).toContain("bottom: 7px;");
-    expect(chipAccentBlock).toContain("background: var(--user-accent);");
-    expect(chipAccentBlock).toContain("pointer-events: none;");
-    expect(chipAccentBlock).not.toMatch(/animation/);
+    // 사이드바 칩도 캡션과 같은 잉크 문법을 탄다 — 3px 좌측 스파인은 폐기됐다. 되살아나면 같은
+    // 정체성이 레일에서는 선으로, Map에서는 글자로 두 문법으로 말한다.
+    expect(components).not.toContain('.side-bar-chip[style*="--user-accent"]::before');
+    expect(chipIdleBlock).toContain("color: color-mix(in oklab, var(--user-accent) 70%, var(--text-tertiary));");
+    expect(chipActiveBlock).toContain("color: var(--user-accent);");
     expect(minimapDotBlock).toContain("background: var(--user-accent);");
-    // 4개 소비처: 미니맵 도트 · 캡션 제목(언포커스 믹스 + 포커스/hover) · 사이드바 칩 스파인.
-    // Map에서 accent는 제목 잉크에만 머물고, 3px 스파인은 레일(사이드바 칩)에만 남는다.
-    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(4);
+    // 5개 소비처: 미니맵 도트 · 캡션 제목(언포커스 믹스 + 포커스/hover) · 사이드바 칩 이름(언포커스 믹스 + hover/active).
+    // accent는 어디서나 제목 잉크에만 머물고 면·선 채널은 열지 않는다.
+    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(5);
     expect(accentSources).not.toMatch(/--op-accent|--chip-accent/);
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1358,7 +1358,8 @@ describe("Instrument core design contract", () => {
     // 정체성이 레일에서는 선으로, Map에서는 글자로 두 문법으로 말한다.
     expect(components).not.toContain('.side-bar-chip[style*="--user-accent"]::before');
     expect(chipIdleBlock).toContain("color: color-mix(in oklab, var(--user-accent) 70%, var(--text-tertiary));");
-    expect(chipActiveBlock).toContain("color: var(--user-accent);");
+    // hover/active도 원색이 아니라 2티어 글자색 쪽 25% 믹스 — Whites chrome 워시 위 13px AA의 하한이다.
+    expect(chipActiveBlock).toContain("color: color-mix(in oklab, var(--user-accent) 75%, var(--text-secondary));");
     expect(minimapDotBlock).toContain("background: var(--user-accent);");
     // 5개 소비처: 미니맵 도트 · 캡션 제목(언포커스 믹스 + 포커스/hover) · 사이드바 칩 이름(언포커스 믹스 + hover/active).
     // accent는 어디서나 제목 잉크에만 머물고 면·선 채널은 열지 않는다.


### PR DESCRIPTION
## Summary
- A sidebar chip's user accent now colors the chip title with the same grammar as the panel caption (idle: 70% accent mixed toward the tertiary text tier; hover/active: full accent). The 3px left accent spine on the chip is removed.
- The design contract test, `runtime/fleet-console/CLAUDE.md`, and the accent palette comment now describe identity as caption and chip title ink plus the minimap dot.
- Adds a `fleet-console` changelog fragment for the visible change.

## Test Plan
- [x] `vitest run tests/instrument-design-contract.test.ts` (98 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Isolated Console (console-e2e): chips with teal/crimson/no accent — active chip title reads the accent, idle reads the mix, no-accent chip keeps the neutral tier, `::before` spine is `content: none`, no page errors