### PR TITLE
fix(settings): isolate saves and prevent settings flicker

### DIFF
--- a/runtime/fleet-console/core/client/src/global-settings-store.ts
+++ b/runtime/fleet-console/core/client/src/global-settings-store.ts
@@ -9,8 +9,7 @@ interface GlobalSettingsStoreState {
   readonly loadStatus: "pending" | "ready" | "failed";
   readonly loading: boolean;
   readonly state: GlobalSettingsState | null;
-  /** 지금 저장 중인 필드 중 하나. 아무것도 저장 중이 아니면 null. */
-  readonly savingField: GlobalSettingsField | null;
+  readonly savingFields: ReadonlySet<GlobalSettingsField>;
   /** 아직 해소되지 않은 저장 실패 중 가장 최근 것. 해소되면 사라진다. */
   readonly error: string | null;
 }
@@ -33,9 +32,10 @@ let snapshot: GlobalSettingsStoreState = {
   loadStatus: "pending",
   loading: false,
   state: null,
-  savingField: null,
+  savingFields: new Set(),
   error: null,
 };
+let loadGeneration = 0;
 
 export function useGlobalSettingsStore(): GlobalSettingsStoreState {
   return useSyncExternalStore(subscribe, getGlobalSettingsStoreState, getGlobalSettingsStoreState);
@@ -46,6 +46,7 @@ export function getGlobalSettingsStoreState(): GlobalSettingsStoreState {
 }
 
 export function hydrateGlobalSettings(state: GlobalSettingsState): void {
+  loadGeneration += 1;
   // 서버가 권위 있는 상태를 다시 준 순간, 그 전의 저장 실패는 더 이상 화면이 말할 사실이
   // 아니다. 여기서 거두지 않으면 다음에 성공하는 저장이 이미 사라진 경고를 되살린다.
   failedFields.clear();
@@ -71,14 +72,20 @@ export function subscribe(listener: Listener): () => void {
 }
 
 export async function loadGlobalSettings(signal?: AbortSignal): Promise<void> {
-  setSnapshot({ loading: true, error: null });
+  // 저장 중인 값은 GET보다 최신이다. 저장 전 출발한 읽기도 세대로 걸러낸다.
+  if (signal?.aborted || savingFields.size > 0) return;
+  const generation = ++loadGeneration;
+  setSnapshot({ loading: true });
   try {
     const state = await fetchGlobalSettingsState(signal);
+    if (signal?.aborted || generation !== loadGeneration) return;
     failedFields.clear();
-    setSnapshot({ loadStatus: "ready", loading: false, state, error: null });
+    setSnapshot({ loadStatus: "ready", state, error: null });
   } catch (error) {
-    if (signal?.aborted) return;
-    setSnapshot({ loadStatus: "failed", loading: false, error: toErrorMessage(error) });
+    if (signal?.aborted || generation !== loadGeneration) return;
+    setSnapshot({ loadStatus: "failed", error: toErrorMessage(error) });
+  } finally {
+    if (generation === loadGeneration) setSnapshot({ loading: false });
   }
 }
 
@@ -86,12 +93,13 @@ export async function setGlobalSettingsField<Field extends GlobalSettingsField>(
   // 같은 필드에 대한 겹친 저장만 막는다. 다른 필드는 서로를 기다릴 이유가 없고, 기다리게 하면
   // 그 사이 눌린 설정이 아무 말 없이 버려진다.
   if (savingFields.has(field)) return false;
+  loadGeneration += 1;
   const previousValue = snapshot.state ? snapshot.state[field] : undefined;
   const optimisticState = snapshot.state ? { ...snapshot.state, [field]: value } as GlobalSettingsState : null;
   savingFields.add(field);
   // 이 필드를 다시 시도하는 것이므로 이 필드의 지난 실패만 거둔다.
   failedFields.delete(field);
-  setSnapshot({ state: optimisticState, savingField: field, error: currentError() });
+  setSnapshot({ state: optimisticState, loading: false, error: currentError() });
   try {
     const result = await updateGlobalSettings({ [field]: value });
     savingFields.delete(field);
@@ -101,7 +109,7 @@ export async function setGlobalSettingsField<Field extends GlobalSettingsField>(
       ? { ...snapshot.state, [field]: result.state[field] } as GlobalSettingsState
       : result.state;
     failedFields.delete(field);
-    setSnapshot({ state: merged, savingField: anySavingField(), error: currentError() });
+    setSnapshot({ state: merged, error: currentError() });
     return true;
   } catch (error) {
     savingFields.delete(field);
@@ -110,14 +118,9 @@ export async function setGlobalSettingsField<Field extends GlobalSettingsField>(
       ? { ...snapshot.state, [field]: previousValue } as GlobalSettingsState
       : snapshot.state;
     failedFields.set(field, toErrorMessage(error));
-    setSnapshot({ state: reverted, savingField: anySavingField(), error: currentError() });
+    setSnapshot({ state: reverted, error: currentError() });
     return false;
   }
-}
-
-function anySavingField(): GlobalSettingsField | null {
-  for (const field of savingFields) return field;
-  return null;
 }
 
 /** 해소되지 않은 실패 중 가장 최근 것. 하나도 없으면 null이라 화면이 조용해진다. */
@@ -128,7 +131,7 @@ function currentError(): string | null {
 }
 
 function setSnapshot(patch: Partial<GlobalSettingsStoreState>): void {
-  snapshot = { ...snapshot, ...patch };
+  snapshot = { ...snapshot, ...patch, savingFields: new Set(savingFields) };
   for (const listener of listeners) listener();
 }
 

--- a/runtime/fleet-console/core/client/src/mobile/mobile-settings-page.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/mobile-settings-page.tsx
@@ -50,7 +50,7 @@ interface MobileSettingsLocationState {
 export function MobileSettingsPage() {
   const settings = useGlobalSettingsStore();
   const state = settings.state;
-  const saving = settings.savingField !== null;
+  const saving = settings.savingFields.size > 0;
   const registry = usePluginRegistry();
   const locale = useConsoleLocale();
   const t = useT();
@@ -105,7 +105,7 @@ export function MobileSettingsPage() {
         <div className="mobile-settings-scroll">
           <div className="mobile-settings-detail">
             {settings.error !== null ? <p className="global-settings-error" role="alert">{settings.error}</p> : null}
-            {renderSettingsSection(active.id, state, saving, pluginSections, t)}
+            {renderSettingsSection(active.id, state, settings.savingFields, pluginSections, t)}
           </div>
         </div>
       </section>

--- a/runtime/fleet-console/core/client/src/settings/sections.tsx
+++ b/runtime/fleet-console/core/client/src/settings/sections.tsx
@@ -14,7 +14,7 @@ import { SettingsHelp } from "../components/settings-help.js";
 import { ExperimentsSection } from "./experiments-section.js";
 import { PairDeviceDialog } from "../components/pair-device-dialog.js";
 import { createRemoteAccessLink, fetchRemoteAccessStatus, revokeRemoteAccessDevice, revokeRemoteAccessLink, revokeRemoteAccessSession, rotateRemoteIdentity } from "../global-settings-api.js";
-import { getGlobalSettingsStoreState, setGlobalSettingsField } from "../global-settings-store.js";
+import { isSavingGlobalSettingsField, setGlobalSettingsField, type GlobalSettingsField } from "../global-settings-store.js";
 import { renderMessage, useT, type CoreMessageKey } from "../i18n/index.js";
 import { isDesktopShell } from "../desktop-shell.js";
 import { forgetRemoteHost, probeRemoteHost, refreshRemoteHosts, renameRemoteHost, useRemoteHosts, type RemoteHost, type RemoteHostReach } from "../remote-hosts.js";
@@ -211,7 +211,7 @@ export function PluginSettingsSectionBody({ render }: { readonly render: () => R
   return <>{render()}</>;
 }
 
-export function renderSettingsSection(sectionId: SettingsSectionId, state: GlobalSettingsState | null, saving: boolean, pluginSections: readonly PluginSettingsNavItem[], t: T, options?: {
+export function renderSettingsSection(sectionId: SettingsSectionId, state: GlobalSettingsState | null, saving: ReadonlySet<GlobalSettingsField>, pluginSections: readonly PluginSettingsNavItem[], t: T, options?: {
   /** 데스크톱 페인이 테마 카드에 덧세우는 행(우측 사이드바 불투명도) — 레일 없는 모바일은 넘기지 않는다. */
   readonly themeCardExtras?: ReactNode;
 }) {
@@ -227,22 +227,22 @@ export function renderSettingsSection(sectionId: SettingsSectionId, state: Globa
     case "appearance":
       return (
         <>
-          {state === null ? null : <LanguageCard state={state} saving={saving} />}
+          {state === null ? null : <LanguageCard state={state} saving={saving.has("language")} />}
           <ThemeCard state={state} saving={saving} extras={options?.themeCardExtras} />
-          <TypographyCard state={state} saving={saving} />
+          <TypographyCard state={state} saving={saving.has("uiFont")} />
         </>
       );
     // 언어는 겉모습에 품겨 있다 — 주소로 직접 들어온 옛 링크만 이 가지를 탄다.
     case "language":
       if (state === null) return <p className="global-settings-help">{t("settings.general.loading")}</p>;
-      return <LanguageCard state={state} saving={saving} />;
+      return <LanguageCard state={state} saving={saving.has("language")} />;
     case "connectivity":
       if (state === null) return <p className="global-settings-help">{t("settings.general.loading")}</p>;
       return (
         <>
-          <ConsolePortCard state={state} saving={saving} />
+          <ConsolePortCard state={state} saving={saving.has("consolePortMode") || saving.has("consoleStaticPort")} />
           {/* 목록에서 뺀 것과 별개로 경로도 막는다 — 주소로 직접 들어오는 길이 남으면 숨긴 것이 아니다. */}
-          {state.remoteAccess === undefined ? null : <RemoteAccessSection remote={state.remoteAccess} saving={saving} />}
+          {state.remoteAccess === undefined ? null : <RemoteAccessSection remote={state.remoteAccess} saving={saving.has("remoteAccess")} />}
         </>
       );
     case "advanced":
@@ -251,10 +251,10 @@ export function renderSettingsSection(sectionId: SettingsSectionId, state: Globa
       if (state === null) return <p className="global-settings-help">{t("settings.general.loading")}</p>;
       return (
         <>
-          <ExperimentsSection state={state} saving={saving} />
+          <ExperimentsSection state={state} saving={saving.has("experiments")} />
           {renderEmbeddedPluginSections(pluginSections, t)}
-          <ConsolePortCard state={state} saving={saving} />
-          {state.remoteAccess === undefined ? null : <RemoteAccessSection remote={state.remoteAccess} saving={saving} />}
+          <ConsolePortCard state={state} saving={saving.has("consolePortMode") || saving.has("consoleStaticPort")} />
+          {state.remoteAccess === undefined ? null : <RemoteAccessSection remote={state.remoteAccess} saving={saving.has("remoteAccess")} />}
         </>
       );
   }
@@ -304,7 +304,7 @@ export function ThemeCard({
   extras,
 }: {
   readonly state: GlobalSettingsState | null;
-  readonly saving: boolean;
+  readonly saving: ReadonlySet<GlobalSettingsField>;
   /** 비포커스 패널 흐리기 아래에 서는 추가 행 — 데스크톱 전용 크롬 재질 취향(좌·우 사이드바)이 들어온다. */
   readonly extras?: ReactNode;
 }) {
@@ -312,7 +312,7 @@ export function ThemeCard({
   const themes = buildThemeOptions(t);
   const activeTheme = state?.theme ?? "instrument";
   const selectTheme = (theme: ThemeId) => {
-    if (getGlobalSettingsStoreState().savingField !== null) return;
+    if (isSavingGlobalSettingsField("theme")) return;
     const previousTheme = activeTheme;
     setActiveTheme(theme);
     void setGlobalSettingsField("theme", theme).then((saved) => {
@@ -380,7 +380,7 @@ export function ThemeCard({
                     type="button"
                     aria-pressed={isActive}
                     className={`theme-card ${isActive ? "is-active" : ""}`}
-                    disabled={saving}
+                    disabled={saving.has("theme") || state === null}
                     onClick={() => selectTheme(theme.id)}
                   >
                     <span className="theme-card-swatch" aria-hidden="true">
@@ -409,7 +409,7 @@ export function ThemeCard({
             </div>
             <SettingsToggle
               checked={liquidGlass}
-              disabled={saving || state === null || lightTheme}
+              disabled={saving.has("liquidGlass") || state === null || lightTheme}
               ariaLabel={t("settings.theme.liquidGlass")}
               onChange={toggleLiquidGlass}
             />
@@ -431,7 +431,7 @@ export function ThemeCard({
               min={UNFOCUSED_PANEL_FADE_MIN}
               max={UNFOCUSED_PANEL_FADE_MAX}
               step={5}
-              disabled={saving || state === null}
+              disabled={saving.has("unfocusedPanelFade") || state === null}
               label={t("settings.theme.panelFade")}
               formatValue={(value) => `${value}%`}
               decreaseLabel={t("settings.slider.decrease", { title: t("settings.theme.panelFade") })}
@@ -487,7 +487,7 @@ export function TypographyCard({
   }, [t]);
 
   const saveUiFont = (uiFont: UiFontSettings) => {
-    if (getGlobalSettingsStoreState().savingField !== null) return;
+    if (isSavingGlobalSettingsField("uiFont")) return;
     const previousUiFont = activeUiFont;
     setActiveUiFont(uiFont);
     void setGlobalSettingsField("uiFont", uiFont).then((saved) => {

--- a/runtime/fleet-console/core/client/src/settings/settings-pane.tsx
+++ b/runtime/fleet-console/core/client/src/settings/settings-pane.tsx
@@ -179,7 +179,7 @@ function SettingsPaneBody({ ctx }: { readonly ctx: PaneContext }) {
   const registry = usePluginRegistry();
   const settings = useGlobalSettingsStore();
   const state = settings.state;
-  const saving = settings.savingField !== null;
+  const saving = settings.savingFields;
   const [query, setQuery] = useState("");
 
   useEffect(() => {

--- a/runtime/fleet-console/tests/global-settings-overlapping-saves.test.ts
+++ b/runtime/fleet-console/tests/global-settings-overlapping-saves.test.ts
@@ -95,6 +95,25 @@ describe("overlapping global settings saves", () => {
     expect(store.getGlobalSettingsStoreState().error).toBeNull();
   });
 
+  it("does not let a read started before a save restore the old value", async () => {
+    const api = await import("../core/client/src/global-settings-api.js");
+    let resolveRead!: (state: GlobalSettingsState) => void;
+    vi.mocked(api.fetchGlobalSettingsState).mockImplementationOnce(() => new Promise((resolve) => { resolveRead = resolve; }));
+    const store = await import("../core/client/src/global-settings-store.js");
+    store.hydrateGlobalSettings(BASE);
+    const reading = store.loadGlobalSettings();
+    const saving = store.setGlobalSettingsField("language", "ko");
+    expect(store.getGlobalSettingsStoreState().savingFields.has("language")).toBe(true);
+    expect(store.getGlobalSettingsStoreState().savingFields.has("theme")).toBe(false);
+    deferred.get("language")!.resolve({ state: { ...BASE, language: "ko" } });
+    await saving;
+    resolveRead(BASE);
+    await reading;
+    expect(store.getGlobalSettingsStoreState().state?.language).toBe("ko");
+    expect(store.getGlobalSettingsStoreState().loading).toBe(false);
+    expect(store.getGlobalSettingsStoreState().savingFields.size).toBe(0);
+  });
+
   it("still refuses a second write to the same field while one is in flight", async () => {
     const store = await import("../core/client/src/global-settings-store.js");
     store.hydrateGlobalSettings(BASE);

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -881,7 +881,16 @@ function SettingsHelp({ title, id, children }: {
   );
 }
 
+function useLoadSystemPromptSettings() {
+  React.useEffect(() => {
+    const controller = new AbortController();
+    void loadSystemPromptSettings(controller.signal);
+    return () => controller.abort();
+  }, []);
+}
+
 function HarnessSection() {
+  useLoadSystemPromptSettings();
   // 카드를 Fragment로 직접 반환한다 — 간격은 호스트의 .global-settings-detail이 진다.
   return (
     <>
@@ -901,13 +910,7 @@ function ClaudeCodeHarnessCard() {
   const t = getT(useTerminalLocale());
   const settings = useSystemPromptSettingsStore();
   const state = settings.state;
-  const saving = settings.savingField !== null;
-
-  React.useEffect(() => {
-    const controller = new AbortController();
-    void loadSystemPromptSettings(controller.signal);
-    return () => controller.abort();
-  }, []);
+  const saving = settings.savingFields;
 
   return (
     <section className="global-settings-card" aria-label={t("terminal.settings.harnessClaudeCode")}>
@@ -939,7 +942,7 @@ function ClaudeCodeHarnessCard() {
             {/* 행 제목이 뜻을 말하므로 스위치 옆에 "켬/끔" 글자를 따로 세우지 않는다 — Settings의 다른 스위치와 같다. */}
             <SettingsToggle
               checked={state.claudeCodeSkipPermissions}
-              disabled={saving}
+              disabled={saving.has("claudeCodeSkipPermissions")}
               ariaLabel={t("terminal.settings.skipPermissionsTitle")}
               onChange={(next) => void setSystemPromptSettingsField("claudeCodeSkipPermissions", next)}
             />
@@ -954,7 +957,7 @@ function ClaudeCodeHarnessCard() {
             <Select
               aria-labelledby="claude-code-system-prompt-label"
               value={state.claudeCodeSystemPrompt}
-              disabled={saving}
+              disabled={saving.has("claudeCodeSystemPrompt")}
               options={[
                 { value: "on", label: t("terminal.settings.claudeSystemPromptOn") },
                 { value: "off", label: t("terminal.settings.claudeSystemPromptOff") },
@@ -967,7 +970,7 @@ function ClaudeCodeHarnessCard() {
           </div>
           <ClaudeBuiltInAgentsRows
             disabled={state.claudeCodeDisabledAgents}
-            saving={saving}
+            saving={saving.has("claudeCodeDisabledAgents")}
             onChange={(next) => void setSystemPromptSettingsField("claudeCodeDisabledAgents", next)}
           />
         </>
@@ -1129,13 +1132,7 @@ function AgentSessionsSettingsCard() {
   const t = getT(useTerminalLocale());
   const settings = useSystemPromptSettingsStore();
   const state = settings.state;
-  const saving = settings.savingField !== null;
-
-  React.useEffect(() => {
-    const controller = new AbortController();
-    void loadSystemPromptSettings(controller.signal);
-    return () => controller.abort();
-  }, []);
+  const saving = settings.savingFields;
 
   const selectValue = state?.agentIdleDormantMinutes === null
     ? "off"
@@ -1180,7 +1177,7 @@ function AgentSessionsSettingsCard() {
           <Select
             aria-labelledby="idle-agent-sessions-label"
             value={selectValue}
-            disabled={saving}
+            disabled={saving.has("agentIdleDormantMinutes")}
             options={idleOptions}
             onChange={(raw) => {
               const next = raw === "off" ? null : Number(raw);
@@ -1196,6 +1193,7 @@ function AgentSessionsSettingsCard() {
 }
 
 function AgentCliSection() {
+  useLoadSystemPromptSettings();
   // 카드를 Fragment로 직접 반환한다. 카드 간 간격은 호스트의 .global-settings-detail(그리드 gap)이
   // 제공하므로, 플러그인은 자체 래퍼로 감싸 그 간격을 가로채지 않는다(간격은 호스트 소관).
   return (
@@ -1353,18 +1351,12 @@ function AiGatewayCompactTimingCard() {
   const t = getT(useTerminalLocale());
   const settings = useSystemPromptSettingsStore();
   const state = settings.state;
-  const saving = settings.savingField !== null;
+  const saving = settings.savingFields.has("compactCeiling");
   const [previewId, setPreviewId] = React.useState<string>("");
   const [dragPercent, setDragPercent] = React.useState<number | null>(null);
   const trackRef = React.useRef<HTMLDivElement | null>(null);
   const draggingRef = React.useRef(false);
   const dragPercentRef = React.useRef<number | null>(null);
-
-  React.useEffect(() => {
-    const controller = new AbortController();
-    void loadSystemPromptSettings(controller.signal);
-    return () => controller.abort();
-  }, []);
 
   if (!state) {
     return (
@@ -1466,7 +1458,6 @@ function AiGatewayCompactTimingCard() {
             options={previewModels.map((model) => ({ id: model.id, label: model.name, provider: model.provider, contextWindow: model.contextWindow }))}
             aria-labelledby="compact-timing-preview-label"
             onChange={(id) => setPreviewId(id)}
-            disabled={saving}
           />
         </div>
       ) : null}
@@ -1559,7 +1550,7 @@ function AiGatewayDiagnosticsCard() {
   const t = getT(useTerminalLocale());
   const settings = useSystemPromptSettingsStore();
   const state = settings.state;
-  const saving = settings.savingField !== null;
+  const saving = settings.savingFields;
 
   if (!state) {
     return (
@@ -1577,7 +1568,7 @@ function AiGatewayDiagnosticsCard() {
         title={t("terminal.settings.aiGatewayDiagnostics")}
         help={t("terminal.settings.aiGatewayDiagnosticsHelp")}
         value={state.cursorDiagnosticsEnabled}
-        disabled={saving}
+        disabled={saving.has("cursorDiagnosticsEnabled")}
         onToggle={() => void setSystemPromptSettingsField(
           "cursorDiagnosticsEnabled",
           !state.cursorDiagnosticsEnabled,
@@ -1587,7 +1578,7 @@ function AiGatewayDiagnosticsCard() {
         title={t("terminal.settings.aiGatewayWireLog")}
         help={t("terminal.settings.aiGatewayWireLogHelp")}
         value={state.wireLogEnabled}
-        disabled={saving}
+        disabled={saving.has("wireLogEnabled")}
         onToggle={() => void setSystemPromptSettingsField("wireLogEnabled", !state.wireLogEnabled)}
       />
     </section>
@@ -1667,7 +1658,7 @@ function AiGatewayModelsCard() {
   const settings = useSystemPromptSettingsStore();
   const auth = useModelAuthStore();
   const state = settings.state;
-  const saving = settings.savingField !== null;
+  const saving = settings.savingFields.has("aiGateway");
   const [paletteOpen, setPaletteOpen] = React.useState(false);
   const addButtonRef = React.useRef<HTMLButtonElement | null>(null);
   // 닫힐 때 포커스는 연 버튼으로 돌아온다 — 팔레트 안에 있던 포커스가 문서 바닥으로 떨어지면
@@ -1679,7 +1670,6 @@ function AiGatewayModelsCard() {
 
   React.useEffect(() => {
     const controller = new AbortController();
-    void loadSystemPromptSettings(controller.signal);
     void loadModelAuth(controller.signal);
     return () => controller.abort();
   }, []);
@@ -1863,7 +1853,7 @@ function AiGatewayModelsCard() {
                     <span className="ai-gateway-provider-name">{t(AI_GATEWAY_PROVIDER_LABEL_KEYS[providerId])}</span>
                     <span className="ai-gateway-chip">{t("terminal.settings.aiGatewayModelCount", { count: group.entries.length })}</span>
                     <span className="ai-gateway-group-controls">
-                      {group.provider.id === "xai" ? <AiGatewayXaiEndpointRow saving={saving} /> : null}
+                      {group.provider.id === "xai" ? <AiGatewayXaiEndpointRow saving={settings.savingFields.has("xaiEndpoint")} /> : null}
                       {/* 순위 셀렉트는 라벨과 함께 서고, hover·포커스에서 말풍선이 뜻을 말한다. 목록을 열면 말풍선은 물러난다. */}
                       <span className="ai-gateway-priority-wrap">
                         <span className="ai-gateway-field-label">{t("terminal.settings.aiGatewayPriority")}</span>

--- a/runtime/fleet-plugins/terminal/client/agent/settings.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/settings.ts
@@ -192,7 +192,7 @@ export type SystemPromptSettingsField = "agentIdleDormantMinutes" | "claudeCodeS
 interface SystemPromptSettingsStoreState {
   readonly loading: boolean;
   readonly state: SystemPromptSettingsState | null;
-  readonly savingField: SystemPromptSettingsField | null;
+  readonly savingFields: ReadonlySet<SystemPromptSettingsField>;
   readonly error: string | null;
 }
 
@@ -202,17 +202,19 @@ const listeners = new Set<Listener>();
 let snapshot: SystemPromptSettingsStoreState = {
   loading: false,
   state: null,
-  savingField: null,
+  savingFields: new Set(),
   error: null,
 };
 // 로드 세대값. 저장(낙관적 갱신)이 시작되면 증가시켜, 그 이전에 출발한 in-flight GET 응답을 폐기한다.
 let loadGeneration = 0;
+const savingFields = new Set<SystemPromptSettingsField>();
+const failedFields = new Map<SystemPromptSettingsField, string>();
 
 export function useSystemPromptSettingsStore(): SystemPromptSettingsStoreState {
   return React.useSyncExternalStore(subscribe, getSystemPromptSettingsStoreState, getSystemPromptSettingsStoreState);
 }
 
-function getSystemPromptSettingsStoreState(): SystemPromptSettingsStoreState {
+export function getSystemPromptSettingsStoreState(): SystemPromptSettingsStoreState {
   return snapshot;
 }
 
@@ -224,16 +226,19 @@ export function subscribe(listener: Listener): () => void {
 }
 
 export async function loadSystemPromptSettings(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted || savingFields.size > 0) return;
   const generation = ++loadGeneration;
-  setSnapshot({ loading: true, error: null });
+  setSnapshot({ loading: true });
   try {
     const state = await fetchSystemPromptSettings(signal);
-    // 저장이 끼어들어 세대가 바뀌었으면 stale 응답이므로 저장 결과를 덮지 않는다.
-    if (generation !== loadGeneration) return;
-    setSnapshot({ loading: false, state, error: null });
+    if (signal?.aborted || generation !== loadGeneration) return;
+    failedFields.clear();
+    setSnapshot({ state, error: null });
   } catch (error) {
     if (signal?.aborted || generation !== loadGeneration) return;
-    setSnapshot({ loading: false, error: toErrorMessage(error) });
+    setSnapshot({ error: toErrorMessage(error) });
+  } finally {
+    if (generation === loadGeneration) setSnapshot({ loading: false });
   }
 }
 
@@ -242,18 +247,24 @@ export async function setSystemPromptSettingsField<Field extends SystemPromptSet
   value: SystemPromptSettingsState[Field],
 ): Promise<boolean> {
   const current = snapshot.state;
-  if (!current) return false;
-  // 진행 중인 로드 응답이 이 저장 결과를 덮지 않도록 세대값을 올린다.
+  if (!current || savingFields.has(field)) return false;
   loadGeneration += 1;
   const optimistic = { ...current, [field]: value };
   const update = toSettingsUpdate(field, optimistic);
-  setSnapshot({ state: optimistic, savingField: field, error: null });
+  savingFields.add(field);
+  failedFields.delete(field);
+  setSnapshot({ state: optimistic, loading: false, error: currentError() });
   try {
     const state = await saveSystemPromptSettings(update);
-    setSnapshot({ state, savingField: null, error: null });
+    savingFields.delete(field);
+    failedFields.delete(field);
+    // 전체 응답은 다른 필드의 낙관값과 카탈로그를 되감는다. 저장한 필드만 확정한다.
+    setSnapshot({ state: { ...snapshot.state!, [field]: state[field] }, error: currentError() });
     return true;
   } catch (error) {
-    setSnapshot({ state: current, savingField: null, error: toErrorMessage(error) });
+    savingFields.delete(field);
+    failedFields.set(field, toErrorMessage(error));
+    setSnapshot({ state: { ...snapshot.state!, [field]: current[field] }, error: currentError() });
     return false;
   }
 }
@@ -287,8 +298,14 @@ function toSettingsUpdate(field: SystemPromptSettingsField, state: SystemPromptS
   return { agentIdleDormantMinutes: state.agentIdleDormantMinutes };
 }
 
+function currentError(): string | null {
+  let latest: string | null = null;
+  for (const message of failedFields.values()) latest = message;
+  return latest;
+}
+
 function setSnapshot(patch: Partial<SystemPromptSettingsStoreState>): void {
-  snapshot = { ...snapshot, ...patch };
+  snapshot = { ...snapshot, ...patch, savingFields: new Set(savingFields) };
   for (const listener of listeners) listener();
 }
 

--- a/runtime/fleet-plugins/terminal/tests/settings-save-lifecycle.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-save-lifecycle.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SystemPromptSettingsState } from "../client/agent/settings.js";
+
+const BASE: SystemPromptSettingsState = {
+  agentIdleDormantMinutes: 60,
+  claudeCodeSystemPrompt: "on",
+  claudeCodeSkipPermissions: false,
+  claudeCodeDisabledAgents: [],
+  aiGateway: null,
+  aiGatewayCatalog: { providers: [] },
+  cursorDiagnosticsEnabled: false,
+  wireLogEnabled: false,
+  compactCeiling: null,
+  xaiEndpoint: "cli-proxy",
+};
+
+const response = (state: SystemPromptSettingsState) => new Response(JSON.stringify(state));
+
+// 저장 응답 경합은 HTTP 라우트 테스트로 잡히지 않는다. 설정값·실패 복원의 경계를 검증한다.
+describe("terminal settings save lifecycle", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("keeps independent saves and failures isolated while preventing duplicate writes", async () => {
+    const pending = new Map<string, (response: Response) => void>();
+    vi.stubGlobal("fetch", vi.fn((_url: string, init?: RequestInit) => {
+      if (init?.method !== "PUT") return Promise.resolve(response(BASE));
+      return new Promise<Response>((resolve) => pending.set(Object.keys(JSON.parse(init.body as string))[0]!, resolve));
+    }));
+    const store = await import("../client/agent/settings.js");
+    await store.loadSystemPromptSettings();
+    const permission = store.setSystemPromptSettingsField("claudeCodeSkipPermissions", true);
+    const prompt = store.setSystemPromptSettingsField("claudeCodeSystemPrompt", "off");
+    await expect(store.setSystemPromptSettingsField("claudeCodeSkipPermissions", false)).resolves.toBe(false);
+    expect(store.getSystemPromptSettingsStoreState().savingFields.size).toBe(2);
+    pending.get("claudeCodeSkipPermissions")!(new Response(JSON.stringify({ error: "permission write refused" }), { status: 500 }));
+    await expect(permission).resolves.toBe(false);
+    pending.get("claudeCodeSystemPrompt")!(response({ ...BASE, claudeCodeSystemPrompt: "off" }));
+    await expect(prompt).resolves.toBe(true);
+    expect(store.getSystemPromptSettingsStoreState()).toMatchObject({
+      state: { claudeCodeSkipPermissions: false, claudeCodeSystemPrompt: "off" },
+      error: "permission write refused",
+    });
+    expect(store.getSystemPromptSettingsStoreState().savingFields.size).toBe(0);
+  });
+
+  it("ignores stale reads after saving and settles cancelled loads", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response(BASE));
+    vi.stubGlobal("fetch", fetchMock);
+    const store = await import("../client/agent/settings.js");
+    await store.loadSystemPromptSettings();
+    let resolveRead!: (response: Response) => void;
+    fetchMock.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveRead = resolve; }));
+    const read = store.loadSystemPromptSettings();
+    fetchMock.mockResolvedValueOnce(response({ ...BASE, claudeCodeSkipPermissions: true }));
+    await store.setSystemPromptSettingsField("claudeCodeSkipPermissions", true);
+    resolveRead(response(BASE));
+    await read;
+    expect(store.getSystemPromptSettingsStoreState().state?.claudeCodeSkipPermissions).toBe(true);
+    expect(store.getSystemPromptSettingsStoreState().loading).toBe(false);
+
+    const controller = new AbortController();
+    fetchMock.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveRead = resolve; }));
+    const cancelled = store.loadSystemPromptSettings(controller.signal);
+    controller.abort();
+    resolveRead(response(BASE));
+    await cancelled;
+    expect(store.getSystemPromptSettingsStoreState().loading).toBe(false);
+    expect(store.getSystemPromptSettingsStoreState().state?.claudeCodeSkipPermissions).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- 설정 하나를 저장할 때 무관한 컨트롤까지 흐려지던 동작을 필드별 저장 잠금으로 교체합니다. 겉모습·하네스·AI Gateway 및 모바일 Settings가 같은 저장 상태를 사용합니다.
- 오래된 조회 응답이 최신 값을 덮지 않도록 차단하고, 독립 필드의 저장 성공·실패를 각각 병합·복원합니다.
- 하네스·AI Gateway의 중복 조회를 섹션당 한 번으로 통합합니다. 하네스 저장 중 비활성 컨트롤은 실측 9개에서 해당 스위치 1개로 줄었고, 본문·입력 DOM은 유지됐습니다.

## Test Plan
- [x] Console typecheck 및 전체 build (배포 번들 검사 포함)
- [x] Terminal typecheck
- [x] Console 설정 계약 테스트 12개 통과
- [x] Terminal 설정 라우트·저장 수명 테스트 7개 통과
- [x] 격리된 실제 브라우저에서 데스크톱·400px 모바일 검증: 지연 저장, 독립 필드 동시 저장, 실패 복원, 역방향 변경, DOM 유지, Escape 닫기·포커스 복귀
- [x] 최종 제공 자산과 worktree 빌드 일치, 브라우저 오류·unhandled rejection 없음, 소유한 검증 브라우저·서버 종료
- [ ] Electron 네이티브 동작 및 전체 저장소 테스트 스위트는 이번 SPA 설정 수정의 검증 범위에 포함하지 않음
