### PR TITLE
fix(console): anchor launch menus across the global viewport

### DIFF
--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -12,7 +12,7 @@ import { launchProviderFromGroupId, launchProviderGlyph } from "../components/la
 import { ChatBubbleIcon, TerminalViewIcon } from "../components/start-view-glyphs.js";
 
 interface CanvasContextMenuProps {
-  // 캔버스(<main>) 기준 화면 좌표. 메뉴를 이 지점에 띄운다.
+  // body 포털에서 쓰는 Console 뷰포트 좌표. 메뉴를 이 지점에 띄운다.
   readonly anchor: { readonly x: number; readonly y: number };
   readonly viewportBounds?: { readonly width: number; readonly height: number };
   // above = anchor.y를 캔버스 하단 거리로 보고 메뉴를 위로 띄운다(런처). cursor = anchor를 좌상단으로 본다(우클릭).
@@ -23,9 +23,6 @@ interface CanvasContextMenuProps {
   readonly renderKindIcon: (pluginId: string | null, kind: OperationLaunchKind) => ReactNode;
   readonly onLaunchKind: (pluginId: string | null, kind: OperationLaunchKind, variantLaunch?: Readonly<Record<string, string>>) => void;
   readonly onClose: () => void;
-  // true면 anchor를 뷰포트 기준 좌표로 보고 position: fixed로 띄운다 — 선별 처리처럼
-  // 월드/스테이지 프레임이 anchor 좌표계를 침범하는 모드에서 쓴다.
-  readonly fixed?: boolean;
 }
 
 // 폭은 세 곳이 함께 알아야 한다 — 이 상수(측정 전 clamp 폴백), .canvas-context-menu의 width,
@@ -67,7 +64,7 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
 }
 
-export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", fixed = false, catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
+export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
   const t = useT();
   const globalSettings = useGlobalSettingsStore();
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -125,15 +122,16 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   };
   const openEffortMenu = (rowId: string) => {
     cancelEffortClose();
+    if (openEffortRow === rowId) return;
     const item = effortAnchorRefs.current.get(rowId);
-    const container = containerRef.current;
-    if (!item || !container) return;
+    const menu = menuRef.current;
+    if (!item || !menu) return;
+    const bounds = menu.getBoundingClientRect();
     const placement = placeCascade({
-      // 부모 상자는 컨테이너 왼쪽 끝에서 시작한다 — 그 바깥 경계가 다음 단의 기준이다.
-      boxLeft: containerLeft(container),
-      boxWidth: menuSize?.width ?? MENU_WIDTH,
-      top: itemTop(item, container),
-      width: EFFORT_SUBMENU_WIDTH,
+      boxLeft: bounds.left,
+      boxWidth: bounds.width,
+      top: item.getBoundingClientRect().top - 6,
+      width: effortMenuRef.current?.offsetWidth ?? EFFORT_SUBMENU_WIDTH,
       boundsWidth: viewportBounds?.width,
       preferLeft: false,
     });
@@ -273,26 +271,46 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     };
   }, []);
 
