### PR TITLE
fix(console): move Quick Launch glass off the card root so popovers blur

### DIFF
--- a/.changelog.d/fix-quick-launch-popover-glass.md
+++ b/.changelog.d/fix-quick-launch-popover-glass.md
@@ -1,0 +1,8 @@
+---
+branch: fix/quick-launch-popover-glass
+---
+
+### fleet-console
+#### Fixed
+- Quick Launch `@` and `/` decks and the Theater/model popovers now blur the screen behind them like the chat view's command menu, instead of letting terminal text show through sharply.
+  ko: Quick Launch의 `@`·`/` 덱과 Theater/모델 팝오버가 채팅 뷰의 명령 메뉴처럼 뒤 화면을 흐리게 처리해, 터미널 글자가 선명하게 비치던 문제를 수정했습니다.

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -1533,6 +1533,8 @@ export function QuickLaunch() {
         onDrop={handleDrop}
         style={{ maxWidth: CARD_WIDTH_FALLBACK }}
       >
+        {/* 유리 재질 층 — 카드 루트에 두면 안쪽 팝오버의 blur가 죽는다(components.css 주석 참조). */}
+        <span className="quick-launch-glass" aria-hidden="true" />
         {/* 접힌 한 줄 — 물러난 바가 남기는 유일한 컨트롤이다. 초안 자취를 싣고, 누르면 펼쳐진다.
             접힌 동안 아래 컨트롤은 inert라 Tab이 닿지 않으므로 이 버튼이 되돌아오는 통로다. */}
         {pinned ? (

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -14097,15 +14097,11 @@ body[data-expanded-surface="true"] .operations-canvas .expanded-surface {
   max-width: 100%;
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-md);
-  /* 팝업 판독성 계약: pillar 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조). */
-  background:
-    linear-gradient(
-      color-mix(in oklch, var(--glass-tint-pillar) 92%, transparent),
-      color-mix(in oklch, var(--glass-tint-pillar) 92%, transparent)
-    ),
-    var(--glass-underlay);
-  -webkit-backdrop-filter: var(--glass-backdrop-strong);
-  backdrop-filter: var(--glass-backdrop-strong);
+  /* 유리는 루트가 아니라 자식 없는 .quick-launch-glass가 진다 — 루트 backdrop-filter는 backdrop root가
+     되어 안쪽 앵커 팝업(멘션 덱·명령 덱·theater/model 팝오버)의 blur가 카드 밖 화면을 샘플링하지
+     못하게 만든다(팝오버 뒤 코드가 선명하게 비치던 원인). ::before/::after는 ultracode 구슬·링이
+     쓰므로 전용 요소를 둔다(.operations-side-bar::before와 같은 계약). */
+  background: none;
   box-shadow: var(--shadow-floating);
   /* 고정 시 언포커스가 물러나는 깊이. 접힘과 한 동작으로 걸린다. */
   --quick-launch-idle-opacity: 0.55;
@@ -14117,6 +14113,25 @@ body[data-expanded-surface="true"] .operations-canvas .expanded-surface {
 
 .quick-launch-card:focus-visible {
   outline: none;
+}
+
+/* 팝업 판독성 계약: pillar 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조).
+   z:-1이라 카드가 스택 컨텍스트가 아닐 때는 오버레이 스크림 위·카드 내용 아래에, 고정(transform)으로
+   스택 컨텍스트가 되면 카드 최하층에 깔린다 — 어느 쪽이든 테두리·글자 아래다. */
+.quick-launch-glass {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      color-mix(in oklch, var(--glass-tint-pillar) 92%, transparent),
+      color-mix(in oklch, var(--glass-tint-pillar) 92%, transparent)
+    ),
+    var(--glass-underlay);
+  -webkit-backdrop-filter: var(--glass-backdrop-strong);
+  backdrop-filter: var(--glass-backdrop-strong);
+  pointer-events: none;
 }
 
 /* ── `ultracode` 무장 외곽 ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `.quick-launch-card` carried `backdrop-filter` on its root, making it a backdrop root; the `@`/`/` decks and Theater/model popovers anchored inside could only sample the card's own content, so terminal text behind them stayed sharp.
- Move tint, opaque underlay, and blur to a childless `.quick-launch-glass` layer (z:-1), same contract as `.operations-side-bar::before`; the root keeps border and shadow, and `::before`/`::after` remain with the ultracode bead and ring.
- Adds a `fleet-console` `Fixed` changelog fragment.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` and `typecheck`
- [x] Isolated Console (console-e2e): `/` and `@` decks compute `blur(24px) saturate(1.7)` and blur DOM content behind them, centered and pinned; no page errors
- [x] Console handoff: user confirmed blur over a live terminal