### PR TITLE
fix(repository): keep staging sections at full height inside the changes list

### DIFF
--- a/.changelog.d/repository-staging-section-shrink.md
+++ b/.changelog.d/repository-staging-section-shrink.md
@@ -1,0 +1,8 @@
+---
+branch: repository-staging-section-shrink
+---
+
+### fleet-console
+#### Fixed
+- Keep the Repository changes list from drawing the staged section over a long unstaged list; each section now holds its full height inside the scrolling list.
+  ko: Repository 변경 탭에서 미스테이지 목록이 길 때 스테이지 섹션이 목록 위에 겹쳐 그려지던 문제를 바로잡았습니다. 이제 각 섹션이 스크롤 목록 안에서 제 높이를 지킵니다.

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1560,7 +1560,9 @@
   .repository-staging-root.has-hunk > .repository-hunk-pane { border-left: 0; border-top: 1px solid var(--surface-rim); }
 }
 .repository-staging-lists { display: flex; flex-direction: column; min-height: 0; overflow-y: auto; }
-.repository-staging-section { display: flex; flex-direction: column; min-height: 0; }
+/* 섹션은 목록 스크롤 컨테이너 안에서 제 높이를 지켜야 한다. 축소를 허용하면 두 섹션이 컨테이너 높이에
+   맞춰 눌리고, 긴 미스테이지 목록이 넘쳐 흐른 위로 스테이지 헤더가 겹쳐 그려진다(362개 변경 재현). */
+.repository-staging-section { display: flex; flex-direction: column; flex: none; }
 .repository-staging-head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- `.repository-staging-section` allowed flex shrink with `min-height: 0`, so with many unstaged files both sections compressed to the container height, the unstaged rows overflowed, and the sticky "Staged" head was painted in the middle of the unstaged list.
- Set the section to `flex: none` so each section keeps its full height inside the scrolling list; the staged section now follows the unstaged list.
- Add a `fleet-console` Fixed changelog fragment.

## Test Plan
- [x] Built Console in the worktree and served an isolated instance; verified the served CSS bundle contains the change.
- [x] Registered a fixture repo with 68 changes; unstaged section measured at its full 1812px height with the staged section placed after it. Mid-scroll and bottom screenshots show no overlap.
- [x] Injected the previous rule at runtime to confirm the shrink mechanism (sections collapse to 254px / 11px).
- [x] No page errors or rejections; owned browser session and isolated Console cleaned up.