### PR TITLE
fix(gateway): replay reasoning for DeepSeek V4.1 Flash

### DIFF
--- a/packages/core-ai-gateway/src/upstream/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/opencode-go/chat-completions/adapter.ts
@@ -344,7 +344,8 @@ function forChatCompletionsBackend(
   //   함께 도착한 발화이므로 결과 직후가 의미상 제자리다).
   // DeepSeek V4 assistant/tool-turn reasoning 재생은 레거시 generic 어댑터의 HEAD
   // 공개 동작으로 유지한다. OpenCode 전용 정책은 instance-bound gate로만 적용한다.
-  const replayReasoning = request.model.startsWith("deepseek-v4-");
+  const replayReasoning = request.model.startsWith("deepseek-v4-")
+    || request.model === "deepseek-v4.1-flash";
   let pendingToolCalls: ChatWireToolCall[] = [];
   let pendingAssistantText: string | undefined;
   let pendingAssistantReasoning: string | undefined;

--- a/packages/core-ai-gateway/src/upstream/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/upstream/opencode-go/chat-completions/adapter.ts
@@ -143,7 +143,9 @@ export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
     const reasoningEffort = requestedEffort === undefined
       ? undefined
       : reasoningEffortPolicy.get(this)?.(request.model, requestedEffort);
-    const payload = forChatCompletionsBackend(request, supportsImageInput, omitTools, reasoningEffort);
+    const replayReasoning = request.model.startsWith("deepseek-v4-")
+      || (reasoningReplayPolicy.has(this) && request.model === "deepseek-v4.1-flash");
+    const payload = forChatCompletionsBackend(request, supportsImageInput, omitTools, reasoningEffort, replayReasoning);
     wireLog("openai-chat.wire.request", { url: this.url, payload });
     let response: Response;
 
@@ -194,6 +196,8 @@ export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
 }
 
 const sessionHeaderPolicy = new WeakMap<OpenAIChatCompletionsAdapter, typeof opencodeSessionHeaders>();
+// 기존 V4 범용 계약 외의 추론 재생은 OpenCode 인스턴스에만 적용한다.
+const reasoningReplayPolicy = new WeakSet<OpenAIChatCompletionsAdapter>();
 
 const imageInputPolicy = new WeakMap<
   OpenAIChatCompletionsAdapter,
@@ -259,6 +263,7 @@ export class OpencodeGoChatCompletionsAdapter extends OpenAIChatCompletionsAdapt
       ...(options.headers ? { headers: options.headers } : {}),
     });
     sessionHeaderPolicy.set(this, opencodeSessionHeaders);
+    reasoningReplayPolicy.add(this);
     // DeepSeek V4 텍스트 모델은 image_url을 거부하지만 Vision Exp는 이미지 입력을 받는다.
     // 기존 차단을 유지하되 공식 Go 카탈로그의 Vision 모델만 예외로 둔다.
     imageInputPolicy.set(this, (model) =>
@@ -328,7 +333,8 @@ function forChatCompletionsBackend(
   request: CanonicalResponseRequest,
   supportsImageInput: boolean,
   omitTools = false,
-  reasoningEffort?: ReasoningEffort,
+  reasoningEffort: ReasoningEffort | undefined,
+  replayReasoning: boolean,
 ): ChatWireRequest {
   const messages: ChatWireMessage[] = [];
   if (request.instructions !== undefined && request.instructions.length > 0) {
@@ -342,10 +348,6 @@ function forChatCompletionsBackend(
   //   assistant 메시지로 병합하고,
   // - 사이에 낀 user/developer 텍스트는 해당 호출의 결과 뒤로 미룬다(원문에서도 결과와
   //   함께 도착한 발화이므로 결과 직후가 의미상 제자리다).
-  // DeepSeek V4 assistant/tool-turn reasoning 재생은 레거시 generic 어댑터의 HEAD
-  // 공개 동작으로 유지한다. OpenCode 전용 정책은 instance-bound gate로만 적용한다.
-  const replayReasoning = request.model.startsWith("deepseek-v4-")
-    || request.model === "deepseek-v4.1-flash";
   let pendingToolCalls: ChatWireToolCall[] = [];
   let pendingAssistantText: string | undefined;
   let pendingAssistantReasoning: string | undefined;

--- a/packages/core-ai-gateway/tests/upstream/opencode-go/chat-completions/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/upstream/opencode-go/chat-completions/adapter.test.ts
@@ -59,16 +59,17 @@ async function collect(events: AsyncIterable<CanonicalResponseEvent>): Promise<C
 describe("chat completions request translation", () => {
   it("threads instructions, tool calls, and tool replies through chat roles", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
-    await adapter(fetchMock).stream(request({
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      model: "deepseek-v4.1-flash",
       instructions: "Be terse.",
       input: [
         { type: "message", role: "developer", content: "House rules." },
         { type: "message", role: "user", content: "run both tools" },
-        { type: "function_call", call_id: "call-a", name: "ToolA", arguments: "{\"x\":1}" },
+        { type: "function_call", call_id: "call-a", name: "ToolA", arguments: "{\"x\":1}", reasoning_content: "Run both tools." },
         { type: "function_call", call_id: "call-b", name: "ToolB", arguments: "{}" },
         { type: "function_call_output", call_id: "call-a", output: "alpha", is_error: true, tool_references: ["ToolB"] },
         { type: "function_call_output", call_id: "call-b", output: "beta" },
-        { type: "message", role: "assistant", content: "done" },
+        { type: "message", role: "assistant", content: "done", reasoning_content: "Both tools finished." },
       ],
       tools: [{
         type: "function",
@@ -91,6 +92,7 @@ describe("chat completions request translation", () => {
       {
         role: "assistant",
         content: null,
+        reasoning_content: "Run both tools.",
         // 연속 function_call은 하나의 assistant 메시지로 합쳐져 tool 응답 인접성을 지킨다.
         tool_calls: [
           { id: "call-a", type: "function", function: { name: "ToolA", arguments: "{\"x\":1}" } },
@@ -99,7 +101,7 @@ describe("chat completions request translation", () => {
       },
       { role: "tool", tool_call_id: "call-a", content: "alpha" },
       { role: "tool", tool_call_id: "call-b", content: "beta" },
-      { role: "assistant", content: "done" },
+      { role: "assistant", content: "done", reasoning_content: "Both tools finished." },
     ]);
     expect(body.tools).toEqual([{
       type: "function",


### PR DESCRIPTION
## Summary
- `deepseek-v4.1-flash`가 기존 `deepseek-v4-` 조건에서 제외되어 후속 요청의 `reasoning_content`가 누락되는 문제를 수정합니다.
- 기존 도구 교환 대표 테스트에서 V4.1 도구 호출 및 assistant 메시지의 추론 보존을 검증합니다. 기존 V4 및 다른 모델의 정책은 유지합니다.

## Test Plan
- [x] 수정 전 대표 테스트 실패: assistant 두 메시지의 reasoning_content 누락 확인
- [x] Gateway 전체 테스트: 28개 파일, 194개 테스트 통과
- [x] Gateway typecheck 및 build 통과
- [x] git diff --check 통과
- [ ] Live provider 호출은 수행하지 않음; 실제 어댑터의 outbound 요청 본문을 로컬에서 검증