### PR TITLE
fix(ai-gateway): drop tool regex patterns the Responses backend rejects

### DIFF
--- a/.changelog.d/codex-tool-pattern-re2.md
+++ b/.changelog.d/codex-tool-pattern-re2.md
@@ -1,0 +1,13 @@
+---
+branch: codex-tool-pattern-re2
+---
+
+### fleet-cli
+#### Fixed
+- Claude Code sessions on Codex (GPT) gateway models answer again. A tool whose JSON Schema carried a regular expression the Responses backend cannot compile, such as the lookahead and Unicode property patterns in Claude Code's Artifact tool, failed the entire request with a 400 before any reply arrived.
+  ko: Codex(GPT) 게이트웨이 모델의 Claude Code 세션이 다시 답변합니다. Claude Code Artifact 도구의 lookahead·유니코드 속성 패턴처럼 Responses 백엔드가 컴파일하지 못하는 정규식이 도구 JSON Schema에 있으면, 답변이 오기 전에 요청 전체가 400으로 실패했습니다.
+
+### fleet-console
+#### Fixed
+- Chat in an Operation running on a Codex (GPT) gateway model works again. A tool whose JSON Schema carried a regular expression the Responses backend cannot compile, such as the lookahead and Unicode property patterns in Claude Code's Artifact tool, failed the entire request with a 400, so the first message you sent never produced an answer.
+  ko: Codex(GPT) 게이트웨이 모델로 도는 Operation의 채팅이 다시 동작합니다. Claude Code Artifact 도구의 lookahead·유니코드 속성 패턴처럼 Responses 백엔드가 컴파일하지 못하는 정규식이 도구 JSON Schema에 있으면 요청 전체가 400으로 실패해, 처음 보낸 메시지가 끝내 답변을 받지 못했습니다.

