### PR TITLE
fix(console): keep quick launch hooks stable when opening

### DIFF
--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -106,6 +106,7 @@ export function QuickLaunch() {
   const navigate = useNavigate();
   const location = useLocation();
   const registry = usePluginRegistry();
+  useShortcutOverrides();
   // Cmd+K·사이드바·커맨드 밴드와 같은 마크 축. 미확인 완료도 어느 Operation을 고르는
   // 표면인가에 따라 사라지지 않아야 하므로 멘션 덱이 같은 외부 원장을 구독한다.
   const idleArrivalIds = useSyncExternalStore(subscribeIdleArrival, getIdleArrivalIds, getIdleArrivalIds);
@@ -1504,7 +1505,6 @@ export function QuickLaunch() {
       ? registry.providers.find((plugin) => plugin.id === target.pluginId)?.renderLaunchIcon?.(target.kind) ?? null
       : null);
   // 접힌 띠의 힌트는 등록부의 현재 조합을 말한다 — 재배정이 바뀌면 함께 바뀐다.
-  useShortcutOverrides();
   const toggleChords = resolveShortcutChords("console.quick-launch");
 
   return (


### PR DESCRIPTION
## Summary
- 퀵런치를 열 때 발생하는 React #310 오류와 Console 전체 화면 소실을 수정합니다.
- 단축키 설정 구독 Hook을 닫힘 상태의 조기 반환 앞으로 이동하여 기존 단축키·고정 동작과 설정 구독을 유지합니다.

## Test Plan
- [x] Console build 및 typecheck 통과
- [x] quick-launch, shortcut-bindings, console-shortcut-containment: 3개 파일, 8개 테스트 통과
- [x] macOS 실제 Chromium에서 수정 전 검은 화면과 React #310 재현
- [x] 수정 후 ⌘J / Ctrl+Space 열기, Escape 닫기, 고정·해제 후 재열기: Console 유지, 오류 0건
- [x] Tab 순환 및 모달 뒤 단축키 억제 확인
- [x] git diff --check 통과; 격리 브라우저·서버 정리
- [ ] Electron 셸 자체 및 전체 테스트 스위트는 미실행