### PR TITLE
style(console): compact the GNB and native desktop title bars

### DIFF
--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -385,7 +385,7 @@
   --weight-medium: 600;
   --weight-bold: 700;
 
-  --chrome-band-height: 44px;
+  --chrome-band-height: 36px;
 
   /* 전면 오버레이 층 사다리 — 값이 아니라 순서가 계약이다: 공지·모달(overlay) < 라이트박스 <
      모드 커튼 < 온보딩 투어 < teardown(사라지는 콘솔보다 급한 화면은 없다). 번들이 달라도

--- a/runtime/fleet-console/core/host/desktop-contract.ts
+++ b/runtime/fleet-console/core/host/desktop-contract.ts
@@ -167,10 +167,10 @@ export const DESKTOP_THEME_EVENTS_PATH = "/api/v1/desktop/theme/events";
 export const DESKTOP_THEME_EVENT = "desktop:theme";
 
 const DESKTOP_TITLE_BAR_OVERLAYS: Readonly<Record<ConsoleThemeId, DesktopThemeSnapshot["titleBarOverlay"]>> = {
-  instrument: { color: "#03080e", symbolColor: "#989fa6", height: 43 },
-  maritime: { color: "#041729", symbolColor: "#c8c4b7", height: 43 },
-  carbon: { color: "#101215", symbolColor: "#bfc1c3", height: 43 },
-  whites: { color: "#f1f0ec", symbolColor: "#424038", height: 43 },
+  instrument: { color: "#03080e", symbolColor: "#989fa6", height: 35 },
+  maritime: { color: "#041729", symbolColor: "#c8c4b7", height: 35 },
+  carbon: { color: "#101215", symbolColor: "#bfc1c3", height: 35 },
+  whites: { color: "#f1f0ec", symbolColor: "#424038", height: 35 },
 };
 
 export function desktopThemeSnapshot(theme: ConsoleThemeId): DesktopThemeSnapshot {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2182,7 +2182,7 @@ describe("Instrument core design contract", () => {
     expect(app).not.toContain("GlobalNavigation");
     expect(layout).not.toContain("--console-gnb-height");
     expect(layout).not.toContain("is-focus-mode");
-    expect(theme).toContain("--chrome-band-height: 44px;");
+    expect(theme).toContain("--chrome-band-height: 36px;");
     expect(commandBand).toContain("<BrandHome />");
     expect(commandBand).toContain("<CommandBandSystemCluster />");
     expect(commandBand).toContain('className="command-band-button command-band-search"');

--- a/runtime/fleet-desktop/assets/entry/entry.css
+++ b/runtime/fleet-desktop/assets/entry/entry.css
@@ -19,7 +19,7 @@
   --coral: oklch(68% 0.13 25);
   --hairline: oklch(29% 0.018 245);
   --radius-xs: 6px;
-  --chrome-band-height: 44px;
+  --chrome-band-height: 36px;
   --font-display: "Fraunces Variable", "Fraunces", "Pretendard Variable", ui-serif, Georgia, serif;
   --font-body: "Manrope Variable", "Manrope", "Pretendard Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   --font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;

--- a/runtime/fleet-desktop/assets/entry/entry.css
+++ b/runtime/fleet-desktop/assets/entry/entry.css
@@ -30,7 +30,7 @@
 
 * { box-sizing: border-box; }
 html, body { height: 100%; margin: 0; }
-body { display: grid; grid-template-rows: 44px 1fr auto; background: var(--ink-abyss); color: var(--ink-spectral); font-family: var(--font-body); }
+body { display: grid; grid-template-rows: var(--chrome-band-height) 1fr auto; background: var(--ink-abyss); color: var(--ink-spectral); font-family: var(--font-body); }
 .chrome-band { height: var(--chrome-band-height); display: flex; align-items: center; padding: 0 16px; border-bottom: 1px solid var(--hairline); background: var(--ink-deep); -webkit-app-region: drag; }
 .brand { display: flex; align-items: baseline; gap: 8px; margin-left: 88px; }
 .brand strong { color: var(--ink-pearl); font-family: var(--font-display); font-size: 17px; font-weight: 600; }

--- a/runtime/fleet-desktop/src/title-bar-overlay-refresh.ts
+++ b/runtime/fleet-desktop/src/title-bar-overlay-refresh.ts
@@ -8,7 +8,7 @@ import type { BrowserWindow, Display, Rectangle } from "electron";
  * 쓴다 — 그래서 창이 배율이 다른 모니터에 놓일 때마다 오버레이를 다시 적용하는 것으로
  * 스테일 배치를 치유한다.
  *
- * 높이는 페이지 줌을 따라간다: Command Band(CSS 44px)는 줌에 비례해 커지고 작아지지만
+ * 높이는 페이지 줌을 따라간다: Command Band(CSS 36px)는 줌에 비례해 커지고 작아지지만
  * 네이티브 오버레이 DIP 높이는 줌과 무관하므로, `round(height × 줌)`을 적용해야 어느
  * 줌에서든 스트립이 밴드의 실제 크기와 정합한다. 줌 1에서는 원값 그대로다.
  */

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -24,7 +24,7 @@ export interface WindowPolicy {
 const DESKTOP_WINDOW_TITLE = "Fleet Console";
 
 const CANVAS_FAR_BACKGROUND_COLOR = "#010204";
-export const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#03080e", symbolColor: "#989fa6", height: 43 } as const;
+export const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#03080e", symbolColor: "#989fa6", height: 35 } as const;
 
 export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, options: SecureWindowOptions): BrowserWindow {
   const windowOptions: BrowserWindowConstructorOptions = {
@@ -35,8 +35,8 @@ export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, opti
     minWidth: 900,
     minHeight: 560,
     ...(options.platform !== "darwin" ? { autoHideMenuBar: false } : {}),
-    // Windows 오버레이 43px + Command Band 하단 divider 1px가 클라이언트 --chrome-band-height: 44px를 채운다. macOS 88px 인셋과 함께 변경 시 양쪽을 동기화한다.
-    ...(options.platform === "darwin" ? { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 14 } } : {}),
+    // Windows 오버레이 35px + Command Band 하단 divider 1px가 클라이언트 --chrome-band-height: 36px를 채운다. macOS 88px 인셋과 함께 변경 시 양쪽을 동기화한다.
+    ...(options.platform === "darwin" ? { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 10 } } : {}),
     ...(options.platform === "win32" ? { titleBarStyle: "hidden", titleBarOverlay: INITIAL_WINDOWS_TITLE_BAR_OVERLAY } : {}),
     webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true },
   };