--- a/packages/core-ai-gateway/src/upstream/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/codex/responses/adapter.ts
@@ -641,13 +641,18 @@ function forOpenAIResponsesBackend(
 
   const wireTools: OpenAIResponsesWireTool[] = (canonicalTools ?? []).map((tool) => {
     const { defer_loading: _deferLoading, ...wireTool } = tool;
+    // Runs on every tool, strict or not: the backend compiles `pattern` before it reads
+    // `strict`, so an unreadable one fails the request either way.
+    const parameters = re2SafeParameters(wireTool.parameters);
     // A schema outside strict mode's subset is rejected with a 400 that fails the whole
     // request, not just that tool, so an incompatible tool keeps its original schema and
     // forfeits the guarantee rather than taking every other tool down with it.
-    if (!strictCompatible(wireTool.parameters)) return wireTool;
+    if (!strictCompatible(parameters)) {
+      return parameters === wireTool.parameters ? wireTool : { ...wireTool, parameters };
+    }
     return {
       ...wireTool,
-      parameters: strictParameters(wireTool.parameters),
+      parameters: strictParameters(parameters),
       strict: true,
     };
   });
@@ -940,6 +945,62 @@ function usage(value: unknown): CanonicalUsage {
     ...(reasoningOutputTokens === undefined ? {} : { reasoning_output_tokens: reasoningOutputTokens }),
     ...(totalTokens === undefined ? {} : { total_tokens: totalTokens })
   };
+}
+
+/**
+ * `pattern` values the Responses backend cannot compile.
+ *
+ * It runs every function tool's `pattern` through RE2, which has neither lookaround nor
+ * Unicode property escapes, and refuses the request as a whole — `param: "tools"`, not the one
+ * tool — so a single unreadable pattern kills the turn before any output reaches the client.
+ * Measured 2026-09-09 against `gpt-6-astra`: `(?!…)` returns `regex lookaround is not
+ * supported` and `\p{…}` returns `is not a 'regex'`, both with and without `strict`, which is
+ * why the sanitizer runs ahead of the strict branch rather than inside it.
+ *
+ * Claude Code's `Artifact` tool carries five of them (`collection`, `doc_id`, `field`, and the
+ * two inside `writes`), so every Console turn on a Codex model died on its first message.
+ * `pattern` only advises the model about a value's shape and nothing downstream enforces it,
+ * so dropping the ones RE2 cannot read costs nothing observable — the same trade `strictSchema`
+ * already makes for `format`.
+ *
+ * `packages/core-ai-gateway/src/upstream/opencode-go/responses/adapter.ts` carries the same
+ * rule for the same wire contract; a change here belongs there too.
+ */
+const RE2_HOSTILE_PATTERN = /\(\?[=!<]|\\[pP]\{/u;
+
+function re2SafeParameters(schema: Record<string, unknown>): Record<string, unknown> {
+  const converted = re2SafeSchema(schema);
+  return isRecord(converted) ? converted : schema;
+}
+
+/**
+ * Drops the `pattern` constraints RE2 rejects and keeps every one it accepts.
+ *
+ * Walks the value generically rather than following JSON Schema keywords: the offending
+ * patterns sit wherever the tool author put them, and a keyword walk would have to be widened
+ * for each new nesting shape. Only a **string** under a `pattern` key is dropped, so a property
+ * that happens to be named `pattern` keeps its subschema. Unchanged nodes are returned by
+ * identity so a tool with no hostile pattern reaches the wire as the object it already was.
+ */
+function re2SafeSchema(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const next = value.map(re2SafeSchema);
+    return next.some((entry, index) => entry !== value[index]) ? next : value;
+  }
+  if (!isRecord(value)) return value;
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "pattern" && typeof entry === "string" && RE2_HOSTILE_PATTERN.test(entry)) {
+      changed = true;
+      continue;
+    }
+    const converted = re2SafeSchema(entry);
+    if (converted !== entry) changed = true;
+    next[key] = converted;
+  }
+  return changed ? next : value;
 }
 
 /**

--- a/packages/core-ai-gateway/src/upstream/opencode-go/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/opencode-go/responses/adapter.ts
@@ -214,13 +214,18 @@ function forOpenCodeGoResponsesBackend(
 
   const wireTools: OpenCodeResponsesWireTool[] = (canonicalTools ?? []).map((tool) => {
     const { defer_loading: _deferLoading, ...wireTool } = tool;
+    // Runs on every tool, strict or not: an OpenAI Responses backend compiles `pattern` before
+    // it reads `strict`, so an unreadable one fails the request either way.
+    const parameters = re2SafeParameters(wireTool.parameters);
     // A schema outside strict mode's subset is rejected with a 400 that fails the whole
     // request, not just that tool, so an incompatible tool keeps its original schema and
     // forfeits the guarantee rather than taking every other tool down with it.
-    if (!strictCompatible(wireTool.parameters)) return wireTool;
+    if (!strictCompatible(parameters)) {
+      return parameters === wireTool.parameters ? wireTool : { ...wireTool, parameters };
+    }
     return {
       ...wireTool,
-      parameters: strictParameters(wireTool.parameters),
+      parameters: strictParameters(parameters),
       strict: true,
     };
   });
@@ -441,6 +446,57 @@ function usage(value: unknown): CanonicalUsage {
     ...(reasoningOutputTokens === undefined ? {} : { reasoning_output_tokens: reasoningOutputTokens }),
     ...(totalTokens === undefined ? {} : { total_tokens: totalTokens })
   };
+}
+
+/**
+ * `pattern` values an OpenAI Responses backend cannot compile.
+ *
+ * Such a backend runs every function tool's `pattern` through RE2, which has neither lookaround
+ * nor Unicode property escapes, and refuses the request as a whole — `param: "tools"`, not the
+ * one tool. Claude Code's `Artifact` tool carries five of them, which is what took every Codex
+ * turn down at its first message. `pattern` only advises the model about a value's shape and
+ * nothing downstream enforces it, so dropping the ones RE2 cannot read costs nothing observable
+ * and is safe on a backend that would have accepted them.
+ *
+ * Measured against ChatGPT's Codex backend, not this one:
+ * `packages/core-ai-gateway/src/upstream/codex/responses/adapter.ts` holds the measurements and
+ * the same rule for the same wire contract; a change here belongs there too.
+ */
+const RE2_HOSTILE_PATTERN = /\(\?[=!<]|\\[pP]\{/u;
+
+function re2SafeParameters(schema: Record<string, unknown>): Record<string, unknown> {
+  const converted = re2SafeSchema(schema);
+  return isRecord(converted) ? converted : schema;
+}
+
+/**
+ * Drops the `pattern` constraints RE2 rejects and keeps every one it accepts.
+ *
+ * Walks the value generically rather than following JSON Schema keywords: the offending
+ * patterns sit wherever the tool author put them, and a keyword walk would have to be widened
+ * for each new nesting shape. Only a **string** under a `pattern` key is dropped, so a property
+ * that happens to be named `pattern` keeps its subschema. Unchanged nodes are returned by
+ * identity so a tool with no hostile pattern reaches the wire as the object it already was.
+ */
+function re2SafeSchema(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const next = value.map(re2SafeSchema);
+    return next.some((entry, index) => entry !== value[index]) ? next : value;
+  }
+  if (!isRecord(value)) return value;
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "pattern" && typeof entry === "string" && RE2_HOSTILE_PATTERN.test(entry)) {
+      changed = true;
+      continue;
+    }
+    const converted = re2SafeSchema(entry);
+    if (converted !== entry) changed = true;
+    next[key] = converted;
+  }
+  return changed ? next : value;
 }
 
 /**

--- a/packages/core-ai-gateway/tests/upstream/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/codex/responses/adapter.test.ts
@@ -115,6 +115,47 @@ describe("codex responses adapter", () => {
     expect(body).not.toHaveProperty("include");
   });
 
+  it("drops only the tool patterns the backend's regex engine rejects", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request({
+      tools: [{
+        type: "function",
+        name: "Artifact",
+        parameters: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            // Lookaround and Unicode property escapes: RE2 reads neither, and the backend
+            // refuses the whole request rather than the one tool.
+            field: { type: "string", pattern: "^(?!__.*__$)[^\\p{Cc}\\p{Cf}]{1,200}$" },
+            asset_id: { type: "string", pattern: "^[0-9a-f]{32}$" },
+            writes: {
+              type: "array",
+              items: {
+                type: "object",
+                additionalProperties: false,
+                properties: { doc_id: { type: "string", pattern: "^(?!\\.\\.?$)[A-Za-z0-9_-]{1,200}$" } },
+                required: ["doc_id"],
+              },
+            },
+          },
+          required: ["field", "asset_id", "writes"],
+        },
+      }],
+      tool_choice: "auto",
+    }), { apiKey: "k" });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      tools: Array<{ parameters: { properties: Record<string, Record<string, unknown>> } }>;
+    };
+    const properties = body.tools[0]!.parameters.properties;
+    expect(properties.field).not.toHaveProperty("pattern");
+    expect(properties.asset_id).toHaveProperty("pattern", "^[0-9a-f]{32}$");
+    expect(
+      (properties.writes!.items as { properties: Record<string, Record<string, unknown>> }).properties.doc_id,
+    ).not.toHaveProperty("pattern");
+  });
+
   it("does not retry UND_ERR_SOCKET after caller-visible output was yielded", async () => {
     const encoder = new TextEncoder();
     const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });


### PR DESCRIPTION
## Summary
- The ChatGPT Codex backend compiles every function tool's `pattern` with RE2 and refuses the whole request (`param: "tools"`) when it cannot read one. Claude Code's `Artifact` tool carries five such patterns (lookahead in `collection`/`doc_id`/`writes.*`, lookahead plus `\p{...}` in `field`), so every Console Operation on a Codex (GPT) gateway model died with `400 Invalid schema for function 'Artifact'` on its first message.
- Sanitize every tool's schema ahead of the strict branch and drop only the patterns RE2 rejects, keeping the ones it accepts. The refusal is independent of `strict`, so the old strict-only path never ran for `Artifact` at all. `pattern` only advises the model about a value's shape, which is the same trade `strictSchema` already makes for `format`.
- Apply the same rule to the opencode-go Responses adapter, which serves GPT models (`opencode--gpt-5.6-luna`) over the identical wire contract. That backend is not live-verified here; the change is inert on a backend that would have accepted the patterns.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (28 files, 193 tests) with a new adapter case asserting the hostile patterns are dropped and RE2-safe ones survive; verified the case fails on the unpatched adapter.
- [x] `pnpm typecheck`, `pnpm test` (full workspace), `pnpm check:core-boundary`, `pnpm check:localized-attributes`, `pnpm check:claude-agent-sdk-boundary`, `node --test scripts/*.test.mjs`, `node scripts/compile-changelog-fragments.mjs --check`.
- [x] Live: the real `Artifact` schema through an unpatched wire returns `400 ... is not a 'regex'`; the same schema through the patched gateway to the live Codex backend returns 200 and answers, with only the three RE2-safe patterns reaching the upstream body.