### PR TITLE
fix(terminal): include fork in built-in agent opt-outs

### DIFF
--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -1015,6 +1015,8 @@ function ClaudeBuiltInAgentsRows({ disabled, saving, onChange }: {
   }, [read]);
 
   const disabledSet = new Set(disabled);
+  // 현재 로스터에서 빠진 제외 항목도 사용자가 다시 허용할 수 있어야 한다.
+  const agentNames = [...new Set([...(roster?.agents ?? []), ...disabled])];
   const toggle = (name: string, enabled: boolean) => {
     // 실행 조건이나 CLI 버전 때문에 로스터에서 빠진 Agent의 제외 설정도 유지한다.
     const next = disabled.filter((entry) => entry !== name);
@@ -1033,12 +1035,12 @@ function ClaudeBuiltInAgentsRows({ disabled, saving, onChange }: {
         {t(roster.error === "cli_not_found" ? "terminal.settings.builtInAgentsNotFound" : "terminal.settings.builtInAgentsFailed")}
       </p>
     );
-  } else if (roster.agents.length === 0) {
+  } else if (agentNames.length === 0) {
     body = <p className="global-settings-help">{t("terminal.settings.builtInAgentsEmpty")}</p>;
   } else {
     body = (
       <ul className="claude-agent-list" aria-label={t("terminal.settings.builtInAgentsTitle")}>
-        {roster.agents.map((name) => {
+        {agentNames.map((name) => {
           const labelId = `claude-agent-${name}-label`;
           return (
             <li key={name} className="global-settings-row claude-agent-row" role="group" aria-labelledby={labelId}>

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -1016,9 +1016,8 @@ function ClaudeBuiltInAgentsRows({ disabled, saving, onChange }: {
 
   const disabledSet = new Set(disabled);
   const toggle = (name: string, enabled: boolean) => {
-    // 로스터에 있는 이름만 남긴다 — 사라진 옵트아웃은 여기서 함께 걷힌다.
-    const known = new Set(roster?.agents ?? []);
-    const next = disabled.filter((entry) => known.has(entry) && entry !== name);
+    // 실행 조건이나 CLI 버전 때문에 로스터에서 빠진 Agent의 제외 설정도 유지한다.
+    const next = disabled.filter((entry) => entry !== name);
     if (!enabled) next.push(name);
     onChange(next);
   };

--- a/runtime/fleet-plugins/terminal/server/agent-api/claude-builtin-agents.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/claude-builtin-agents.ts
@@ -5,6 +5,7 @@
 // `Plan`, `statusline-setup`; 진입점·환경 변수·정책에 따라 달라진다), 문서화된 열거 API는 없다. 유일하게
 // 안정된 표면은 `--output-format stream-json`의 첫 줄인 `system/init` 메시지의 `agents` 배열이다.
 // 그래서 설치된 CLI를 격리 환경에서 잠깐 띄워 그 첫 줄만 읽고 바로 죽인다.
+// 단, init 로스터에 없는 특수 타입 fork는 제외 설정용 선택지로 별도 보완한다.
 //
 // 격리의 이유: 사용자의 Claude 홈(`CLAUDE_CONFIG_DIR`)과 프로젝트 디렉터리를 읽으면 사용자
 // 정의 Agent와 플러그인 Agent가 같은 배열에 섞여 내장을 가릴 수 없다. 빈 임시 홈과 빈 임시
@@ -89,7 +90,9 @@ export function createClaudeBuiltInAgentProbe(deps: ClaudeBuiltInAgentProbeDeps)
     let snapshot: ClaudeBuiltInAgentsSnapshot;
     try {
       const payload = await runProbe(resolved, deps.env ?? process.env);
-      snapshot = { available: true, agents: payload.agents, version: payload.version, error: null };
+      // fork는 init 로스터 밖에서 추가되는 특수 Agent지만 Agent(fork) deny는 지원한다.
+      const agents = [...new Set([...payload.agents, "fork"])];
+      snapshot = { available: true, agents, version: payload.version, error: null };
     } catch {
       snapshot = { available: false, agents: [], version: null, error: "probe_failed" };
     }


### PR DESCRIPTION
## Summary
- Supplement the probed built-in agent roster with the special fork agent, which Claude Code does not enumerate in system/init.agents.
- Preserve existing opt-outs when an agent is absent from the current roster.

## Test Plan
- [x] Console production build, including bundled plugins and distribution gates.
- [x] Terminal TypeScript build.
- [x] Terminal settings route tests: 5 passed.
- [x] Real Console browser: fork checkbox is visible.
- [x] Fully isolated Fleet data root: add Codex GPT-5.6-Luna 272K and expose it in the launch menu.
- [ ] Live host fork enabled/disabled acceptance: blocked. The Luna PTY Operation exited before a captured provider request; a resume attempt also exited without diagnostic output. No fork success or denial has been verified.
- [x] Real browser: preserving out-of-roster Explore while disabling fork, then clearing Explore and fork independently; stored lists [Explore, fork] -> [fork] -> []. No browser errors/rejections.

Live provider acceptance remains blocked as documented above; local builds, settings tests, and changed UI behavior are verified. Owned browser and Console processes were cleaned up. No live-host success is claimed.
