### PR TITLE
fix(ai-gateway): disable Astra async tools by default

### DIFF
--- a/packages/core-ai-gateway/src/downstream/harness/claude-code/profile.ts
+++ b/packages/core-ai-gateway/src/downstream/harness/claude-code/profile.ts
@@ -63,7 +63,7 @@ export const claudeCodeHarnessProfile: GatewayHarnessProfile = {
   ),
   retryableStatus: claudeRetryableUpstreamStatus,
   transientErrorStatus: GATEWAY_TRANSIENT_ERROR_STATUS,
-  asyncToolNames: ["Read", "Grep", "Glob"],
+  asyncToolNames: [],
 };
 
 export { ANTHROPIC_CREDENTIAL_PREFIX };

--- a/packages/core-ai-gateway/tests/router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/router/routes.test.ts
@@ -153,7 +153,7 @@ describe("oversized skill payloads", () => {
 // 전체를 받아 주면, raw id를 아는 호출자가 사용자가 끈 모델로 그 구독을 그대로 쓴다.
 
 describe("Astra asynchronous tools", () => {
-  it("opts streaming read-only calls into async without widening caller execution authority", async () => {
+  it("keeps async tools disabled by default and preserves caller parallel-tool control", async () => {
     const bodies: Array<Record<string, any>> = [];
     const fetchMock = vi.fn<typeof fetch>(async (_url, init) => {
       bodies.push(JSON.parse(String(init?.body)));
@@ -179,9 +179,7 @@ describe("Astra asynchronous tools", () => {
         await router.handle(ctx({ res, token: ANTHROPIC_CRED, rawBody }));
         expect(res.status).toBe(200);
       }
-      expect(bodies[0]?.tools.filter((tool: { async?: boolean }) => tool.async).map((tool: { name: string }) => tool.name))
-        .toEqual(["Read", "Grep", "Glob"]);
-      for (const body of bodies.slice(1)) {
+      for (const body of bodies) {
         expect(body.tools.every((tool: { async?: boolean }) => tool.async === undefined)).toBe(true);
       }
       expect(bodies[0]?.store).toBe(false);


### PR DESCRIPTION
## Summary
- Claude Code의 기본 `asyncToolNames` 목록을 비워 Astra의 비동기 도구 실행을 기본 비활성화합니다.
- Astra 어댑터·라우터의 비동기 실행 기능과 명시적 opt-in 경로는 유지합니다. 일반 `parallel_tool_calls`의 백엔드 기본값 및 호출자 제어는 변경하지 않습니다.
- 기존 라우터 수용 테스트를 새 기본값에 맞춥니다. 새 설정 UI나 환경 변수는 추가하지 않습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 28 files, 193 tests passed
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `git diff --check`
- 실제 유료 모델 호출 및 UI 검증은 수행하지 않았습니다. UI 변경은 없습니다.