### PR TITLE
fix(gateway): send OpenCode conversation session headers

### DIFF
--- a/packages/core-ai-gateway/src/router/opencode-dispatch.ts
+++ b/packages/core-ai-gateway/src/router/opencode-dispatch.ts
@@ -62,7 +62,7 @@ export async function proxyToOpencode(
   signal: AbortSignal,
 ): Promise<void> {
   // 헤더·본문 정책은 core-ai-gateway가 소유한다. 여기는 요청을 실어 보낼 뿐이다.
-  const headers = opencodeAnthropicHeaders(requestHeaders, apiKey);
+  const headers = opencodeAnthropicHeaders(requestHeaders, apiKey, body.metadata?.user_id);
   // 클라이언트 요청 model은 provider wire id로 재작성되기 전 원본을 에코용으로 남긴다.
   const responseModel = typeof body.model === "string" ? body.model : undefined;
   await proxyAnthropicMessages(res, opencodeRequestBody(body, model), {

--- a/packages/core-ai-gateway/src/upstream/opencode-go/anthropic/index.ts
+++ b/packages/core-ai-gateway/src/upstream/opencode-go/anthropic/index.ts
@@ -1,3 +1,4 @@
+import { opencodeSessionHeaders } from "../session.js";
 import { eagerAnthropicRequestBody } from "../../../downstream/wire/anthropic-messages/passthrough.js";
 import type { AnthropicMessagesRequest } from "../../../downstream/wire/anthropic-messages/protocol.js";
 
@@ -29,6 +30,7 @@ export function opencodeRequestBody(
 export function opencodeAnthropicHeaders(
   requestHeaders: Readonly<Record<string, unknown>>,
   apiKey: string,
+  userId?: unknown,
 ): Record<string, string> {
   const headers: Record<string, string> = {
     "content-type": "application/json",
@@ -36,6 +38,7 @@ export function opencodeAnthropicHeaders(
       ? requestHeaders["anthropic-version"]
       : "2023-06-01",
     "x-api-key": apiKey,
+    ...opencodeSessionHeaders(userId),
   };
   for (const name of ["anthropic-beta", "user-agent"]) {
     const value = requestHeaders[name];

--- a/packages/core-ai-gateway/src/upstream/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/opencode-go/chat-completions/adapter.ts
@@ -23,6 +23,7 @@ import {
   type FetchLike,
   type UpstreamReadOptions,
 } from "../../../transport/upstream-sse.js";
+import { opencodeSessionHeaders } from "../session.js";
 import { logRawWireEvent, wireLog, type RawWireEventPayload } from "../../../transport/wire-log.js";
 
 /** OpenCode Go 구독이 노출하는 Chat Completions 네임스페이스 엔드포인트. */
@@ -154,6 +155,7 @@ export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
           authorization: `Bearer ${options.apiKey}`,
           "content-type": "application/json",
           ...this.extraHeaders,
+          ...sessionHeaderPolicy.get(this)?.(request.metadata?.user_id),
         },
         body: JSON.stringify(payload),
         signal: controller.signal,
@@ -190,6 +192,8 @@ export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
     };
   }
 }
+
+const sessionHeaderPolicy = new WeakMap<OpenAIChatCompletionsAdapter, typeof opencodeSessionHeaders>();
 
 const imageInputPolicy = new WeakMap<
   OpenAIChatCompletionsAdapter,
@@ -254,6 +258,7 @@ export class OpencodeGoChatCompletionsAdapter extends OpenAIChatCompletionsAdapt
       ...(options.idleTimeoutMs !== undefined ? { idleTimeoutMs: options.idleTimeoutMs } : {}),
       ...(options.headers ? { headers: options.headers } : {}),
     });
+    sessionHeaderPolicy.set(this, opencodeSessionHeaders);
     // DeepSeek V4 텍스트 모델은 image_url을 거부하지만 Vision Exp는 이미지 입력을 받는다.
     // 기존 차단을 유지하되 공식 Go 카탈로그의 Vision 모델만 예외로 둔다.
     imageInputPolicy.set(this, (model) =>

--- a/packages/core-ai-gateway/src/upstream/opencode-go/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/opencode-go/responses/adapter.ts
@@ -23,6 +23,7 @@ import {
   type FetchLike,
   type UpstreamReadOptions,
 } from "../../../transport/upstream-sse.js";
+import { opencodeSessionHeaders } from "../session.js";
 import { logRawWireEvent, wireLog } from "../../../transport/wire-log.js";
 
 /** OpenCode Go 구독이 노출하는 Responses 네임스페이스 엔드포인트. */
@@ -137,7 +138,8 @@ export class OpencodeGoResponsesAdapter implements AiGatewayAdapter {
           accept: "text/event-stream",
           authorization: `Bearer ${options.apiKey}`,
           "content-type": "application/json",
-          ...this.extraHeaders
+          ...this.extraHeaders,
+          ...opencodeSessionHeaders(request.metadata?.user_id),
         },
         body: JSON.stringify(payload),
         signal: controller.signal

--- a/packages/core-ai-gateway/src/upstream/opencode-go/session.ts
+++ b/packages/core-ai-gateway/src/upstream/opencode-go/session.ts
@@ -1,0 +1,11 @@
+import { createHash, randomUUID } from "node:crypto";
+
+/** 원본 사용자 정보는 노출하지 않고, 같은 대화는 요청·wire가 달라도 같은 라우팅 키를 쓴다. */
+export function opencodeSessionHeaders(userId: unknown): Record<string, string> {
+  const identity = typeof userId === "string" ? userId.trim() : "";
+  // 정체성이 없는 독립 호출은 서로 합치지 않는다. 프로세스 공용 ID는 다른 대화를 섞는다.
+  const session = identity
+    ? createHash("sha256").update("fleet:opencode:session:").update(identity).digest("hex")
+    : randomUUID();
+  return { "x-opencode-session": session };
+}

--- a/packages/core-ai-gateway/tests/router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/router/routes.test.ts
@@ -190,6 +190,49 @@ describe("Astra asynchronous tools", () => {
   });
 });
 
