### PR TITLE
fix(console): animate War Room minimization into the sidebar

### DIFF
--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -1148,6 +1148,7 @@ export function OperationsCanvas({
             onMinimize: () => {
               if (state.activeOperationId === operation.id) setActiveOperation(null);
               clearIdleArrival(operation.id);
+              playMinimizeFlight(operation.id);
               if (triageActive) {
                 // War Room의 최소화는 deck에서 내리는 동작이다. 무대에 서 있던 패널이면 지목까지
                 // 거둬 무대를 함께 비운다 — 지목이 남으면 큐가 비어도 그 패널이 무대에 붙어 있다.
@@ -1155,7 +1156,6 @@ export function OperationsCanvas({
                 setTheaterOperationMinimized(operation.theaterId, operation.id, true);
                 return;
               }
-              playMinimizeFlight(operation.id);
               minimizeOperation(operation.id);
             },
             onMaximize: () => {

--- a/runtime/fleet-console/core/client/src/canvas/panel-motion.ts
+++ b/runtime/fleet-console/core/client/src/canvas/panel-motion.ts
@@ -23,8 +23,12 @@ export function playMinimizeFlight(operationId: string): void {
   const from = panel.getBoundingClientRect();
   window.requestAnimationFrame(() => {
     const chip = chipElement(operationId);
-    if (!isVisiblyRendered(chip)) return;
-    flyPanelMotionGhost(from, chip.getBoundingClientRect(), () => pulseChip(chip));
+    // War Room의 좁은 레일은 개별 칩 대신 최소화 선반의 건수만 보여 준다.
+    const target = isVisiblyRendered(chip)
+      ? chip
+      : document.querySelector<HTMLElement>("[data-panel-motion-shelf]");
+    if (!isVisiblyRendered(target)) return;
+    flyPanelMotionGhost(from, target.getBoundingClientRect(), () => pulseChip(target));
   });
 }
 

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -314,7 +314,7 @@ export function TriageSideBar({
           ) : null}
           {shelvedCount > 0 ? (
             <li className="side-bar-rail-section side-bar-rail-section--shelved">
-              <span className="side-bar-rail-section-mark" aria-label={`${minimizedSection.label} ${minimizedEntries.length}${dormantSection ? ` · ${dormantSection.label} ${dormantSection.entries.length}` : ""}`}>
+              <span className="side-bar-rail-section-mark" data-panel-motion-shelf aria-label={`${minimizedSection.label} ${minimizedEntries.length}${dormantSection ? ` · ${dormantSection.label} ${dormantSection.entries.length}` : ""}`}>
                 <span className="side-bar-rail-section-dot" aria-hidden="true" />
                 <span className="side-bar-rail-section-count">{shelvedCount}</span>
               </span>


### PR DESCRIPTION
## Summary
- War Room의 덱 카드와 무대 패널이 기존 Cruise/Tactical 최소화 flight를 실행한 뒤 최소화 상태로 전환하도록 연결했습니다.
- 좁은 대기열 레일에서는 숨겨진 개별 칩 대신 보이는 최소화 선반 건수를 도착점으로 사용합니다.
- 기존 상태 커밋, 무대 지목 해제, 복원 정책과 reduced-motion 가드를 유지합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/operation-minimize.test.ts tests/triage-store.test.ts tests/operations-boot-minimization.integration.test.ts` — 3 files / 7 tests passed
- [x] `git diff --check`
- [x] 격리 Chromium의 실제 Console에서 워룸 덱/무대 최소화, 넓은 목록/정착된 좁은 레일, 선반 복원, reduced-motion, Cruise/Tactical 회귀 검증
- [x] 동일 worktree의 제공 JS/CSS 번들 일치 확인; 마지막 오류·rejection·잔여 ghost 0

브라우저 검증은 무과금 UI fixture로 수행했으며, 체험용 로컬 데모 Console은 사용자 요청으로 종료했습니다. Electron 네이티브 동작 및 전체 테스트 스위트는 이번 SPA 변경 범위에서 실행하지 않았습니다.