### PR TITLE
fix(rail): preserve column widths through expanded surfaces

### DIFF
--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -184,7 +184,7 @@ export const RailSurface = memo(function RailSurface({
   if (standing.length > 0) splitWidthRef.current = desiredPrimaryWidth;
   const primaryWidth = clampPrimaryWidth(desiredPrimaryWidth, limits);
   const soloWidth = standing.length === 0 && splitWidthRef.current !== undefined
-    ? desiredPrimaryWidth
+    ? Math.min(Math.max(primary?.minWidth ?? MIN_PANE_PX, desiredPrimaryWidth), splitMaxWidthRef.current ?? Infinity)
     : null;
   const soloMaxWidth = soloWidth === null ? null : splitMaxWidthRef.current;
   useLayoutEffect(() => {

--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -14,6 +14,7 @@ import { PaneCaption } from "./pane-caption.js";
 import { PaneDivider } from "./pane-divider.js";
 import { clampPrimaryWidth, MIN_PANE_PX, type PaneSplitLimits } from "./pane-geometry.js";
 import { resolvePaneDefaultWidth } from "../rail/pane-width.js";
+import { requestRailPanelSoloWidth } from "../rail/rail-store.js";
 import { setPaneWidth, usePaneWidths } from "./pane-width-store.js";
 import { usePaneIndex, type HostPaneContext, type RailEntryBinding } from "./pane-registry.js";
 import { closePane, focusPane, openPane, replacePaneParams, resetSurfacePanes, useFocusedPaneId, useRailPanes } from "./pane-store.js";
@@ -162,15 +163,23 @@ export const RailSurface = memo(function RailSurface({
     ),
   }), [primary?.minWidth, standing, surfaceWidth]);
 
-  // 순서가 곧 근거의 순서다: 사용자가 끈 폭 → 갈라지기 직전의 폭 → 서술자의 기본값.
-  // 실측 전에는 soloWidth가 0이므로 `??`로 이으면 0이 기본값을 이겨 열이 최소폭으로 접힌다.
-  const primaryWidth = clampPrimaryWidth(
-    paneWidths[primary?.id ?? ""]
-      ?? (soloWidthRef.current > 0 ? soloWidthRef.current : undefined)
-      ?? (primary === null ? undefined : resolvePaneDefaultWidth(primary))
-      ?? MIN_PANE_PX,
-    limits,
-  );
+  // 첫 분할의 기준은 이 표면이 기억한다. detail을 확대하면 solo 실측이 전체 카드 폭으로
+  // 바뀌므로, 복귀 때 그 값을 다시 채택하면 목록이 넓어지고 문서는 좁아진다. 화면 제약으로
+  // 잘린 실측이 아니라 원하는 폭을 남겨, 좁은 창을 거쳐 돌아와도 원래 분할로 복원한다.
+  const splitWidthRef = useRef<number | undefined>(undefined);
+  const desiredPrimaryWidth = paneWidths[primary?.id ?? ""]
+    ?? splitWidthRef.current
+    ?? (soloWidthRef.current > 0 ? soloWidthRef.current : undefined)
+    ?? (primary === undefined ? undefined : resolvePaneDefaultWidth(primary))
+    ?? MIN_PANE_PX;
+  if (standing.length > 0) splitWidthRef.current = desiredPrimaryWidth;
+  const primaryWidth = clampPrimaryWidth(desiredPrimaryWidth, limits);
+  const soloWidth = standing.length === 0 && splitWidthRef.current !== undefined
+    ? desiredPrimaryWidth
+    : null;
+  useLayoutEffect(() => {
+    requestRailPanelSoloWidth(entryId, soloWidth);
+  }, [entryId, soloWidth]);
 
   // detail이 서면 표면 전체가 그만큼 넓어져야 한다 — 그러지 않으면 새 열은 primary를 잘라
   // 먹는다. 예전에 플러그인이 `requestExtraWidth`로 하던 일이며, 이제 표면이 자기가 세운

--- a/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
+++ b/runtime/fleet-console/core/client/src/pane/rail-surface.tsx
@@ -12,9 +12,9 @@ import { isPaneExpanded, openExpandedPane } from "./expanded-pane-surface.js";
 import { PaneBody, usePaneContext } from "./pane-body.js";
 import { PaneCaption } from "./pane-caption.js";
 import { PaneDivider } from "./pane-divider.js";
-import { clampPrimaryWidth, MIN_PANE_PX, type PaneSplitLimits } from "./pane-geometry.js";
+import { clampPrimaryWidth, maxPrimaryWidth, MIN_PANE_PX, type PaneSplitLimits } from "./pane-geometry.js";
 import { resolvePaneDefaultWidth } from "../rail/pane-width.js";
-import { requestRailPanelSoloWidth } from "../rail/rail-store.js";
+import { requestRailPanelSoloWidth, useRailPanelWidthReset } from "../rail/rail-store.js";
 import { setPaneWidth, usePaneWidths } from "./pane-width-store.js";
 import { usePaneIndex, type HostPaneContext, type RailEntryBinding } from "./pane-registry.js";
 import { closePane, focusPane, openPane, replacePaneParams, resetSurfacePanes, useFocusedPaneId, useRailPanes } from "./pane-store.js";
@@ -167,6 +167,15 @@ export const RailSurface = memo(function RailSurface({
   // 바뀌므로, 복귀 때 그 값을 다시 채택하면 목록이 넓어지고 문서는 좁아진다. 화면 제약으로
   // 잘린 실측이 아니라 원하는 폭을 남겨, 좁은 창을 거쳐 돌아와도 원래 분할로 복원한다.
   const splitWidthRef = useRef<number | undefined>(undefined);
+  const splitMaxWidthRef = useRef<number | null>(null);
+  const widthReset = useRailPanelWidthReset();
+  const previousWidthResetRef = useRef(widthReset);
+  if (previousWidthResetRef.current !== widthReset) {
+    previousWidthResetRef.current = widthReset;
+    splitWidthRef.current = resolvePaneDefaultWidth(primary) - 2;
+    soloWidthRef.current = 0;
+  }
+  if (standing.length > 0 && surfaceWidth > 0) splitMaxWidthRef.current = maxPrimaryWidth(limits);
   const desiredPrimaryWidth = paneWidths[primary?.id ?? ""]
     ?? splitWidthRef.current
     ?? (soloWidthRef.current > 0 ? soloWidthRef.current : undefined)
@@ -177,9 +186,10 @@ export const RailSurface = memo(function RailSurface({
   const soloWidth = standing.length === 0 && splitWidthRef.current !== undefined
     ? desiredPrimaryWidth
     : null;
+  const soloMaxWidth = soloWidth === null ? null : splitMaxWidthRef.current;
   useLayoutEffect(() => {
-    requestRailPanelSoloWidth(entryId, soloWidth);
-  }, [entryId, soloWidth]);
+    requestRailPanelSoloWidth(entryId, soloWidth, soloMaxWidth);
+  }, [entryId, soloWidth, soloMaxWidth]);
 
   // detail이 서면 표면 전체가 그만큼 넓어져야 한다 — 그러지 않으면 새 열은 primary를 잘라
   // 먹는다. 예전에 플러그인이 `requestExtraWidth`로 하던 일이며, 이제 표면이 자기가 세운

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -12,6 +12,8 @@ interface RailStore {
   readonly panelExtraWidth: number;
   /** detail이 떠난 동안 유지할 primary 열 폭. 카드의 분할 폭 기억과는 별개다. */
   readonly panelSoloWidth: number | null;
+  readonly panelSoloMaxWidth: number | null;
+  readonly panelWidthReset: number;
   readonly overlayAlpha: RailOverlayAlpha;
   /** 레일 카드가 캔버스 위에서 점유하는 실측 폭(px) — RightRail이 보고하고 아레나 계산이 소비한다. */
   readonly railOccupiedPx: number;
@@ -37,6 +39,8 @@ let store: RailStore = {
   railChromeExpanded: readStoredChromeExpanded(),
   panelExtraWidth: 0,
   panelSoloWidth: null,
+  panelSoloMaxWidth: null,
+  panelWidthReset: 0,
   overlayAlpha: readStoredOverlayAlpha(),
   railOccupiedPx: 0,
   railPeeking: false,
@@ -105,11 +109,24 @@ export function requestRailPanelExtraWidth(panelId: string, px: number | null): 
   setStore({ ...store, panelExtraWidth: clamped });
 }
 
-export function requestRailPanelSoloWidth(panelId: string, px: number | null): void {
+export function requestRailPanelSoloWidth(panelId: string, px: number | null, maxWidth: number | null): void {
   if (store.activePanelId !== panelId) return;
   const next = px !== null && Number.isFinite(px) ? Math.max(0, Math.round(px)) : null;
-  if (next === store.panelSoloWidth) return;
-  setStore({ ...store, panelSoloWidth: next });
+  if (next === store.panelSoloWidth && maxWidth === store.panelSoloMaxWidth) return;
+  setStore({ ...store, panelSoloWidth: next, panelSoloMaxWidth: maxWidth });
+}
+
+export function resetRailPanelWidth(panelId: string): void {
+  if (store.activePanelId !== panelId) return;
+  setStore({ ...store, panelWidthReset: store.panelWidthReset + 1 });
+}
+
+export function useRailPanelWidthReset(): number {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelWidthReset;
+}
+
+export function useRailPanelSoloMaxWidth(): number | null {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelSoloMaxWidth;
 }
 
 export function useRailPanelSoloWidth(): number | null {
@@ -150,13 +167,13 @@ export function useRailPeeking(): boolean {
 function activateRailPanel(id: string): void {
   if (store.activePanelId === id) return;
   // 교체는 이전 패널의 확장 폭 요구도 함께 내린다 — 화면에 없는 요구가 아레나를 점유하면 안 된다.
-  setStore({ ...store, activePanelId: id, panelExtraWidth: 0, panelSoloWidth: null });
+  setStore({ ...store, activePanelId: id, panelExtraWidth: 0, panelSoloWidth: null, panelSoloMaxWidth: null });
   saveStoredActivePanelId(id);
 }
 
 function deactivateRailPanel(): void {
   if (store.activePanelId === null) return;
-  setStore({ ...store, activePanelId: null, panelExtraWidth: 0, panelSoloWidth: null });
+  setStore({ ...store, activePanelId: null, panelExtraWidth: 0, panelSoloWidth: null, panelSoloMaxWidth: null });
   saveStoredActivePanelId(null);
 }
 

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -10,6 +10,8 @@ interface RailStore {
   readonly railChromeExpanded: boolean;
   /** 활성 패널의 확장 폭 요구(px) — 독점 슬롯이라 요구도 하나다. 패널 교체·닫힘에 0으로 리셋. */
   readonly panelExtraWidth: number;
+  /** detail이 떠난 동안 유지할 primary 열 폭. 카드의 분할 폭 기억과는 별개다. */
+  readonly panelSoloWidth: number | null;
   readonly overlayAlpha: RailOverlayAlpha;
   /** 레일 카드가 캔버스 위에서 점유하는 실측 폭(px) — RightRail이 보고하고 아레나 계산이 소비한다. */
   readonly railOccupiedPx: number;
@@ -34,6 +36,7 @@ let store: RailStore = {
   activePanelId: readStoredActivePanelId(),
   railChromeExpanded: readStoredChromeExpanded(),
   panelExtraWidth: 0,
+  panelSoloWidth: null,
   overlayAlpha: readStoredOverlayAlpha(),
   railOccupiedPx: 0,
   railPeeking: false,
@@ -102,6 +105,17 @@ export function requestRailPanelExtraWidth(panelId: string, px: number | null): 
   setStore({ ...store, panelExtraWidth: clamped });
 }
 
+export function requestRailPanelSoloWidth(panelId: string, px: number | null): void {
+  if (store.activePanelId !== panelId) return;
+  const next = px !== null && Number.isFinite(px) ? Math.max(0, Math.round(px)) : null;
+  if (next === store.panelSoloWidth) return;
+  setStore({ ...store, panelSoloWidth: next });
+}
+
+export function useRailPanelSoloWidth(): number | null {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelSoloWidth;
+}
+
 /** RightRail이 레이아웃 후 자기 점유 폭을 보고한다 — Operations 페이지의 아레나 계산 원료. */
 export function reportRailOccupiedPx(px: number): void {
   const normalized = Math.max(0, Math.round(px));
@@ -136,13 +150,13 @@ export function useRailPeeking(): boolean {
 function activateRailPanel(id: string): void {
   if (store.activePanelId === id) return;
   // 교체는 이전 패널의 확장 폭 요구도 함께 내린다 — 화면에 없는 요구가 아레나를 점유하면 안 된다.
-  setStore({ ...store, activePanelId: id, panelExtraWidth: 0 });
+  setStore({ ...store, activePanelId: id, panelExtraWidth: 0, panelSoloWidth: null });
   saveStoredActivePanelId(id);
 }
 
 function deactivateRailPanel(): void {
   if (store.activePanelId === null) return;
-  setStore({ ...store, activePanelId: null, panelExtraWidth: 0 });
+  setStore({ ...store, activePanelId: null, panelExtraWidth: 0, panelSoloWidth: null });
   saveStoredActivePanelId(null);
 }
 

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -17,7 +17,7 @@ import { getState, subscribe } from "../store.js";
 import { sideBarOccupiedWidth, useSideBarState } from "../sidebar/operations-side-bar-store.js";
 import type { ConnectionState } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
-import { closeRailPanel, reportRailOccupiedPx, requestRailPanelExtraWidth, setRailChromeExpanded, setRailPeeking, toggleRailPanel, useRailActivePanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelExtraWidth, useRailPeeking } from "./rail-store.js";
+import { closeRailPanel, reportRailOccupiedPx, requestRailPanelExtraWidth, setRailChromeExpanded, setRailPeeking, toggleRailPanel, useRailActivePanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelExtraWidth, useRailPanelSoloWidth, useRailPeeking } from "./rail-store.js";
 import {
   MIN_PANEL_WIDTH,
   clearStoredPanelWidth,
@@ -29,6 +29,7 @@ import {
 import { GearGlyph, SETTINGS_RAIL_ENTRY_ID } from "../settings/settings-entry.js";
 import { useRailEntries, type RailEntryBinding } from "../pane/pane-registry.js";
 import { RailSurface } from "../pane/rail-surface.js";
+import { setPaneWidth } from "../pane/pane-width-store.js";
 
 interface RightRailProps {
   readonly theaterId: string | null;
@@ -40,6 +41,8 @@ interface RightRailProps {
 const STABLE_RAIL_SURFACES = createHostCapabilities().surfaces;
 /** 아이콘 열 폭 — rail.css .right-rail-icons와 한 값. */
 const RAIL_ICON_STRIP_WIDTH = 44;
+/** 카드 양쪽 테두리 — 열 실측과 카드 폭 사이의 차이. */
+const RAIL_CARD_BORDER_WIDTH = 2;
 /** 엔트리의 대표 페인 — 폭 기본값 등 표면 차원의 힌트를 primary가 말한다(pane 계약). */
 function primaryPaneOf(binding: RailEntryBinding | null) {
   if (binding === null) return null;
@@ -67,7 +70,9 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
   const rootRef = useRef<HTMLDivElement>(null);
   const activePanelId = useRailActivePanelId();
-  const extraWidth = useRailPanelExtraWidth();
+  const requestedExtraWidth = useRailPanelExtraWidth();
+  const soloWidth = useRailPanelSoloWidth();
+  const extraWidth = soloWidth === null ? requestedExtraWidth : 0;
   const railChromeExpanded = useRailChromeExpanded();
   const railPeeking = useRailPeeking();
   const overlayAlpha = useRailOverlayAlpha();
@@ -123,9 +128,13 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   // 저장 폭은 클램프 없이 desired로 보존한다 — init에서 클램프한 값을 desired로 심으면
   // 큰 화면에서 저장한 폭이 좁은 창 로드 한 번에 소실되어, 창을 다시 넓혀도 복원되지
   // 않는다(Codex 리뷰 확정 — 구 폭 기억 effect의 restore-on-expansion 계약 승계).
-  const desiredWidth = activeBinding === null
-    ? declaredWidthOf(null)
-    : Math.max(MIN_PANEL_WIDTH, storedWidths[activeBinding.entry.id] ?? declaredWidthOf(activeBinding));
+  // 분할 카드 폭에는 문서에 준 여유도 포함된다. 문서가 떠나면 목록 폭만 세우고,
+  // 분할 카드의 기억은 그대로 두어 돌아올 때 문서가 같은 자리를 되찾게 한다.
+  const desiredWidth = soloWidth !== null
+    ? soloWidth + RAIL_CARD_BORDER_WIDTH
+    : activeBinding === null
+      ? declaredWidthOf(null)
+      : Math.max(MIN_PANEL_WIDTH, storedWidths[activeBinding.entry.id] ?? declaredWidthOf(activeBinding));
   const [cardWidth, setCardWidthState] = useState(() => Math.min(maxPanelWidth, desiredWidth));
   const cardWidthRef = useRef(cardWidth);
   const [isDragging, setIsDragging] = useState(false);
@@ -136,6 +145,8 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   // 조절은 언제나 **화면에 선 도구**의 몫이다 — 핸들러는 안정 참조로 두고 대상만 ref로 읽는다.
   const activePaneIdRef = useRef<string | null>(null);
   activePaneIdRef.current = activeBinding?.entry.id ?? null;
+  const soloPaneRef = useRef<ReturnType<typeof primaryPaneOf>>(null);
+  soloPaneRef.current = soloWidth === null ? null : primaryPaneOf(activeBinding);
 
   useLayoutEffect(() => {
     const onResize = () => {
@@ -182,6 +193,7 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
     // 제스처가 지속되는 동안 플러그인의 `panels.open`이나 라우트 변경이 다른 패널을 세울 수
     // 있고, 놓는 순간의 활성 도구를 읽으면 끌던 폭이 도착한 도구의 기억으로 샌다.
     const dragPanelId = activePaneIdRef.current;
+    const soloPane = soloPaneRef.current;
     setIsDragging(true);
 
     const onMove = (ev: PointerEvent) => {
@@ -196,7 +208,8 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
       document.removeEventListener("pointermove", onMove);
       document.removeEventListener("pointerup", onUp);
       setIsDragging(false);
-      if (dragPanelId !== null) setStoredWidths(saveStoredPanelWidth(storedWidthsRef.current, dragPanelId, cardWidthRef.current));
+      if (soloPane !== null) setPaneWidth(soloPane.id, cardWidthRef.current - RAIL_CARD_BORDER_WIDTH);
+      else if (dragPanelId !== null) setStoredWidths(saveStoredPanelWidth(storedWidthsRef.current, dragPanelId, cardWidthRef.current));
     };
 
     document.addEventListener("pointermove", onMove);
@@ -230,7 +243,9 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
     cardWidthRef.current = next;
     setCardWidthState(next);
     const panelId = activePaneIdRef.current;
-    if (panelId !== null) setStoredWidths(saveStoredPanelWidth(storedWidthsRef.current, panelId, next));
+    const soloPane = soloPaneRef.current;
+    if (soloPane !== null) setPaneWidth(soloPane.id, next - RAIL_CARD_BORDER_WIDTH);
+    else if (panelId !== null) setStoredWidths(saveStoredPanelWidth(storedWidthsRef.current, panelId, next));
   }, []);
 
   // 가장자리 더블클릭의 "패널 폭 초기화" — 그 도구의 기억만 지운다. 폭은 그 뒤 클램프
@@ -238,7 +253,9 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   const handleResetCardWidth = useCallback(() => {
     const panelId = activePaneIdRef.current;
     if (panelId === null) return;
-    setStoredWidths(clearStoredPanelWidth(storedWidthsRef.current, panelId));
+    const soloPane = soloPaneRef.current;
+    if (soloPane !== null) setPaneWidth(soloPane.id, Math.max(MIN_PANEL_WIDTH, resolvePaneDefaultWidth(soloPane)) - RAIL_CARD_BORDER_WIDTH);
+    else setStoredWidths(clearStoredPanelWidth(storedWidthsRef.current, panelId));
   }, []);
 
   const baseCtx: RailPanelContext = useMemo(() => ({

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -17,7 +17,7 @@ import { getState, subscribe } from "../store.js";
 import { sideBarOccupiedWidth, useSideBarState } from "../sidebar/operations-side-bar-store.js";
 import type { ConnectionState } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
-import { closeRailPanel, reportRailOccupiedPx, requestRailPanelExtraWidth, setRailChromeExpanded, setRailPeeking, toggleRailPanel, useRailActivePanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelExtraWidth, useRailPanelSoloWidth, useRailPeeking } from "./rail-store.js";
+import { closeRailPanel, reportRailOccupiedPx, requestRailPanelExtraWidth, resetRailPanelWidth, setRailChromeExpanded, setRailPeeking, toggleRailPanel, useRailActivePanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelExtraWidth, useRailPanelSoloWidth, useRailPanelSoloMaxWidth, useRailPeeking } from "./rail-store.js";
 import {
   MIN_PANEL_WIDTH,
   clearStoredPanelWidth,
@@ -29,7 +29,7 @@ import {
 import { GearGlyph, SETTINGS_RAIL_ENTRY_ID } from "../settings/settings-entry.js";
 import { useRailEntries, type RailEntryBinding } from "../pane/pane-registry.js";
 import { RailSurface } from "../pane/rail-surface.js";
-import { setPaneWidth } from "../pane/pane-width-store.js";
+import { clearPaneWidth, setPaneWidth } from "../pane/pane-width-store.js";
 
 interface RightRailProps {
   readonly theaterId: string | null;
@@ -72,6 +72,9 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   const activePanelId = useRailActivePanelId();
   const requestedExtraWidth = useRailPanelExtraWidth();
   const soloWidth = useRailPanelSoloWidth();
+  const soloMaxWidth = useRailPanelSoloMaxWidth();
+  const soloMaxWidthRef = useRef(soloMaxWidth);
+  soloMaxWidthRef.current = soloMaxWidth;
   const extraWidth = soloWidth === null ? requestedExtraWidth : 0;
   const railChromeExpanded = useRailChromeExpanded();
   const railPeeking = useRailPeeking();
@@ -118,6 +121,7 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   // 바닥나면 MIN 바닥이 이긴다 — 그때 넘치는 쪽은 아래 슬롯 총폭 캡이 extra를 깎아 회수한다.
   const widthBudget = Math.floor(viewportWidth - 148 - sideBarOccupiedPx);
   const maxPanelWidth = Math.max(MIN_PANEL_WIDTH, widthBudget - extraWidth);
+  const maxResizeWidth = soloMaxWidth === null ? maxPanelWidth : Math.min(maxPanelWidth, soloMaxWidth + RAIL_CARD_BORDER_WIDTH);
 
   // 폭은 카드가 아니라 도구가 기억한다. 조절한 도구만 자기 값을 갖고, 손대지 않은 도구는
   // 계속 자기 선언값으로 열린다 — 그래야 페인이 기본값을 고쳤을 때 그 개선이 사용자에게 닿는다.
@@ -198,7 +202,10 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
 
     const onMove = (ev: PointerEvent) => {
       const dx = startX - ev.clientX;
-      const maxWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidthRef.current - sideBarOccupiedRef.current));
+      const maxWidth = Math.max(MIN_PANEL_WIDTH, Math.min(
+        Math.floor(window.innerWidth - 148 - extraWidthRef.current - sideBarOccupiedRef.current),
+        soloMaxWidthRef.current === null ? Infinity : soloMaxWidthRef.current + RAIL_CARD_BORDER_WIDTH,
+      ));
       const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, Math.round(startWidth + dx)));
       cardWidthRef.current = next;
       setCardWidthState(next);
@@ -219,7 +226,10 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
   const handleResizeKeyDown = useCallback((event: React.KeyboardEvent) => {
     let next: number;
     const step = event.shiftKey ? 64 : 16;
-    const currentMaxWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidthRef.current - sideBarOccupiedRef.current));
+    const currentMaxWidth = Math.max(MIN_PANEL_WIDTH, Math.min(
+      Math.floor(window.innerWidth - 148 - extraWidthRef.current - sideBarOccupiedRef.current),
+      soloMaxWidthRef.current === null ? Infinity : soloMaxWidthRef.current + RAIL_CARD_BORDER_WIDTH,
+    ));
 
     switch (event.key) {
       case "ArrowLeft":
@@ -254,7 +264,10 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
     const panelId = activePaneIdRef.current;
     if (panelId === null) return;
     const soloPane = soloPaneRef.current;
-    if (soloPane !== null) setPaneWidth(soloPane.id, Math.max(MIN_PANEL_WIDTH, resolvePaneDefaultWidth(soloPane)) - RAIL_CARD_BORDER_WIDTH);
+    if (soloPane !== null) {
+      clearPaneWidth(soloPane.id);
+      resetRailPanelWidth(panelId);
+    }
     else setStoredWidths(clearStoredPanelWidth(storedWidthsRef.current, panelId));
   }, []);
 
@@ -304,7 +317,7 @@ export function RightRail({ theaterId, api, onLaunchOperation }: RightRailProps)
             aria-label={t("rail.chrome.resizeCard")}
             aria-valuenow={Math.round(cardWidth)}
             aria-valuemin={MIN_PANEL_WIDTH}
-            aria-valuemax={maxPanelWidth}
+            aria-valuemax={maxResizeWidth}
           />
         )}
         {activeBinding !== null && (


### PR DESCRIPTION
## Summary
- Codex·File Explorer에서 문서를 확대해도 오른쪽 목록 폭을 유지하고, 복귀 시 기존 목록·문서 분할 폭을 복원합니다.
- 단독 목록 폭과 분할 카드 폭의 기억을 분리하며, 확대 중 목록 조절은 해당 primary 열에 적용합니다.
- 패널 전환·닫기 시 단독 폭 요청을 초기화합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] 격리된 실제 Console에서 Codex 확대 전→중→복귀 목록 420→420→420px, 사용자 분할 356→356→356px 확인
- [x] File Explorer 확대 전→중→복귀 목록 372→372→372px, 문서 466→466px 확인
- [x] 확대 중 목록 조절, 좁은 창 왕복, 키보드·포인터 조절, 브라우저 오류 없음 확인
- [x] `git diff --check`
- [ ] 기존 디자인 계약 검사: 97 passed / 1 pre-existing failure. `instrument-design-contract.test.ts:974`의 `disabled={saving || state === null || lightTheme}` 정규식이 기존 Settings의 `saving.has("liquidGlass")`와 불일치합니다. 수정 전 HEAD의 동일 코드에서도 불일치를 확인했으며, 이 PR은 해당 파일들을 변경하지 않습니다.

## Product Context Record
- 요청: Codex 및 File Explorer의 우측 레일 폭이 확대 표면 이동과 복귀에도 유지되어야 합니다. 사용자 후속 스크린샷에 따라 확대 중 목록 폭 유지도 필수 조건입니다.
- 수용 기준: 동일 뷰포트에서 확대 전·중·후 primary 폭 보존, 복귀 시 detail 폭 복원, 명시적 폭 조절 우선, 화면 제약은 임시 클램프로 처리.
- 제외: 플러그인 확대/닫기 수명 변경, 새로고침·패널 재마운트의 새로운 영속 계약, unrelated Settings 테스트 수정, UI 재설계.
- 보존: Codex 자동 레일 복귀, File Explorer 기존 재선택 경로, 드래그·키보드 조절, 도구별 폭 격리, 실제 사용자 데이터 비접근.
- 근거: 사용자 최초 요청 및 두 번째 스크린샷 피드백; 격리 브라우저 실측·스크린샷; 3개 변경 파일의 diff.
- REVIEW_BASE_HEAD: `466b583a2b9532390cdff727b672d3e1ec603c82`
