### PR TITLE
feat(console): show Operation branch and folder on Cmd+K rows

### DIFF
--- a/.changelog.d/palette-operation-context.md
+++ b/.changelog.d/palette-operation-context.md
@@ -1,0 +1,8 @@
+---
+branch: palette-operation-context
+---
+
+### fleet-console
+#### Changed
+- With "Show Operation location" on, the Cmd+K Operation rows now carry the same branch and working-folder line as the sidebar chips, inline after the name so each row stays one line.
+  ko: 「Operation 위치 표시」를 켜면 Cmd+K의 Operation 행에도 사이드바 칩과 같은 브랜치·작업 폴더 표시가 이름 옆 한 줄로 붙습니다.

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -10,6 +10,8 @@ import { openPane } from "../pane/pane-store.js";
 import type { RailPanelDescriptor, RailSearchResult } from "@fleet-console/sdk/rail";
 
 import { OperationNameMark } from "./operation-name-mark.js";
+import { OperationWorkspaceContext, describeWorkspace, visibleWorkspace } from "./operation-workspace-context.js";
+import { useAgentState } from "../agent/store.js";
 import { setGlobalSettingsField } from "../global-settings-store.js";
 import { toggleCommandBandDocked } from "../fullscreen-band-store.js";
 import {
@@ -93,6 +95,7 @@ export function OperationSearch({
 }: OperationSearchProps) {
   const t = useT();
   const zenMode = useZenMode();
+  const sessions = useAgentState().sessions;
   const railBindings = useRailEntries();
   const navigate = useNavigate();
   const location = useLocation();
@@ -817,6 +820,7 @@ export function OperationSearch({
                       const resultKey = operationResultKey(entry.operationId);
                       const stripOpen = actionsFor === entry.operationId;
                       const actions = stripOpen ? rowActions(entry) : [];
+                      const workspace = visibleWorkspace(sessions[entry.operationId]?.workspace);
                       return (
                         <div key={entry.operationId} className={`operation-search-row${stripOpen ? " has-actions" : ""}`}>
                           <button
@@ -829,6 +833,7 @@ export function OperationSearch({
                             className={`operation-search-result ${active ? "is-active" : ""}`}
                             role="option"
                             aria-selected={active}
+                            aria-label={workspace ? `${entry.operationName}${describeWorkspace(t, workspace)}` : undefined}
                             onMouseEnter={() => setSelectedIndex(index)}
                             onClick={() => selectEntry(entry.operationId)}
                           >
@@ -841,8 +846,11 @@ export function OperationSearch({
                                 status={resolveOperationMarkVisual({ activity: entry.activity, operationId: entry.operationId, idleArrivalIds })}
                               />
                             </span>
-                            <span className="operation-search-result-text">
+                            {/* "지금 어디"는 사이드바 칩과 같은 투영(실험 기능이 켜진 동안만 온다)이다. 팔레트는
+                                한 줄 행을 지키려고 이름 옆 같은 줄에 붙이고, 접근성 이름(aria-label)에는 문장으로 싣는다. */}
+                            <span className={`operation-search-result-text${workspace ? " operation-search-result-text-inline" : ""}`}>
                               <strong>{highlightText(entry.operationName, tokens)}</strong>
+                              {workspace ? <OperationWorkspaceContext workspace={workspace} /> : null}
                             </span>
                             <span className="operation-search-row-arrow" aria-hidden="true">{stripOpen ? "◂" : "▸"}</span>
                           </button>

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -833,7 +833,6 @@ export function OperationSearch({
                             className={`operation-search-result ${active ? "is-active" : ""}`}
                             role="option"
                             aria-selected={active}
-                            aria-label={workspace ? `${entry.operationName}${describeWorkspace(t, workspace)}` : undefined}
                             onMouseEnter={() => setSelectedIndex(index)}
                             onClick={() => selectEntry(entry.operationId)}
                           >
@@ -847,10 +846,12 @@ export function OperationSearch({
                               />
                             </span>
                             {/* "지금 어디"는 사이드바 칩과 같은 투영(실험 기능이 켜진 동안만 온다)이다. 팔레트는
-                                한 줄 행을 지키려고 이름 옆 같은 줄에 붙이고, 접근성 이름(aria-label)에는 문장으로 싣는다. */}
+                                한 줄 행을 지키려고 이름 옆 같은 줄에 붙이고, 접근성 이름에는 숨은 문장으로 덧붙인다 — aria-label로
+                                덮으면 활동 마크(실행 중·대기 등)의 이름까지 지워지므로 자손 텍스트로 남긴다. */}
                             <span className={`operation-search-result-text${workspace ? " operation-search-result-text-inline" : ""}`}>
                               <strong>{highlightText(entry.operationName, tokens)}</strong>
                               {workspace ? <OperationWorkspaceContext workspace={workspace} /> : null}
+                              {workspace ? <span className="operation-search-sr-only">{describeWorkspace(t, workspace)}</span> : null}
                             </span>
                             <span className="operation-search-row-arrow" aria-hidden="true">{stripOpen ? "◂" : "▸"}</span>
                           </button>

--- a/runtime/fleet-console/core/client/src/components/operation-workspace-context.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-workspace-context.tsx
@@ -1,0 +1,41 @@
+import type { OperationWorkspace } from "../agent/types.js";
+import { useT } from "../i18n/index.js";
+
+/**
+ * Operation의 "지금 어디" 줄 — 실험 기능(Operation 위치 표시)이 켜진 동안 서버가 세션 DTO에 실어
+ * 보내는 투영을 사이드바 칩과 ⌘K 팔레트가 같은 문법으로 그린다. 브랜치는 늘, 폴더는 Theater 루트를
+ * 벗어났을 때만. 글자색 위계만 쓰고 상태·brass·정체성 채널은 건드리지 않는다. 폴더는 마지막 마디만
+ * 보이고 전체는 툴팁이 든다. 장식(aria-hidden)이므로 접근성 이름은 {@link describeWorkspace}로 싣는다.
+ */
+export function OperationWorkspaceContext({ workspace, className }: { readonly workspace: OperationWorkspace; readonly className?: string }) {
+  const t = useT();
+  const folder = workspace.folder;
+  const folderLabel = folder === null ? null : folder.includes("/") ? `…/${folder.slice(folder.lastIndexOf("/") + 1)}` : folder;
+  const classes = ["operation-context", folder !== null ? "operation-context--deviates" : "", className ?? ""].filter(Boolean).join(" ");
+  return (
+    <span className={classes} aria-hidden="true">
+      {workspace.branch ? (
+        <span className="operation-context-branch" title={t("sidebar.chip.branchTitle", { branch: workspace.branch })}>{workspace.branch}</span>
+      ) : null}
+      {workspace.branch && folderLabel ? <span className="operation-context-sep">·</span> : null}
+      {folderLabel ? (
+        <span
+          className={`operation-context-folder${workspace.outside ? " is-outside" : ""}`}
+          title={workspace.outside ? t("sidebar.chip.outsideTitle", { folder: folderLabel }) : t("sidebar.chip.folderTitle", { folder: folder ?? "" })}
+        >
+          {folderLabel}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/** 브랜치·폴더 편차가 하나라도 있어야 줄을 낸다 — 없으면 오늘의 한 줄 행과 같다. */
+export function visibleWorkspace(workspace: OperationWorkspace | null | undefined): OperationWorkspace | null {
+  return workspace && (workspace.branch || workspace.folder) ? workspace : null;
+}
+
+export function describeWorkspace(t: ReturnType<typeof useT>, workspace: OperationWorkspace): string {
+  return (workspace.branch ? t("sidebar.chip.onBranch", { branch: workspace.branch }) : "")
+    + (workspace.folder ? (workspace.outside ? t("sidebar.chip.outsideFolder", { folder: workspace.folder }) : t("sidebar.chip.inFolder", { folder: workspace.folder })) : "");
+}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef, type CSSProperties, type PointerEvent as ReactPointe
 
 
 import { useAgentState } from "../agent/store.js";
-import type { OperationWorkspace } from "../agent/types.js";
 import { OperationNameMark } from "../components/operation-name-mark.js";
+import { OperationWorkspaceContext, describeWorkspace, visibleWorkspace } from "../components/operation-workspace-context.js";
 import { useT } from "../i18n/index.js";
 import { type OperationActivityVisual, type OperationMarkVisual } from "../operation-activity.js";
 import { useInlineRename } from "../use-inline-rename.js";
@@ -107,8 +107,7 @@ export function OperationsSideBarChip({
   const theaterContext = theaterName ? t("sidebar.chip.inTheater", { name: theaterName }) : "";
   // "지금 어디" 축 — 실험 기능이 켜진 동안 서버가 세션 DTO에 실어 보내는 투영이다. 칩은 이름 아래
   // 한 줄로 그리되, 브랜치도 폴더 편차도 없으면 줄 자체를 내지 않아 오늘의 한 줄 칩과 같다.
-  const workspace = useAgentState().sessions[operation.id]?.workspace ?? null;
-  const context = workspace && (workspace.branch || workspace.folder) ? workspace : null;
+  const context = visibleWorkspace(useAgentState().sessions[operation.id]?.workspace);
   const workspaceContext = context ? describeWorkspace(t, context) : "";
   const groupContext = (statusAxis && groupMark ? t("sidebar.chip.inGroup", { name: groupMark.name }) : "") + theaterContext + workspaceContext;
   // 미확인 도착은 활동 축과 별개의 사실이 아니다 — 그 조건이 곧 표시 활동의 AWAITING이므로
@@ -262,7 +261,7 @@ export function OperationsSideBarChip({
         ) : (
           <span className="side-bar-chip-name" onDoubleClick={preview ? undefined : rename.begin}>{title}</span>
         )}
-        {context ? <WorkspaceContextLine workspace={context} /> : null}
+        {context ? <OperationWorkspaceContext workspace={context} className="side-bar-chip-context" /> : null}
       </span>
       {theaterName ? (
         <span className="side-bar-chip-theater-pill" title={theaterName} aria-hidden="true">
@@ -322,35 +321,6 @@ export function OperationsSideBarChip({
 
 function displayTitle(operation: OperationNode): string {
   return operation.title;
-}
-
-/* 브랜치는 늘, 폴더는 Theater 루트를 벗어났을 때만 — 두 줄이 곧 "이 칩은 다른 자리에 있다"는 신호다.
-   글자색 위계만 쓰고 상태·brass·정체성 채널은 건드리지 않는다. 폴더는 마지막 마디만 보이고 전체는 툴팁이 든다. */
-function WorkspaceContextLine({ workspace }: { readonly workspace: OperationWorkspace }) {
-  const t = useT();
-  const folder = workspace.folder;
-  const folderLabel = folder === null ? null : folder.includes("/") ? `…/${folder.slice(folder.lastIndexOf("/") + 1)}` : folder;
-  return (
-    <span className={`side-bar-chip-context${folder !== null ? " side-bar-chip-context--deviates" : ""}`} aria-hidden="true">
-      {workspace.branch ? (
-        <span className="side-bar-chip-context-branch" title={t("sidebar.chip.branchTitle", { branch: workspace.branch })}>{workspace.branch}</span>
-      ) : null}
-      {workspace.branch && folderLabel ? <span className="side-bar-chip-context-sep">·</span> : null}
-      {folderLabel ? (
-        <span
-          className={`side-bar-chip-context-folder${workspace.outside ? " is-outside" : ""}`}
-          title={workspace.outside ? t("sidebar.chip.outsideTitle", { folder: folderLabel }) : t("sidebar.chip.folderTitle", { folder: folder ?? "" })}
-        >
-          {folderLabel}
-        </span>
-      ) : null}
-    </span>
-  );
-}
-
-function describeWorkspace(t: ReturnType<typeof useT>, workspace: OperationWorkspace): string {
-  return (workspace.branch ? t("sidebar.chip.onBranch", { branch: workspace.branch }) : "")
-    + (workspace.folder ? (workspace.outside ? t("sidebar.chip.outsideFolder", { folder: workspace.folder }) : t("sidebar.chip.inFolder", { folder: workspace.folder })) : "");
 }
 
 function SideBarCloseIcon() {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -10856,6 +10856,16 @@ body[data-side-bar-animating="true"] .canvas-operation {
   flex: 0 1 auto;
 }
 
+/* 위치 줄의 문장형(브랜치 …, 폴더 …)은 보조기기에만 — 활동 마크의 이름과 함께 option의 접근성 이름에 남는다. */
+.operation-search-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
 .operation-search-result strong {
   display: block;
   min-width: 0;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6173,6 +6173,67 @@ body[data-side-bar-animating="true"] .canvas-operation {
   line-height: 1.3;
 }
 
+/* 옵트인 실험 「Operation 위치 표시」의 한 줄 — 사이드바 칩과 ⌘K 팔레트가 공유한다. 브랜치는 늘,
+   폴더는 Theater 루트를 벗어났을 때만. 글자색은 3티어이고 편차가 있을 때만 2티어로 한 단계 오른다.
+   상태(aurora/warn/coral/positive)·brass·--id-* 채널은 쓰지 않는다: 이 줄은 위치 사실이지 상태도 정체성도 아니다. */
+.operation-context {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  font-weight: var(--weight-medium);
+  line-height: 1.3;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.operation-context > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.operation-context-branch {
+  flex: 0 1 auto;
+}
+
+.operation-context-branch::before {
+  content: "⎇ ";
+  opacity: 0.8;
+}
+
+.operation-context-sep {
+  flex: none;
+  opacity: 0.6;
+}
+
+.operation-context-folder {
+  flex: 1 1 auto;
+}
+
+.operation-context-folder.is-outside::before {
+  content: "↗ ";
+  opacity: 0.8;
+}
+
+.operation-context--deviates {
+  color: var(--text-secondary);
+}
+
+/* 사이드바 칩의 "지금 어디" 줄 — 공통 .operation-context 문법을 쓰고, 최소화된 칩에서만 잉크가 한 단계 내려간다. */
+.side-bar-chip--minimized .side-bar-chip-context {
+  color: var(--ink-muted);
+}
+
+.side-bar-chip-rename-input {
+  flex: none;
+  width: 100%;
+  line-height: 1.3;
+}
+
 /* 옵트인 실험 「Operation 위치 표시」의 한 줄 — 브랜치는 늘, 폴더는 Theater 루트를 벗어났을 때만.
    글자색은 3티어이고 편차가 있을 때만 2티어로 한 단계 오른다. 상태(aurora/warn/coral/positive)·
    brass·--id-* 채널은 쓰지 않는다: 이 줄은 위치 사실이지 상태도 정체성도 아니다. */
@@ -10780,6 +10841,19 @@ body[data-side-bar-animating="true"] .canvas-operation {
 
 .operation-search-result-text-inline small {
   flex: 1 1 0;
+}
+
+/* ⌘K Operation 행의 "지금 어디" — 한 줄을 유지하려고 이름 옆에 같은 줄로 붙인다. 이름이 먼저 자리를
+   갖고 위치 줄은 남은 폭에서 잘린다. 사이드바와 같은 .operation-context 문법·잉크 위계를 쓰고,
+   활성 행에서도 brass를 받지 않는다. */
+.operation-search-result-text-inline .operation-context {
+  flex: 1 1 0;
+  letter-spacing: 0;
+  transform: translateY(-0.5px);
+}
+
+.operation-search-result-text-inline .operation-context-folder {
+  flex: 0 1 auto;
 }
 
 .operation-search-result strong {


### PR DESCRIPTION
## Summary
- With the "Show Operation location" experiment on, Cmd+K Operation rows now carry the same branch / working-folder line the sidebar chips got in #1069, inline after the name so rows stay one line; the sentence form is carried in `aria-label`.
- The sidebar chip's context line is extracted into a shared `OperationWorkspaceContext` component with generic `.operation-context` styles so both surfaces render one grammar.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` and `build`
- [x] vitest files touching the palette and sidebar chip (3 files, 101 passed)
- [x] console-e2e (headless, isolated Console built from this branch): experiment on → sidebar chip and Cmd+K row both show `⎇ palette-operation-context`; row height unchanged (28.9px) with and without the line; experiment off → line removed from both; no page errors/rejections