### PR TITLE
fix(console): sit Instrument popup pillar next to ink-deep when glass is off

### DIFF
--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -200,7 +200,12 @@
      Whites가 자기 값을 따로 잡는다. 패널 면과 같은 값이 되면 로그 위계가 통째로 사라진다. */
   --surface-panel-raised: var(--ink-mid);
   --surface-glass-strong: var(--ink-mid);
-  --surface-pillar: var(--ink-veil);
+  /* 부유 카드(⌘K/⌘P 검색·Quick Launch)의 pillar 티어. 유리가 꺼진 순간 --glass-tint-pillar가
+     이 값으로 떨어지므로, 유리 ON(ink-veil α52% + 블러 → 실측 L≈18%)과 같은 자리에 서야 한다.
+     ink-veil(L 23.5%) 불투명을 그대로 두면 Instrument만 크롬(ink-deep L 16.5%)보다 7단 밝은
+     슬레이트 판이 되어 테마와 동떨어진다 — Maritime(L 22%/α86%)·Carbon(L 20%/α88%)처럼
+     deep 바로 위의 반투명 리터럴로 둔다. */
+  --surface-pillar: oklch(19% 0.018 245 / 86%);
   --surface-rim: var(--hairline);
   --surface-rim-strong: var(--hairline-strong);
   --surface-band: var(--canvas-sea-core);


### PR DESCRIPTION
## Summary
- With liquid glass disabled, the ⌘K/⌘P search card and Quick Launch paint `--glass-tint-pillar`, which falls back to `--surface-pillar`. Instrument aliased that to opaque `--ink-veil` (L 23.5%), leaving the cards seven lightness steps above the chrome as a detached blue-grey slab. Maritime and Carbon already keep pillar as a translucent literal just above `--ink-deep`.
- Give Instrument the same relationship (`oklch(19% 0.018 245 / 86%)`), matching the measured glass-on tone (L≈18%) so both glass states sit on the same material. Other themes are untouched.

## Test Plan
- [x] Isolated headless Console (`console-e2e`): Instrument + glass off, ⌘K and ⌘P card background changes from `oklch(0.235 …)` to `oklch(0.19 … / 0.79)` and reads as the sidebar's material in screenshots
- [x] Instrument + glass on and Maritime + glass off unchanged
- [x] Other `--surface-pillar` consumers (Codex panel pressed segments) still readable; no page errors
- [x] `tests/instrument-design-contract.test.ts` — 98 passed
- [ ] Quick Launch (⌘J) visual check blocked by a pre-existing React #310 crash on canary `f46bf1f`; it shares the same recipe as the ⌘K card