### PR TITLE
fix(console): keep Quaker aides visible in Zen mode

### DIFF
--- a/runtime/fleet-console/core/client/src/floating-widget-layer.tsx
+++ b/runtime/fleet-console/core/client/src/floating-widget-layer.tsx
@@ -26,10 +26,7 @@ import { createHostCapabilities } from "./plugin-capabilities.js";
 import { usePluginRegistry } from "./plugin-registry.js";
 import { focusOperation, getState, openQuickLaunch, openQuickLaunchWithDraft, subscribe as subscribeStore } from "./store.js";
 
-import { useZenMode } from "./zen-mode.js";
-
 export function FloatingWidgetLayer() {
-  const zenMode = useZenMode();
   const { floatingWidgets } = usePluginRegistry();
   const language = useConsoleLocale();
   const navigate = useNavigate();
@@ -75,7 +72,7 @@ export function FloatingWidgetLayer() {
   if (floatingWidgets.length === 0) return null;
 
   return (
-    <div className="floating-widget-layer" hidden={zenMode} inert={zenMode}>
+    <div className="floating-widget-layer">
       {floatingWidgets.map((descriptor) => (
         <div key={descriptor.id} className="floating-widget">
           <PluginErrorBoundary>

--- a/runtime/fleet-console/core/client/src/floating-widget-layer.tsx
+++ b/runtime/fleet-console/core/client/src/floating-widget-layer.tsx
@@ -268,13 +268,15 @@ interface ManagedKeepOutCapability {
 
 /**
  * 위젯이 덮으면 안 되는 표면들. 열린 레일 페인(설정 포함), Quick Launch 카드와 그 덱, 모달
- * 대화상자의 본문이다. 화면 대부분을 덮는 커튼(취역·제어권 인계)은 제외한다 — 그 안에 서 있을
+ * 대화상자의 본문, Zen 종료·대기 알림 버튼이다. 화면 대부분을 덮는 커튼(취역·제어권 인계)은 제외한다 — 그 안에 서 있을
  * 곳이 없고, 그런 표면은 이미 위젯의 포인터 입력을 막는다(layout.css 계약).
  */
 const KEEP_OUT_SELECTOR = [
   ".rail-pane:not(.is-parked)",
   ".quick-launch-card",
   ".quick-launch-overlay [role=\"listbox\"]",
+  ".zen-mode-exit:not([hidden])",
+  ".zen-mode-attention",
   "[aria-modal=\"true\"]",
   "[role=\"dialog\"]:not([aria-modal=\"true\"]):not(.quick-launch-overlay):not(.floating-widget-layer *)",
 ].join(", ");

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -375,8 +375,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .console-shell.is-zen .command-band-edge-reveal,
 .console-shell.is-zen .canvas-minimap,
 .console-shell.is-zen .canvas-minimap-fab,
-.console-shell.is-zen .canvas-shortcuts,
-.floating-widget-layer[hidden] { display: none; }
+.console-shell.is-zen .canvas-shortcuts { display: none; }
 .console-shell.is-zen .right-rail { width: var(--right-rail-panel-width, 0px); }
 .console-shell.is-zen .right-rail::before { display: none; }
 .zen-mode-attention {


### PR DESCRIPTION
## Summary
- Zen 모드가 floating widget 전체에 적용하던 `hidden`/`inert`를 제거하여 퀘이커 부관단의 표시와 조작을 유지합니다.
- 사용하지 않는 floating widget 숨김 CSS를 제거합니다. 탐색 영역 숨김과 모달 입력 독점은 유지합니다.

## Test Plan
- [x] 격리된 실제 Console에서 Zen 활성화 시 부관 소실 재현 (`hidden=true`, `inert=true`, `display=none`) 및 전후 스크린샷 확인
- [x] 수정 빌드에서 Zen 중 부관 표시 (`hidden=false`, `inert=false`, `display=block`), 대화 단축키 및 왕복 전환 후 초안 보존 확인
- [x] 모달이 열린 동안 부관 포인터와 단축키 차단 유지, 브라우저 오류·미처리 rejection 없음
- [x] Console build 및 typecheck
- [x] instrument-design-contract: 98 tests passed
- [x] git diff --check 및 격리 브라우저·서버 정리

## Product Context Record
- 요청: Zen 활성화로 퀘이커 부관단이 사라지는 문제를 재현·수정·검증합니다.
- 수용 기준: 활성 부관의 표시와 조작이 Zen 진입/종료와 독립적으로 유지됩니다.
- 보존: 부관 설정·대화 상태·모달 입력 독점, 기존 Zen 탐색 영역 숨김.
- 제외: 부관 대화/모델 실행 변경, 새로운 설정·SDK 정책·레이아웃 재설계. 실제 모델 호출은 수행하지 않았습니다.
- 근거: 실제 브라우저 재현과 FloatingWidgetLayer의 Zen 기반 hidden/inert 직접 적용.
- REVIEW_BASE_HEAD: 2c6396bb8 (최초 푸시된 수정 커밋; 리뷰 수정 전 기준).