-  // Effort submenu uses a measured-height clamp — opening near the bottom would
-  // otherwise leave lower effort choices off-screen.
+  // 실제 폭으로 좌우를 고른다 — 최악 폭으로 왼쪽을 배치하면 짧은 트랙과 메뉴 사이가 벌어진다.
+  // offset 치수는 진입 애니메이션의 transform을 제외하므로 팝오버가 움직이는 중에도 안정적이다.
   useLayoutEffect(() => {
     const element = effortMenuRef.current;
-    if (!element || !viewportBounds || !openEffortRow) return;
+    const menu = menuRef.current;
+    const item = openEffortRow === null ? null : effortAnchorRefs.current.get(openEffortRow);
+    if (!element || !menu || !item || !openEffortRow) return;
     const measure = () => {
-      const height = element.getBoundingClientRect().height;
-      const maxTop = Math.max(MENU_MARGIN, viewportBounds.height - height - MENU_MARGIN);
+      const bounds = menu.getBoundingClientRect();
+      const position = placeCascade({
+        boxLeft: bounds.left,
+        boxWidth: bounds.width,
+        top: item.getBoundingClientRect().top - 6,
+        width: element.offsetWidth,
+        boundsWidth: viewportBounds?.width,
+        preferLeft: false,
+      });
+      const maxTop = viewportBounds
+        ? Math.max(MENU_MARGIN, viewportBounds.height - element.offsetHeight - MENU_MARGIN)
+        : Number.POSITIVE_INFINITY;
+      const top = Math.min(position.top, maxTop);
       setEffortPosition((previous) => {
         if (!previous || previous.id !== openEffortRow) return previous;
-        const nextTop = Math.max(MENU_MARGIN, Math.min(previous.top, maxTop));
-        return Math.abs(nextTop - previous.top) < 0.5 ? previous : { ...previous, top: nextTop };
+        return Math.abs(position.left - previous.left) < 0.5 && Math.abs(top - previous.top) < 0.5
+          && position.opensLeft === previous.opensLeft
+          ? previous
+          : { id: openEffortRow, ...position, top };
       });
     };
     measure();
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(measure);
     observer.observe(element);
-    return () => observer.disconnect();
-  }, [openEffortRow, viewportBounds]);
+    observer.observe(menu);
+    menu.addEventListener("scroll", measure, { passive: true });
+    return () => {
+      observer.disconnect();
+      menu.removeEventListener("scroll", measure);
+    };
+  }, [openEffortRow, viewportBounds, menuSize]);
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent) => {
@@ -343,7 +361,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         closeEffortMenu();
         return;
       }
-      openEffortMenu(openEffortRow);
     };
     menu.addEventListener("scroll", follow, { passive: true });
     return () => menu.removeEventListener("scroll", follow);
@@ -518,9 +535,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
 
   return (
     <div
-      className={`operation-launch-control operation-launch-control--canvas ${fixed ? "operation-launch-control--triage" : ""} ${placement === "above" ? "operation-launch-control--up" : ""}`}
+      className={`operation-launch-control operation-launch-control--canvas ${placement === "above" ? "operation-launch-control--up" : ""}`}
       ref={containerRef}
-      style={clampedAnchorStyle(anchor, viewportBounds, placement, menuSize, fixed)}
+      style={clampedAnchorStyle(anchor, viewportBounds, placement, menuSize)}
       data-canvas-blocker
     >
       <div
@@ -871,20 +888,6 @@ function expandsVariants(kind: OperationLaunchKind, canLaunch: boolean): boolean
   return canLaunch && kind.disabled !== true && (kind.variants?.length ?? 0) > 0;
 }
 
-// 컨테이너는 자기 좌표를 인라인 스타일로 들고 있다. 캐스케이드의 모든 단이 이 좌표계 위에서
-// 계산된다 — 각 단은 fixed로 그 자리에 그려지므로, 다음 단의 기준은 DOM 측정이 아니라 앞 단이
-// 이미 확정한 좌표다.
-function containerLeft(container: HTMLElement): number {
-  const styled = Number.parseFloat(container.style.left);
-  return Number.isFinite(styled) ? styled : container.offsetLeft;
-}
-
-function itemTop(item: HTMLElement, container: HTMLElement): number {
-  const styled = Number.parseFloat(container.style.top);
-  const top = Number.isFinite(styled) ? styled : container.offsetTop;
-  return top + item.getBoundingClientRect().top - container.getBoundingClientRect().top - 6;
-}
-
 // 캐스케이드 한 단의 배치. 두 축의 기준이 서로 다르다: 가로는 앞 단의 **상자**가 정하고, 세로만
 // 짚은 행이 정한다. 가로까지 행에 맡기면 행은 상자 안쪽 패딩만큼 좁아, 다음 단이 부모 위로
 // 그만큼 파고든다.
