### PR TITLE
fix(console): keep session analyst caption readiness stable

### DIFF
--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -117,6 +117,10 @@ export function OperationsCanvas({
   onDismissOperationMenu,
 }: OperationsCanvasProps) {
   const canvasRef = useRef<HTMLElement | null>(null);
+  // 캡션·companion의 API 의존 effect가 메뉴·기하 변경마다 재시작되지 않게 수명을 Canvas에 묶는다.
+  const capabilities = useMemo(() => createHostCapabilities(() => {
+    void fetchOperations(null).then(hydrateOperations).catch(() => {});
+  }), []);
   const t = useT();
   const canvas = useCanvasState();
   const formationLayout = useFormationLayout();
@@ -1086,6 +1090,7 @@ export function OperationsCanvas({
           const topEdge = !operationTriageStage && !operationMaximized && !operationCompanion && !formationSlot && !deckSlot
             && screenViewport.y + frameGeometry.y * operationZoom < TITLEBAR_OUTSET_PX * operationZoom;
           return renderPluginOperation(operation, {
+            capabilities,
             active: activePluginOperationId === operation.id,
             unseen: idleArrivalIds.has(operation.id),
             keyboardFocusRequestId: state.keyboardFocusRequest?.operationId === operation.id
@@ -1457,6 +1462,7 @@ function operationAccentFromNode(operation: OperationNode): string | null {
 }
 
 function renderPluginOperation(operation: OperationNode, options: {
+  readonly capabilities: ReturnType<typeof createHostCapabilities>;
   readonly active: boolean;
   readonly unseen: boolean;
   readonly keyboardFocusRequestId: number;
@@ -1501,9 +1507,7 @@ function renderPluginOperation(operation: OperationNode, options: {
   const descriptor = options.operationKindRegistry.find((kind) => kind.pluginId === operation.pluginId && kind.type === operation.type);
   const geometry = options.geometry;
   if (!descriptor?.render) return null;
-  const capabilities = createHostCapabilities(() => {
-    void fetchOperations(null).then(hydrateOperations).catch(() => {});
-  });
+  const capabilities = options.capabilities;
   const onRequestCompanions = (open: boolean) => {
     if (open) {
       setActiveOperation(operation.id);


### PR DESCRIPTION
## Summary
- 캡션의 `…` 메뉴 등 다른 컨트롤을 조작할 때 Session Analyst 버튼이 깜빡이는 문제를 수정합니다.
- Canvas 수명 동안 host capabilities를 재사용하여 API 객체 변경으로 인한 준비 상태 초기화와 중복 조회를 제거합니다. 기존 준비 상태 판정과 비활성화 가드는 유지합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run core/client/src/agent/analysis-ready.test.tsx core/client/src/agent/analysis-panel.test.tsx tests/instrument-design-contract.test.ts` — 3개 파일, 102개 테스트 통과
- [x] macOS arm64 격리 Console·headless Chromium에서 실제 포인터로 `…` 열기 및 Escape 닫기 재현: 수정 전 매 동작마다 disabled 전환·준비 상태 재조회 발생, 수정 후 각각 0회
- [x] 키보드 Enter로 메뉴 열기, Escape 포커스 복귀, 최대화·복원, 분석가 드로어 열기·닫기 및 열린 상태에서 메뉴 조작 확인
- [x] 수정 빌드의 served asset 일치, 브라우저 오류·미처리 rejection 없음, 검증 프로세스 정리 확인

실제 모델 호출 없이 격리된 휴면 Operation fixture로 검증했습니다. Electron 네이티브 및 Windows 환경은 검증 범위에 포함하지 않았습니다.
