### PR TITLE
feat(console): flatten agent turns and animate the thinking tail

### DIFF
--- a/.changelog.d/chat-stream-flat.md
+++ b/.changelog.d/chat-stream-flat.md
@@ -1,0 +1,10 @@
+---
+branch: chat-stream-flat
+---
+
+### fleet-console
+#### Changed
+- Flatten agent turns in Chat view, the Analyst panel, and the Codex cowork thread by removing the left spine and status node; the working clock, fold line, and outcome text already carry that state.
+  ko: 채팅뷰, Analyst 패널, Codex cowork 스레드의 에이전트 턴에서 좌측 세로 스파인과 상태 노드를 제거해 평평하게 만들었습니다. 진행 시계, 접힘 줄, 결말 문구가 이미 그 상태를 말합니다.
+- Animate the thinking tail in Chat view: the dots now step through one, two, and three, and the dashed thinking glyph slowly spins while the model is between tool calls.
+  ko: 채팅뷰의 생각 중 꼬리에 움직임을 더했습니다. 점이 하나, 둘, 셋으로 차오르며 순환하고, 도구 호출 사이에 점선 생각 글리프가 천천히 회전합니다.

--- a/runtime/fleet-console/core/client/src/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-console/core/client/src/agent/analysis-chat-panel.tsx
@@ -480,7 +480,7 @@ export function AnalystCaption({ context }: { readonly context: OperationRenderC
   );
 }
 
-/* 분석가 턴 — 채팅뷰 원장 문법: 스파인 노드가 상태를, 구간(문장+스텝)이 과정을,
+/* 분석가 턴 — 채팅뷰 원장 문법: 시계·접힘 줄·결말 문구가 상태를, 구간(문장+스텝)이 과정을,
    응답 seam 아래가 확정 답을 말한다. 끝난 턴의 과정은 fold 한 줄로 접힌다.
    entry=null이면 아직 아무 이벤트도 없는 진행/오류/중단의 합성 턴이다. 역사 턴은 봉인된
    entry.receipt만으로 그린다 — 전역 상태는 다음 send에서 이미 초기화됐다. */