--- a/runtime/fleet-desktop/tests/window-policy.test.ts
+++ b/runtime/fleet-desktop/tests/window-policy.test.ts
@@ -39,7 +39,7 @@ describe("secure window policy", () => {
   it("creates a renderer without Node or preload privilege", () => {
     const Ctor = vi.fn();
     createSecureWindow(Ctor as never, { iconPath: "/assets/icon.png", platform: "darwin" });
-    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 14 }, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
+    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 10 }, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
   });
 
   it("allows only exact-origin Console routes", () => {


### PR DESCRIPTION
## Summary
- GNB 높이를 44px에서 36px로 줄이고 Desktop 시작 화면도 맞췄습니다.
- Windows 네이티브 오버레이 높이를 43px에서 35px로 줄이고 macOS 신호등을 위로 4px 정렬했습니다.
- 사용자 결정에 따라 네이티브 버튼과 가로 예약 폭을 유지합니다. 커스텀 창 버튼·IPC 추가는 제외합니다.

## Test Plan
- [x] Console 및 Desktop build
- [x] Desktop typecheck 및 119 tests
- [x] Console instrument-design-contract 98 tests
- [x] 실제 브라우저에서 GNB 36px, 도움말 메뉴 열기/Escape, reload 및 런타임 오류 없음 확인
- [x] 격리 macOS Desktop 기동 및 소유 Console HTTP 200 확인, 사용자 인도 후 종료 확인
- [ ] macOS 네이티브 시각·드래그 검증: 화면 기록/손쉬운 사용 권한 부재. 기동 로그의 GPU overlay 오류는 시각 영향 미확인.
- [ ] Windows 네이티브 실기 검증: Windows 환경 없음

## Product Context Record
- 요청: Codex처럼 GNB와 OS 창 버튼을 컴팩트하게 정렬.
- 확정 범위: GNB 36px, Windows overlay 35px, macOS trafficLightPosition y=10. 기존 24px 앱 컨트롤과 드래그·창 제어 동작 유지.
- 명시적 결정: Electron 43 네이티브 버튼 폭은 높이와 독립적이며 공개 API로 조절 불가. 사용자가 '네이티브 유지, 높이만 축소'를 선택했습니다.
- 제외: Windows 버튼 가로 폭 축소, 커스텀 창 버튼, 새 preload/IPC, 색상·정보 구조 개편.
- REVIEW_BASE_HEAD: 5eafb9402 (최초 push; 리뷰 수정 전)