@@ -942,14 +945,12 @@ function clampedAnchorStyle(
   bounds: { readonly width: number; readonly height: number } | undefined,
   placement: "above" | "cursor",
   size: { readonly width: number; readonly height: number } | null,
-  fixed: boolean,
 ): CSSProperties {
   // 상한도 뷰포트에서 산출한다 — 520px보다 낮은 화면에서 메뉴가 잘려 나가지 않게.
   const maxHeight = bounds
     ? Math.max(MENU_MIN_HEIGHT, Math.min(MENU_MAX_HEIGHT, bounds.height - MENU_MARGIN * 2))
     : MENU_MAX_HEIGHT;
-  const base = fixed ? { position: "fixed", "--canvas-menu-max-height": `${maxHeight}px` } as CSSProperties
-    : { "--canvas-menu-max-height": `${maxHeight}px` };
+  const base = { "--canvas-menu-max-height": `${maxHeight}px` };
   const width = size?.width ?? MENU_WIDTH;
   // 측정 전 첫 렌더는 높이 0으로 두어 커서 좌표를 그대로 쓴다 —
   // useLayoutEffect 측정이 페인트 전에 반영되므로 위치가 튀지 않는다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -416,27 +416,20 @@ export function OperationsCanvas({
     const rect = canvasRef.current?.getBoundingClientRect();
     const anchor = rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : null;
     if (!anchor) return;
-    // 표시 앵커는 아레나 안으로 끌어들인다 — 사이드바 왼쪽 12px 거터의 우클릭은 캔버스에
-    // 닿지만, 그 자리에서 열면 메뉴가 더 높은 층의 부유 카드 밑에 그려져 보이지 않는 채
-    // 포커스만 쥔다(Codex 리뷰 확정). 발사 월드 좌표는 원 커서 기준을 유지한다.
-    const displayAnchor = { x: Math.max(anchor.x, arenaInsets.left + 12), y: anchor.y };
-    // 월드 환산은 아레나 원점을 더한 screenViewport로 — 저장 좌표는 아레나-상대다.
-    setContextMenu({ anchor: displayAnchor, canvasPoint: screenToCanvas(anchor, screenViewport) });
+    // 표시는 Console 뷰포트, 실행 위치는 캔버스 월드 좌표다 — 부유 크롬은 메뉴의 경계가 아니다.
+    setContextMenu({
+      anchor: { x: event.clientX, y: event.clientY },
+      canvasPoint: screenToCanvas(anchor, screenViewport),
+    });
     onRefreshCatalog?.();
   };
 
   const openTriageTheaterLaunchMenu = (theaterId: string, cursor: CanvasPoint) => {
     const canvasRect = canvasRef.current?.getBoundingClientRect();
     if (!canvasRect) return;
-    // 앵커와 클램프 경계는 같은 좌표계여야 한다 — 메뉴는 캔버스 크기로 클램프되므로 앵커도 캔버스-local이다.
-    // position: fixed도 뷰포트에 걸리지 않는다: .operations-canvas의 contain: paint가 고정 위치의
-    // 컨테이닝 블록이 되어 캔버스에 재앵커한다(실측). 뷰포트 좌표를 그대로 넘기면 메뉴가 커서에서
-    // 캔버스 왼쪽 여백만큼 밀리고, 오른쪽 끝에서는 캔버스 폭으로 클램프돼 커서와 크게 어긋난다.
     const local = { x: cursor.x - canvasRect.left, y: cursor.y - canvasRect.top };
-    // 표시 앵커의 아레나 좌측 클램프는 Cruise 경로와 같은 이유다 — 발사 좌표는 원 커서 기준.
-    const displayLocal = { x: Math.max(local.x, arenaInsets.left + 12), y: local.y };
     setContextMenu({
-      anchor: displayLocal,
+      anchor: cursor,
       // 실행 좌표는 그 Theater의 world 좌표여야 한다 — canvasPointToGeometry는 받은 점을 world로
       // 취급한다. War Room은 전 Theater를 한 판에 얹으므로 화면-local을 그대로 넘기면 그 Theater를
       // 다시 열었을 때 패널이 보이는 자리 밖에 놓인다. 로드된 Theater가 아닐 수 있으니 저장된
@@ -1306,13 +1299,11 @@ export function OperationsCanvas({
         />
       ) : null}
       {interaction.rubberBand ? <RubberBand rect={interaction.rubberBand} viewport={screenViewport} /> : null}
-      {contextMenu ? (
+      {contextMenu ? createPortal(
         <CanvasContextMenu
           key={`${contextMenu.anchor.x}:${contextMenu.anchor.y}`}
           anchor={contextMenu.anchor}
-          // 우/하단 클램프 경계에서 부유 크롬 점유 폭을 빼 메뉴가 카드 밑으로 파고들지 않게 한다.
-          // 좌측은 커서가 크롬 위에서는 캔버스에 닿지 않으므로 별도 하한이 필요 없다.
-          viewportBounds={viewportBoundsFor(canvasRef.current, arenaInsets)}
+          viewportBounds={{ width: window.innerWidth, height: window.innerHeight }}
           placement="cursor"
           catalog={catalog}
           // 실행 가부는 모드가 아니라 Theater가 정한다 — 사이드바와 좌하단 런처는 어느 모드에서도
@@ -1322,8 +1313,8 @@ export function OperationsCanvas({
           renderKindIcon={renderKindIcon}
           onLaunchKind={handleContextMenuLaunchKind}
           onClose={() => setContextMenu(null)}
-          fixed={triageActive}
-        />
+        />,
+        document.body,
       ) : null}
       <CanvasMinimap
         operations={visibleOperations}
@@ -1348,15 +1339,6 @@ export function OperationsCanvas({
       />
     </main>
   );
-}
-
-function viewportBoundsFor(element: HTMLElement | null, arenaInsets?: CanvasArenaInsets): { readonly width: number; readonly height: number } | undefined {
-  if (!element) return undefined;
-  const rect = element.getBoundingClientRect();
-  return {
-    width: rect.width - (arenaInsets?.right ?? 0),
-    height: rect.height - (arenaInsets?.bottom ?? 0),
-  };
 }
 
 function rectToGeometry(rect: CanvasRect): OperationGeometry {

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -851,13 +851,9 @@ export function OperationsCanvas({
   // 판 위의 커서는 월드와 무관하고, 활성 Theater는 지도 배율(0.02)이라 커서 투영이 수만 단위
   // 밖에 떨어진다. 화면 중앙은 그 Theater를 올렸을 때 보이는 자리라 새 패널이 시야 안에 선다.
   const openFleetMapTheaterLaunchMenu = (theaterId: string, cursor: CanvasPoint) => {
-    const canvasRect = canvasRef.current?.getBoundingClientRect();
-    if (!canvasRect) return;
-    const local = { x: cursor.x - canvasRect.left, y: cursor.y - canvasRect.top };
-    const displayLocal = { x: Math.max(local.x, arenaInsets.left + 12), y: local.y };
     const theaterViewport = getTheaterCanvasSnapshot(theaterId).viewport;
     setContextMenu({
-      anchor: displayLocal,
+      anchor: cursor,
       canvasPoint: screenToCanvas({ x: arena.x + arena.width / 2, y: arena.y + arena.height / 2 }, {
         x: theaterViewport.x + arena.x,
         y: theaterViewport.y + arena.y,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3195,19 +3195,14 @@
 }
 
 .operation-launch-control--canvas {
-  position: absolute;
-  z-index: 30;
+  /* body 포털: Map의 contain/clip과 부유 사이드바를 벗어나 Console 전역에 선다. */
+  position: fixed;
+  z-index: var(--z-overlay);
   /* 캔버스 메뉴 폭의 단일 소유자. 메뉴 박스와 설명 어사이드의 기준점이 여기 하나로 모인다 —
      컨테이너에 폭이 없으면 어사이드의 100%가 메뉴 오른쪽이 아니라 왼쪽 모서리를 가리켜
      설명이 메뉴 위를 덮는다. 컴포넌트의 MENU_WIDTH(측정 전 clamp 폴백)만 이 값을 따로 안다. */
   --canvas-menu-width: 264px;
   width: var(--canvas-menu-width);
-}
-
-/* War Room의 메뉴는 이 모드의 층 위에 서야 한다 — 덱(80)과 레일(90)이 같은 스태킹 문맥에서 위에
-   있으면 메뉴가 보여도 항목의 클릭을 덱 카드가 먼저 받는다. Cruise의 30은 그대로 둔다. */
-.operation-launch-control--triage {
-  z-index: var(--z-overlay);
 }
 
 .workspace-add-button {
@@ -3678,8 +3673,7 @@
   position: absolute;
   /* 덱과 같은 자리 — 아레나 인셋 위 26px, 가로는 부유 카드에 12px 가산으로 다가선다. */
   inset: calc(var(--arena-top, 0px) + 26px) max(26px, var(--arena-right, 0px) + 12px) calc(var(--arena-bottom, 0px) + 26px) max(26px, var(--arena-left, 0px) + 12px);
-  /* 캔버스 실행 메뉴(.operation-launch-control--canvas, 30) 아래 — 판이 메뉴를 덮으면 메뉴는
-     보이는데 눌리지 않는다(핸드오프 1차 결함). 월드(무 z-index)와 미니맵(14)보다는 위. */
+  /* Console 전역 실행 메뉴 아래, 월드(무 z-index)와 미니맵(14)보다는 위. */
   z-index: 20;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -4524,12 +4524,12 @@ describe("War Room deck panel grammar", () => {
   });
 
   it("keeps the fleet map under the canvas launch menu and marks its nameplates on the brass channel", () => {
-    // 판이 메뉴를 덮으면 메뉴는 보이는데 눌리지 않는다 — 판(20)은 캔버스 실행 메뉴(30) 아래,
-    // 월드(무 z-index)와 미니맵(14) 위에 선다.
+    // 판(20)은 Console 전역 실행 메뉴 아래, 월드(무 z-index)와 미니맵(14) 위에 선다.
     const plate = components.match(/\.canvas-fleet-map \{[^}]*\}/)?.[0] ?? "";
     expect(plate).toContain("z-index: 20;");
     const launch = components.match(/\.operation-launch-control--canvas \{[^}]*\}/)?.[0] ?? "";
-    expect(launch).toContain("z-index: 30;");
+    expect(launch).toContain("position: fixed;");
+    expect(launch).toContain("z-index: var(--z-overlay);");
     // 표석의 hover/focus는 위치 채널(brass)만 쓴다 — 신호 토큰이 끼면 상태로 읽힌다.
     const nameplate = components.match(/\.canvas-fleet-map-zone-pick:hover,\n\.canvas-fleet-map-zone-pick:focus-visible \{[^}]*\}/)?.[0] ?? "";
     expect(nameplate).toContain("var(--brass)");


### PR DESCRIPTION
## Summary
- 우클릭 실행 메뉴를 Map 내부에서 Console 전역 body 포털로 옮겨 우측 사이드바 위에도 표시합니다. 메뉴 표시 좌표와 Operation 실행 월드 좌표는 분리해 기존 실행 위치를 보존합니다.
- 강도 팝오버를 실제 렌더 폭으로 배치해 왼쪽으로 열릴 때 발생하던 약 91px 빈 간격을 약 10px로 바로잡고, 확장·스크롤 시 다시 배치합니다.
- 기존 디자인 계약을 전역 overlay 토큰에 맞춰 갱신합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts` — 98 passed
- [x] 격리 Console + macOS headless Chromium에서 실제 우클릭/hover로 기존 결함 재현 및 수정 후 스크린샷 비교
- [x] 우측 Codex 사이드바 위 메뉴·강도 팝오버 표시, 실제 포인터 이동과 hit testing
- [x] 좌우 반전, 하단 배치, MAX·ULTRACODE 확장, 방향키 진입과 포커스 복귀, Escape·Tab·외부 클릭 닫힘
- [x] Cruise·War Room·사이드바 실행 메뉴 경로 확인, 브라우저 errors/rejections 없음
- [x] 전용 브라우저 세션과 격리 Console 종료 확인

실제 유료 Agent 실행, Electron 네이티브 동작, 전체 테스트 스위트는 이번 UI 위치 수정의 검증 범위에서 제외했습니다.