+describe("OpenCode conversation routing", () => {
+  it("sends a stable, isolated session through each provider wire", async () => {
+    const sessions: string[] = [];
+    const fetchMock = vi.fn<typeof fetch>(async (url, init) => {
+      const session = new Headers(init?.headers).get("x-opencode-session");
+      expect(session).toBeTruthy();
+      expect(session).not.toContain("private-user");
+      sessions.push(session!);
+      const endpoint = String(url);
+      if (endpoint.endsWith("/messages")) {
+        return new Response('data: {"type":"message_stop"}\n\n', {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return new Response(endpoint.endsWith("/responses")
+        ? 'data: {"type":"response.completed","response":{"id":"r","model":"grok-4.6","usage":{"input_tokens":1,"output_tokens":1}}}\n\n'
+        : 'data: [DONE]\n\n', { headers: { "content-type": "text/event-stream" } });
+    });
+    const router = createAiGatewayRouter({ fetch: fetchMock, readOpencodeApiKey: async () => "test-key" });
+    try {
+      for (const model of ["minimax-m3", "grok-4.6", "deepseek-v4.1-flash"]) {
+        for (const userId of ["private-user-session-a", "private-user-session-a", "private-user-session-b", null, null]) {
+          const res = response();
+          await router.handle(ctx({
+            res, token: ANTHROPIC_CRED, model: `claude-gateway--opencode--${model}`,
+            metadata: userId === null ? null : { user_id: userId },
+          }));
+          expect(res.status).toBe(200);
+        }
+      }
+      expect(sessions).toHaveLength(15);
+      for (let index = 0; index < sessions.length; index += 5) {
+        expect(sessions[index]).toBe(sessions[0]);
+        expect(sessions[index + 1]).toBe(sessions[index]);
+        expect(sessions[index + 2]).not.toBe(sessions[index]);
+        expect(sessions[index + 3]).not.toBe(sessions[index + 4]);
+      }
+    } finally {
+      router.dispose();
+    }
+  });
+});
+
 describe("request body limit", () => {
   it("refuses a body past the limit with a 413 that does not arm reactive compaction", async () => {
     // "context window"가 들어간 413만 Claude Code의 압축을 무장시킨다(canonical/index.ts).


### PR DESCRIPTION
## Summary
- OpenCode Go의 세 wire에 필수 `x-opencode-session` 헤더를 전송합니다.
- 대화 식별자를 해시해 요청 간 안정성을 유지하고, 식별자가 없는 호출은 독립 ID로 분리합니다. 범용 Chat Completions 인스턴스에는 적용하지 않습니다.
- 라우터 경계에서 헤더 누락, 대화별 안정성·분리를 검증합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build` — ESM/CJS 및 선언 생성
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 28 files, 194 tests
- [x] `git diff --check`
- [x] 수정된 빌드로 실제 OpenCode Go 요청: MiniMax-M3 정상 답변 및 스트림 완료; DeepSeek-V4.1-Flash HTTP 200 및 스트림 완료(128-token 한도에서 답변 텍스트 없음)
- [x] Responses 세션 헤더 전송 확인: Grok-4.6은 별도 `Upstream request failed` 400; Muse-Spark-1.3은 HTTP 200 후 `response.completed` 없이 종료. 모든 모델의 추론 완료를 검증한 것은 아닙니다.

## Product Context Record
- 요청: core-ai-gateway의 OpenCode Go `Request is missing x-opencode-session` 오류 수정 및 검증.
- 수용 기준: 세 wire에 대화별 안정적 헤더 전달, 대화 분리, 범용 어댑터 동작 보존, 타입·빌드·테스트 검증.
- 제외: 공급자별 별도 추론/프레이밍 장애 수정, 카탈로그 변경, 실행 중인 사용자 Console 교체.
- 절충: 식별자가 없으면 임의 대화를 합치는 대신 호출별 ID 사용. 원본 user_id를 헤더로 노출하지 않음.
- 근거: https://opencode.ai/docs/go/#where-can-i-use-it 의 대화별 안정적인 session ID 요구; 현재 라우터의 하네스 정체성→metadata.user_id 전달 계약.
- REVIEW_BASE_HEAD: 6b97d2e32 (리뷰 수정 전 최초 pushed head; 전체 SHA는 PR commit 참조).