@@ -508,7 +508,6 @@ function AnalystTurn({ state, language, entry, isLast, liveElapsedMs, decorateEv
     : null;
   return (
     <li className={`session-analyst__message session-analyst__message--analyst${working ? " is-working" : ""}${isError ? " is-error" : ""}${!isError && isStopped ? " is-stopped" : ""}`}>
-      <span className="session-analyst__turn-spine" aria-hidden="true"><span className="session-analyst__turn-node" /></span>
       <div className="session-analyst__turn-main">
         {/* 도는 동안의 시계는 채팅 원장과 같은 명도 물결을 진다 — 두 면이 같은 사실("이 턴이
             아직 살아 있다")을 말하므로 어휘가 갈리면 안 된다. */}

--- a/runtime/fleet-console/core/client/src/agent/analysis.css
+++ b/runtime/fleet-console/core/client/src/agent/analysis.css
@@ -91,15 +91,9 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 .session-analyst__ask-meta .session-analyst__ask-who { color: color-mix(in oklch, var(--id-cerulean) 75%, var(--text-tertiary)); }
 .session-analyst__ask-bubble { max-width: 64ch; background: color-mix(in oklch, var(--id-cerulean) 10%, var(--surface-panel-raised)); border: 1px solid color-mix(in oklch, var(--id-cerulean) 18%, var(--hairline)); border-radius: 14px 14px 5px 14px; padding: var(--space-2) var(--space-3); color: var(--text-primary); font-size: var(--t-base); line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
 
-/* 분석가 턴 — 좌측 스파인 노드가 상태를 신호 토큰으로만 말한다. */
-.session-analyst__message--analyst { display: grid; grid-template-columns: 14px minmax(0, 1fr); gap: var(--space-3); animation: analyst-answer-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__turn-spine { position: relative; }
-.session-analyst__turn-spine::before { content: ""; position: absolute; left: 5px; top: 22px; bottom: 2px; width: 2px; border-radius: var(--radius-pill); background: var(--hairline); }
-.session-analyst__turn-node { position: absolute; left: 0; top: 4px; width: 12px; height: 12px; border-radius: var(--radius-pill); border: 2px solid var(--positive); /* 노드는 스파인 위에 뚫린 구멍이다 — 채움은 뒤의 패널 면을 그대로 따라가야 링으로 읽힌다. */ background: var(--glass-tint-panel); }
-.session-analyst__message--analyst.is-working .session-analyst__turn-node { border-color: var(--aurora); animation: analyst-node-pulse 1.6s ease-in-out infinite; }
-.session-analyst__message--analyst.is-working .session-analyst__turn-spine::before { background: color-mix(in oklch, var(--aurora) 40%, var(--hairline)); }
-.session-analyst__message--analyst.is-error .session-analyst__turn-node { border-color: var(--coral); }
-.session-analyst__message--analyst.is-stopped .session-analyst__turn-node { border-color: var(--text-tertiary); }
+/* 분석가 턴 — 단일 열. 스파인·노드는 채팅 원장과 함께 퇴역했다: 상태는 시계·접힘 줄·결말 문구가 말한다. */
+.session-analyst__message--analyst { display: block; animation: analyst-answer-rise var(--duration-base) var(--ease-glide) both; }
+.session-analyst__turn-main { min-width: 0; }
 .session-analyst__turn-head { display: flex; align-items: baseline; flex-wrap: wrap; gap: var(--space-2); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: .06em; color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
 
 /* 진행 펄스 행 — 채팅 뷰의 agent-chat-pulse와 한 계열. 정직성 마이크로카피가 아래에 붙는다. */
@@ -363,7 +357,6 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
 
 @keyframes analyst-orbit { to { transform: rotate(360deg); } }
 @keyframes analyst-orbit-pulse { from { opacity: .7; transform: scale(.92); } to { opacity: 0; transform: scale(1.12); } }
-@keyframes analyst-node-pulse { 0%, 100% { opacity: .55; } 50% { opacity: 1; box-shadow: 0 0 10px 1px var(--aurora-glow); } }
 @keyframes analyst-chip-dot-pulse { 0%, 100% { opacity: .55; } 50% { opacity: 1; } }
 @keyframes analyst-status-rise { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes analyst-answer-rise { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
@@ -390,10 +383,10 @@ button.session-analyst__chip:disabled { color: var(--text-tertiary); cursor: def
   .session-analyst__pulse-copy strong.session-analyst__live-text { animation: none; background-image: none; color: var(--text-secondary); }
   .session-analyst__turn-head .session-analyst__live-text { color: var(--text-tertiary); }
 
-  .session-analyst__chip, .session-analyst__suggestions button, .session-analyst__followups-row button, .session-analyst__queue-item button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__select, .session-analyst__model-chip, .session-analyst__slash-hint, .session-analyst__send, .session-analyst__artifact-count, .session-analyst__artifact-count i, .session-analyst__receipt-chev, .session-analyst__chat-pane, .session-analyst__artifacts, .session-analyst__turn-node, .session-analyst__settle { transition: none; }
+  .session-analyst__chip, .session-analyst__suggestions button, .session-analyst__followups-row button, .session-analyst__queue-item button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__select, .session-analyst__model-chip, .session-analyst__slash-hint, .session-analyst__send, .session-analyst__artifact-count, .session-analyst__artifact-count i, .session-analyst__receipt-chev, .session-analyst__chat-pane, .session-analyst__artifacts, .session-analyst__settle { transition: none; }
   .session-analyst__step[data-tone="live"] .session-analyst__step-mark { animation: none; }
   .session-analyst__suggestions button:hover, .session-analyst__followups-row button:hover { transform: none; }
-  .session-analyst__chip-dot, .session-analyst__turn-node, .session-analyst__pulse-orbit { animation: none !important; }
+  .session-analyst__chip-dot, .session-analyst__pulse-orbit { animation: none !important; }
 }
 
 /* ── 세션 관찰(실험) 결과 말풍선 — 캡션 눈 버튼 아래 ────────────────────────

--- a/runtime/fleet-console/core/client/src/agent/chat/chat-view.tsx
+++ b/runtime/fleet-console/core/client/src/agent/chat/chat-view.tsx
@@ -699,7 +699,6 @@ function ChatTurn({
       ) : null}
       {turn.items.length > 0 || working || view.answer !== null ? (
         <div className={`agent-chat-turn is-${turn.state}`}>
-          <div className="agent-chat-turn-spine" aria-hidden="true"><span className="agent-chat-turn-node" /></div>
           <div className="agent-chat-turn-body">
             {/* 모델·강도는 상단 세션 바가 이미 말한다 — 진행 중 헤드는 턴의 시간축만 맡는다.
                 완료 턴에는 따로 두지 않는다: 접힘 줄이 같은 시간을 말하므로 두 줄이 겹친다. */}

--- a/runtime/fleet-console/core/client/src/agent/chat/chat.css
+++ b/runtime/fleet-console/core/client/src/agent/chat/chat.css
@@ -248,56 +248,14 @@
   overflow-wrap: anywhere;
 }
 
-/* 에이전트 턴 — 좌측 스파인 노드가 상태를 신호 토큰으로만 말한다. */
+/* 에이전트 턴 — 단일 열. 좌측 스파인·노드 띠는 퇴역했다: 상태는 본문의 시계·접힘 줄·결말 문구가
+   이미 말하고, 14px 띠는 그 말을 한 번 더 하면서 읽는 폭만 먹었다. */
 .agent-chat-turn {
-  display: grid;
-  grid-template-columns: 14px minmax(0, 1fr);
-  gap: var(--space-3);
+  display: block;
 }
 
-.agent-chat-turn-spine {
-  position: relative;
-}
-
-.agent-chat-turn-spine::before {
-  content: "";
-  position: absolute;
-  left: 5px;
-  top: 22px;
-  bottom: 2px;
-  width: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--hairline);
-}
-
-.agent-chat-turn-node {
-  position: absolute;
-  left: 0;
-  top: 4px;
-  width: 12px;
-  height: 12px;
-  border-radius: var(--radius-pill);
-  border: 2px solid var(--positive);
-  /* 노드는 스파인 위에 뚫린 구멍이다 — 채움은 뒤의 패널 면을 그대로 따라가야 링으로 읽힌다. */
-  background: var(--glass-tint-panel);
-}
-
-.agent-chat-turn.is-working .agent-chat-turn-node {
-  border-color: var(--aurora);
-  animation: agent-chat-node-pulse 1.6s ease-in-out infinite;
-}
-
-.agent-chat-turn.is-working .agent-chat-turn-spine::before {
-  background: color-mix(in oklch, var(--aurora) 40%, var(--hairline));
-}
-
-.agent-chat-turn.is-error .agent-chat-turn-node {
-  border-color: var(--coral);
-}
-
-@keyframes agent-chat-node-pulse {
-  0%, 100% { opacity: 0.55; }
-  50% { opacity: 1; box-shadow: 0 0 10px 1px var(--aurora-glow); }
+.agent-chat-turn-body {
+  min-width: 0;
 }
 
 .agent-chat-turn-head {
@@ -445,6 +403,16 @@
   color: var(--text-secondary);
 }
 
+/* 생각의 점선 원은 라이브 줄에서 천천히 돈다 — 내용 없는 원이 "시간만 흐른다"를 말하는데, 멈춘
+   원은 그 시간을 말하지 않는다. 링(0.9s)보다 느려 두 번째 스피너가 아니라 숨으로 읽힌다. */
+.agent-chat-tally.is-live .agent-chat-tally-glyph > .agent-glyph[data-glyph="think"] {
+  animation: agent-chat-think-spin 3s linear infinite;
+}
+
+@keyframes agent-chat-think-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* 글리프 알파벳의 한 글자. 24 뷰박스에 1.8 스트로크를 13px로 그리면 12px 모노 활자와
    같은 시각 무게가 된다(실측: 문자 글리프 ▤·❯의 x-높이 자리). */
 .agent-glyph {
@@ -481,13 +449,17 @@
   width: 3ch;
 }
 
+/* 점은 opacity가 아니라 visibility로 숨긴다. 이 점들은 물결(.agent-chat-live-text)의 자식이고,
+   물결은 배경을 글자 모양으로 클립해 그리므로 자식의 opacity가 0이어도 부모의 배경이 그 글자
+   모양대로 그대로 비쳐 세 점이 항상 켜져 있었다(실측: "생각 중..." 고정). visibility: hidden은
+   글자를 아예 그리지 않아 클립 마스크에서도 빠진다 — 자리는 지키므로 폭이 흔들리지 않는다. */
 .agent-chat-thinking-dots > span {
   width: 1ch;
-  opacity: 0;
+  visibility: hidden;
 }
 
 .agent-chat-thinking-dots > span:first-child {
-  opacity: 1;
+  visibility: visible;
 }
 
 .agent-chat-thinking-dots > span:nth-child(2) {
@@ -499,13 +471,13 @@
 }
 
 @keyframes agent-chat-thinking-dot-mid {
-  0%, 33.332% { opacity: 0; }
-  33.333%, 100% { opacity: 1; }
+  0%, 33.332% { visibility: hidden; }
+  33.333%, 100% { visibility: visible; }
 }
 
 @keyframes agent-chat-thinking-dot-end {
-  0%, 66.665% { opacity: 0; }
-  66.666%, 100% { opacity: 1; }
+  0%, 66.665% { visibility: hidden; }
+  66.666%, 100% { visibility: visible; }
 }
 
 /* 도는 구간의 집계 줄. 예전에는 최근 여덟 스텝이 전폭 행으로 흘러가는 것이 "일하는 중"의
@@ -2353,10 +2325,15 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .agent-chat-turn.is-working .agent-chat-turn-node,
   .agent-chat-ask-dot,
   .agent-chat-step-orbit,
+  /* 점의 순환만 멎고 세 점은 다 켜 둔다 — 하나만 남기면 생각 중이 아니라 문장이 끝난 것처럼 읽힌다. */
   .agent-chat-thinking-dots > span {
+    animation: none;
+    visibility: visible;
+  }
+
+  .agent-chat-tally-glyph > .agent-glyph[data-glyph="think"] {
     animation: none;
   }
 

--- a/runtime/fleet-console/core/client/src/agent/chat/chat.css
+++ b/runtime/fleet-console/core/client/src/agent/chat/chat.css
@@ -2333,7 +2333,8 @@
     visibility: visible;
   }
 
-  .agent-chat-tally-glyph > .agent-glyph[data-glyph="think"] {
+  /* 라이브 규칙과 같은 선택자로 못을 박는다 — 짧은 선택자는 특정성에서 져서 회전이 멎지 않는다. */
+  .agent-chat-tally.is-live .agent-chat-tally-glyph > .agent-glyph[data-glyph="think"] {
     animation: none;
   }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2689,9 +2689,10 @@ describe("Instrument core design contract", () => {
     expect(chatRootBlock).toContain("background: var(--glass-tint-panel-face);");
     expect(chatRootBlock).not.toContain("--surface-window");
     expect(chatRootBlock).not.toContain("transition: background");
-    const chatNodeBlock = chat.match(/^\.agent-chat-turn-node \{[^}]*\}/m)?.[0] ?? "";
-    expect(chatNodeBlock).toContain("background: var(--glass-tint-panel);");
-    expect(chatNodeBlock).not.toContain("--surface-window");
+    // 좌측 스파인·노드 띠는 퇴역했다 — 상태는 본문의 시계·접힘 줄·결말 문구가 말한다. 세 표면이
+    // 같은 문법을 썼으므로 함께 물러난다.
+    expect(chat).not.toContain(".agent-chat-turn-spine");
+    expect(chat).not.toContain(".agent-chat-turn-node");
     // 상단 세션 띠바는 여전히 폐기 상태다 — 지속 크롬으로 패널 높이를 쓰면서 누를 것이 없었다.
     expect(chat).not.toContain(".agent-chat-head");
     // 떠 있던 잡 스트립은 폐기됐다 — 로그와 컴포저의 이음새에 걸터앉아 어느 쪽에도 속하지
@@ -2887,13 +2888,14 @@ describe("Instrument core design contract", () => {
     expect(chatView0).toContain('className="agent-chat-thinking-dots" aria-hidden="true"');
     const thinkingDotsBlock = chat.match(/\.agent-chat-thinking-dots > span \{[^}]*\}/)?.[0] ?? "";
     expect(thinkingDotsBlock).toContain("width: 1ch;");
-    expect(thinkingDotsBlock).toContain("opacity: 0;");
-    expect(chat).toMatch(/\.agent-chat-thinking-dots > span:first-child \{\s*opacity: 1;\s*\}/);
+    expect(thinkingDotsBlock).toContain("visibility: hidden;");
+    expect(thinkingDotsBlock).not.toContain("opacity");
+    expect(chat).toMatch(/\.agent-chat-thinking-dots > span:first-child \{\s*visibility: visible;\s*\}/);
     expect(chat).toMatch(/\.agent-chat-thinking-dots > span:nth-child\(2\) \{\s*animation: agent-chat-thinking-dot-mid 1\.2s steps\(1, end\) infinite;\s*\}/);
     expect(chat).toMatch(/\.agent-chat-thinking-dots > span:nth-child\(3\) \{\s*animation: agent-chat-thinking-dot-end 1\.2s steps\(1, end\) infinite;\s*\}/);
-    expect(chat).toMatch(/@keyframes agent-chat-thinking-dot-mid \{\s*0%, 33\.332% \{ opacity: 0; \}\s*33\.333%, 100% \{ opacity: 1; \}\s*\}/);
-    expect(chat).toMatch(/@keyframes agent-chat-thinking-dot-end \{\s*0%, 66\.665% \{ opacity: 0; \}\s*66\.666%, 100% \{ opacity: 1; \}\s*\}/);
-    expect(chat).toMatch(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.agent-chat-thinking-dots > span \{\s*animation: none;\s*\}/);
+    expect(chat).toMatch(/@keyframes agent-chat-thinking-dot-mid \{\s*0%, 33\.332% \{ visibility: hidden; \}\s*33\.333%, 100% \{ visibility: visible; \}\s*\}/);
+    expect(chat).toMatch(/@keyframes agent-chat-thinking-dot-end \{\s*0%, 66\.665% \{ visibility: hidden; \}\s*66\.666%, 100% \{ visibility: visible; \}\s*\}/);
+    expect(chat).toMatch(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.agent-chat-thinking-dots > span \{\s*animation: none;\s*visibility: visible;\s*\}/);
     // 흐르는 글의 표식 — 캐럿은 secondary 잉크(채널 없음)로 마지막 블록 끝에 서고, 끝단
     // 옅어짐은 알파 마스크다. 둘 다 흐르는 동안만 걸리고 감속 모션에서 점멸·마스크가 걷힌다.
     const chatCaretBlock = chat.match(/\.agent-chat-stream\.is-streaming > :last-child:not\(ol, ul, pre\)::after,[\s\S]*?\}/)?.[0] ?? "";
@@ -3202,7 +3204,7 @@ describe("Instrument core design contract", () => {
     // 정체·상태·모드는 호스트 캡션 밴드가 진다 — 본문 위에 떠서 첫 문단을 가리지 않는다.
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__chips \{/);
     expect(terminalAnalysisCss).not.toMatch(/\.session-analyst__chips \{[^}]*position: absolute/);
-    expect(terminalAnalysisCss).toMatch(/\.session-analyst__turn-node \{/);
+    expect(terminalAnalysisCss).not.toContain(".session-analyst__turn-node");
     expect(terminalAnalysisCss).toMatch(/\.session-analyst__receipt > summary \{/);
     // 끝난 턴의 접힘은 채팅 원장의 `.agent-chat-fold`와 같은 문법이다 — 문장이지 카드가 아니다.
     // 알약(면·테두리)으로 되돌아가면 이 줄이 결말을 말하는 문장이 아니라 물건으로 읽힌다.
@@ -3210,7 +3212,7 @@ describe("Instrument core design contract", () => {
     expect(analystReceiptSummary).not.toContain("border:");
     expect(analystReceiptSummary).not.toContain("background:");
     expect(analystReceiptSummary).not.toContain("radius-pill");
-    // 결말의 성패는 스파인 노드가 진다 — 접힘 줄이 ✓를 또 들면 두 곳이 같은 말을 한다.
+    // 결말의 성패는 접힘 줄 아래 결말 문구가 진다 — 접힘 줄이 ✓를 또 들면 두 곳이 같은 말을 한다.
     expect(terminalAnalysisCss).not.toContain(".session-analyst__receipt-mark");
     // 물결은 채팅 원장의 것과 한 벌이다. 값이 갈라지면 같은 사실을 두 면이 다른 속도로 말한다.
     // 줄머리에 못을 박는다 — 앵커 없는 `.session-analyst__live-text {`는 합성 규칙의

--- a/runtime/fleet-plugins/codex/client/codex/cowork-controller.ts
+++ b/runtime/fleet-plugins/codex/client/codex/cowork-controller.ts
@@ -650,6 +650,10 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
         const turn = currentTurn();
         if (turn) patchTurn(turn.id, { state: "error", endedAt: Date.now(), error: cause instanceof Error ? cause.message : null });
         annotations = annotations.map(card => card.status === "sent" ? { ...card, status: "pending" } : card);
+        // 세션 생성(ensureSession)은 mutate를 거치지 않아 여기 도착해도 알림이 없다. 턴의 스파인
+        // 노드가 물러난 뒤에는 이 알림 카드가 실패를 말하는 유일한 자리다 — mutate가 이미 같은
+        // 원인으로 세운 알림은 같은 값으로 덮이므로 두 번 서지 않는다.
+        notice = noticeFrom(cause);
       }
     } finally {
       if (!attempt.cancelled && promptAttempt === attempt) {

--- a/runtime/fleet-plugins/codex/client/codex/cowork-thread.tsx
+++ b/runtime/fleet-plugins/codex/client/codex/cowork-thread.tsx
@@ -168,7 +168,6 @@ function TurnView({ turn, last, state }: { readonly turn: CoworkTurn; readonly l
   const showFold = !working && turn.steps.length > 0;
   return (
     <li className={`cowork-turn ${tone}`}>
-      <div className="cowork-turn-spine" aria-hidden="true"><span className="cowork-turn-node" /></div>
       <div className="cowork-turn-body">
         <div className="cowork-turn-head">
           <span className="cowork-turn-who">{t("codex.cowork.you")}</span>

--- a/runtime/fleet-plugins/codex/client/codex/styles/components.css
+++ b/runtime/fleet-plugins/codex/client/codex/styles/components.css
@@ -3046,27 +3046,9 @@ button.chip:focus-visible {
 }
 .cowork-hero-suggestion:hover { border-color: var(--brass); color: var(--text-primary); }
 
-/* ── 스레드 — 스파인 + 턴. 공식은 agent-chat과 같다(14px 열, 2px 스파인, 12px 노드). ── */
+/* ── 스레드 — 단일 열 턴. 스파인·노드는 agent-chat과 함께 퇴역했다: 상태는 접힘 줄·결말 문구가 말한다. ── */
 .cowork-thread { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--space-3); }
-.cowork-turn { display: grid; grid-template-columns: 14px minmax(0, 1fr); gap: var(--space-3); }
-.cowork-turn-spine { position: relative; }
-.cowork-turn-spine::before { content: ""; position: absolute; left: 5px; top: 22px; bottom: 2px; width: 2px; border-radius: var(--radius-pill); background: var(--hairline); }
-.cowork-turn-node {
-  position: absolute;
-  left: 0;
-  top: 4px;
-  width: 12px;
-  height: 12px;
-  border-radius: var(--radius-pill);
-  border: 2px solid var(--positive);
-  /* 노드는 스파인 위에 뚫린 구멍이다 — 채움은 뒤의 면을 따라야 링으로 읽힌다. */
-  background: var(--surface-panel);
-}
-.cowork-turn.is-working .cowork-turn-node { border-color: var(--aurora); animation: cowork-node-pulse 1.6s ease-in-out infinite; }
-.cowork-turn.is-working .cowork-turn-spine::before { background: color-mix(in oklch, var(--aurora) 40%, var(--hairline)); }
-.cowork-turn.is-error .cowork-turn-node { border-color: var(--coral); }
-.cowork-turn.is-stopped .cowork-turn-node { border-color: var(--hairline-strong); }
-.cowork-turn.is-review .cowork-turn-node { border-color: var(--brass); }
+.cowork-turn { display: block; }
 .cowork-turn-body { display: grid; gap: var(--space-2); min-width: 0; }
 .cowork-turn-head { display: flex; align-items: baseline; gap: var(--space-2); font-family: var(--font-mono); font-size: var(--t-xs); letter-spacing: 0.06em; color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
 .cowork-turn-who { color: var(--text-secondary); }
@@ -3345,7 +3327,6 @@ button.chip:focus-visible {
 @keyframes cowork-pop { from { opacity: 0; transform: translateX(-50%) scale(0.92); } to { opacity: 1; transform: translateX(-50%) scale(1); } }
 @keyframes cowork-rise { from { opacity: 0; translate: 0 6px; } to { opacity: 1; translate: 0 0; } }
 @keyframes cowork-orbit { to { transform: rotate(360deg); } }
-@keyframes cowork-node-pulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; box-shadow: 0 0 10px 1px var(--aurora-glow); } }
 @keyframes cowork-live-sweep { from { background-position: 0 0; } to { background-position: -200% 0; } }
 @keyframes cowork-caret { 50% { opacity: 0; } }
 @keyframes cowork-dot-mid { 0%, 33.332% { opacity: 0; } 33.333%, 100% { opacity: 1; } }
@@ -3358,7 +3339,7 @@ button.chip:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .cowork-pill, .cowork-composer, .cowork-dock-zone.is-open, .cowork-turn-node, .cowork-orbit, .cowork-thinking-dots > span, .cowork-answer-body::after { animation: none !important; }
+  .cowork-pill, .cowork-composer, .cowork-dock-zone.is-open, .cowork-orbit, .cowork-thinking-dots > span, .cowork-answer-body::after { animation: none !important; }
   .cowork-live-text { background-image: none; color: var(--text-secondary); animation: none; }
   .cowork-thinking-dots > span { opacity: 1; }
   .cowork-ghost, .cowork-solid, .cowork-chip, .cowork-send, .cowork-model-chip, .cowork-card, .cowork-composer-frame, .cowork-fold-chev, .cowork-hero-suggestion { transition: none; }


### PR DESCRIPTION
## Summary
- Remove the left spine and status node from agent turns in Chat view, the Analyst panel, and the Codex cowork thread; the working clock, fold line, and outcome text already carry that state, so each turn is now a single column.
- Hide the thinking dots with `visibility` instead of `opacity`: the live-text background clip painted the parent gradient through the hidden dots' glyph shapes, so the `.` → `..` → `...` cycle never showed.
- Spin the dashed thinking glyph slowly (3s) while the live tail says thinking.

## Test Plan
- [x] `pnpm typecheck` in `runtime/fleet-console` and `runtime/fleet-plugins/codex`
- [x] `vitest run tests/instrument-design-contract.test.ts core/client/src/agent` (fleet-console) and codex plugin tests
- [x] Isolated Console built from this branch: live Gemini Flash chat turn shows no spine, single-column turn, dots cycling (`vvv` → `vvh` → `vhh` visibility samples), rotating think glyph; settled turn renders fold + answer; no page errors
- [ ] Analyst panel and Codex cowork thread verified visually (CSS/typecheck only)